### PR TITLE
Add FoundationPreview 6.2 as an allowed availability annotation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ list(APPEND _SwiftFoundation_versions
     "0.3"
     "0.4"
     "6.0.2"
+    "6.2"
     )
 
 # Each availability name to define

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let availabilityTags: [_Availability] = [
     _Availability("FoundationPredicate", availability: .macOS14_0), // Predicate relies on pack parameter runtime support
     _Availability("FoundationPredicateRegex", availability: .macOS15_0) // Predicate regexes rely on new stdlib APIs
 ]
-let versionNumbers = ["0.1", "0.2", "0.3", "0.4", "6.0.2"]
+let versionNumbers = ["0.1", "0.2", "0.3", "0.4", "6.0.2", "6.2"]
 
 // Availability Macro Utilities
 


### PR DESCRIPTION
Now that we've branched for `release/6.1`, changes targeting main will need to be annotated via a new 6.2-aligned availability. This PR adds `FoundationPreview 6.2` as an allowed availability annotation so that future API work can use this to properly mark availability on platforms where Foundation ships as part of an SDK.