### PR TITLE
Performance improvements for `Calendar.RecurrenceRule`

### DIFF
--- a/Benchmarks/Benchmarks/Internationalization/BenchmarkCalendar.swift
+++ b/Benchmarks/Benchmarks/Internationalization/BenchmarkCalendar.swift
@@ -29,7 +29,7 @@ let benchmarks = {
     let thanksgivingComponents = DateComponents(month: 11, weekday: 5, weekdayOrdinal: 4)
     let cal = Calendar(identifier: .gregorian)
     let currentCalendar = Calendar.current
-    let thanksgivingStart = Date(timeIntervalSinceReferenceDate: 496359355.795410) //2016-09-23T14:35:55-0700
+    let thanksgivingStart = Date(timeIntervalSince1970: 1474666555.0) //2016-09-23T14:35:55-0700
     
     Benchmark("nextThousandThursdaysInTheFourthWeekOfNovember") { benchmark in
         // This benchmark used to be nextThousandThanksgivings, but the name was deceiving since it does not compute the next thousand thanksgivings
@@ -54,7 +54,7 @@ let benchmarks = {
     }
 
     // Only available in Swift 6 for non-Darwin platforms, macOS 15 for Darwin
-    #if swift(>=6.0)
+    #if compiler(>=6.0)
     if #available(macOS 15, *) {
         Benchmark("nextThousandThanksgivingsSequence") { benchmark in
             var count = 1000
@@ -66,7 +66,7 @@ let benchmarks = {
             }
         }
 
-        Benchmark("nextThousandThanksgivingsUsingRecurrenceRule") { benchmark in
+        Benchmark("RecurrenceRuleThanksgivings") { benchmark in
             var rule = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(1000))
             rule.months = [11]
             rule.weekdays = [.nth(4, .thursday)]
@@ -76,6 +76,43 @@ let benchmarks = {
                 count += 1
             }
             assert(count == 1000)
+        }
+        Benchmark("RecurrenceRuleThanksgivingMeals") { benchmark in
+            var rule = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(1000))
+            rule.months = [11]
+            rule.weekdays = [.nth(4, .thursday)]
+            rule.hours = [14, 18]
+            rule.matchingPolicy = .nextTime
+            for date in rule.recurrences(of: thanksgivingStart) {
+                Benchmark.blackHole(date)
+            }
+        }
+        Benchmark("RecurrenceRuleLaborDay") { benchmark in
+            var rule = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(1000))
+            rule.months = [9]
+            rule.weekdays = [.nth(1, .monday)]
+            rule.matchingPolicy = .nextTime
+            for date in rule.recurrences(of: thanksgivingStart) {
+                Benchmark.blackHole(date)
+            }
+        }
+        Benchmark("RecurrenceRuleBikeParties") { benchmark in
+            var rule = Calendar.RecurrenceRule(calendar: cal, frequency: .monthly, end: .afterOccurrences(1000))
+            rule.weekdays = [.nth(1, .friday), .nth(-1, .friday)]
+            rule.matchingPolicy = .nextTime
+            for date in rule.recurrences(of: thanksgivingStart) {
+                Benchmark.blackHole(date)
+            }
+        }
+        Benchmark("RecurrenceRuleDailyWithTimes") { benchmark in
+            var rule = Calendar.RecurrenceRule(calendar: cal, frequency: .daily, end: .afterOccurrences(1000))
+            rule.hours = [9, 10]
+            rule.minutes = [0, 30]
+            rule.weekdays = [.every(.monday), .every(.tuesday), .every(.wednesday)]
+            rule.matchingPolicy = .nextTime
+            for date in rule.recurrences(of: thanksgivingStart) {
+                Benchmark.blackHole(date)
+            }
         }
     } // #available(macOS 15, *)
     #endif // swift(>=6.0)
