### PR TITLE
RecurrenceRule: Respect leap months

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -228,7 +228,7 @@ extension Calendar {
                     case .daily:    [.second, .minute, .hour]
                     case .weekly:   [.second, .minute, .hour, .weekday]
                     case .monthly:  [.second, .minute, .hour, .day]
-                    case .yearly:   [.second, .minute, .hour, .day, .month]
+                    case .yearly:   [.second, .minute, .hour, .day, .month, .isLeapMonth]
                 }
                 let componentsForEnumerating = recurrence.calendar._dateComponents(components, from: start) 
                 


### PR DESCRIPTION
This change makes a fix to `Calendar.RecurrenceRule` with regards to leap months and adds a few tests to verify correctness. When constructing the base sequence, we include `isLeapMonth` of the start date in the date components. Before, start dates falling on a leap month would have been treated the same as dates which do fall on the non-leap month before.