### PR TITLE
Fix fast-path for [Int] inserting a trailing comma (rdar://108386573)

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -1398,7 +1398,12 @@ extension Array : _JSONDirectArrayEncodable where Element: _JSONSimpleValueArray
             result += element.jsonRepresentation(options: options) + ","
         }
         
+        if !self.isEmpty {
+            // Replace the last ,
+            let _ = result.popLast()
+        }
         result += "]"
+
         return result
     }
     

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -97,6 +97,16 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTrip(of: EnhancedBool.false, expectedJSON: "false".data(using: String._Encoding.utf8)!)
         _testRoundTrip(of: EnhancedBool.fileNotFound, expectedJSON: "null".data(using: String._Encoding.utf8)!)
     }
+    
+    func testEncodingTopLevelArrayOfInt() {
+        let a = [1,2,3]
+        let result1 = String(data: try! JSONEncoder().encode(a), encoding: String._Encoding.utf8)
+        XCTAssertEqual(result1, "[1,2,3]")
+        
+        let b : [Int] = []
+        let result2 = String(data: try! JSONEncoder().encode(b), encoding: String._Encoding.utf8)
+        XCTAssertEqual(result2, "[]")
+    }
 
 #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
     func testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey() {


### PR DESCRIPTION
#35 added a fast path for `[Int]`, but it wound up always inserting a trailing comma. Add a fix for that, plus a test.