### PR TITLE
Delete CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-# Code of Conduct
-
-The code of conduct for this project can be found at https://swift.org/code-of-conduct.
-
-<!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
preparing for move to /swiftlang

we have an org wide code of conduct policy set at the root .github repo of /swiftlang that all repos will adhere to. this file present at the root means there is a different process than the rest of the org.