### PR TITLE
Remove unused AttributedString initializers

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -140,18 +140,6 @@ extension Dictionary where Key == NSAttributedString.Key, Value == Any {
         try self.init(container, attributeTable: S.attributeKeyTypes())
     }
     
-    // These includingOnly SPI initializers were provided originally when conversion boxed attributes outside of the given scope as an AnyObject
-    // After rdar://80201634, these SPI initializers have the same behavior as the API initializers
-    @_spi(AttributedString)
-    public init<S: AttributeScope>(_ container: AttributeContainer, includingOnly scope: KeyPath<AttributeScopes, S.Type>) throws {
-        try self.init(container, including: S.self)
-    }
-    
-    @_spi(AttributedString)
-    public init<S: AttributeScope>(_ container: AttributeContainer, includingOnly scope: S.Type) throws {
-        try self.init(container, including: S.self)
-    }
-    
     fileprivate init(_ container: AttributeContainer, attributeTable: [String : any AttributedStringKey.Type], options: _AttributeConversionOptions = []) throws {
         self.init()
         for key in container.storage.keys {
@@ -184,16 +172,6 @@ extension NSAttributedString {
     
     public convenience init<S: AttributeScope>(_ attrStr: AttributedString, including scope: S.Type) throws {
         try self.init(attrStr, attributeTable: scope.attributeKeyTypes())
-    }
-    
-    @_spi(AttributedString)
-    public convenience init<S: AttributeScope>(_ attrStr: AttributedString, includingOnly scope: KeyPath<AttributeScopes, S.Type>) throws {
-        try self.init(attrStr, including: S.self)
-    }
-    
-    @_spi(AttributedString)
-    public convenience init<S: AttributeScope>(_ attrStr: AttributedString, includingOnly scope: S.Type) throws {
-        try self.init(attrStr, including: scope)
     }
     
     internal convenience init(

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -1774,12 +1774,6 @@ E {
 #endif
     }
     
-    func testConversionIncludingOnly() throws {
-        let str = AttributedString("Hello, world", attributes: .init().testInt(2).link(URL(string: "http://apple.com")!))
-        let nsStr = try NSAttributedString(str, includingOnly: \.test)
-        XCTAssertEqual(nsStr, NSAttributedString(string: "Hello, world", attributes: [.testInt: 2]))
-    }
-    
     func testConversionCoalescing() throws {
         let nsStr = NSMutableAttributedString("Hello, world")
         nsStr.setAttributes([.link : NSURL(string: "http://apple.com")!, .testInt : NSNumber(integerLiteral: 2)], range: NSRange(location: 0, length: 6))


### PR DESCRIPTION
These SPI `AttributedString` initializers are unused and can be removed to reduce clutter