### PR TITLE
Add `.index-build` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Package.resolved
 .swiftpm
 
 **/.build*
+.index-build
 
 # VSCode
 **/.vscode


### PR DESCRIPTION
### Motivation:

The `.index-build` directory is created by SourceKit-LSP when background indexing is enabled, contains auto-generated transient files similar in purpose to `.build`, and it should be ignored.
  
### Modifications:

Updated `.gitignore` file accordingly.

### Result:

Developers no longer need to exclude `.index-build` manually from their commits when editing the package with SourceKit-LSP.