### PR TITLE
Adopt Variadic Generics for PredicateBindings.init

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -35,7 +35,7 @@ let package = Package(
         ]),
 
         // FoundationEssentials
-        .target(name: "FoundationEssentials", dependencies: ["_CShims"]),
+        .target(name: "FoundationEssentials", dependencies: ["_CShims"], swiftSettings: [.enableExperimentalFeature("VariadicGenerics")]),
         .testTarget(name: "FoundationEssentialsTests", dependencies: [
             "TestSupport",
             "FoundationEssentials"

--- a/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
@@ -16,8 +16,9 @@ public struct PredicateBindings {
     // Store as a values as an array instead of a dictionary (since it is almost always very few elements, this reduces heap allocation and hashing overhead)
     private var storage: [(id: PredicateExpressions.VariableID, value: Any)]
     
-    public init<T>(_ values: (PredicateExpressions.Variable<T>, T)) {
-        storage = [(values.0.key, values.1)]
+    public init<each T>(_ value: repeat (PredicateExpressions.Variable<each T>, each T)) {
+        storage = []
+        _ = (repeat storage.append(((each value).0.key, (each value).1)))
     }
     
     public subscript<T>(_ variable: PredicateExpressions.Variable<T>) -> T? {


### PR DESCRIPTION
This enables the VariadicGenerics experimental feature flag and adopts Variadic Generics for the `PredicateBindings` initializer, which also requires a 5.9 toolchain so this bumps the minimum tools version as well

Resolves rdar://108066094