### PR TITLE
[6.0.x] String+Path performance improvements and bug fixes

### DIFF
--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -258,6 +258,12 @@ class DataIOTests : XCTestCase {
         XCTAssertEqual("/a/b/c/".deletingLastPathComponent(), "/a/b")
         XCTAssertEqual("hello".deletingLastPathComponent(), "")
         XCTAssertEqual("hello/".deletingLastPathComponent(), "")
+        XCTAssertEqual("/hello/".deletingLastPathComponent(), "/")
+        XCTAssertEqual("hello///".deletingLastPathComponent(), "")
+        XCTAssertEqual("a/".deletingLastPathComponent(), "")
+        XCTAssertEqual("a/b".deletingLastPathComponent(), "a")
+        XCTAssertEqual("a/b/".deletingLastPathComponent(), "a")
+        XCTAssertEqual("a//b//".deletingLastPathComponent(), "a")
     }
     
     func testAppendingPathComponent() {
@@ -292,6 +298,8 @@ class DataIOTests : XCTestCase {
         XCTAssertEqual("/a/b/c/".lastPathComponent, "c")
         XCTAssertEqual("hello".lastPathComponent, "hello")
         XCTAssertEqual("hello/".lastPathComponent, "hello")
+        XCTAssertEqual("hello///".lastPathComponent, "hello")
+        XCTAssertEqual("//a//".lastPathComponent, "a")
     }
 }
 


### PR DESCRIPTION
**Explanation:** Rewrote String+Path functions for performance and functionality. ~2-6x speedup. Fixed bugs where `.deletingLastPathComponent()` didn't skip over trailing slashes, and where `"/path/".deletingLastPathComponent()` would delete the entire string instead of leaving the leading `"/"` (https://github.com/swiftlang/swift-foundation/issues/980).
**Scope:** Impacts various Foundation types like `URL` that use these `String` extensions on file paths.
**Original PR:** #927 
**Risk:** Low/Med - Well-tested to ensure correct behavior, but does touch several commonly used `String` extensions.
**Testing:** Added unit tests, local, swift-ci, stable in `main` for over a month
**Reviewer:** @jmschonfeld 

Resolves https://github.com/swiftlang/swift-foundation/issues/980 for `release/6.0`