### PR TITLE
improve CustomNSError.errorDomain calculation

### DIFF
--- a/Sources/FoundationEssentials/Error/CocoaError.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError.swift
@@ -229,7 +229,7 @@ public protocol CustomNSError : Error {
 public extension CustomNSError {
     /// Default domain of the error.
     static var errorDomain: String {
-        return String(reflecting: self)
+        return _typeName(self, qualified: true)
     }
 
     /// The error code within the given domain.


### PR DESCRIPTION
Optimized `CustomNSError.errorDomain` calculation.

`String(reflecting:)` for `Any.Type` objects eventually calls `_type(:qualified:)`. But `String(reflecting:)` call has overhead because of `as?` checks. 

All details are listed in [issue](https://github.com/swiftlang/swift-foundation/issues/1031).

Also I've opened same MR for non-Darwin platforms: https://github.com/swiftlang/swift-corelibs-foundation/pull/5132