### PR TITLE
Disable GregorianCalendarCompatibilityTests

### DIFF
--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -1278,6 +1278,7 @@ final class CalendarBridgingTests : XCTestCase {
 
 
 // This test validates the results against FoundationInternationalization's calendar implementation temporarily until we completely ported the calendar
+#if false // Disabled because these tests are extensive and have long runtimes to validate full compatibility, they can be enabled locally to validate changes
 final class GregorianCalendarCompatibilityTests: XCTestCase {
 
     func testDateFromComponentsCompatibility() {
@@ -2345,3 +2346,4 @@ final class GregorianCalendarCompatibilityTests: XCTestCase {
     }
 
 }
+#endif


### PR DESCRIPTION
These tests are compatibility tests that are extensive and long running. Their goal is not to check each change but rather provide exhaustive compatibility validations and they're intended to be run at desk rather than routinely in CI. This disables the tests - they can be enabled locally to validate changes on-demand.