### PR TITLE
Update Package.swift tools-version requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
JSONDecoder's definition uses SE-0367, which requires a 5.8 compiler.

[This construct](https://github.com/apple/swift-foundation/blob/0354dfba6028463800bf9a2e1f6544096d1622f4/Sources/FoundationEssentials/JSON/JSONDecoder.swift#L41&L43) is not compatible with a 5.7 compiler/toolchain.