### PR TITLE
Don't fail `createDirectory` if directory is created concurrently by another process

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -269,7 +269,18 @@ extension _FileManagerImpl {
 
                 let parent = path.deletingLastPathComponent()
                 if !parent.isEmpty {
-                    try createDirectory(atPath: parent, withIntermediateDirectories: true, attributes: attributes)
+                    do {
+                        try createDirectory(atPath: parent, withIntermediateDirectories: true, attributes: attributes)
+                    } catch {
+                        var isDirectory: Bool = false
+                        if fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory {
+                            // `createDirectory` failed but we have a directory now. This might happen if the directory
+                            // is created by another process between the check above and the call to `createDirectory`.
+                            // Since we have the expected end result, this is fine.
+                        } else {
+                            throw error
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
The recursive directory might have been created concurrently by another process between the check for `fileExists` and `createDirectory(atPath: parent, …)`, causing `createDirectory` to fail even though we would have had the expected result.

Ironically, I found this issue as a nondeterministic failure in Swift CI while fixing the same bug in swift-tools-support-core: https://github.com/swiftlang/swift-tools-support-core/pull/490