### PR TITLE
Rename `CalendarBenchmarks` to `InternationalizationBenchmarks`

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -101,9 +101,9 @@ let package = Package(
             ]
         ),
         .executableTarget(
-            name: "CalendarBenchmarks",
+            name: "InternationalizationBenchmarks",
             dependencies: targetDependency,
-            path: "Benchmarks/Calendar",
+            path: "Benchmarks/Internationalization",
             swiftSettings: swiftSettings,
             plugins: [
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")


### PR DESCRIPTION
### Motivation

The Benchmarks package currently fails to resolve. It errors because it can't find `Benchmarks/Calendar`:

```
Showing All Issues
invalid custom path 'Benchmarks/Calendar' for target 'CalendarBenchmarks'
```

### Change

- Rename `Benchmarks/Calendar` to `Benchmarks/Internationalization`
- Rename target `CalendarBenchmarks` to `InternationalizationBenchmarks`

### Result

Benchmarks run again.