### PR TITLE
[wasm] Fix CocoaError construction for unsupported copy/link operations

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -920,10 +920,11 @@ enum _FileOperations {
             try delegate.throwIfNecessary(errno, src, dst)
             return
         }
+        let copyFile = delegate.copyData
         guard !stat.isDirectory else {
             // wasi-libc does not support FTS for now, so we don't support copying/linking
             // directories on WASI for now.
-            let error = CocoaError.fileOperationError(.featureUnsupported, src, dst)
+            let error = CocoaError.errorWithFilePath(.featureUnsupported, src, variant: copyFile ? "Copy" : "Link", source: src, destination: dst)
             try delegate.throwIfNecessary(error, src, dst)
             return
         }
@@ -943,7 +944,7 @@ enum _FileOperations {
                 try delegate.throwIfNecessary(errno, src, dst)
             }
         } else {
-            if delegate.copyData {
+            if copyFile {
                 try _copyRegularFile(srcPtr, dstPtr, delegate: delegate)
             } else {
                 if link(srcPtr, dstPtr) != 0 {


### PR DESCRIPTION
This is a follow-up fix for 6c0a3e8453cdde633e1c55f6112fd53a0d756979, which re-organized CocoaError helper functions, to repair the following build failure:

```
/home/build-user/swift-foundation/Sources/FoundationEssentials/FileManager/FileOperations.swift:926:36: error: 'fileOperationError' is inaccessible due to 'private' protection level
  74 |     }
  75 | #else
  76 |     private static func fileOperationError(_ errNum: Int32, _ suspectedErroneousPath: String, sourcePath: String? = nil, destinationPath: String? = nil, variant: String? = nil) -> CocoaError {
     |                         `- note: 'fileOperationError(_:_:sourcePath:destinationPath:variant:)' declared here
  77 |         // Try to be a little bit more intelligent about which path should be reported in the error. In the case of ENAMETOOLONG, we can more accurately guess which path is causing the error without racily checking the file system after the fact. This may not be perfect in the face of operations which span file systems, or on file systems that only support names/paths less than NAME_MAX or PATH_MAX, but it's better than nothing.
  78 |         var erroneousPath = suspectedErroneousPath
     :
 924 |             // wasi-libc does not support FTS for now, so we don't support copying/linking
 925 |             // directories on WASI for now.
 926 |             let error = CocoaError.fileOperationError(.featureUnsupported, src, dst)
     |                                    `- error: 'fileOperationError' is inaccessible due to 'private' protection level
 927 |             try delegate.throwIfNecessary(error, src, dst)
 928 |             return
```