### PR TITLE
`URL.deletingLastPathComponent()` should append .. in special cases

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1357,6 +1357,11 @@ public struct URL: Equatable, Sendable, Hashable {
         return URL.fileSystemPath(for: path())
     }
 
+    /// True if the URL's relative path would resolve against a base URL path
+    private var pathResolvesAgainstBase: Bool {
+        return _parseInfo.scheme == nil && !hasAuthority && relativePath().utf8.first != ._slash
+    }
+
     /// Returns the path component of the URL if present, otherwise returns an empty string.
     ///
     /// - note: This function will resolve against the base `URL`.
@@ -1649,7 +1654,9 @@ public struct URL: Equatable, Sendable, Hashable {
     /// Returns a URL constructed by removing the last path component of self.
     ///
     /// This function may either remove a path component or append `/..`.
-    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    /// If the URL has an empty path that is not resolved against a base URL
+    /// (e.g., `http://www.example.com`),
+    /// then this function will return the URL unchanged.
     public func deletingLastPathComponent() -> URL {
         #if FOUNDATION_FRAMEWORK
         guard foundation_swift_url_enabled() else {
@@ -1658,7 +1665,17 @@ public struct URL: Equatable, Sendable, Hashable {
             return result
         }
         #endif
-        guard !relativePath().isEmpty else { return self }
+        let shouldAppendDotDot = (
+            pathResolvesAgainstBase && (
+                relativePath().isEmpty
+                || relativePath().lastPathComponent == "."
+                || relativePath().lastPathComponent == ".."
+            )
+        )
+        if shouldAppendDotDot {
+            return self.appending(path: "..", directoryHint: .isDirectory)
+        }
+
         var components = URLComponents(parseInfo: _parseInfo)
         var newPath = components.percentEncodedPath.deletingLastPathComponent()
         // .deletingLastPathComponent() removes the trailing "/", but we know it's a directory
@@ -2226,7 +2243,15 @@ extension URL {
             pathToAppend = String(decoding: utf8, as: UTF8.self)
         }
 
-        if newPath.utf8.last != ._slash && pathToAppend.utf8.first != ._slash {
+        // If the current path is empty (relative), don't append a slash which
+        // would make the path absolute--unless we have an authority.
+
+        // If we have an authority, we must add a slash to separate the path from the authority,
+        // e.g. URL("http://example.com").appending(path: "path") == "http://example.com/path"
+
+        if newPath.isEmpty && !hasAuthority {
+            // Do nothing, path will be directly appended
+        } else if newPath.utf8.last != ._slash && pathToAppend.utf8.first != ._slash {
             newPath += "/"
         } else if newPath.utf8.last == ._slash && pathToAppend.utf8.first == ._slash {
             _ = newPath.popLast()

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -23,6 +23,18 @@ import TestSupport
 @testable import Foundation
 #endif
 
+private func checkBehavior<T: Equatable>(_ result: T, new: T, old: T) {
+    #if FOUNDATION_FRAMEWORK
+    if foundation_swift_url_enabled() {
+        XCTAssertEqual(result, new)
+    } else {
+        XCTAssertEqual(result, old)
+    }
+    #else
+    XCTAssertEqual(result, new)
+    #endif
+}
+
 final class URLTests : XCTestCase {
 
     func testURLBasics() throws {
@@ -87,11 +99,7 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(relativeURLWithBase.password(), baseURL.password())
         XCTAssertEqual(relativeURLWithBase.host(), baseURL.host())
         XCTAssertEqual(relativeURLWithBase.port, baseURL.port)
-        #if !FOUNDATION_FRAMEWORK_NSURL
-        XCTAssertEqual(relativeURLWithBase.path(), "/base/relative/path")
-        #else
-        XCTAssertEqual(relativeURLWithBase.path(), "relative/path")
-        #endif
+        checkBehavior(relativeURLWithBase.path(), new: "/base/relative/path", old: "relative/path")
         XCTAssertEqual(relativeURLWithBase.relativePath, "relative/path")
         XCTAssertEqual(relativeURLWithBase.query(), "query")
         XCTAssertEqual(relativeURLWithBase.fragment(), "fragment")
@@ -565,13 +573,8 @@ final class URLTests : XCTestCase {
         // `appending(component:)` should explicitly treat `component` as a single
         // path component, meaning "/" should be encoded to "%2F" before appending
         appended = url.appending(component: slashComponent, directoryHint: .notDirectory)
-        #if FOUNDATION_FRAMEWORK_NSURL
-        XCTAssertEqual(appended.absoluteString, "file:///var/mobile/relative/with:slash")
-        XCTAssertEqual(appended.relativePath, "relative/with:slash")
-        #else
-        XCTAssertEqual(appended.absoluteString, "file:///var/mobile/relative/%2Fwith:slash")
-        XCTAssertEqual(appended.relativePath, "relative/%2Fwith:slash")
-        #endif
+        checkBehavior(appended.absoluteString, new: "file:///var/mobile/relative/%2Fwith:slash", old: "file:///var/mobile/relative/with:slash")
+        checkBehavior(appended.relativePath, new: "relative/%2Fwith:slash", old: "relative/with:slash")
 
         appended = url.appendingPathComponent(component, isDirectory: false)
         XCTAssertEqual(appended.absoluteString, "file:///var/mobile/relative/no:slash")
@@ -581,6 +584,156 @@ final class URLTests : XCTestCase {
         appended = url.appendingPathComponent(slashComponent, isDirectory: false)
         XCTAssertEqual(appended.absoluteString, "file:///var/mobile/relative/with:slash")
         XCTAssertEqual(appended.relativePath, "relative/with:slash")
+    }
+
+    func testURLDeletingLastPathComponent() throws {
+        var absolute = URL(filePath: "/absolute/path", directoryHint: .notDirectory)
+        // Note: .relativePath strips the trailing slash for compatibility
+        XCTAssertEqual(absolute.relativePath, "/absolute/path")
+        XCTAssertFalse(absolute.hasDirectoryPath)
+
+        absolute.deleteLastPathComponent()
+        XCTAssertEqual(absolute.relativePath, "/absolute")
+        XCTAssertTrue(absolute.hasDirectoryPath)
+
+        absolute.deleteLastPathComponent()
+        XCTAssertEqual(absolute.relativePath, "/")
+        XCTAssertTrue(absolute.hasDirectoryPath)
+
+        // The old .deleteLastPathComponent() implementation appends ".." to the
+        // root directory "/", resulting in "/../". This resolves back to "/".
+        // The new implementation simply leaves "/" as-is.
+        absolute.deleteLastPathComponent()
+        checkBehavior(absolute.relativePath, new: "/", old: "/..")
+        XCTAssertTrue(absolute.hasDirectoryPath)
+
+        absolute.append(path: "absolute", directoryHint: .isDirectory)
+        checkBehavior(absolute.path, new: "/absolute", old: "/../absolute")
+
+        // Reset `var absolute` to "/absolute" to prevent having
+        // a "/../" prefix in all the old expectations.
+        absolute = URL(filePath: "/absolute", directoryHint: .isDirectory)
+
+        var relative = URL(filePath: "relative/path", directoryHint: .notDirectory, relativeTo: absolute)
+        XCTAssertEqual(relative.relativePath, "relative/path")
+        XCTAssertFalse(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute/relative/path")
+
+        relative.deleteLastPathComponent()
+        XCTAssertEqual(relative.relativePath, "relative")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute/relative")
+
+        relative.deleteLastPathComponent()
+        checkBehavior(relative.relativePath, new: "", old: ".")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute")
+
+        relative.deleteLastPathComponent()
+        XCTAssertEqual(relative.relativePath, "..")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/")
+
+        relative.deleteLastPathComponent()
+        XCTAssertEqual(relative.relativePath, "../..")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        checkBehavior(relative.path, new:"/", old: "/..")
+
+        relative.append(path: "path", directoryHint: .isDirectory)
+        XCTAssertEqual(relative.relativePath, "../../path")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        checkBehavior(relative.path, new: "/path", old: "/../path")
+
+        relative.deleteLastPathComponent()
+        XCTAssertEqual(relative.relativePath, "../..")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        checkBehavior(relative.path, new: "/", old: "/..")
+
+        relative = URL(filePath: "", relativeTo: absolute)
+        checkBehavior(relative.relativePath, new: "", old: ".")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute")
+
+        relative.deleteLastPathComponent()
+        checkBehavior(relative.relativePath, new: "..", old: "..")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/")
+
+        relative.deleteLastPathComponent()
+        checkBehavior(relative.relativePath, new: "../..", old: "../..")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        checkBehavior(relative.path, new: "/", old: "/..")
+
+        relative = URL(filePath: "relative/./", relativeTo: absolute)
+        // According to RFC 3986, "." and ".." segments should not be removed
+        // until the path is resolved against the base URL (when calling .path)
+        checkBehavior(relative.relativePath, new: "relative/.", old: "relative")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute/relative")
+
+        relative.deleteLastPathComponent()
+        checkBehavior(relative.relativePath, new: "relative/./..", old: ".")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute")
+
+        relative = URL(filePath: "relative/.", directoryHint: .isDirectory, relativeTo: absolute)
+        checkBehavior(relative.relativePath, new: "relative/.", old: "relative")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute/relative")
+
+        relative.deleteLastPathComponent()
+        checkBehavior(relative.relativePath, new: "relative/./..", old: ".")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute")
+
+        relative = URL(filePath: "relative/..", relativeTo: absolute)
+        XCTAssertEqual(relative.relativePath, "relative/..")
+        checkBehavior(relative.hasDirectoryPath, new: true, old: false)
+        XCTAssertEqual(relative.path, "/absolute")
+
+        relative.deleteLastPathComponent()
+        XCTAssertEqual(relative.relativePath, "relative/../..")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/")
+
+        relative = URL(filePath: "relative/..", directoryHint: .isDirectory, relativeTo: absolute)
+        XCTAssertEqual(relative.relativePath, "relative/..")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/absolute")
+
+        relative.deleteLastPathComponent()
+        XCTAssertEqual(relative.relativePath, "relative/../..")
+        XCTAssertTrue(relative.hasDirectoryPath)
+        XCTAssertEqual(relative.path, "/")
+
+        var url = try XCTUnwrap(URL(string: "scheme://host.with.no.path"))
+        XCTAssertTrue(url.path().isEmpty)
+
+        url.deleteLastPathComponent()
+        XCTAssertEqual(url.absoluteString, "scheme://host.with.no.path")
+        XCTAssertTrue(url.path().isEmpty)
+
+        let unusedBase = URL(string: "base://url")
+        url = try XCTUnwrap(URL(string: "scheme://host.with.no.path", relativeTo: unusedBase))
+        XCTAssertEqual(url.absoluteString, "scheme://host.with.no.path")
+        XCTAssertTrue(url.path().isEmpty)
+
+        url.deleteLastPathComponent()
+        XCTAssertEqual(url.absoluteString, "scheme://host.with.no.path")
+        XCTAssertTrue(url.path().isEmpty)
+
+        var schemeRelative = try XCTUnwrap(URL(string: "scheme:relative/path"))
+        // Bug in the old implementation where a relative path is not recognized
+        checkBehavior(schemeRelative.relativePath, new: "relative/path", old: "")
+
+        schemeRelative.deleteLastPathComponent()
+        checkBehavior(schemeRelative.relativePath, new: "relative", old: "")
+
+        schemeRelative.deleteLastPathComponent()
+        XCTAssertEqual(schemeRelative.relativePath, "")
+
+        schemeRelative.deleteLastPathComponent()
+        XCTAssertEqual(schemeRelative.relativePath, "")
     }
 
     func testURLFilePathDropsTrailingSlashes() throws {
@@ -685,12 +838,8 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.path(), "/path.foo/")
         url.append(path: "/////")
         url.deletePathExtension()
-        #if !FOUNDATION_FRAMEWORK_NSURL
-        XCTAssertEqual(url.path(), "/path/")
-        #else
         // Old behavior only searches the last empty component, so the extension isn't actually removed
-        XCTAssertEqual(url.path(), "/path.foo///")
-        #endif
+        checkBehavior(url.path(), new: "/path/", old: "/path.foo///")
     }
 
     func testURLComponentsPercentEncodedUnencodedProperties() throws {


### PR DESCRIPTION
If a URL's relative path is being resolved against a base URL, we should append ".." as a means of deleting the last path component in the following cases:
- The relative path is empty
- The last relative path component is "."
- The last relative path component is ".."

Otherwise, we can just remove the last path component as normal.