### PR TITLE
rdar://105145407 (PredicateExpressions.VariableID should use UInt not UUID)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
             "FoundationEssentials",
             "FoundationInternationalization",
             "FoundationNetworking"
-        ]),
+        ], swiftSettings: swiftSettings),
 
         // FoundationEssentials
         .target(name: "FoundationEssentials", dependencies: ["_CShims"], swiftSettings: swiftSettings),

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+@_implementationOnly import os
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+internal struct LockedState<State> {
+
+    // Internal implementation for a cheap lock to aid sharing code across platforms
+    private struct _Lock {
+#if canImport(Darwin)
+        typealias Primitive = os_unfair_lock
+#elseif canImport(Glibc)
+        typealias Primitive = pthread_mutex_t
+#endif
+
+        typealias PlatformLock = UnsafeMutablePointer<Primitive>
+        var _platformLock: PlatformLock
+
+        fileprivate static func initialize(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+            platformLock.initialize(to: os_unfair_lock())
+#elseif canImport(Glibc)
+            pthread_mutex_init(platformLock, nil)
+#endif
+        }
+
+        fileprivate static func deinitialize(_ platformLock: PlatformLock) {
+#if canImport(Glibc)
+            pthread_mutex_destroy(platformLock)
+#endif
+            platformLock.deinitialize(count: 1)
+        }
+
+        static fileprivate func lock(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+            os_unfair_lock_lock(platformLock)
+#elseif canImport(Glibc)
+            pthread_mutex_lock(platformLock)
+#endif
+        }
+
+        static fileprivate func unlock(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+            os_unfair_lock_unlock(platformLock)
+#elseif canImport(Glibc)
+            pthread_mutex_unlock(platformLock)
+#endif
+        }
+    }
+
+    private class _Buffer: ManagedBuffer<State, _Lock.Primitive> {
+        deinit {
+            withUnsafeMutablePointerToElements {
+                _Lock.deinitialize($0)
+            }
+        }
+    }
+
+    private let _buffer: ManagedBuffer<State, _Lock.Primitive>
+
+    init(initialState: State) {
+        _buffer = _Buffer.create(minimumCapacity: 1, makingHeaderWith: { buf in
+            buf.withUnsafeMutablePointerToElements {
+                _Lock.initialize($0)
+            }
+            return initialState
+        })
+    }
+
+    func withLock<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
+        try _buffer.withUnsafeMutablePointers { state, lock in
+            _Lock.lock(lock)
+            defer { _Lock.unlock(lock) }
+            return try body(&state.pointee)
+        }
+    }
+
+    // Ensures the managed state outlives the locked `body`.
+    func withLockExtendingLifetimeOfState<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
+        try _buffer.withUnsafeMutablePointers { state, lock in
+            _Lock.lock(lock)
+            return try withExtendedLifetime(state.pointee) {
+                let result = try body(&state.pointee)
+                _Lock.unlock(lock)
+                return result
+            }
+        }
+    }
+}
+
+extension LockedState where State == Void {
+    init() {
+        self.init(initialState: ())
+    }
+
+    func withLock<R: Sendable>(_ body: @Sendable () throws -> R) rethrows -> R {
+        return try withLock { _ in
+            try body()
+        }
+    }
+
+    func lock() {
+        _buffer.withUnsafeMutablePointerToElements { lock in
+            _Lock.lock(lock)
+        }
+    }
+
+    func unlock() {
+        _buffer.withUnsafeMutablePointerToElements { lock in
+            _Lock.unlock(lock)
+        }
+    }
+}
+
+extension LockedState: @unchecked Sendable where State: Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -71,10 +71,16 @@ public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
 @available(Future, *)
 extension PredicateExpressions {
     public struct VariableID: Hashable, Codable, Sendable {
-        let uuid: UUID
+        let id: UInt
+        private static let nextID = LockedState(initialState: UInt(0))
         
         fileprivate init() {
-            uuid = UUID()
+            self.id = Self.nextID.withLock { value in
+                defer {
+                    (value, _) = value.addingReportingOverflow(1)
+                }
+                return value
+            }
         }
     }
     

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -45,8 +45,8 @@ final class PredicateTests: XCTestCase {
                 rhs: PredicateExpressions.build_Arg(compareTo)
             )
         }
-        try print(predicate.evaluate(Object(a: 1, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
-        try print(predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+        try XCTAssertFalse(predicate.evaluate(Object(a: 1, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+        try XCTAssertTrue(predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
     #if false // TODO: Re-enable with Variadic Generics


### PR DESCRIPTION
Generating a UUID is very expensive, so let's switch `VariableID` to use a monotonically increasing `UInt` instead which is far cheaper to produce. This change drastically improves performance of predicate creation.