### PR TITLE
Ensure predicate diagnostics contain source information when possible

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ var dependencies: [Package.Dependency] {
                 branch: "main"),
             .package(
                 url: "https://github.com/swiftlang/swift-syntax",
-                from: "600.0.0")
+                branch: "main")
         ]
     }
 }


### PR DESCRIPTION
`#Predicate` currently performs its transformation in two passes over the AST:

1. Rewrite all optional chaining as explicit calls to `flatMap` (ex. `foo?.bar` --> `foo.flatMap { $0.bar }`)
2. Perform transformation to `PredicateExpression` builder calls (ex. `foo.bar()` --> `PredicateExpressions.build_bar(PredicateExpressions.build_Arg(foo))`)

Unfortunately, performing the rewrite in Step 1 creates a new AST that lacks all source information from the original code in the source file. This means that when diagnostics are emitted during pass 2, the diagnostics are detached from any source locations and only appear as standalone messages in the build log which makes for a challenging debugging experience.

After talking with the swift-syntax folks, in the fullness of time we will need to rewrite the `#Predicate` implementation to perform its rewrite in a single pass to retain all source location information. However, until we can perform such a rewrite (which is not trivial) this PR helps by "skipping" step 1 when optional chaining is not present. For predicates that don't contain optional chaining, pass 1 will now just pass on the original AST with source information so that pass 2 emits diagnostics with attached locations. This change also updates our unit testing infrastructure to fail if any diagnostics are emitted without attached source locations so that we'll pick up issues like this in CI in the future.

_Note:_ I also had to switch the package dependency from `swift-syntax@600.0.0` to `swift-syntax@main`. This is fine because when building Foundation in the toolchain, we build against `main` anyways and this mirrors how we build against `swift-foundation-icu`.

Resolves rdar://125125964