### PR TITLE
Add Support for Collection Subscripts in Predicates

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -27,6 +27,7 @@ public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
         case undefinedVariable
         case forceUnwrapFailure(String?)
         case forceCastFailure(String?)
+        case invalidInput(String?)
     }
     
     private let _error: _Error
@@ -43,6 +44,8 @@ public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
             return string ?? "Attempted to force unwrap a nil value"
         case .forceCastFailure(let string):
             return string ?? "Failed to cast a value to the desired type"
+        case .invalidInput(let string):
+            return string ?? "The inputs to this expression are invalid"
         }
     }
     
@@ -60,12 +63,18 @@ public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
                 return true
             }
             return false
+        case .invalidInput(_):
+            if case .invalidInput(_) = rhs._error {
+                return true
+            }
+            return false
         }
     }
     
     public static let undefinedVariable = Self(.undefinedVariable)
     public static let forceUnwrapFailure = Self(.forceUnwrapFailure(nil))
     public static let forceCastFailure = Self(.forceCastFailure(nil))
+    public static let invalidInput = Self(.invalidInput(nil))
 }
 
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)

--- a/Sources/FoundationEssentials/Predicate/Expressions/Collection.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Collection.swift
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct CollectionIndexSubscript<
+        Wrapped : PredicateExpression,
+        Index : PredicateExpression
+    > : PredicateExpression
+    where
+        Wrapped.Output : Collection,
+        Index.Output == Wrapped.Output.Index
+    {
+        public typealias Output = Wrapped.Output.Element
+        
+        public let wrapped: Wrapped
+        public let index: Index
+        
+        public init(wrapped: Wrapped, index: Index) {
+            self.wrapped = wrapped
+            self.index = index
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            let collection = try wrapped.evaluate(bindings)
+            let indexValue = try index.evaluate(bindings)
+            guard indexValue >= collection.startIndex && indexValue < collection.endIndex else {
+                throw PredicateError(.invalidInput("Index \(indexValue) was not within the valid bounds of the collection (\(collection.startIndex) ..< \(collection.endIndex))"))
+            }
+            return collection[indexValue]
+        }
+    }
+    
+    public static func build_subscript<Wrapped, Index>(_ wrapped: Wrapped, _ index: Index) -> CollectionIndexSubscript<Wrapped, Index> {
+        CollectionIndexSubscript(wrapped: wrapped, index: index)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.CollectionIndexSubscript : Sendable where Wrapped : Sendable, Index : Sendable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.CollectionIndexSubscript : Codable where Wrapped : Codable, Index : Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(wrapped)
+        try container.encode(index)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.wrapped = try container.decode(Wrapped.self)
+        self.index = try container.decode(Index.self)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.CollectionIndexSubscript : StandardPredicateExpression where Wrapped : StandardPredicateExpression, Index : StandardPredicateExpression {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct CollectionRangeSubscript<
+        Wrapped : PredicateExpression,
+        Range : PredicateExpression
+    > : PredicateExpression
+    where
+        Wrapped.Output : Collection,
+        Range.Output == Swift.Range<Wrapped.Output.Index>
+    {
+        public typealias Output = Wrapped.Output.SubSequence
+        
+        public let wrapped: Wrapped
+        public let range: Range
+        
+        public init(wrapped: Wrapped, range: Range) {
+            self.wrapped = wrapped
+            self.range = range
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            let collection = try wrapped.evaluate(bindings)
+            let rangeValue = try range.evaluate(bindings)
+            
+            guard rangeValue.lowerBound >= collection.startIndex && rangeValue.lowerBound <= collection.endIndex else {
+                throw PredicateError(.invalidInput("Index \(rangeValue.lowerBound) was not within the valid bounds of the collection (\(collection.startIndex) ... \(collection.endIndex))"))
+            }
+            guard rangeValue.upperBound >= collection.startIndex && rangeValue.upperBound <= collection.endIndex else {
+                throw PredicateError(.invalidInput("Index \(rangeValue.upperBound) was not within the valid bounds of the collection (\(collection.startIndex) ... \(collection.endIndex))"))
+            }
+            
+            return collection[rangeValue]
+        }
+    }
+    
+    public static func build_subscript<Wrapped, Range>(_ wrapped: Wrapped, _ range: Range) -> CollectionRangeSubscript<Wrapped, Range> {
+        CollectionRangeSubscript(wrapped: wrapped, range: range)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.CollectionRangeSubscript : Sendable where Wrapped : Sendable, Range : Sendable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.CollectionRangeSubscript : Codable where Wrapped : Codable, Range : Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(wrapped)
+        try container.encode(range)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.wrapped = try container.decode(Wrapped.self)
+        self.range = try container.decode(Range.self)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.CollectionRangeSubscript : StandardPredicateExpression where Wrapped : StandardPredicateExpression, Range : StandardPredicateExpression {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Dictionary.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Dictionary.swift
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct DictionaryKeySubscript<
+        Wrapped : PredicateExpression,
+        Key : PredicateExpression,
+        Value
+    > : PredicateExpression
+    where
+        Wrapped.Output == Dictionary<Key.Output, Value>
+    {
+        public typealias Output = Optional<Value>
+        
+        public let wrapped: Wrapped
+        public let key: Key
+        
+        public init(wrapped: Wrapped, key: Key) {
+            self.wrapped = wrapped
+            self.key = key
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            try wrapped.evaluate(bindings)[try key.evaluate(bindings)]
+        }
+    }
+    
+    public static func build_subscript<Wrapped, Key, Value>(_ wrapped: Wrapped, _ key: Key) -> DictionaryKeySubscript<Wrapped, Key, Value> {
+        DictionaryKeySubscript(wrapped: wrapped, key: key)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.DictionaryKeySubscript : Sendable where Wrapped : Sendable, Key : Sendable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.DictionaryKeySubscript : Codable where Wrapped : Codable, Key : Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(wrapped)
+        try container.encode(key)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.wrapped = try container.decode(Wrapped.self)
+        self.key = try container.decode(Key.self)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.DictionaryKeySubscript : StandardPredicateExpression where Wrapped : StandardPredicateExpression, Key : StandardPredicateExpression {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct DictionaryKeyDefaultValueSubscript<
+        Wrapped : PredicateExpression,
+        Key : PredicateExpression,
+        Default : PredicateExpression
+    > : PredicateExpression
+    where
+        Wrapped.Output == Dictionary<Key.Output, Default.Output>
+    {
+        public typealias Output = Default.Output
+        
+        public let wrapped: Wrapped
+        public let key: Key
+        public let `default`: Default
+        
+        public init(wrapped: Wrapped, key: Key, `default`: Default) {
+            self.wrapped = wrapped
+            self.key = key
+            self.`default` = `default`
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            let defaultValue = try `default`.evaluate(bindings)
+            return try wrapped.evaluate(bindings)[try key.evaluate(bindings), default: defaultValue]
+        }
+    }
+    
+    public static func build_subscript<Wrapped, Key, Default>(_ wrapped: Wrapped, _ key: Key, default: Default) -> DictionaryKeyDefaultValueSubscript<Wrapped, Key, Default> {
+        DictionaryKeyDefaultValueSubscript(wrapped: wrapped, key: key, default: `default`)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : Sendable where Wrapped : Sendable, Key : Sendable, Default : Sendable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : Codable where Wrapped : Codable, Key : Codable, Default : Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(wrapped)
+        try container.encode(key)
+        try container.encode(`default`)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.wrapped = try container.decode(Wrapped.self)
+        self.key = try container.decode(Key.self)
+        self.`default` = try container.decode(Default.self)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : StandardPredicateExpression where Wrapped : StandardPredicateExpression, Key : StandardPredicateExpression, Default : StandardPredicateExpression {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Range.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Range.swift
@@ -33,7 +33,10 @@ extension PredicateExpressions {
         public func evaluate(_ bindings: PredicateBindings) throws -> Swift.Range<LHS.Output> {
             let low = try lower.evaluate(bindings)
             let high = try upper.evaluate(bindings)
-            return low..<high
+            guard low <= high else {
+                throw PredicateError(.invalidInput("Range requires that lowerBound (\(low)) <= upperBound (\(high))"))
+            }
+            return low ..< high
         }
     }
     

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -525,4 +525,45 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
         XCTAssert(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
+    
+    func testSubscripts() throws {
+        var predicate = Predicate<Object> {
+            // $0.g[0] == 0
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_subscript(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.g
+                    ),
+                    PredicateExpressions.build_Arg(0)
+                ),
+                rhs: PredicateExpressions.build_Arg(0)
+            )
+        }
+        
+        XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0])))
+        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1])))
+        XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
+        
+        predicate = Predicate<Object> {
+            // $0.g[0 ..< 2].isEmpty
+            PredicateExpressions.build_KeyPath(
+                root: PredicateExpressions.build_subscript(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.g
+                    ),
+                    PredicateExpressions.build_Range(
+                        lower: PredicateExpressions.build_Arg(0),
+                        upper: PredicateExpressions.build_Arg(2))
+                ),
+                keyPath: \.isEmpty
+            )
+        }
+        
+        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0, 1, 2])))
+        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0, 1])))
+        XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0])))
+        XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
+    }
 }


### PR DESCRIPTION
This change adds new `PredicateExpression` types to represent calls to various subscript operators on `Collection`s and `Dictionary`s for use in `Predicate`s

Resolves rdar://107321451