### PR TITLE
Prevent crash when bridging an invalid CFURL to Swift URL

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1988,7 +1988,12 @@ public struct URL: Equatable, Sendable, Hashable {
             return
         }
         #endif
-        _parseInfo = Parser.parse(urlString: _url.relativeString, encodingInvalidCharacters: true)!
+        if let parseInfo = Parser.parse(urlString: _url.relativeString, encodingInvalidCharacters: true) {
+            _parseInfo = parseInfo
+        } else {
+            // Go to compatibility jail (allow `URL` as a dummy string container for `NSURL` instead of crashing)
+            _parseInfo = URLParseInfo(urlString: _url.relativeString, urlParser: .RFC3986, schemeRange: nil, userRange: nil, passwordRange: nil, hostRange: nil, portRange: nil, pathRange: nil, queryRange: nil, fragmentRange: nil, isIPLiteral: false, didPercentEncodeHost: false, pathHasPercent: false)
+        }
         _baseParseInfo = reference.baseURL?._parseInfo
     }
 


### PR DESCRIPTION
Bridging an invalid `CFURL` like `https://2001:db8::1:433` to `URL` in Swift causes a crash since the Swift parser returns `nil`. For compatibility, we can allow bridging to proceed by storing the string in a `URLParseInfo` with all `nil` ranges. This prevents the crash and allows `URL` to be a dummy container for the string, but otherwise will not return info that may be ambiguous.