### PR TITLE
Properly write non-ASCII file names on Windows for file creation

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1049,4 +1049,18 @@ final class FileManagerTests : XCTestCase {
         XCTAssertEqual(FileManager.default.homeDirectory(forUser: UUID().uuidString), fallbackPath)
         #endif
     }
+
+    func testWindowsDirectoryCreationCrash() throws {
+        try FileManagerPlayground {
+            Directory("a\u{301}") {
+
+            }
+        }.test {
+            XCTAssertTrue($0.fileExists(atPath: "a\u{301}"))
+            let data = randomData()
+            XCTAssertTrue($0.createFile(atPath: "a\u{301}/test", contents: data))
+            XCTAssertTrue($0.fileExists(atPath: "a\u{301}/test"))
+            XCTAssertEqual($0.contents(atPath: "a\u{301}/test"), data)
+        }
+    }
 }


### PR DESCRIPTION
Previously, using `Data.write(to:)` (or `FileManager.createFile(atPath:)` which calls to that function) with a path that contained non-ASCII characters would crash. This crash was caused by an incorrect buffer length calculation that used `String.count` instead of the actual length of the buffer (which will differ for non-ASCII paths). Fixing the crash however revealed incorrect behavior where file creation would fail due to providing a UTF-8 file name to `_sopen_s`. Instead, we need to transcode the file name to UTF-16 and open the file with `_wsopen_s` to ensure that non-ASCII file names can be opened. The added unit test previously crashed (and then failed when the crash was resolved) but now successfully creates the file.

Resolves https://github.com/swiftlang/swift-foundation/issues/1058