### PR TITLE
(rdar://108066668) Fixed decoding of unusual zero values

### DIFF
--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1192,8 +1192,8 @@ final class JSONEncoderTests : XCTestCase {
     }
 
     func test_JSONNumberFragments() {
-        let array = ["0 ", "1.0 ", "0.1 ", "1e3 ", "-2.01e-3 ", "0", "1.0", "1e3", "-2.01e-3"]
-        let expected = [0, 1.0, 0.1, 1000, -0.00201, 0, 1.0, 1000, -0.00201]
+        let array = ["0 ", "1.0 ", "0.1 ", "1e3 ", "-2.01e-3 ", "0", "1.0", "1e3", "-2.01e-3", "0e-10"]
+        let expected = [0, 1.0, 0.1, 1000, -0.00201, 0, 1.0, 1000, -0.00201, 0]
         for (json, expected) in zip(array, expected) {
             _test(JSONString: json, to: expected)
         }


### PR DESCRIPTION
The `isTrueZero` workaround didn't properly accommodate "weird" zero values with exponents, like -0e-10.