@@ -93,7 +130,7 @@ let benchmarks = {
 
     // MARK: - Allocations
 
-    let reference = Date(timeIntervalSinceReferenceDate: 496359355.795410) //2016-09-23T14:35:55-0700
+    let reference = Date(timeIntervalSince1970: 1474666555.0) //2016-09-23T14:35:55-0700
     
     let allocationsConfiguration = Benchmark.Configuration(
         metrics: [.cpuTotal, .mallocCountTotal, .peakMemoryResident, .throughput],

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -516,11 +516,38 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
     func testYearlyRecurrenceWithWeekNumberExpansion() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.firstWeekday = 2 // Week starts on Monday
+        calendar.minimumDaysInFirstWeek = 4
+        
+        let start = Date(timeIntervalSince1970: 1357048800.0) // 2013-01-01T14:00:00-0000
+        let end   = Date(timeIntervalSince1970: 1483279200.0) // 2017-01-01T14:00:00-0000
+        
+        var rule = Calendar.RecurrenceRule(calendar: calendar, frequency: .yearly)
+        rule.weeks = [1, 2]
+        
+        let results = Array(rule.recurrences(of: start, in: start..<end))
+        
+        let expectedResults: [Date] = [
+            Date(timeIntervalSince1970: 1357048800.0), // 2013-01-01T14:00:00-0000
+            Date(timeIntervalSince1970: 1357653600.0), // 2013-01-08T14:00:00-0000
+            Date(timeIntervalSince1970: 1388584800.0), // 2014-01-01T14:00:00-0000
+            Date(timeIntervalSince1970: 1389189600.0), // 2014-01-08T14:00:00-0000
+            Date(timeIntervalSince1970: 1420120800.0), // 2015-01-01T14:00:00-0000
+            Date(timeIntervalSince1970: 1420725600.0), // 2015-01-08T14:00:00-0000
+            Date(timeIntervalSince1970: 1452261600.0), // 2016-01-08T14:00:00-0000
+            Date(timeIntervalSince1970: 1452866400.0), // 2016-01-15T14:00:00-0000
+        ]
+        
+        XCTAssertEqual(results, expectedResults)
+    }
+    
+    func testYearlyRecurrenceWithWeekNumberExpansionCountingBack() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 2 // Week starts on Monday
         
         let start = Date(timeIntervalSince1970: 1704117600.0) // 2024-01-01T14:00:00-0000
         let end   = Date(timeIntervalSince1970: 1767225600.0) // 2026-01-01T00:00:00-0000
         
-        var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .yearly)
+        var rule = Calendar.RecurrenceRule(calendar: calendar, frequency: .yearly)
         rule.weeks = [1, -1]
         
         let results = Array(rule.recurrences(of: start, in: start..<end))
@@ -636,4 +663,17 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         }
         // If we get here, there isn't an infinite loop
    }
+    
+   func testOutOfRangeComponents() {
+        let start = Date(timeIntervalSince1970: 1695304800.0) // 2023-09-21T14:00:00-0000
+        let end   = Date(timeIntervalSince1970: 1729519200.0) // 2024-10-21T14:00:00-0000
+        
+        var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .monthly)
+        rule.daysOfTheMonth = [32, -32]
+        
+        let eventStart = Date(timeIntervalSince1970: 1285077600.0) // 2010-09-21T14:00:00-0000
+        let results = Array(rule.recurrences(of: eventStart, in: start..<end))
+        
+        XCTAssertEqual(results, [])
+    }
 }


### PR DESCRIPTION
The original implementation of `Calendar.RecurrenceRule` expanded recurrences of
dates using the Calendar APIs for matching date components. This would result in
multiple sequences for matching date components even when just a single sequence
would have sufficed, thus requiring more time and memory to complete enumeration

E.g: finding the dates for Thanksgivings (fourth Thursday of each November) took
~4 times as much time using RecurrenceRule when compared to simply matching date
components.

This commit optimizes how we expand dates for recurrences. Instead of creating a
sequence for each value of each component in the recurrence rule, we introduce a
new type of sequence closely resembling Calendar.DatesByMatching, but which also
allows multiple values per date component.
 
 Addresses #555

<details> 
<summary> Preliminary benchmarks </summary>

