### PR TITLE
rdar://133742708 (JSONDecoder crashes whole app on invalid input instead of throwing Error)

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -786,8 +786,8 @@ extension JSONDecoderImpl: Decoder {
 
         var iter = jsonMap.makeObjectIterator(from: region.startOffset)
         while let (keyValue, value) = iter.next() {
-            // Failing to unwrap a string here is impossible, as scanning already guarantees that dictionary keys are strings.
-            let key = try! self.unwrapString(from: keyValue, for: dictCodingPathNode, _CodingKey?.none)
+            // We know these values are keys, but UTF-8 decoding could still fail.
+            let key = try self.unwrapString(from: keyValue, for: dictCodingPathNode, _CodingKey?.none)
             let value = try self.unwrap(value, as: dictType.elementType, for: dictCodingPathNode, _CodingKey(stringValue: key)!)
             result[key]._setIfNil(to: value)
         }
@@ -1202,14 +1202,14 @@ extension JSONDecoderImpl {
             switch keyDecodingStrategy {
             case .useDefaultKeys:
                 while let (keyValue, value) = iter.next() {
-                    // Failing to unwrap a string here is impossible, as scanning already guarantees that dictionary keys are strings.
-                    let key = try! impl.unwrapString(from: keyValue, for: codingPathNode, _CodingKey?.none)
+                    // We know these values are keys, but UTF-8 decoding could still fail.
+                    let key = try impl.unwrapString(from: keyValue, for: codingPathNode, _CodingKey?.none)
                     result[key]._setIfNil(to: value)
                 }
             case .convertFromSnakeCase:
                 while let (keyValue, value) = iter.next() {
-                    // Failing to unwrap a string here is impossible, as scanning already guarantees that dictionary keys are strings.
-                    let key = try! impl.unwrapString(from: keyValue, for: codingPathNode, _CodingKey?.none)
+                    // We know these values are keys, but UTF-8 decoding could still fail.
+                    let key = try impl.unwrapString(from: keyValue, for: codingPathNode, _CodingKey?.none)
 
                     // Convert the snake case keys in the container to camel case.
                     // If we hit a duplicate key after conversion, then we'll use the first one we saw.
@@ -1219,8 +1219,8 @@ extension JSONDecoderImpl {
             case .custom(let converter):
                 let codingPathForCustomConverter = codingPathNode.path
                 while let (keyValue, value) = iter.next() {
-                    // Failing to unwrap a string here is impossible, as scanning already guarantees that dictionary keys are strings.
-                    let key = try! impl.unwrapString(from: keyValue, for: codingPathNode, _CodingKey?.none)
+                    // We know these values are keys, but UTF-8 decoding could still fail. 
+                    let key = try impl.unwrapString(from: keyValue, for: codingPathNode, _CodingKey?.none)
 
                     var pathForKey = codingPathForCustomConverter
                     pathForKey.append(_CodingKey(stringValue: key)!)

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1641,6 +1641,16 @@ final class JSONEncoderTests : XCTestCase {
         
         XCTAssertThrowsError(try decoder.decode(String.self, from: utf8_BOM + json.data(using: String._Encoding.utf16BigEndian)!))
     }
+    
+    func test_invalidKeyUTF8() {
+        // {"key[255]":"value"}
+        // The invalid UTF-8 byte sequence in the key should trigger a thrown error, not a crash.
+        let data = Data([123, 34, 107, 101, 121, 255, 34, 58, 34, 118, 97, 108, 117, 101, 34, 125])
+        struct Example: Decodable {
+            let key: String
+        }
+        XCTAssertThrowsError(try JSONDecoder().decode(Example.self, from: data))
+    }
 
     func test_valueNotFoundError() {
         struct ValueNotFound : Decodable {


### PR DESCRIPTION
These `try!` assertions were incorrect. They were focused on the fact that the type of the value in the input JSON was guaranteed to be a string, but with the on-demand parsing behavior, there is no longer any initial UTF-8 validation step, which means decoding the keys into String values could fail. This needs to actually throw an error instead of trapping. Fortunately, this is an (embarrassingly) easy change to make.