### PR TITLE
Fix 'var currentDirectoryPath: String' crash when the directory is removed

### DIFF
--- a/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
@@ -285,7 +285,7 @@ open class FileManager : @unchecked Sendable {
     }
 
     open var currentDirectoryPath: String {
-        _impl.currentDirectoryPath!
+        _impl.currentDirectoryPath ?? ""
     }
 
     open func changeCurrentDirectoryPath(_ path: String) -> Bool {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -729,9 +729,6 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["bar", "dir", "dir/foo"])
             XCTAssertFalse($0.changeCurrentDirectoryPath("does_not_exist"))
             
-            XCTAssertThrowsError(try $0.removeItem(atPath: $0.currentDirectoryPath)) {
-                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
-            }
             // Test get current directory path when it's parent directory was removed.
             XCTAssertTrue($0.changeCurrentDirectoryPath("dir"))
 #if os(Windows)

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -729,10 +729,14 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["bar", "dir", "dir/foo"])
             XCTAssertFalse($0.changeCurrentDirectoryPath("does_not_exist"))
             
+            #if !os(Windows)
             // Test get current directory path when it's parent directory was removed.
+            // It's will be remove failed on Windows when directory is using.
             XCTAssertTrue($0.changeCurrentDirectoryPath("dir"))
             try $0.removeItem(atPath: $0.currentDirectoryPath)
             XCTAssertEqual($0.currentDirectoryPath, "")
+            #endif
+            
         }
     }
     

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -732,7 +732,7 @@ final class FileManagerTests : XCTestCase {
             // Test get current directory path when it's parent directory was removed.
             XCTAssertTrue($0.changeCurrentDirectoryPath("dir"))
 #if os(Windows)
-            // It's will be remove failed on Windows when directory is using.
+            // Removing the current working directory fails on Windows because the directory is in use.
             XCTAssertThrowsError(try $0.removeItem(atPath: $0.currentDirectoryPath)) {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteNoPermission)
             }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -728,6 +728,11 @@ final class FileManagerTests : XCTestCase {
             XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
             XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["bar", "dir", "dir/foo"])
             XCTAssertFalse($0.changeCurrentDirectoryPath("does_not_exist"))
+            
+            // Test get current directory path when it's parent directory was removed.
+            XCTAssertTrue($0.changeCurrentDirectoryPath("dir"))
+            try $0.removeItem(atPath: "../dir")
+            XCTAssertEqual($0.currentDirectoryPath, "")
         }
     }
     

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -729,14 +729,20 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["bar", "dir", "dir/foo"])
             XCTAssertFalse($0.changeCurrentDirectoryPath("does_not_exist"))
             
-            #if !os(Windows)
+            XCTAssertThrowsError(try $0.removeItem(atPath: $0.currentDirectoryPath)) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
+            }
             // Test get current directory path when it's parent directory was removed.
-            // It's will be remove failed on Windows when directory is using.
             XCTAssertTrue($0.changeCurrentDirectoryPath("dir"))
+#if os(Windows)
+            // It's will be remove failed on Windows when directory is using.
+            XCTAssertThrowsError(try $0.removeItem(atPath: $0.currentDirectoryPath)) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteNoPermission)
+            }
+#else
             try $0.removeItem(atPath: $0.currentDirectoryPath)
             XCTAssertEqual($0.currentDirectoryPath, "")
-            #endif
-            
+#endif
         }
     }
     

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -731,7 +731,7 @@ final class FileManagerTests : XCTestCase {
             
             // Test get current directory path when it's parent directory was removed.
             XCTAssertTrue($0.changeCurrentDirectoryPath("dir"))
-            try $0.removeItem(atPath: "../dir")
+            try $0.removeItem(atPath: $0.currentDirectoryPath)
             XCTAssertEqual($0.currentDirectoryPath, "")
         }
     }


### PR DESCRIPTION
Forced unpacking caused a crash.

```
let dest = "/tmp/a/b/c"
let fm = FileManager.default
try fm.createDirectory(atPath: dest, withIntermediateDirectories: true, attributes: nil)
let _ = fm.changeCurrentDirectoryPath(dest)
let _ = fm.currentDirectoryPath // it's ok
try fm.removeItem(atPath: dest)
let _ = fm.currentDirectoryPath // will crash
```
The same code in the old version(<5.10) of swift will be empty string.
