### PR TITLE
[wasm] Make `FileManager.createFile()` work on WASI

### DIFF
--- a/Benchmarks/Benchmarks/DataIO/BenchmarkDataIO.swift
+++ b/Benchmarks/Benchmarks/DataIO/BenchmarkDataIO.swift
@@ -88,9 +88,11 @@ let benchmarks = {
         try data.write(to: testPath)
     }
     
+#if !os(WASI) // atomic writing is unavailable on WASI
     Benchmark("write-regularFile-atomic", configuration: .cleanupTestPathConfig) { benchmark in
         try data.write(to: testPath, options: .atomic)
     }
+#endif
     
     Benchmark("write-regularFile-alreadyExists",
               configuration: .init(
@@ -103,6 +105,7 @@ let benchmarks = {
         try? data.write(to: testPath)
     }
     
+#if !os(WASI) // atomic writing is unavailable on WASI
     Benchmark("write-regularFile-alreadyExists-atomic",
               configuration: .init(
                 setup: {
@@ -113,6 +116,7 @@ let benchmarks = {
     ) { benchmark in
         try? data.write(to: testPath, options: .atomic)
     }
+#endif
     
     Benchmark("read-regularFile", 
               configuration: .init(

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -261,7 +261,7 @@ extension _FileManagerImpl {
             attr?[.protectionKey] = nil
         }
         #elseif os(WASI)
-        // WASI doesn't support a temporary file, so can't use `.atomic`
+        // `.atomic` is unavailable on WASI
         let opts: Data.WritingOptions = []
         #else
         let opts = Data.WritingOptions.atomic

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -260,6 +260,9 @@ extension _FileManagerImpl {
             }
             attr?[.protectionKey] = nil
         }
+        #elseif os(WASI)
+        // WASI doesn't support a temporary file, so can't use `.atomic`
+        let opts: Data.WritingOptions = []
         #else
         let opts = Data.WritingOptions.atomic
         #endif

--- a/Sources/FoundationEssentials/String/String+IO.swift
+++ b/Sources/FoundationEssentials/String/String+IO.swift
@@ -433,7 +433,12 @@ extension StringProtocol {
             attributes = [:]
         }
 
+#if os(WASI)
+        guard !useAuxiliaryFile else { throw CocoaError(.featureUnsupported) }
+        let options : Data.WritingOptions = []
+#else
         let options : Data.WritingOptions = useAuxiliaryFile ? [.atomic] : []
+#endif
 
         try writeToFile(path: .path(String(path)), data: data, options: options, attributes: attributes, reportProgress: false)
     }
@@ -451,7 +456,12 @@ extension StringProtocol {
             attributes = [:]
         }
 
+#if os(WASI)
+        guard !useAuxiliaryFile else { throw CocoaError(.featureUnsupported) }
+        let options : Data.WritingOptions = []
+#else
         let options : Data.WritingOptions = useAuxiliaryFile ? [.atomic] : []
+#endif
 
         try writeToFile(path: .url(url), data: data, options: options, attributes: attributes, reportProgress: false)
     }

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -93,6 +93,9 @@ class DataIOTests : XCTestCase {
 
     // Atomic writing is a very different code path
     func test_readWriteAtomic() throws {
+        #if os(WASI)
+        try XCTSkip("atomic writing is not supported on WASI")
+        #else
         let url = testURL()
         // Perform an atomic write to a file that does not exist
         try writeAndVerifyTestData(to: url, writeOptions: [.atomic])
@@ -101,6 +104,7 @@ class DataIOTests : XCTestCase {
         try writeAndVerifyTestData(to: url, writeOptions: [.atomic])
 
         cleanup(at: url)
+        #endif
     }
 
     func test_readWriteMapped() throws {


### PR DESCRIPTION
fixes swiftwasm/swift#5593

`FileManager.createFile()` currently doesn't work on WASI because it requires `.atomic`, it requires creating a temporary file, and it isn't suppported on WASI.

So I have fixed that by removing the `.atomic` requirement only on WASI.