### PR TITLE
`URL.path` should not strip trailing slash for root paths on Windows

### DIFF
--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -340,13 +340,39 @@ final class URLTests : XCTestCase {
 
     #if os(Windows)
     func testURLWindowsDriveLetterPath() throws {
-        let url = URL(filePath: "C:\\test\\path", directoryHint: .notDirectory)
+        var url = URL(filePath: #"C:\test\path"#, directoryHint: .notDirectory)
         // .absoluteString and .path() use the RFC 8089 URL path
         XCTAssertEqual(url.absoluteString, "file:///C:/test/path")
         XCTAssertEqual(url.path(), "/C:/test/path")
         // .path and .fileSystemPath strip the leading slash
         XCTAssertEqual(url.path, "C:/test/path")
         XCTAssertEqual(url.fileSystemPath, "C:/test/path")
+
+        url = URL(filePath: #"C:\"#, directoryHint: .isDirectory)
+        XCTAssertEqual(url.absoluteString, "file:///C:/")
+        XCTAssertEqual(url.path(), "/C:/")
+        XCTAssertEqual(url.path, "C:/")
+        XCTAssertEqual(url.fileSystemPath, "C:/")
+
+        url = URL(filePath: #"C:\\\"#, directoryHint: .isDirectory)
+        XCTAssertEqual(url.absoluteString, "file:///C:///")
+        XCTAssertEqual(url.path(), "/C:///")
+        XCTAssertEqual(url.path, "C:/")
+        XCTAssertEqual(url.fileSystemPath, "C:/")
+
+        url = URL(filePath: #"\C:\"#, directoryHint: .isDirectory)
+        XCTAssertEqual(url.absoluteString, "file:///C:/")
+        XCTAssertEqual(url.path(), "/C:/")
+        XCTAssertEqual(url.path, "C:/")
+        XCTAssertEqual(url.fileSystemPath, "C:/")
+
+        let base = URL(filePath: #"\d:\path\"#, directoryHint: .isDirectory)
+        url = URL(filePath: #"%43:\fake\letter"#, directoryHint: .notDirectory, relativeTo: base)
+        // ":" is encoded to "%3A" in the first path segment so it's not mistaken as the scheme separator
+        XCTAssertEqual(url.relativeString, "%2543%3A/fake/letter")
+        XCTAssertEqual(url.path(), "/d:/path/%2543%3A/fake/letter")
+        XCTAssertEqual(url.path, "d:/path/%43:/fake/letter")
+        XCTAssertEqual(url.fileSystemPath, "d:/path/%43:/fake/letter")
     }
     #endif
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -373,6 +373,17 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.path(), "/d:/path/%2543%3A/fake/letter")
         XCTAssertEqual(url.path, "d:/path/%43:/fake/letter")
         XCTAssertEqual(url.fileSystemPath, "d:/path/%43:/fake/letter")
+
+        let cwd = URL.currentDirectory()
+        var iter = cwd.path().utf8.makeIterator()
+        if iter.next() == ._slash,
+           let driveLetter = iter.next(), driveLetter.isLetter!,
+           iter.next() == ._colon {
+            let path = #"\\?\"# + "\(Unicode.Scalar(driveLetter))" + #":\"#
+            url = URL(filePath: path, directoryHint: .isDirectory)
+            XCTAssertEqual(url.path.last, "/")
+            XCTAssertEqual(url.fileSystemPath.last, "/")
+        }
     }
     #endif
 


### PR DESCRIPTION
We should not strip the trailing slash when getting the `fileSystemPath` for `C:\` on Windows, since `C:\` represents the root while `C:` does not. Similarly, we should not strip the trailing slash for any UNC path, since the trailing slash might be root.

Resolves https://github.com/swiftlang/swift-foundation/issues/976 and https://github.com/swiftlang/swift-foundation/issues/977