### PR TITLE
URL path extension APIs should strip trailing slashes

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -186,7 +186,11 @@ extension String {
         guard let lastDot = utf8.lastIndex(of: ._dot) else {
             return self
         }
-        return String(self[..<lastDot])
+        var result = String(self[..<lastDot])
+        if utf8.last == ._slash {
+            result += "/"
+        }
+        return result
     }
 
     private func validatePathExtension(_ pathExtension: String) -> Bool {
@@ -206,7 +210,16 @@ extension String {
         guard validatePathExtension(pathExtension) else {
             return self
         }
-        return self + ".\(pathExtension)"
+        var result = self._droppingTrailingSlashes
+        guard result != "/" else {
+            // Path was all slashes
+            return self + ".\(pathExtension)"
+        }
+        result += ".\(pathExtension)"
+        if utf8.last == ._slash {
+            result += "/"
+        }
+        return result
     }
 
     internal var pathExtension: String {

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -813,6 +813,19 @@ final class StringTests : XCTestCase {
         }
     }
 
+    func testAppendingPathExtension() {
+        XCTAssertEqual("".appendingPathExtension("foo"), ".foo")
+        XCTAssertEqual("/".appendingPathExtension("foo"), "/.foo")
+        XCTAssertEqual("//".appendingPathExtension("foo"), "//.foo")
+        XCTAssertEqual("/path".appendingPathExtension("foo"), "/path.foo")
+        XCTAssertEqual("/path.zip".appendingPathExtension("foo"), "/path.zip.foo")
+        XCTAssertEqual("/path/".appendingPathExtension("foo"), "/path.foo/")
+        XCTAssertEqual("/path//".appendingPathExtension("foo"), "/path.foo/")
+        XCTAssertEqual("path".appendingPathExtension("foo"), "path.foo")
+        XCTAssertEqual("path/".appendingPathExtension("foo"), "path.foo/")
+        XCTAssertEqual("path//".appendingPathExtension("foo"), "path.foo/")
+    }
+
     func testDeletingPathExtenstion() {
         XCTAssertEqual("".deletingPathExtension(), "")
         XCTAssertEqual("/".deletingPathExtension(), "/")
@@ -835,6 +848,15 @@ final class StringTests : XCTestCase {
         XCTAssertEqual("/foo.bar/bar.baz/baz.zip".deletingPathExtension(), "/foo.bar/bar.baz/baz")
         XCTAssertEqual("/.././.././a.zip".deletingPathExtension(), "/.././.././a")
         XCTAssertEqual("/.././.././.".deletingPathExtension(), "/.././.././.")
+
+        XCTAssertEqual("path.foo".deletingPathExtension(), "path")
+        XCTAssertEqual("path.foo.zip".deletingPathExtension(), "path.foo")
+        XCTAssertEqual("/path.foo".deletingPathExtension(), "/path")
+        XCTAssertEqual("/path.foo.zip".deletingPathExtension(), "/path.foo")
+        XCTAssertEqual("path.foo/".deletingPathExtension(), "path/")
+        XCTAssertEqual("path.foo//".deletingPathExtension(), "path/")
+        XCTAssertEqual("/path.foo/".deletingPathExtension(), "/path/")
+        XCTAssertEqual("/path.foo//".deletingPathExtension(), "/path/")
     }
 
     func testPathComponents() {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -647,6 +647,27 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.path().utf8.last, ._slash)
     }
 
+    func testURLPathExtensions() throws {
+        var url = URL(filePath: "/path", directoryHint: .notDirectory)
+        url.appendPathExtension("foo")
+        XCTAssertEqual(url.path(), "/path.foo")
+        url.deletePathExtension()
+        XCTAssertEqual(url.path(), "/path")
+
+        url = URL(filePath: "/path", directoryHint: .isDirectory)
+        url.appendPathExtension("foo")
+        XCTAssertEqual(url.path(), "/path.foo/")
+        url.deletePathExtension()
+        XCTAssertEqual(url.path(), "/path/")
+
+        url = URL(filePath: "/path/", directoryHint: .inferFromPath)
+        url.appendPathExtension("foo")
+        XCTAssertEqual(url.path(), "/path.foo/")
+        url.append(path: "/////")
+        url.deletePathExtension()
+        XCTAssertEqual(url.path(), "/path/")
+    }
+
     func testURLComponentsPercentEncodedUnencodedProperties() throws {
         var comp = URLComponents()
 


### PR DESCRIPTION
When supplying a directory to `URL` like `URL(filePath: "/my/directory", directoryHint: .checkFileSystem)`, the initializer will automatically append a trailing slash, so the `.path()` is `/my/directory/`.

The current logic for `.appendingPathExtension("zip")` then directly appends the path extension, creating the unexpected path: `/my/directory/.zip`. A similar issue occurs where `.deletingPathExtension()` does not search before the trailing slash.

This PR restores the behavior from before the Swift `URL` implementation, which strips the trailing slash before appending or deleting the path extension, then appends a slash if the path was a directory. E.g. after appending the path extension, the resulting `.path()` is now `/my/directory.zip/` as expected.