### PR TITLE
FileManager: avoid a TOCTOU issue in computing CWD

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -466,13 +466,22 @@ extension _FileManagerImpl {
     
     var currentDirectoryPath: String? {
 #if os(Windows)
-        let dwLength: DWORD = GetCurrentDirectoryW(0, nil)
-        return withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) {
-            if GetCurrentDirectoryW(dwLength, $0.baseAddress) == dwLength - 1 {
-                return String(decodingCString: $0.baseAddress!, as: UTF16.self)
+        var dwLength: DWORD = GetCurrentDirectoryW(0, nil)
+        guard dwLength > 0 else { return nil }
+
+        for _ in 0 ... 8 {
+            if let szCurrentDirectory = withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength), {
+                let dwResult: DWORD = GetCurrentDirectoryW(dwLength, $0.baseAddress)
+                if dwResult == dwLength - 1 {
+                    return String(decodingCString: $0.baseAddress!, as: UTF16.self)
+                }
+                dwLength = dwResult
+                return nil
+            }) {
+                return szCurrentDirectory
             }
-            return nil
         }
+        return nil
 #else
         withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
             guard getcwd(buffer.baseAddress!, FileManager.MAX_PATH_SIZE) != nil else {


### PR DESCRIPTION
On Windows, we could potentially return a `nil` for the current working directory in the rare case that the current working directory was changed during the computation:

```swift
let dwLength: DWORD = GetCurrentDirectoryW(0, nil)                                // 1
return withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) {
    if GetCurrentDirectoryW(dwLength, $0.baseAddress) == dwLength - 1 {           // 2
        return String(decodingCString: $0.baseAddress!, as: UTF16.self)
    }
    return nil                                                                    // 3
}
```

Consider the case where at step 1, we receive $n$. We then are interrupted, the CWD changed. We then perform step 2, where we receive $m$ (st $m != n$). We would then proceed to point 3, where we return `nil`. Avoid this TOCTOU issue by repeating this operation to a fixed point.

Because we are guaranteed a current directory on Windows (unless the initial query for the buffer size fails), we will eventually succeed. In order to avoid a DoS attack vector, limit the attempt to quiescence to a fixed number.

Fixes: #1034 