```
----------------------------------------------------------------------------------------------------------------------------
RecurrenceRuleBikeParties metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (total CPU) (μs) *          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │     326 │     327 │     327 │     329 │     335 │     338 │     338 │      10 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │     174 │     175 │     175 │     176 │     177 │     178 │     178 │      18 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -152 │    -152 │    -152 │    -153 │    -158 │    -160 │    -160 │       8 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      47 │      46 │      46 │      47 │      47 │      47 │      47 │       8 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (K)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │       3 │       3 │       3 │       3 │       3 │       3 │       3 │      10 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │       6 │       6 │       6 │       6 │       6 │       6 │       6 │      18 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       3 │       3 │       3 │       3 │       3 │       3 │       3 │       8 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │     100 │     100 │     100 │     100 │     100 │     100 │     100 │       8 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│             Malloc (total) *             │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │     358 │     358 │     358 │     358 │     358 │     358 │     358 │      10 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │     208 │     208 │     208 │     208 │     208 │     208 │     208 │      18 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -150 │    -150 │    -150 │    -150 │    -150 │    -150 │    -150 │       8 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      42 │      42 │      42 │      42 │      42 │      42 │      42 │       8 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
RecurrenceRuleDailyWithTimes metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (total CPU) (μs) *          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │    7127 │    7127 │    7127 │    7127 │    7127 │    7127 │    7127 │       1 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │    3190 │    3190 │    3190 │    3190 │    3190 │    3190 │    3190 │       1 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │   -3937 │   -3937 │   -3937 │   -3937 │   -3937 │   -3937 │   -3937 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      55 │      55 │      55 │      55 │      55 │      55 │      55 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│             Malloc (total) *             │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │    1567 │    1567 │    1567 │    1567 │    1567 │    1567 │    1567 │       1 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │    1713 │    1713 │    1713 │    1713 │    1713 │    1713 │    1713 │       1 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     146 │     146 │     146 │     146 │     146 │     146 │     146 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      -9 │      -9 │      -9 │      -9 │      -9 │      -9 │      -9 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
RecurrenceRuleLaborDay metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (total CPU) (μs) *          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │     626 │     627 │     630 │     633 │     657 │     657 │     657 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │     290 │     291 │     291 │     292 │     293 │     294 │     294 │      11 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -336 │    -336 │    -339 │    -341 │    -364 │    -363 │    -363 │       6 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      54 │      54 │      54 │      54 │      55 │      55 │      55 │       6 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (K)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │       2 │       2 │       2 │       2 │       1 │       1 │       1 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │       3 │       3 │       3 │       3 │       3 │       3 │       3 │      11 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       1 │       1 │       1 │       1 │       2 │       2 │       2 │       6 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      50 │      50 │      50 │      50 │     200 │     200 │     200 │       6 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│             Malloc (total) *             │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │     744 │     744 │     744 │     744 │     744 │     744 │     744 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │     411 │     411 │     411 │     411 │     411 │     411 │     411 │      11 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -333 │    -333 │    -333 │    -333 │    -333 │    -333 │    -333 │       6 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      45 │      45 │      45 │      45 │      45 │      45 │      45 │       6 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
RecurrenceRuleThanksgivingMeals metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (total CPU) (μs) *          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │     283 │     284 │     284 │     284 │     285 │     286 │     286 │      11 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │     197 │     198 │     198 │     198 │     199 │     203 │     203 │      16 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -86 │     -86 │     -86 │     -86 │     -86 │     -83 │     -83 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      30 │      30 │      30 │      30 │      30 │      29 │      29 │       5 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (K)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │       4 │       4 │       4 │       4 │       4 │       3 │       3 │      11 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │       5 │       5 │       5 │       5 │       5 │       5 │       5 │      16 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       1 │       1 │       1 │       1 │       1 │       2 │       2 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      25 │      25 │      25 │      25 │      25 │      67 │      67 │       5 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│             Malloc (total) *             │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │     287 │     287 │     287 │     287 │     287 │     287 │     287 │      11 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │     253 │     253 │     253 │     253 │     253 │     253 │     253 │      16 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -34 │     -34 │     -34 │     -34 │     -34 │     -34 │     -34 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      12 │      12 │      12 │      12 │      12 │      12 │      12 │       5 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
RecurrenceRuleThanksgivings metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (total CPU) (μs) *          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │     628 │     628 │     629 │     632 │     634 │     634 │     634 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │     339 │     340 │     340 │     341 │     351 │     351 │     351 │       9 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -289 │    -288 │    -289 │    -291 │    -283 │    -283 │    -283 │       4 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      46 │      46 │      46 │      46 │      45 │      45 │      45 │       4 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (K)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │       2 │       2 │       2 │       2 │       2 │       2 │       2 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │       3 │       3 │       3 │       3 │       3 │       3 │       3 │       9 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       1 │       1 │       1 │       1 │       1 │       1 │       1 │       4 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      50 │      50 │      50 │      50 │      50 │      50 │      50 │       4 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│             Malloc (total) *             │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  before                  │     809 │     809 │     809 │     809 │     809 │     809 │     809 │       5 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  after                   │     493 │     493 │     493 │     493 │     493 │     493 │     493 │       9 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -316 │    -316 │    -316 │    -316 │    -316 │    -316 │    -316 │       4 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      39 │      39 │      39 │      39 │      39 │      39 │      39 │       4 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
</details>