### PR TITLE
rdar://100474708 (Make AttributedString Sendable)

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
@@ -10,10 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_nonSendable
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public struct AttributeContainer {
+public struct AttributeContainer : Sendable {
     internal var storage : AttributedString._AttributeStorage
     
     public init() {
@@ -27,12 +26,14 @@ public struct AttributeContainer {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeContainer {
-    public subscript<T: AttributedStringKey>(_: T.Type) -> T.Value? {
+    @preconcurrency
+    public subscript<T: AttributedStringKey>(_: T.Type) -> T.Value? where T.Value : Sendable {
         get { storage[T.self] }
         set { storage[T.self] = newValue }
     }
 
-    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? {
+    @preconcurrency
+    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? where K.Value : Sendable {
         get { self[K.self] }
         set { self[K.self] = newValue }
     }
@@ -63,11 +64,11 @@ extension AttributeContainer {
         return Builder(container: self)
     }
 
-    @_nonSendable
-    public struct Builder<T: AttributedStringKey> {
+    public struct Builder<T: AttributedStringKey> : Sendable {
         var container : AttributeContainer
 
-        public func callAsFunction(_ value: T.Value) -> AttributeContainer {
+        @preconcurrency
+        public func callAsFunction(_ value: T.Value) -> AttributeContainer where T.Value : Sendable {
             var new = container
             new[T.self] = value
             return new

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
@@ -12,8 +12,8 @@
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    @_nonSendable
-    public struct SingleAttributeTransformer<T: AttributedStringKey> {
+    @preconcurrency
+    public struct SingleAttributeTransformer<T: AttributedStringKey> : Sendable where T.Value : Sendable {
         public var range: Range<Index>
 
         internal var attrName = T.name
@@ -24,12 +24,14 @@ extension AttributedString {
             set { attr = .wrapIfPresent(newValue, for: T.self) }
         }
 
-        public mutating func replace<U: AttributedStringKey>(with key: U.Type, value: U.Value) {
+        @preconcurrency
+        public mutating func replace<U: AttributedStringKey>(with key: U.Type, value: U.Value) where U.Value : Sendable {
             attrName = key.name
             attr = .init(value, for: U.self)
         }
 
-        public mutating func replace<U: AttributedStringKey>(with keyPath: KeyPath<AttributeDynamicLookup, U>, value: U.Value) {
+        @preconcurrency
+        public mutating func replace<U: AttributedStringKey>(with keyPath: KeyPath<AttributeDynamicLookup, U>, value: U.Value) where U.Value : Sendable {
             self.replace(with: U.self, value: value)
         }
     }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -12,8 +12,7 @@
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    @_nonSendable
-    public struct CharacterView {
+    public struct CharacterView : Sendable {
         /// The guts of the base attributed string.
         internal var _guts: Guts
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -12,7 +12,7 @@
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    internal struct _InternalRun : Hashable {
+    internal struct _InternalRun : Hashable, Sendable {
         // UTF-8 Code Unit Length
         internal var length : Int
         internal var attributes : _AttributeStorage
@@ -24,7 +24,7 @@ extension AttributedString {
             return lhs.attributes == rhs.attributes
         }
 
-        internal func get<T: AttributedStringKey>(_ k: T.Type) -> T.Value? {
+        internal func get<T: AttributedStringKey>(_ k: T.Type) -> T.Value? where T.Value : Sendable {
             attributes[k]
         }
     }
@@ -42,7 +42,7 @@ extension AttributedString._InternalRun {
 }
 
 extension AttributedString {
-    internal final class Guts {
+    internal final class Guts : @unchecked Sendable {
         typealias Index = AttributedString.Index
         typealias Runs = AttributedString.Runs
         typealias AttributeMergePolicy = AttributedString.AttributeMergePolicy
@@ -404,7 +404,7 @@ extension AttributedString.Guts {
         }
     }
 
-    func add<K: AttributedStringKey>(value: K.Value, in range: Range<Index>, key: K.Type) {
+    func add<K: AttributedStringKey>(value: K.Value, in range: Range<Index>, key: K.Type) where K.Value : Sendable {
         let _value = _AttributeValue(value, for: K.self)
         self.add(value: _value, in: range, key: K.name)
     }
@@ -429,7 +429,7 @@ extension AttributedString.Guts {
             in: range, type: .attributes, constraintsInvolved: attributes.storage.constraintsInvolved)
     }
 
-    func remove<T : AttributedStringKey>(attribute: T.Type, in range: Range<Index>) {
+    func remove<T : AttributedStringKey>(attribute: T.Type, in range: Range<Index>) where T.Value : Sendable {
         let utf8Range = utf8OffsetRange(from: range)
         self.enumerateRuns(containing: utf8Range) { run, _, _, _ in
             run.attributes[T.self] = nil

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -12,8 +12,8 @@
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs {
-    @_nonSendable
-    public struct AttributesSlice1<T : AttributedStringKey> : BidirectionalCollection {
+    @preconcurrency
+    public struct AttributesSlice1<T : AttributedStringKey> : BidirectionalCollection, Sendable where T.Value : Sendable {
         public typealias Index = AttributedString.Index
 
         // FIXME: Why no labels?
@@ -32,8 +32,7 @@ extension AttributedString.Runs {
             _constraints = T._constraintsInvolved
         }
 
-        @_nonSendable
-        public struct Iterator: IteratorProtocol {
+        public struct Iterator: IteratorProtocol, Sendable {
             // Note: This is basically equivalent to `IndexingIterator`.
 
             public typealias Element = AttributesSlice1.Element
@@ -105,11 +104,15 @@ extension AttributedString.Runs {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs {
-    @_nonSendable
+    @preconcurrency
     public struct AttributesSlice2<
         T : AttributedStringKey,
         U : AttributedStringKey
-    > : BidirectionalCollection {
+    > : BidirectionalCollection, Sendable
+    where
+        T.Value : Sendable,
+        U.Value : Sendable
+    {
         public typealias Index = AttributedString.Index
 
         // FIXME: Why no labels?
@@ -128,9 +131,7 @@ extension AttributedString.Runs {
             _constraints = Array(_contents: T.runBoundaries, U.runBoundaries)
         }
 
-
-        @_nonSendable
-        public struct Iterator: IteratorProtocol {
+        public struct Iterator: IteratorProtocol, Sendable {
             // Note: This is basically equivalent to `IndexingIterator`.
 
             public typealias Element = AttributesSlice2.Element
@@ -214,12 +215,17 @@ extension AttributedString.Runs {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs {
-    @_nonSendable
+    @preconcurrency
     public struct AttributesSlice3<
         T : AttributedStringKey,
         U : AttributedStringKey,
         V : AttributedStringKey
-    > : BidirectionalCollection {
+    > : BidirectionalCollection, Sendable
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable
+    {
         public typealias Index = AttributedString.Index
 
         // FIXME: Why no labels?
@@ -238,8 +244,7 @@ extension AttributedString.Runs {
             _constraints = Array(_contents: T.runBoundaries, U.runBoundaries, V.runBoundaries)
         }
 
-        @_nonSendable
-        public struct Iterator: IteratorProtocol {
+        public struct Iterator: IteratorProtocol, Sendable {
             // Note: This is basically equivalent to `IndexingIterator`.
 
             public typealias Element = AttributesSlice3.Element
@@ -331,13 +336,19 @@ extension AttributedString.Runs {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs {
-    @_nonSendable
+    @preconcurrency
     public struct AttributesSlice4<
         T : AttributedStringKey,
         U : AttributedStringKey,
         V : AttributedStringKey,
         W : AttributedStringKey
-    > : BidirectionalCollection {
+    > : BidirectionalCollection, Sendable
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable,
+        W.Value : Sendable
+    {
         public typealias Index = AttributedString.Index
 
         // FIXME: Why no labels?
@@ -357,8 +368,7 @@ extension AttributedString.Runs {
                 _contents: T.runBoundaries, U.runBoundaries, V.runBoundaries, W.runBoundaries)
         }
 
-        @_nonSendable
-        public struct Iterator: IteratorProtocol {
+        public struct Iterator: IteratorProtocol, Sendable {
             // Note: This is basically equivalent to `IndexingIterator`.
 
             public typealias Element = AttributesSlice4.Element
@@ -460,14 +470,21 @@ extension AttributedString.Runs {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs {
-    @_nonSendable
+    @preconcurrency
     public struct AttributesSlice5<
         T : AttributedStringKey,
         U : AttributedStringKey,
         V : AttributedStringKey,
         W : AttributedStringKey,
         X : AttributedStringKey
-    > : BidirectionalCollection {
+    > : BidirectionalCollection, Sendable
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable,
+        W.Value : Sendable,
+        X.Value : Sendable
+    {
         public typealias Index = AttributedString.Index
 
         // FIXME: Why no labels?
@@ -491,8 +508,7 @@ extension AttributedString.Runs {
                 X.runBoundaries)
         }
 
-        @_nonSendable
-        public struct Iterator: IteratorProtocol {
+        public struct Iterator: IteratorProtocol, Sendable {
             public typealias Element = AttributesSlice5.Element
 
             let _slice: AttributesSlice5
@@ -600,9 +616,8 @@ extension AttributedString.Runs {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs {
-    @_nonSendable
     @_spi(AttributedString)
-    public struct NSAttributesSlice : BidirectionalCollection {
+    public struct NSAttributesSlice : BidirectionalCollection, Sendable {
         public typealias Index = AttributedString.Index
 
         // FIXME: Why no labels?
@@ -621,8 +636,7 @@ extension AttributedString.Runs {
             self._names = keys.map { $0.rawValue }
         }
 
-        @_nonSendable
-        public struct Iterator: IteratorProtocol {
+        public struct Iterator: IteratorProtocol, Sendable {
             // Note: This is basically equivalent to `IndexingIterator`.
 
             public typealias Element = NSAttributesSlice.Element

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
@@ -12,9 +12,8 @@
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs {
-    @_nonSendable
     @dynamicMemberLookup
-    public struct Run {
+    public struct Run : Sendable {
         internal typealias _AttributeStorage = AttributedString._AttributeStorage
         internal typealias _InternalRun = AttributedString._InternalRun
 
@@ -78,11 +77,13 @@ extension AttributedString.Runs.Run {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs.Run {
-    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? {
+    @preconcurrency
+    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? where K.Value : Sendable {
         get { self[K.self] }
     }
 
-    public subscript<K : AttributedStringKey>(_: K.Type) -> K.Value? {
+    @preconcurrency
+    public subscript<K : AttributedStringKey>(_: K.Type) -> K.Value? where K.Value : Sendable {
         get { _internal.attributes[K.self] }
     }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -12,8 +12,7 @@
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    @_nonSendable
-    public struct Runs {
+    public struct Runs : Sendable {
         internal typealias _InternalRun = AttributedString._InternalRun
         internal typealias _AttributeStorage = AttributedString._AttributeStorage
         internal typealias AttributeRunBoundaries = AttributedString.AttributeRunBoundaries

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -12,8 +12,7 @@
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    @_nonSendable
-    public struct UnicodeScalarView {
+    public struct UnicodeScalarView : Sendable {
         internal var _guts : Guts
         internal var _range : Range<Index>
         internal var _identity : Int = 0

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -10,10 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_nonSendable
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public struct AttributedString {
+public struct AttributedString : Sendable {
     internal var _guts: Guts
 
     internal init(_ guts: Guts) {
@@ -23,7 +22,7 @@ public struct AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    internal static var currentIdentity = LockedState(initialState: 0)
+    internal static let currentIdentity = LockedState(initialState: 0)
     internal static var _nextModifyIdentity : Int {
         currentIdentity.withLock { identity in
             identity += 1
@@ -217,7 +216,8 @@ extension AttributedString: AttributedStringProtocol {
         return _guts.endIndex
     }
     
-    public subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? {
+    @preconcurrency
+    public subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? where K.Value : Sendable {
         get { _guts.getValue(in: startIndex ..< endIndex, key: K.self)?.rawValue(as: K.self) }
         set {
             ensureUniqueReference()
@@ -229,7 +229,8 @@ extension AttributedString: AttributedStringProtocol {
         }
     }
     
-    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? {
+    @preconcurrency
+    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? where K.Value : Sendable {
         get { self[K.self] }
         set { self[K.self] = newValue }
     }

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -149,17 +149,17 @@ public enum AttributeDynamicLookup {
     }
 }
 
-@_nonSendable
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public struct ScopedAttributeContainer<S: AttributeScope> {
+public struct ScopedAttributeContainer<S: AttributeScope> : Sendable {
     internal var storage : AttributedString._AttributeStorage
     
     // Record the most recently deleted key for use in AttributedString mutation subscripts that use _modify
     // Note: if ScopedAttributeContainer ever adds a mutating function that can mutate multiple attributes, this will need to record multiple removed keys
     internal var removedKey : String?
 
-    public subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<S, T>) -> T.Value? {
+    @preconcurrency
+    public subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<S, T>) -> T.Value? where T.Value : Sendable {
         get { storage[T.self] }
         set {
             storage[T.self] = newValue

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -35,7 +35,7 @@ public protocol AttributedStringAttributeMutation {
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol AttributedStringProtocol
-    : AttributedStringAttributeMutation, Hashable, CustomStringConvertible
+    : AttributedStringAttributeMutation, Hashable, CustomStringConvertible, Sendable
 {
     var startIndex : AttributedString.Index { get }
     var endIndex : AttributedString.Index { get }
@@ -44,8 +44,8 @@ public protocol AttributedStringProtocol
     var characters : AttributedString.CharacterView { get }
     var unicodeScalars : AttributedString.UnicodeScalarView { get }
 
-    subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? { get set }
-    subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? { get set }
+    @preconcurrency subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? where K.Value : Sendable { get set }
+    @preconcurrency subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? where K.Value : Sendable { get set }
     subscript<S: AttributeScope>(dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>) -> ScopedAttributeContainer<S> { get set }
 
     subscript<R: RangeExpression>(bounds: R) -> AttributedSubstring where R.Bound == AttributedString.Index { get }

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -10,10 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_nonSendable
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public struct AttributedSubstring {
+public struct AttributedSubstring : Sendable {
     /// The guts of the base attributed string.
     internal var _guts: AttributedString.Guts
 
@@ -155,7 +154,8 @@ extension AttributedSubstring : AttributedStringProtocol {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedSubstring {
-    public subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? {
+    @preconcurrency
+    public subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? where K.Value : Sendable {
         get { _guts.getValue(in: _range, key: K.self)?.rawValue(as: K.self) }
         set {
             ensureUniqueReference()
@@ -167,7 +167,8 @@ extension AttributedSubstring {
         }
     }
 
-    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? {
+    @preconcurrency
+    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? where K.Value : Sendable {
         get { self[K.self] }
         set { self[K.self] = newValue }
     }


### PR DESCRIPTION
This patch makes `AttributedString` `Sendable` by adding `where Key.Value : Sendable` constraints to all of its various API surfaces (and `@preconcurrency` where necessary). This cannot require that `AttributedStringKey.Value : Sendable` directly because we cannot introduce a source breaking change with no workaround for downstream libraries that need to maintain binary compatibility.