### PR TITLE
JSON/PropertyList coders userInfo should require Sendable values

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -257,7 +257,8 @@ open class JSONDecoder {
     }
 
     /// Contextual user-provided information for use during decoding.
-    open var userInfo: [CodingUserInfoKey : Any] {
+    @preconcurrency
+    open var userInfo: [CodingUserInfoKey : any Sendable] {
         get {
             optionsLock.lock()
             defer { optionsLock.unlock() }
@@ -309,7 +310,7 @@ open class JSONDecoder {
         var dataDecodingStrategy: DataDecodingStrategy = .base64
         var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
         var keyDecodingStrategy: KeyDecodingStrategy = .useDefaultKeys
-        var userInfo: [CodingUserInfoKey : Any] = [:]
+        var userInfo: [CodingUserInfoKey : any Sendable] = [:]
         var json5: Bool = false
     }
 

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -295,7 +295,8 @@ open class JSONEncoder {
     }
 
     /// Contextual user-provided information for use during encoding.
-    open var userInfo: [CodingUserInfoKey : Any] {
+    @preconcurrency
+    open var userInfo: [CodingUserInfoKey : any Sendable] {
         get {
             optionsLock.lock()
             defer { optionsLock.unlock() }
@@ -324,7 +325,7 @@ open class JSONEncoder {
         var dataEncodingStrategy: DataEncodingStrategy = .base64
         var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy = .throw
         var keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys
-        var userInfo: [CodingUserInfoKey : Any] = [:]
+        var userInfo: [CodingUserInfoKey : any Sendable] = [:]
     }
 
     /// The options set on the top-level encoder.

--- a/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
@@ -38,7 +38,8 @@ open class PropertyListDecoder {
     // MARK: Options
 
     /// Contextual user-provided information for use during decoding.
-    open var userInfo: [CodingUserInfoKey : Any] {
+    @preconcurrency
+    open var userInfo: [CodingUserInfoKey : any Sendable] {
         get {
             optionsLock.lock()
             defer { optionsLock.unlock() }
@@ -62,7 +63,7 @@ open class PropertyListDecoder {
 
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
     internal struct _Options {
-        var userInfo: [CodingUserInfoKey : Any] = [:]
+        var userInfo: [CodingUserInfoKey : any Sendable] = [:]
     }
 
     /// The options set on the top-level decoder.

--- a/Sources/FoundationEssentials/PropertyList/PlistEncoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistEncoder.swift
@@ -51,7 +51,8 @@ open class PropertyListEncoder {
     }
 
     /// Contextual user-provided information for use during encoding.
-    open var userInfo: [CodingUserInfoKey : Any] {
+    @preconcurrency
+    open var userInfo: [CodingUserInfoKey : any Sendable] {
         get {
             optionsLock.lock()
             defer { optionsLock.unlock() }
@@ -76,7 +77,7 @@ open class PropertyListEncoder {
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
     internal struct _Options {
         var outputFormat: PropertyListDecoder.PropertyListFormat = .binary
-        var userInfo: [CodingUserInfoKey : Any] = [:]
+        var userInfo: [CodingUserInfoKey : any Sendable] = [:]
     }
 
     /// The options set on the top-level encoder.


### PR DESCRIPTION
This requires that the userInfo values are `Sendable` since they are stored in `Sendable` types. The `@preconcurrency` attribute ensures that this is not an ABI breaking change or a source breaking change for projects using the Swift 5 language mode.