### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,6 @@ Contributions to Foundation are welcome! This project follows the [contribution 
 
 Please see the [Foundation Evolution Process](Evolution.md) for any change that adds or modifies public API.
 
-## Licensing
-
-By submitting a pull request, you represent that you have the right to license your contribution to Apple and the community, and agree by submitting the patch that your contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
-
 ## Bug reports
 
 We are using [GitHub Issues](https://github.com/apple/swift-foundation/issues) for tracking bugs, feature requests, and other work.


### PR DESCRIPTION
preparing for move to /swiftlang 

the license will be at the root of the repo and we are removing this text from the contributing files for unification. license text will be added to README templates in the future.