### PR TITLE
Annotate _FoundationCShims as a system module

### DIFF
--- a/Sources/_FoundationCShims/include/module.modulemap
+++ b/Sources/_FoundationCShims/include/module.modulemap
@@ -1,4 +1,4 @@
-module _FoundationCShims {
+module _FoundationCShims [system] {
     header "_FoundationCShims.h"
 
     export *


### PR DESCRIPTION
This fixes Clang modularization errors coming out of the Swift compiler when building Swift code that uses C++ interoperability on Linux:
```
/usr/include/c++/v1/istream:198:5: error: 'std::basic_istream<wchar_t>::basic_istream' from module 'SwiftGlibc' is not present in definition of 'std::wistream' in module '_FoundationCShims'
 196 | protected:
 197 |     inline _LIBCPP_INLINE_VISIBILITY
 198 |     basic_istream(basic_istream&& __rhs);
```

Two observations:

1. _FoundationCShims does not list all the headers that it includes in the modulemap. Instead, the modulemap refers to a single headers with several `#include` directives. This means that a different module that includes the same headers might hijack them from _FoundationCShims, depending on compiler flags and the order of inclusion in the translation unit.

2. Some of the headers that _FoundationCShims includes are C headers that have corresponding C++ compatibility headers. When C++ interop is enabled, the C++ headers will be included. Those headers are owned by the std module.

Annotating the _FoundationCShims module as a system module suppresses the errors about these.

rdar://137044915