### PR TITLE
[6.1] Properly write non-ASCII file names on Windows for file creation

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1037,4 +1037,18 @@ final class FileManagerTests : XCTestCase {
         XCTAssertEqual(FileManager.default.homeDirectory(forUser: UUID().uuidString), fallbackPath)
         #endif
     }
+
+    func testWindowsDirectoryCreationCrash() throws {
+        try FileManagerPlayground {
+            Directory("a\u{301}") {
+
+            }
+        }.test {
+            XCTAssertTrue($0.fileExists(atPath: "a\u{301}"))
+            let data = randomData()
+            XCTAssertTrue($0.createFile(atPath: "a\u{301}/test", contents: data))
+            XCTAssertTrue($0.fileExists(atPath: "a\u{301}/test"))
+            XCTAssertEqual($0.contents(atPath: "a\u{301}/test"), data)
+        }
+    }
 }


### PR DESCRIPTION
  - **Explanation**: Fixes creation of files on Windows when the file's path contains non-ASCII characters
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Impacts file creation on Windows via `Data` and `FileManager`
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: https://github.com/swiftlang/swift-foundation/issues/1058
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift-foundation/pull/1059
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low, scope is narrow and change is well tested
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: local testing and testing in CI
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @compnerd 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->
