### PR TITLE
[6.0.x] Restore URL.host bracket stripping for compatibility

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1207,21 +1207,38 @@ public struct URL: Equatable, Sendable, Hashable {
             return nil
         }
         #endif
-        guard let encodedHost else { return nil }
-        let didPercentEncodeHost = hasAuthority ? _parseInfo.didPercentEncodeHost : _baseParseInfo?.didPercentEncodeHost ?? false
-        if percentEncoded {
-            if didPercentEncodeHost {
-                return String(encodedHost)
-            }
-            guard let decoded = Parser.IDNADecodeHost(encodedHost) else {
+        guard let encodedHost else {
+            return nil
+        }
+
+        func requestedHost() -> String? {
+            let didPercentEncodeHost = hasAuthority ? _parseInfo.didPercentEncodeHost : _baseParseInfo?.didPercentEncodeHost ?? false
+            if percentEncoded {
+                if didPercentEncodeHost {
+                    return encodedHost
+                }
+                guard let decoded = Parser.IDNADecodeHost(encodedHost) else {
+                    return encodedHost
+                }
+                return Parser.percentEncode(decoded, component: .host)
+            } else {
+                if didPercentEncodeHost {
+                    return Parser.percentDecode(encodedHost)
+                }
                 return encodedHost
             }
-            return Parser.percentEncode(decoded, component: .host)
+        }
+
+        guard let requestedHost = requestedHost() else {
+            return nil
+        }
+
+        let isIPLiteral = hasAuthority ? _parseInfo.isIPLiteral : _baseParseInfo?.isIPLiteral ?? false
+        if isIPLiteral {
+            // Strip square brackets to be compatible with old URL.host behavior
+            return String(requestedHost.utf8.dropFirst().dropLast())
         } else {
-            if didPercentEncodeHost {
-                return Parser.percentDecode(encodedHost)
-            }
-            return String(encodedHost)
+            return requestedHost
         }
     }
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -642,6 +642,42 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.host, "*.xn--poema-9qae5a.com.br")
     }
 
+    func testURLHostIPLiteralCompatibility() throws {
+        var url = URL(string: "http://[::]")!
+        XCTAssertEqual(url.host, "::")
+        XCTAssertEqual(url.host(), "::")
+
+        url = URL(string: "https://[::1]:433/")!
+        XCTAssertEqual(url.host, "::1")
+        XCTAssertEqual(url.host(), "::1")
+
+        url = URL(string: "https://[2001:db8::]/")!
+        XCTAssertEqual(url.host, "2001:db8::")
+        XCTAssertEqual(url.host(), "2001:db8::")
+
+        url = URL(string: "https://[2001:db8::]:433")!
+        XCTAssertEqual(url.host, "2001:db8::")
+        XCTAssertEqual(url.host(), "2001:db8::")
+
+        url = URL(string: "http://[fe80::a%25en1]")!
+        XCTAssertEqual(url.absoluteString, "http://[fe80::a%25en1]")
+        XCTAssertEqual(url.host, "fe80::a%en1")
+        XCTAssertEqual(url.host(percentEncoded: true), "fe80::a%25en1")
+        XCTAssertEqual(url.host(percentEncoded: false), "fe80::a%en1")
+
+        url = URL(string: "http://[fe80::a%en1]")!
+        XCTAssertEqual(url.absoluteString, "http://[fe80::a%25en1]")
+        XCTAssertEqual(url.host, "fe80::a%en1")
+        XCTAssertEqual(url.host(percentEncoded: true), "fe80::a%25en1")
+        XCTAssertEqual(url.host(percentEncoded: false), "fe80::a%en1")
+
+        url = URL(string: "http://[fe80::a%100%CustomZone]")!
+        XCTAssertEqual(url.absoluteString, "http://[fe80::a%25100%25CustomZone]")
+        XCTAssertEqual(url.host, "fe80::a%100%CustomZone")
+        XCTAssertEqual(url.host(percentEncoded: true), "fe80::a%25100%25CustomZone")
+        XCTAssertEqual(url.host(percentEncoded: false), "fe80::a%100%CustomZone")
+    }
+
     func testURLTildeFilePath() throws {
         var url = URL(filePath: "~")
         // "~" must either be expanded to an absolute path or resolved against a base URL


### PR DESCRIPTION
**Explanation:** Strips the square brackets from IP literal hosts when calling `URL.host`. This restores previous behavior and prevents bincompat issues for clients who take IPv6 addresses from `URL.host` and pass them directly to APIs like `inet_pton(3)`.
**Scope:** Only impacts `URL.host` and `URL.host()` when the host is an IP literal.
**Original PR:** #1008   
**Risk:** Low - Small change to restore previous behavior.
**Testing:** Added unit test, swift-ci, stable in `main`
**Reviewer:** @parkera  

Resolves https://github.com/swiftlang/swift-foundation/issues/957 for `release/6.0`