### PR TITLE
[6.0.x] Fix windows creation of relative symlinks to directories

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -59,7 +59,8 @@ extension _FileManagerImpl {
     ) throws {
 #if os(Windows)
         var bIsDirectory = false
-        _ = fileManager.fileExists(atPath: destPath, isDirectory: &bIsDirectory)
+        let absoluteDestPath = URL(filePath: destPath, relativeTo: URL(filePath: path, directoryHint: .notDirectory)).path
+        _ = fileManager.fileExists(atPath: absoluteDestPath, isDirectory: &bIsDirectory)
 
         try path.withNTPathRepresentation { lpSymlinkFileName in
             try destPath.withFileSystemRepresentation {


### PR DESCRIPTION
Explanation: Fixes creation of relative symlinks to directories on Windows to resolve SwiftPM issues
Scope: Fixes a path calculation while creating symlinks to directories
Original PR: https://github.com/swiftlang/swift-foundation/pull/931
Risk: Low - only impacts Windows and the change is heavily tested via unit tests
Testing: Testing done via swift-ci testing and local testing
Reviewer: @iCharlesHu @compnerd 