### PR TITLE
FileManager Entry Points for ObjC Directory Enumeration

### DIFF
--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+DarwinSearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+DarwinSearchPaths.swift
@@ -57,9 +57,9 @@ struct _DarwinSearchPathsSequence: Sequence {
             switch directory {
             #if os(macOS) && FOUNDATION_FRAMEWORK
             case .trashDirectory:
-                state = .special(domainMask.union([.userDomainMask, .localDomainMask]))
+                state = .special(domainMask.intersection([.userDomainMask, .localDomainMask]))
             case ._homeDirectory, .applicationScriptsDirectory:
-                state = .special(domainMask.union(.userDomainMask))
+                state = .special(domainMask.intersection(.userDomainMask))
             #endif
                 
             default:

--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+DarwinSearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+DarwinSearchPaths.swift
@@ -155,6 +155,11 @@ struct _DarwinSearchPathsSequence: Sequence {
 }
 
 #if os(macOS) && FOUNDATION_FRAMEWORK
+@_cdecl("_NSRealHomeDirectory")
+internal func _NSRealHomeDirectory() -> String {
+    "~".replacingTildeWithRealHomeDirectory
+}
+
 extension String {
     internal var replacingTildeWithRealHomeDirectory: String {
         guard self == "~" || self.hasPrefix("~/") else {

--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+SearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+SearchPaths.swift
@@ -57,6 +57,13 @@ extension FileManager.SearchPathDomainMask {
     }
 }
 
+#if FOUNDATION_FRAMEWORK
+@_cdecl("_NSSearchPathsForDirectoryInDomain")
+func _NSSearchPaths(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, expandTilde: Bool) -> [String] {
+    _SearchPathURLs(for: directory, in: domain, expandTilde: expandTilde).map(\.path)
+}
+#endif
+
 func _SearchPathURLs(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, expandTilde: Bool) -> some Sequence<URL> {
     #if canImport(Darwin)
     let basic = _DarwinSearchPathsSequence(directory: directory, domainMask: domain.intersection(.valid)).lazy.map {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -840,6 +840,13 @@ final class FileManagerTests : XCTestCase {
             }
         }
     }
+    
+    func testSpecialTrashDirectoryDuplication() throws {
+        try FileManagerPlayground {}.test { fileManager in
+            let trashURLs = fileManager.urls(for: .trashDirectory, in: .userDomainMask)
+            XCTAssertEqual(trashURLs.count, 1, "There should only be one trash directory for the user domain, found \(trashURLs)")
+        }
+    }
     #endif
     
     func testSearchPaths() throws {


### PR DESCRIPTION
This adds ObjC-visible entry points to our Swift FileManager code to allow some of the ObjC directory enumeration functions to use the new Swift implementation instead of the old ObjC implementation. This also fixes a bug with enumeration of special directories on macOS that this new coverage discovered.