### PR TITLE
Update to swift-syntax 600.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ var dependencies: [Package.Dependency] {
                 branch: "main"),
             .package(
                 url: "https://github.com/swiftlang/swift-syntax",
-                from: "600.0.0-latest")
+                from: "600.0.0")
         ]
     }
 }

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT SwiftSyntax_FOUND)
     # If building at desk, check out and link against the SwiftSyntax repo's targets
     FetchContent_Declare(SwiftSyntax
         GIT_REPOSITORY https://github.com/swiftlang/swift-syntax.git
-        GIT_TAG 4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c) # 600.0.0-prerelease-2024-06-12
+        GIT_TAG 600.0.0)
     FetchContent_MakeAvailable(SwiftSyntax)
 else()
   message(STATUS "SwiftSyntax_DIR provided, using swift-syntax from ${SwiftSyntax_DIR}")


### PR DESCRIPTION
Now that swift-syntax 600.0.0 is released we can update our manifests to point at this tag. Additionally, this change removes a deprecation warning that was introduced with 600.0.0 and removes an availability check that is no longer needed.