### PR TITLE
NSRange to Range<AttributedString.Index> conversion should be relative to sliced boundaries

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -438,7 +438,8 @@ extension Range where Bound == AttributedString.Index {
         guard range.location != NSNotFound else { return nil }
         guard range.location >= 0, range.length >= 0 else { return nil }
         let endOffset = range.location + range.length
-        let bstr = string.__guts.string
+        let bstrBounds = Range<BigString.Index>(uncheckedBounds: (string.startIndex._value, string.endIndex._value))
+        let bstr = string.__guts.string[bstrBounds]
         guard endOffset <= bstr.utf16.count else { return nil }
 
         let start = bstr.utf16.index(bstr.startIndex, offsetBy: range.location)

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -2372,6 +2372,14 @@ E {
         }
     }
     
+    func testNSRangeConversionOnSlice() throws {
+        let str = AttributedString("012345")
+        let slice = str[str.index(str.startIndex, offsetByCharacters: 3) ..< str.endIndex]
+        let nsRange = NSRange(location: 0, length: 2)
+        let range = try XCTUnwrap(Range(nsRange, in: slice))
+        XCTAssertEqual(String(slice[range].characters), "34")
+    }
+    
 #endif // FOUNDATION_FRAMEWORK
     
     func testOOBRangeConversion() {


### PR DESCRIPTION
When converting an `NSRange` to a `Range<AttributedString.Index>` via our API, the conversion currently does not take the provided `AttributedStringProtocol`'s `startIndex`/`endIndex` into account. This means that the `NSRange`'s location is considered relative to the base's start for an `AttributedSubstring` rather than the substring's start, leading to conversion failing because the `NSRange` is often considered beyond the bounds of the slice.

This updates the conversion to operate on a slice of the underlying `BigString` so that the range calculation is performed from the slice's `startIndex` rather than the base's `startIndex`.