### PR TITLE
rdar://107847458 (Fix FoundationPreview CalendarTests on Linux)

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -16,6 +16,7 @@ import Darwin
 import Glibc
 #endif
 
+@_implementationOnly import _CShims
 
 internal struct JSON5Scanner {
     let options: Options
@@ -1155,7 +1156,7 @@ extension JSON5Scanner {
             jsonBytes.formIndex(after: &index)
         }
 
-        let cmp = jsonBytes[index..<endIndex].prefix(2).withUnsafePointer({ strncasecmp_l($0, "0x", $1, nil) })
+        let cmp = jsonBytes[index..<endIndex].prefix(2).withUnsafePointer({ _cshims_strncasecmp_l($0, "0x", $1, nil) })
         if cmp == 0 {
             jsonBytes.formIndex(&index, offsetBy: 2)
 

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -16,6 +16,8 @@ import Darwin
 import Glibc
 #endif
 
+@_implementationOnly import _CShims
+
 /// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
 /// containing `Decodable` values (in which case it should be exempt from key conversion strategies).
 ///
@@ -875,7 +877,7 @@ extension JSONDecoderImpl: Decoder {
             let result = withBuffer(for: region) { (stringBuffer, _) -> T? in
                 stringBuffer.withUnsafeRawPointer { (ptr, count) -> T? in
                     func bytesAreEqual(_ b: UnsafeBufferPointer<UInt8>) -> Bool {
-                        count == b.count && memcmp(ptr, b.baseAddress, b.count) == 0
+                        count == b.count && memcmp(ptr, b.baseAddress!, b.count) == 0
                     }
                     if posInfString.withUTF8(bytesAreEqual(_:)) { return T.infinity }
                     if negInfString.withUTF8(bytesAreEqual(_:)) { return -T.infinity }

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -59,6 +59,8 @@ import Darwin
 import Glibc
 #endif // canImport(Darwin)
 
+@_implementationOnly import _CShims
+
 internal class JSONMap {
     enum TypeDescriptor : Int {
         case string  // [marker, count, sourceByteOffset]
@@ -1181,7 +1183,7 @@ extension Double : PrevalidatedJSONNumberBufferConvertible {
     init?(prevalidatedBuffer buffer: BufferView<UInt8>) {
         let decodedValue = buffer.withUnsafePointer { nptr, count -> Double? in
             var endPtr: UnsafeMutablePointer<CChar>? = nil
-            let decodedValue = strtod_l(nptr, &endPtr, nil)
+            let decodedValue = _cshims_strtod_l(nptr, &endPtr, nil)
             if let endPtr, nptr.advanced(by: count) == endPtr {
                 return decodedValue
             } else {
@@ -1197,7 +1199,7 @@ extension Float : PrevalidatedJSONNumberBufferConvertible {
     init?(prevalidatedBuffer buffer: BufferView<UInt8>) {
         let decodedValue = buffer.withUnsafePointer { nptr, count -> Float? in
             var endPtr: UnsafeMutablePointer<CChar>? = nil
-            let decodedValue = strtof_l(nptr, &endPtr, nil)
+            let decodedValue = _cshims_strtof_l(nptr, &endPtr, nil)
             if let endPtr, nptr.advanced(by: count) == endPtr {
                 return decodedValue
             } else {

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -481,7 +481,7 @@ extension FloatingPointRoundingRule {
     }
 }
 
-#if FOUNDATION_FRAMEWORK
+#if os(Linux) || FOUNDATION_FRAMEWORK
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointRoundingRule : Codable { }
 #endif

--- a/Sources/_CShims/include/string_shims.h
+++ b/Sources/_CShims/include/string_shims.h
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CSHIMS_STRING_H
+#define CSHIMS_STRING_H
+
+#include <locale.h>
+#include <stddef.h>
+
+#if __has_include(<xlocale.h>)
+#include <xlocale.h>
+#endif
+
+int _cshims_strncasecmp_l(const char * _Nullable s1, const char * _Nullable s2, size_t n, locale_t _Nullable loc);
+
+double _cshims_strtod_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
+
+float _cshims_strtof_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
+
+int _cshims_get_formatted_str_length(double value);
+
+#endif /* CSHIMS_STRING_H */

--- a/Sources/_CShims/string_shims.c
+++ b/Sources/_CShims/string_shims.c
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "include/string_shims.h"
+#include "include/_CShimsTargetConditionals.h"
+
+#include <strings.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <float.h>
+
+int
+_cshims_strncasecmp_l(const char * _Nullable s1,
+                      const char * _Nullable s2,
+                      size_t n,
+                      locale_t _Nullable loc)
+{
+    if (loc != NULL) {
+        return strncasecmp_l(s1, s2, n, loc);
+    }
+    // On Darwin, NULL loc means unlocalized compare.
+    // Uses the standard C locale for Linux in this case
+#if TARGET_OS_MAC
+    return strncasecmp_l(s1, s2, n, NULL);
+#else
+    locale_t clocale = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+    return strncasecmp_l(s1, s2, n, clocale);
+#endif // TARGET_OS_MAC
+}
+
+double
+_cshims_strtod_l(const char * _Nullable restrict nptr,
+                 char * _Nullable * _Nullable restrict endptr,
+                 locale_t _Nullable loc)
+{
+#if TARGET_OS_MAC
+    return strtod_l(nptr, endptr, loc);
+#else
+    // Use the C locale
+    locale_t clocale = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+    locale_t oldLocale = uselocale(clocale);
+    double result = strtod(nptr, endptr);
+    // Restore locale
+    uselocale(oldLocale);
+    return result;
+#endif
+}
+
+float
+_cshims_strtof_l(const char * _Nullable restrict nptr,
+                 char * _Nullable * _Nullable restrict endptr,
+                 locale_t _Nullable loc)
+{
+#if TARGET_OS_MAC
+    return strtof_l(nptr, endptr, loc);
+#else
+    // Use the C locale
+    locale_t clocale = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+    locale_t oldLocale = uselocale(clocale);
+    float result = strtof(nptr, endptr);
+    // Restore locale
+    uselocale(oldLocale);
+    return result;
+#endif
+}
+
+int
+_cshims_get_formatted_str_length(double value)
+{
+    char empty[1];
+    return snprintf(empty, 0, "%0.*g", DBL_DECIMAL_DIG, value);
+}

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -28,6 +28,10 @@ import TestSupport
 @testable import Foundation
 #endif
 
+#if canImport(_CShims)
+@_implementationOnly import _CShims
+#endif
+
 // MARK: - Test Suite
 
 final class JSONEncoderTests : XCTestCase {
@@ -139,10 +143,14 @@ final class JSONEncoderTests : XCTestCase {
     func x_testEncodingDate() {
 
         func formattedLength(of value: Double) -> Int {
+        #if canImport(_CShims)
+            return Int(_cshims_get_formatted_str_length(value))
+        #else
             let empty = UnsafeMutablePointer<Int8>.allocate(capacity: 0)
             defer { empty.deallocate() }
             let length = snprintf(ptr: empty, 0, "%0.*g", DBL_DECIMAL_DIG, value)
             return Int(length)
+        #endif
         }
 
         // Duplicated to handle a special case

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -243,7 +243,9 @@ final class CalendarTests : XCTestCase {
 
         // An arbitrary date, for which we know the answers
         // August 22, 2022 at 3:02:38 PM PDT
-        validateOrdinality(expected, calendar: Calendar(identifier: .gregorian), date: Date(timeIntervalSinceReferenceDate: 682898558.712307))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        validateOrdinality(expected, calendar: calendar, date: Date(timeIntervalSinceReferenceDate: 682898558.712307))
     }
 
     func test_ordinality_dst() {
@@ -267,7 +269,9 @@ final class CalendarTests : XCTestCase {
 
         // A date which corresponds to a DST transition in Pacific Time
         // let d = try! Date("2022-03-13T03:02:08.712-07:00", strategy: .iso8601)
-        validateOrdinality(expected, calendar: Calendar(identifier: .gregorian), date: Date(timeIntervalSinceReferenceDate: 668858528.712))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        validateOrdinality(expected, calendar: calendar, date: Date(timeIntervalSinceReferenceDate: 668858528.712))
     }
     #endif // arch(x86_64) || arch(arm64)
 
@@ -394,7 +398,8 @@ final class CalendarTests : XCTestCase {
         calendar.timeZone = TimeZone(identifier: "UTC")!
         var components = DateComponents(calendar: calendar, month: 9, day: 1)
         components.isLeapMonth = true
-        components.timeZone = TimeZone.default
+        // TimeZone.default points to GTC on Linux
+        components.timeZone = TimeZone(identifier: "America/Los_Angeles")
         components.era = nil
 
         var foundDate: Date?

--- a/Tests/FoundationInternationalizationTests/Formatting/FormatterCacheTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/FormatterCacheTests.swift
@@ -82,6 +82,7 @@ final class FormatterCacheTests: XCTestCase {
         XCTAssertEqual(cache[1000], item)
     }
 
+#if FOUNDATION_FRAMEWORK
     func testSynchronouslyClearingCache() {
         let cache = FormatterCache<Int, TestCacheItem>()
         let group = DispatchGroup()
@@ -107,6 +108,7 @@ final class FormatterCacheTests: XCTestCase {
 
         XCTAssertEqual(group.wait(timeout: .now().advanced(by: .seconds(3))), .success)
     }
+#endif
 }
 
 


### PR DESCRIPTION
This PR fixes Linux building and testing. Specifically:

- Added `string_shims` to shim the different string function behaviors on Linux vs Darwin.
  - On Darwin, passing `nil` locale to `_l` family of functions (such as `strtod_l`) means we are explicitly opting out of locale-specific string comparison. `string_shims` simulates this behavior for Linux by explicitly passing the C locale.
- Fixed `CalendarTest`: these failures were caused by the fact that `TimeZone.default` behaves differently on Darwin and Linux. On Darwin it tries to determine the user current timezone whereas on Linux it falls back to GMT. Fixed the test by explicitly setting a TimeZone.
