### PR TITLE
Calendar.RecurrenceRule: Only match weekday components when filtering by weekday

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -614,8 +614,7 @@ extension Calendar {
     ///   weekdays of intereset, or to filter a list of dates
     func _weekdayComponents(for weekdays: [Calendar.RecurrenceRule.Weekday],
                             in parent: Calendar.Component,
-                            anchor: Date,
-                            anchorComponents: DateComponents? = nil) -> [DateComponents]? {
+                            anchor: Date) -> [DateComponents]? {
         /// Map of weekdays to which occurences of the weekday we are interested
         /// in. `1` is the first such weekday in the interval, `-1` is the last.
         /// An empty array indicates that any weekday is valid
@@ -645,9 +644,6 @@ extension Calendar {
         } else {
             .weekOfYear
         }
-        /// The components we return for matching and enumeration
-        let componentSet: Calendar.ComponentSet = [.weekday, .hour, .minute, .second]
-        
                 
         guard
             let interval = dateInterval(of: parent, for: anchor)
@@ -656,7 +652,6 @@ extension Calendar {
         lazy var weekRange = range(of: weekComponent, in: parent, for: anchor)!
         
         var result: [DateComponents] = []
-        let anchorComponents = anchorComponents ?? _dateComponents(componentSet, from: anchor)
         
         lazy var firstWeekday = component(.weekday, from: interval.start)
         // The end of the interval would always be midnight on the day after, so
@@ -667,7 +662,7 @@ extension Calendar {
         for (weekday, occurences) in map {
             let weekdayIdx = weekday.icuIndex
             if occurences == [] {
-                var components = anchorComponents
+                var components = DateComponents()
                 components.setValue(nil, for: weekComponent)
                 components.weekday = weekdayIdx
                 result.append(components)
@@ -675,7 +670,7 @@ extension Calendar {
                 lazy var firstWeek = weekRange.lowerBound + (weekdayIdx < firstWeekday ? 1 : 0)
                 lazy var lastWeek  = weekRange.upperBound - (weekdayIdx > lastWeekday  ? 1 : 0)
                 for occurence in occurences {
-                    var components = anchorComponents
+                    var components = DateComponents()
                     if occurence > 0 {
                         components.setValue(firstWeek - 1 + occurence, for: weekComponent)
                     } else {
@@ -815,7 +810,7 @@ extension Calendar {
         if let weekdays = combinationComponents.weekdays {
             dates = try dates.flatMap { date, comps in
                 let parentComponent: Calendar.Component = .month
-                let weekdayComponents = _weekdayComponents(for: weekdays, in: parentComponent, anchor: date, anchorComponents: comps)
+                let weekdayComponents = _weekdayComponents(for: weekdays, in: parentComponent, anchor: date)
                 let dates = try weekdayComponents!.map { comps in 
                     var date = date
                     if let result = try dateAfterMatchingWeekOfYear(startingAt: date, components: comps, direction: .forward) {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -739,4 +739,31 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1767484800.0)) // 2026-01-04T00:00:00-0000
         XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1799020800.0)) // 2027-01-04T00:00:00-0000
     }
+
+    func testWeekdayFilter() {
+        var alarms = Calendar.RecurrenceRule(calendar: gregorian, frequency: .daily)
+        alarms.weekdays = [.every(.monday), .every(.tuesday), .every(.wednesday), .every(.thursday), .every(.friday)]
+        alarms.hours = [7, 8]
+        alarms.minutes = [0, 15, 30, 45]
+
+        let start = Date(timeIntervalSince1970: 1695304800.0) // 2023-09-21T14:00:00-0000
+        var results = alarms.recurrences(of: start).makeIterator()
+
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695366000.0)) // 2023-09-22T07:00:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695366900.0)) // 2023-09-22T07:15:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695367800.0)) // 2023-09-22T07:30:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695368700.0)) // 2023-09-22T07:45:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695369600.0)) // 2023-09-22T08:00:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695370500.0)) // 2023-09-22T08:15:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695371400.0)) // 2023-09-22T08:30:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695372300.0)) // 2023-09-22T08:45:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695625200.0)) // 2023-09-25T07:00:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695626100.0)) // 2023-09-25T07:15:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695627000.0)) // 2023-09-25T07:30:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695627900.0)) // 2023-09-25T07:45:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695628800.0)) // 2023-09-25T08:00:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695629700.0)) // 2023-09-25T08:15:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695630600.0)) // 2023-09-25T08:30:00-0000
+        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695631500.0)) // 2023-09-25T08:45:00-0000
+    }
 }


### PR DESCRIPTION

When filtering by weekdays, we match the dates against a set of date components. These components happened to contain the hour, minute and second components from the anchor date, so filtering would undo previous expansions by hour, minute and second.