### PR TITLE
[6.0.x] [Windows] Fix incorrect TimeZone.current lookup logic

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -390,7 +390,7 @@ extension TimeZone {
 
 extension TimeZone {
     internal static func dataFromTZFile(_ name: String) -> Data {
-#if NO_TZFILE
+#if NO_TZFILE || os(Windows)
         return Data()
 #else
         let path = TZDIR + "/" + name

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -50,6 +50,12 @@ dynamic package func _timeZoneGMTClass() -> _TimeZoneProtocol.Type {
 }
 #endif
 
+#if os(Windows)
+dynamic package func _timeZoneIdentifier(forWindowsIdentifier windowsIdentifier: String) -> String? {
+    nil
+}
+#endif
+
 /// Singleton which listens for notifications about preference changes for TimeZone and holds cached values for current, fixed time zones, etc.
 struct TimeZoneCache : Sendable {
     // MARK: - State
@@ -129,18 +135,14 @@ struct TimeZoneCache : Sendable {
             }
 
 #if os(Windows)
-            let hFile = TZDEFAULT.withCString(encodedAs: UTF16.self) {
-                CreateFileW($0, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nil, OPEN_EXISTING, 0, nil)
-            }
-            defer { CloseHandle(hFile) }
-            let dwSize = GetFinalPathNameByHandleW(hFile, nil, 0, VOLUME_NAME_DOS)
-            let path = withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwSize)) {
-                _ = GetFinalPathNameByHandleW(hFile, $0.baseAddress, dwSize, VOLUME_NAME_DOS)
-                return String(decodingCString: $0.baseAddress!, as: UTF16.self)
-            }
-            if let rangeOfZoneInfo = path._range(of: "\(TZDIR)\\", anchored: false, backwards: false) {
-                let name = path[rangeOfZoneInfo.upperBound...]
-                if let result = fixed(String(name)) {
+            var timeZoneInfo = TIME_ZONE_INFORMATION()
+            if GetTimeZoneInformation(&timeZoneInfo) != TIME_ZONE_ID_INVALID {
+                let windowsName = withUnsafePointer(to: &(timeZoneInfo.StandardName)) {
+                    $0.withMemoryRebound(to: WCHAR.self, capacity: 32) {
+                        String(decoding: UnsafeBufferPointer(start: $0, count: wcslen($0)), as: UTF16.self)
+                    }
+                }
+                if let identifier = _timeZoneIdentifier(forWindowsIdentifier: windowsName), let result = fixed(identifier) {
                     return TimeZone(inner: result)
                 }
             }

--- a/Sources/_FoundationCShims/include/_CStdlib.h
+++ b/Sources/_FoundationCShims/include/_CStdlib.h
@@ -156,6 +156,7 @@
 #include <tzfile.h>
 #else
 
+#if TARGET_OS_MAC || TARGET_OS_LINUX
 #ifndef TZDIR
 #define TZDIR    "/usr/share/zoneinfo/" /* Time zone object file directory */
 #endif /* !defined TZDIR */
@@ -163,6 +164,7 @@
 #ifndef TZDEFAULT
 #define TZDEFAULT    "/etc/localtime"
 #endif /* !defined TZDEFAULT */
+#endif /* TARGET_OS_MAC || TARGET_OS_LINUX */
 
 #endif
 


### PR DESCRIPTION
Explanation: Fixes lookup of the current timezone on Windows
Scope: Only impacts `TimeZone.current` on Windows
Original PR: https://github.com/swiftlang/swift-foundation/pull/975
Risk: Low - restores Swift 5.10 behavior and scope is minimal
Testing: Testing done via swift-ci testing and local testing
Reviewer: @parkera @compnerd