### PR TITLE
Use a CShim to avoid an unescapable warning about using mktemp

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -147,7 +147,7 @@ private func createTemporaryFile(at destinationPath: String, inPath: PathOrURL, 
             }
             let flags: CInt = _O_BINARY | _O_CREAT | _O_EXCL | _O_RDWR
 #else
-            guard mktemp(templateFileSystemRep) != nil else {
+            guard _datashims_mktemp(templateFileSystemRep) != nil else {
                 throw CocoaError.errorWithFilePath(inPath, errno: errno, reading: false)
             }
             let flags: CInt = O_CREAT | O_EXCL | O_RDWR

--- a/Sources/_CShims/data_shims.c
+++ b/Sources/_CShims/data_shims.c
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdlib.h>
+#include "data_shims.h"
+
+INTERNAL char *_datashims_mktemp(char *arg) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
+    return mktemp(arg);
+#pragma GCC diagnostic pop
+}

--- a/Sources/_CShims/include/data_shims.h
+++ b/Sources/_CShims/include/data_shims.h
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CSHIMS_DATA_H
+#define CSHIMS_DATA_H
+
+#include "_CShimsMacros.h"
+
+INTERNAL char *_datashims_mktemp(char *arg);
+
+#endif


### PR DESCRIPTION
We work around the security issue with `mktemp` by checking for the existence of a conflict and retrying if necessary. The comment already in the source code explains why we can't use `mkstemp`. To avoid this warning appearing for every client of the package, work around it by adding a C shim before we call it.