### PR TITLE
Fix unexpected Decimal sign behavior from `Decimal(sign:exponent:significand:)`

### DIFF
--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -251,8 +251,11 @@ extension Decimal /* : FloatingPoint */ {
                 self = .nan
             }
         }
-        if sign == .minus {
-            negate()
+
+        guard self._length != 0 else { return }
+        _isNegative = switch sign {
+        case .plus: 0
+        case .minus: 1
         }
     }
 

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -1130,9 +1130,9 @@ final class DecimalTests : XCTestCase {
         var x = -42 as Decimal
         XCTAssertEqual(x.significand.sign, .plus)
         var y = Decimal(sign: .plus, exponent: 0, significand: x)
-        XCTAssertEqual(y, -42)
-        y = Decimal(sign: .minus, exponent: 0, significand: x)
         XCTAssertEqual(y, 42)
+        y = Decimal(sign: .minus, exponent: 0, significand: x)
+        XCTAssertEqual(y, -42)
 
         x = 42 as Decimal
         XCTAssertEqual(x.significand.sign, .plus)


### PR DESCRIPTION
Resolves #833. Fixes an issue that caused the initialized Decimal's sign not to match the passed `sign` when `significand` is negative. More information in the linked issue.