### PR TITLE
Ensure empty AttributedSubstrings produce no runs

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -47,8 +47,7 @@ extension AttributedString {
                     _runOffset: _guts.runs.count,
                     runIndex: _guts.runs.endIndex.base,
                     stringIndex: _strBounds.upperBound)
-            } else if _strBounds.upperBound == _guts.string.startIndex {
-                assert(stringLowerBound == stringUpperBound)
+            } else if _strBounds.upperBound == _strBounds.lowerBound {
                 end = start
             } else {
                 let last = _guts.runs.index(atUTF8Offset: _strBounds.upperBound.utf8Offset - 1).index
@@ -62,7 +61,7 @@ extension AttributedString {
             assert(start._runIndex != nil && start._stringIndex != nil)
             assert(end._runIndex != nil && end._stringIndex != nil)
             assert(start._stringIndex!.utf8Offset <= _strBounds.lowerBound.utf8Offset)
-            assert(end._stringIndex!.utf8Offset >= _strBounds.upperBound.utf8Offset)
+            assert(end == start || end._stringIndex!.utf8Offset >= _strBounds.upperBound.utf8Offset)
             self._bounds = start ..< end
         }
     }

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -43,6 +43,21 @@ final class TestAttributedString: XCTestCase {
         for _ in AttributedString().runs {
             XCTFail("Empty AttributedString should not enumerate any attributes")
         }
+        
+        do {
+            let str = AttributedString("Foo")
+            for _ in str[str.startIndex ..< str.startIndex].runs {
+                XCTFail("Empty AttributedSubstring should not enumerate any attributes")
+            }
+        }
+        
+        do {
+            let str = AttributedString("Foo", attributes: AttributeContainer.testInt(2))
+            let i = str.index(afterCharacter: str.startIndex)
+            for _ in str[i ..< i].runs {
+                XCTFail("Empty AttributedSubstring should not enumerate any attributes")
+            }
+        }
     }
 
     func verifyAttributes<T>(_ runs: AttributedString.Runs.AttributesSlice1<T>, string: AttributedString, expectation: [(String, T.Value?)]) where T.Value : Sendable {


### PR DESCRIPTION
Empty `AttributedSubstring`s should contain no runs, however there was a small index calculation bug in which empty substrings in the middle of the string (neither at the start or end indices) would incorrectly expand their ranges to the next run. This resolves the bug by ensuring that the `Runs.startIndex == Runs.endIndex` for all empty substrings regardless of their location in the string.

Resolves rdar://138432081