### PR TITLE
Fix 5.9 toolchain requirement for Xcode builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/FoundationEssentials/FoundationEssentials.swift
+++ b/Sources/FoundationEssentials/FoundationEssentials.swift
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(<5.9)
+#error("Building FoundationPreview requires a Swift 5.9 toolchain")
+#endif


### PR DESCRIPTION
Package manifests are always built with the default Xcode toolchain, meaning that even if a 5.9 toolchain is selected the `swift-tools-version: 5.9` will not be satisfied without an Xcode installation that comes packaged with a 5.9 toolchain. Instead, lets add a `#error` to FoundationEssentials for older compilers and restore the 5.8 requirement in the package manifest to allow us to build this in Xcode.