### PR TITLE
[6.0.x] Fetching user/group info causes race conditions (#994)

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -275,20 +275,6 @@ extension _FileManagerImpl {
         }
     }
     #endif
-
-#if !os(Windows) && !os(WASI)
-    static func _userAccountNameToNumber(_ name: String) -> uid_t? {
-        name.withCString { ptr in
-            getpwnam(ptr)?.pointee.pw_uid
-        }
-    }
-    
-    static func _groupAccountNameToNumber(_ name: String) -> gid_t? {
-        name.withCString { ptr in
-            getgrnam(ptr)?.pointee.gr_gid
-        }
-    }
-#endif
 }
 
 extension FileManager {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -168,9 +168,8 @@ final class _ProcessInfo: Sendable {
 #if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
         // Darwin and Linux
         let (euid, _) = Platform.getUGIDs()
-        if let upwd = getpwuid(euid),
-           let uname = upwd.pointee.pw_name {
-            return String(cString: uname)
+        if let username = Platform.name(forUID: euid) {
+            return username
         } else if let username = self.environment["USER"] {
             return username
         }
@@ -202,9 +201,8 @@ final class _ProcessInfo: Sendable {
     var fullUserName: String {
 #if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
         let (euid, _) = Platform.getUGIDs()
-        if let upwd = getpwuid(euid),
-           let fullname = upwd.pointee.pw_gecos {
-            return String(cString: fullname)
+        if let fullName = Platform.fullName(forUID: euid) {
+            return fullName
         }
         return ""
 #elseif os(WASI)

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -469,17 +469,16 @@ extension String {
         
         #if !os(WASI) // WASI does not have user concept
         // Next, attempt to find the home directory via getpwnam/getpwuid
-        var pass: UnsafeMutablePointer<passwd>?
         if let user {
-            pass = getpwnam(user)
+            if let dir = Platform.homeDirectory(forUserName: user) {
+                return dir.standardizingPath
+            }
         } else {
             // We use the real UID instead of the EUID here when the EUID is the root user (i.e. a process has called seteuid(0))
             // In this instance, we historically do this to ensure a stable home directory location for processes that call seteuid(0)
-            pass = getpwuid(Platform.getUGIDs(allowEffectiveRootUID: false).uid)
-        }
-        
-        if let dir = pass?.pointee.pw_dir {
-            return String(cString: dir).standardizingPath
+            if let dir = Platform.homeDirectory(forUID: Platform.getUGIDs(allowEffectiveRootUID: false).uid) {
+                return dir.standardizingPath
+            }
         }
         #endif
         

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -2526,17 +2526,6 @@ final class StringTestsStdlib: XCTestCase {
         expectTrue(availableEncodings.contains("abc".smallestEncoding))
     }
 
-    func getHomeDir() -> String {
-#if os(macOS)
-        return String(cString: getpwuid(getuid()).pointee.pw_dir)
-#elseif canImport(Darwin)
-        // getpwuid() returns null in sandboxed apps under iOS simulator.
-        return NSHomeDirectory()
-#else
-        preconditionFailed("implement")
-#endif
-    }
-
     func test_addingPercentEncoding() {
         expectEqual(
             "abcd1234",


### PR DESCRIPTION
Explanation: Replaces uses of thread-unsafe user/group lookup functions with thread-safe versions
Scope: Impacts APIs that lookup user/group info (`FileManager`/`ProcessInfo`)
Original PR: https://github.com/swiftlang/swift-foundation/pull/994
Risk: Low - behavior is well tested by unit tests
Testing: Testing done via swift-ci testing and local testing
Reviewer: @parkera 