### PR TITLE
Fix `IS_DECOMPOSABLE` flag when bridging to `CFURL`

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -658,9 +658,14 @@ public struct URL: Equatable, Sendable, Hashable {
         let string = parseInfo.urlString
         var ranges = [CFRange]()
         var flags: _CFURLFlags = [
-            .isDecomposable,
             .originalAndURLStringsMatch,
         ]
+
+        // CFURL considers a URL decomposable if it does not have a scheme
+        // or if there is a slash directly following the scheme.
+        if parseInfo.scheme == nil || parseInfo.hasAuthority || parseInfo.path.utf8.first == ._slash {
+            flags.insert(.isDecomposable)
+        }
 
         if let schemeRange = parseInfo.schemeRange {
             flags.insert(.hasScheme)


### PR DESCRIPTION
`CFURL` considers a URL decomposable if it can be decomposed into its component parts according to RFC 1808. This varies slightly from an analogous definition of decomposable for RFC 3986, specifically when it comes to relative paths as found in `data:` URLs.

This PR adjusts Swift URL's `CFURL` creation logic to add the `IS_DECOMPOSABLE` flag only if it does not have a scheme or if there is a slash directly following the scheme.