### PR TITLE
`URL.fileSystemPath` should strip leading slash for Windows drive letters

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1146,9 +1146,32 @@ public struct URL: Equatable, Sendable, Hashable {
         }
     }
 
+    private static func windowsPath(for posixPath: String) -> String {
+        let utf8 = posixPath.utf8
+        guard utf8.count >= 4 else {
+            return posixPath
+        }
+        // "C:\" is standardized to "/C:/" on initialization
+        let array = Array(utf8)
+        if array[0] == ._slash,
+           array[1].isAlpha,
+           array[2] == ._colon,
+           array[3] == ._slash {
+            return String(Substring(utf8.dropFirst()))
+        }
+        return posixPath
+    }
+
     private static func fileSystemPath(for urlPath: String) -> String {
         let charsToLeaveEncoded: Set<UInt8> = [._slash, 0]
-        return Parser.percentDecode(urlPath._droppingTrailingSlashes, excluding: charsToLeaveEncoded) ?? ""
+        guard let posixPath = Parser.percentDecode(urlPath._droppingTrailingSlashes, excluding: charsToLeaveEncoded) else {
+            return ""
+        }
+        #if os(Windows)
+        return windowsPath(for: posixPath)
+        #else
+        return posixPath
+        #endif
     }
 
     var fileSystemPath: String {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -330,6 +330,18 @@ final class URLTests : XCTestCase {
         try FileManager.default.removeItem(at: URL(filePath: "\(tempDirectory.path)/tmp-dir"))
     }
 
+    #if os(Windows)
+    func testURLWindowsDriveLetterPath() throws {
+        let url = URL(filePath: "C:\\test\\path", directoryHint: .notDirectory)
+        // .absoluteString and .path() use the RFC 8089 URL path
+        XCTAssertEqual(url.absoluteString, "file:///C:/test/path")
+        XCTAssertEqual(url.path(), "/C:/test/path")
+        // .path and .fileSystemPath strip the leading slash
+        XCTAssertEqual(url.path, "C:/test/path")
+        XCTAssertEqual(url.fileSystemPath, "C:/test/path")
+    }
+    #endif
+
     func testURLFilePathRelativeToBase() throws {
         try FileManagerPlayground {
             Directory("dir") {


### PR DESCRIPTION
On Windows, `URL.fileSystemPath` should ideally provide the path exactly how you would make filesystem calls with it, e.g. by stripping the leading slash from an RFC drive path like `/C:/path` and by converting the slashes to backlashes.

But given that `URL.fileSystemPath` is vended directly to (and synonymous with) the widely-used `URL.path`, we should start by just stripping the leading slash from drive letters for compatibility. This returns `URL.path` to its previous behavior on Windows.

Resolves #857