### PR TITLE
Expose `_identifierCapturingPreferences` for `NSLocale`

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
@@ -508,7 +508,11 @@ internal class _NSSwiftLocale: _NSLocaleBridge, @unchecked Sendable {
     override func _numberingSystem() -> String! {
         locale.numberingSystem.identifier
     }
-    
+
+    override func _identifierCapturingPreferences() -> String {
+        locale.identifierCapturingPreferences
+    }
+
     override func _localeWithNewCalendarIdentifier(_ calendarIdentifier: String?) -> NSLocale? {
         guard let calendarIdentifier else {
             // No real need to copy here; Locale is immutable


### PR DESCRIPTION
`NSLocale` wants to use `Locale._identifierCapturingPreferences` when calling into ICU.

For 55573864