### PR TITLE
Detect current timezone on Android the same as Linux

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -163,7 +163,7 @@ struct TimeZoneCache : Sendable, ~Copyable {
                 }
             }
             
-#if os(Linux)
+#if os(Linux) || os(Android)
             // Try localtime
             tzset()
             var t = time(nil)


### PR DESCRIPTION
The logic for fallback timezone detection on Android should be the same as Linux.