### PR TITLE
Restore `URL.host` bracket stripping for compatibility

### DIFF
--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -792,6 +792,42 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.host, "*.xn--poema-9qae5a.com.br")
     }
 
+    func testURLHostIPLiteralCompatibility() throws {
+        var url = URL(string: "http://[::]")!
+        XCTAssertEqual(url.host, "::")
+        XCTAssertEqual(url.host(), "::")
+
+        url = URL(string: "https://[::1]:433/")!
+        XCTAssertEqual(url.host, "::1")
+        XCTAssertEqual(url.host(), "::1")
+
+        url = URL(string: "https://[2001:db8::]/")!
+        XCTAssertEqual(url.host, "2001:db8::")
+        XCTAssertEqual(url.host(), "2001:db8::")
+
+        url = URL(string: "https://[2001:db8::]:433")!
+        XCTAssertEqual(url.host, "2001:db8::")
+        XCTAssertEqual(url.host(), "2001:db8::")
+
+        url = URL(string: "http://[fe80::a%25en1]")!
+        XCTAssertEqual(url.absoluteString, "http://[fe80::a%25en1]")
+        XCTAssertEqual(url.host, "fe80::a%en1")
+        XCTAssertEqual(url.host(percentEncoded: true), "fe80::a%25en1")
+        XCTAssertEqual(url.host(percentEncoded: false), "fe80::a%en1")
+
+        url = URL(string: "http://[fe80::a%en1]")!
+        XCTAssertEqual(url.absoluteString, "http://[fe80::a%25en1]")
+        XCTAssertEqual(url.host, "fe80::a%en1")
+        XCTAssertEqual(url.host(percentEncoded: true), "fe80::a%25en1")
+        XCTAssertEqual(url.host(percentEncoded: false), "fe80::a%en1")
+
+        url = URL(string: "http://[fe80::a%100%CustomZone]")!
+        XCTAssertEqual(url.absoluteString, "http://[fe80::a%25100%25CustomZone]")
+        XCTAssertEqual(url.host, "fe80::a%100%CustomZone")
+        XCTAssertEqual(url.host(percentEncoded: true), "fe80::a%25100%25CustomZone")
+        XCTAssertEqual(url.host(percentEncoded: false), "fe80::a%100%CustomZone")
+    }
+
     func testURLTildeFilePath() throws {
         func urlIsAbsolute(_ url: URL) -> Bool {
             if url.relativePath.utf8.first == ._slash {


### PR DESCRIPTION
As part of the new Swift `URL` implementation, we unified `URL.host` to behave like `URLComponents.host`, which will return an IP literal with the square brackets included. While RFC 3986 does say that `host` includes these square brackets, this change caused bincompat issues for clients who take IPv6 addresses from `URL.host` and pass them directly to APIs like `inet_pton(3)`.

Because `URL.host` has long behaved by stripping the brackets, and no longer stripping them can cause immediate client breakage that requires workaround, this PR restores the previous behavior. Thank you to all who worked around it for the time being.

Resolves https://github.com/swiftlang/swift-foundation/issues/957