### PR TITLE
Windows macro is _WIN32 not _Win32

### DIFF
--- a/Sources/_CShims/include/_CShimsTargetConditionals.h
+++ b/Sources/_CShims/include/_CShimsTargetConditionals.h
@@ -35,7 +35,7 @@
 #define TARGET_OS_BSD 0
 #endif
 
-#if defined(_Win32)
+#if defined(_WIN32)
 #define TARGET_OS_WINDOWS 1
 #else
 #define TARGET_OS_WINDOWS 0


### PR DESCRIPTION
This fixes the `TARGET_OS_WINDOWS` macro definition.