### PR TITLE
Conditionalize stripping of `\\?\` on it actually being present

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -722,8 +722,14 @@ extension String {
                     return nil
                 }
 
-                // When using `VOLUME_NAME_DOS`, the returned path uses `\\?\`.
-                return String(decodingCString: $0.baseAddress!.advanced(by: 4), as: UTF16.self)
+                let pathBaseAddress: UnsafePointer<WCHAR>
+                if Array($0.prefix(4)) == Array(#"\\?\"#.utf16) {
+                    // When using `VOLUME_NAME_DOS`, the returned path uses `\\?\`.
+                    pathBaseAddress = UnsafePointer($0.baseAddress!.advanced(by: 4))
+                } else {
+                    pathBaseAddress = UnsafePointer($0.baseAddress!)
+                }
+                return String(decodingCString: pathBaseAddress, as: UTF16.self)
             }
         }
         #else // os(Windows)


### PR DESCRIPTION
As far as I know `\\?\` is always returned by `GetFinalPathNameByHandleW` but it’s better to be safe and actually check instead of unconditionally trimming the first 4 characters from the returned path.

See https://github.com/swiftlang/swift-tools-support-core/pull/485#discussion_r1795781075