### PR TITLE
[6.0.2] `URL` path bug fixes

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -364,7 +364,7 @@ extension String {
         return String(cString: output)
     }
 
-    #if !NO_FILESYSTEM
+#if !NO_FILESYSTEM
     internal static func homeDirectoryPath(forUser user: String? = nil) -> String {
 #if os(Windows)
         if let user {
@@ -525,8 +525,10 @@ extension String {
 #else
         return "/tmp/"
 #endif
-#endif
+#endif // os(Windows)
     }
+#endif // !NO_FILESYSTEM
+
     /// Replaces any number of sequential `/`
     /// characters with /
     /// NOTE: Internal so it's testable
@@ -565,7 +567,7 @@ extension String {
         }
     }
 
-    private var _droppingTrailingSlashes: String {
+    internal var _droppingTrailingSlashes: String {
         guard !self.isEmpty else {
             return self
         }
@@ -575,7 +577,9 @@ extension String {
         }
         return String(self[...lastNonSlash])
     }
-    
+
+#if !NO_FILESYSTEM
+
     static var NETWORK_PREFIX: String { #"\\"# }
     
     private var _standardizingPath: String {
@@ -612,7 +616,8 @@ extension String {
     var standardizingPath: String {
         expandingTildeInPath._standardizingPath
     }
-    #endif // !NO_FILESYSTEM
+
+#endif // !NO_FILESYSTEM
     
     // _NSPathComponents
     var pathComponents: [String] {

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -192,7 +192,11 @@ extension String {
         guard let lastDot = self.utf8.lastIndex(of: dot) else {
             return self
         }
-        return String(self[..<lastDot])
+        var result = String(self[..<lastDot])
+        if utf8.last == ._slash {
+            result += "/"
+        }
+        return result
     }
 
     private func validatePathExtension(_ pathExtension: String) -> Bool {
@@ -212,7 +216,16 @@ extension String {
         guard validatePathExtension(pathExtension) else {
             return self
         }
-        return self + ".\(pathExtension)"
+        var result = self._droppingTrailingSlashes
+        guard result != "/" else {
+            // Path was all slashes
+            return self + ".\(pathExtension)"
+        }
+        result += ".\(pathExtension)"
+        if utf8.last == ._slash {
+            result += "/"
+        }
+        return result
     }
 
     internal var pathExtension: String {

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1320,12 +1320,8 @@ public struct URL: Equatable, Sendable, Hashable {
     }
 
     private static func fileSystemPath(for urlPath: String) -> String {
-        var result = urlPath
-        if result.count > 1 && result.utf8.last == UInt8(ascii: "/") {
-            _ = result.popLast()
-        }
         let charsToLeaveEncoded: Set<UInt8> = [._slash, 0]
-        return Parser.percentDecode(result, excluding: charsToLeaveEncoded) ?? ""
+        return Parser.percentDecode(urlPath._droppingTrailingSlashes, excluding: charsToLeaveEncoded) ?? ""
     }
 
     var fileSystemPath: String {

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -812,6 +812,19 @@ final class StringTests : XCTestCase {
         }
     }
 
+    func testAppendingPathExtension() {
+        XCTAssertEqual("".appendingPathExtension("foo"), ".foo")
+        XCTAssertEqual("/".appendingPathExtension("foo"), "/.foo")
+        XCTAssertEqual("//".appendingPathExtension("foo"), "//.foo")
+        XCTAssertEqual("/path".appendingPathExtension("foo"), "/path.foo")
+        XCTAssertEqual("/path.zip".appendingPathExtension("foo"), "/path.zip.foo")
+        XCTAssertEqual("/path/".appendingPathExtension("foo"), "/path.foo/")
+        XCTAssertEqual("/path//".appendingPathExtension("foo"), "/path.foo/")
+        XCTAssertEqual("path".appendingPathExtension("foo"), "path.foo")
+        XCTAssertEqual("path/".appendingPathExtension("foo"), "path.foo/")
+        XCTAssertEqual("path//".appendingPathExtension("foo"), "path.foo/")
+    }
+
     func testDeletingPathExtenstion() {
         XCTAssertEqual("".deletingPathExtension(), "")
         XCTAssertEqual("/".deletingPathExtension(), "/")
@@ -834,6 +847,15 @@ final class StringTests : XCTestCase {
         XCTAssertEqual("/foo.bar/bar.baz/baz.zip".deletingPathExtension(), "/foo.bar/bar.baz/baz")
         XCTAssertEqual("/.././.././a.zip".deletingPathExtension(), "/.././.././a")
         XCTAssertEqual("/.././.././.".deletingPathExtension(), "/.././.././.")
+
+        XCTAssertEqual("path.foo".deletingPathExtension(), "path")
+        XCTAssertEqual("path.foo.zip".deletingPathExtension(), "path.foo")
+        XCTAssertEqual("/path.foo".deletingPathExtension(), "/path")
+        XCTAssertEqual("/path.foo.zip".deletingPathExtension(), "/path.foo")
+        XCTAssertEqual("path.foo/".deletingPathExtension(), "path/")
+        XCTAssertEqual("path.foo//".deletingPathExtension(), "path/")
+        XCTAssertEqual("/path.foo/".deletingPathExtension(), "/path/")
+        XCTAssertEqual("/path.foo//".deletingPathExtension(), "/path/")
     }
 
     func test_dataUsingEncoding() {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -586,6 +586,42 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.fileSystemPath, "/path/slashes")
     }
 
+    func testURLNotDirectoryHintStripsTrailingSlash() throws {
+        // Supply a path with a trailing slash but say it's not a direcotry
+        var url = URL(filePath: "/path/", directoryHint: .notDirectory)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/path")
+
+        url = URL(fileURLWithPath: "/path/", isDirectory: false)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/path")
+
+        url = URL(filePath: "/path///", directoryHint: .notDirectory)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/path")
+
+        url = URL(fileURLWithPath: "/path///", isDirectory: false)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/path")
+
+        // With .checkFileSystem, don't modify the path for a non-existent file
+        url = URL(filePath: "/my/non/existent/path/", directoryHint: .checkFileSystem)
+        XCTAssertTrue(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/my/non/existent/path/")
+
+        url = URL(fileURLWithPath: "/my/non/existent/path/")
+        XCTAssertTrue(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/my/non/existent/path/")
+
+        url = URL(filePath: "/my/non/existent/path", directoryHint: .checkFileSystem)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/my/non/existent/path")
+
+        url = URL(fileURLWithPath: "/my/non/existent/path")
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/my/non/existent/path")
+    }
+
     func testURLHostRetainsIDNAEncoding() throws {
         let url = URL(string: "ftp://user:password@*.xn--poema-9qae5a.com.br:4343/cat.txt")!
         XCTAssertEqual(url.host, "*.xn--poema-9qae5a.com.br")

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -659,6 +659,27 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.path().utf8.last, ._slash)
     }
 
+    func testURLPathExtensions() throws {
+        var url = URL(filePath: "/path", directoryHint: .notDirectory)
+        url.appendPathExtension("foo")
+        XCTAssertEqual(url.path(), "/path.foo")
+        url.deletePathExtension()
+        XCTAssertEqual(url.path(), "/path")
+
+        url = URL(filePath: "/path", directoryHint: .isDirectory)
+        url.appendPathExtension("foo")
+        XCTAssertEqual(url.path(), "/path.foo/")
+        url.deletePathExtension()
+        XCTAssertEqual(url.path(), "/path/")
+
+        url = URL(filePath: "/path/", directoryHint: .inferFromPath)
+        url.appendPathExtension("foo")
+        XCTAssertEqual(url.path(), "/path.foo/")
+        url.append(path: "/////")
+        url.deletePathExtension()
+        XCTAssertEqual(url.path(), "/path/")
+    }
+
     func testURLComponentsPercentEncodedUnencodedProperties() throws {
         var comp = URLComponents()
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -571,6 +571,21 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(appended.relativePath, "relative/with:slash")
     }
 
+    func testURLFilePathDropsTrailingSlashes() throws {
+        var url = URL(filePath: "/path/slashes///")
+        XCTAssertEqual(url.path(), "/path/slashes///")
+        // TODO: Update this once .fileSystemPath uses backslashes for Windows
+        XCTAssertEqual(url.fileSystemPath, "/path/slashes")
+
+        url = URL(filePath: "/path/slashes/")
+        XCTAssertEqual(url.path(), "/path/slashes/")
+        XCTAssertEqual(url.fileSystemPath, "/path/slashes")
+
+        url = URL(filePath: "/path/slashes")
+        XCTAssertEqual(url.path(), "/path/slashes")
+        XCTAssertEqual(url.fileSystemPath, "/path/slashes")
+    }
+
     func testURLHostRetainsIDNAEncoding() throws {
         let url = URL(string: "ftp://user:password@*.xn--poema-9qae5a.com.br:4343/cat.txt")!
         XCTAssertEqual(url.host, "*.xn--poema-9qae5a.com.br")

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -627,6 +627,26 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.host, "*.xn--poema-9qae5a.com.br")
     }
 
+    func testURLTildeFilePath() throws {
+        var url = URL(filePath: "~")
+        // "~" must either be expanded to an absolute path or resolved against a base URL
+        XCTAssertTrue(
+            url.relativePath.utf8.first == ._slash || (url.baseURL != nil && url.path().utf8.first == ._slash)
+        )
+
+        url = URL(filePath: "~", directoryHint: .isDirectory)
+        XCTAssertTrue(
+            url.relativePath.utf8.first == ._slash || (url.baseURL != nil && url.path().utf8.first == ._slash)
+        )
+        XCTAssertEqual(url.path().utf8.last, ._slash)
+
+        url = URL(filePath: "~/")
+        XCTAssertTrue(
+            url.relativePath.utf8.first == ._slash || (url.baseURL != nil && url.path().utf8.first == ._slash)
+        )
+        XCTAssertEqual(url.path().utf8.last, ._slash)
+    }
+
     func testURLComponentsPercentEncodedUnencodedProperties() throws {
         var comp = URLComponents()
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -330,6 +330,18 @@ final class URLTests : XCTestCase {
         try FileManager.default.removeItem(at: URL(filePath: "\(tempDirectory.path)/tmp-dir"))
     }
 
+    #if os(Windows)
+    func testURLWindowsDriveLetterPath() throws {
+        let url = URL(filePath: "C:\\test\\path", directoryHint: .notDirectory)
+        // .absoluteString and .path() use the RFC 8089 URL path
+        XCTAssertEqual(url.absoluteString, "file:///C:/test/path")
+        XCTAssertEqual(url.path(), "/C:/test/path")
+        // .path and .fileSystemPath strip the leading slash
+        XCTAssertEqual(url.path, "C:/test/path")
+        XCTAssertEqual(url.fileSystemPath, "C:/test/path")
+    }
+    #endif
+
     func testURLFilePathRelativeToBase() throws {
         try FileManagerPlayground {
             Directory("dir") {


### PR DESCRIPTION
**Explanation:** Fixes various `URL` path API behaviors to match the expected behavior from before the Swift URL implementation:
- Drops trailing slashes from `URL.fileSystemPath` and `URL.path`
- Strips trailing slashes in `URL(filePath:)` if a user supplies `.notDirectory`
- Does not treat `~` paths as absolute in `URL(filePath:)`, resolves the tilde and prevents a crash during initialization
- Strips the leading slash of Windows drive letter paths on Windows
- Prevents unexpected path extension API behavior when the path is a directory

**Scope:** Targeted changes to `URL` path APIs to maintain compatibility
**Original PRs:** #852, #867, #961, #964, #965
**Risk:** Low - Targeted scope, restores expected behavior
**Testing:** Local, swift-ci from `swift`, `swift-foundation`, and `swift-corelibs-foundation`, stable in `main`
**Reviewers:** @jmschonfeld @iCharlesHu 