### PR TITLE
JSONEncoder using large amount of memory when encoding array of structs

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -589,7 +589,7 @@ enum JSONFuture {
         var dict: [String: JSONFuture] = [:]
 
         init() {
-            self.dict.reserveCapacity(20)
+            self.dict.reserveCapacity(4)
         }
 
         init(dict: [String: JSONFuture]) {


### PR DESCRIPTION
Pulling in a change from previous swift-corelibs-foundation code in an attempt to reduce memory consumption without making a large sacrifice on CPU