### PR TITLE
[wasm] Fix WASI build around TimeZone

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -390,7 +390,7 @@ extension TimeZone {
 
 extension TimeZone {
     internal static func dataFromTZFile(_ name: String) -> Data {
-#if NO_TZFILE || os(Windows)
+#if NO_TZFILE || os(Windows) || os(WASI)
         return Data()
 #else
         let path = TZDIR + "/" + name

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -131,6 +131,9 @@ struct TimeZoneCache : Sendable, ~Copyable {
                     return TimeZone(inner: result)
                 }
             }
+#elseif os(WASI)
+            // WASI doesn't provide a way to get the current timezone for now, so
+            // just return the default GMT timezone.
 #else
             let buffer = UnsafeMutableBufferPointer<CChar>.allocate(capacity: Int(PATH_MAX + 1))
             defer { buffer.deallocate() }


### PR DESCRIPTION
https://github.com/swiftlang/swift-foundation/pull/975 started to restrict the fallback value for `TZDIR` and it revealed that WASI platform implicitly depends on TZDIR even though it won't have such directory. This patch explicitly handles the case for WASI platform for timezone operations.