### PR TITLE
Fix typo in String.replacingTildeWithRealHomeDirectory

### DIFF
--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+DarwinSearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+DarwinSearchPaths.swift
@@ -162,10 +162,10 @@ extension String {
         }
         let euid = geteuid()
         let trueUid = euid == 0 ? getuid() : euid
-        guard let name = Platform.name(forUID: trueUid) else {
+        guard let home = Platform.homeDirectory(forUID: trueUid) else {
             return self
         }
-        return name.appendingPathComponent(String(self.dropFirst()))
+        return home.appendingPathComponent(String(self.dropFirst()))
     }
 }
 #endif // os(macOS) && FOUNDATION_FRAMEWORK


### PR DESCRIPTION
Fixes a typo where we created a path with just the user's name rather than the user's home directory due to a recent change in this function.