### PR TITLE
Clean up Swift URL build flags

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -608,11 +608,11 @@ public struct URLResourceValues {
 extension URLResourceValues : Sendable {}
 #endif // FOUNDATION_FRAMEWORK
 
-#if FOUNDATION_FRAMEWORK_NSURL
+#if FOUNDATION_FRAMEWORK
 internal func foundation_swift_url_enabled() -> Bool {
     return _foundation_swift_url_feature_enabled()
 }
-#elseif FOUNDATION_FRAMEWORK
+#else
 internal func foundation_swift_url_enabled() -> Bool { return true }
 #endif
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -847,6 +847,7 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.host(percentEncoded: false), "fe80::a%100%CustomZone")
     }
 
+    #if !os(Windows)
     func testURLTildeFilePath() throws {
         func urlIsAbsolute(_ url: URL) -> Bool {
             if url.relativePath.utf8.first == ._slash {
@@ -870,6 +871,7 @@ final class URLTests : XCTestCase {
         XCTAssertTrue(urlIsAbsolute(url))
         XCTAssertEqual(url.path().utf8.last, ._slash)
     }
+    #endif // !os(Windows)
 
     func testURLPathExtensions() throws {
         var url = URL(filePath: "/path", directoryHint: .notDirectory)

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -162,7 +162,6 @@ final class URLTests : XCTestCase {
             "http:g"        :  "http:g", // For strict parsers
         ]
 
-        #if FOUNDATION_FRAMEWORK
         let testsFailingWithoutSwiftURL = Set([
             "",
             "../../../g",
@@ -170,14 +169,11 @@ final class URLTests : XCTestCase {
             "/./g",
             "/../g",
         ])
-        #endif
 
         for test in tests {
-            #if FOUNDATION_FRAMEWORK
             if !foundation_swift_url_enabled(), testsFailingWithoutSwiftURL.contains(test.key) {
                 continue
             }
-            #endif
 
             let url = URL(string: test.key, relativeTo: base)
             XCTAssertNotNil(url, "Got nil url for string: \(test.key)")
@@ -186,9 +182,7 @@ final class URLTests : XCTestCase {
     }
 
     func testURLPathAPIsResolveAgainstBase() throws {
-        #if FOUNDATION_FRAMEWORK
         try XCTSkipIf(!foundation_swift_url_enabled())
-        #endif
         // Borrowing the same test cases from RFC 3986, but checking paths
         let base = URL(string: "http://a/b/c/d;p?q")
         let tests = [
@@ -254,9 +248,7 @@ final class URLTests : XCTestCase {
     }
 
     func testURLPathComponentsPercentEncodedSlash() throws {
-        #if FOUNDATION_FRAMEWORK
         try XCTSkipIf(!foundation_swift_url_enabled())
-        #endif
 
         var url = try XCTUnwrap(URL(string: "https://example.com/https%3A%2F%2Fexample.com"))
         XCTAssertEqual(url.pathComponents, ["/", "https://example.com"])
@@ -278,9 +270,7 @@ final class URLTests : XCTestCase {
     }
 
     func testURLRootlessPath() throws {
-        #if FOUNDATION_FRAMEWORK
         try XCTSkipIf(!foundation_swift_url_enabled())
-        #endif
 
         let paths = ["", "path"]
         let queries = [nil, "query"]
@@ -412,18 +402,10 @@ final class URLTests : XCTestCase {
     func testURLRelativeDotDotResolution() throws {
         let baseURL = URL(filePath: "/docs/src/")
         var result = URL(filePath: "../images/foo.png", relativeTo: baseURL)
-        #if FOUNDATION_FRAMEWORK_NSURL
         XCTAssertEqual(result.path, "/docs/images/foo.png")
-        #else
-        XCTAssertEqual(result.path(), "/docs/images/foo.png")
-        #endif
 
         result = URL(filePath: "/../images/foo.png", relativeTo: baseURL)
-        #if FOUNDATION_FRAMEWORK_NSURL
         XCTAssertEqual(result.path, "/../images/foo.png")
-        #else
-        XCTAssertEqual(result.path(), "/../images/foo.png")
-        #endif
     }
 
     func testAppendFamily() throws {
@@ -873,11 +855,7 @@ final class URLTests : XCTestCase {
             guard url.baseURL != nil else {
                 return false
             }
-            #if !FOUNDATION_FRAMEWORK_NSURL
-            return url.path().utf8.first == ._slash
-            #else
             return url.path.utf8.first == ._slash
-            #endif
         }
 
         // "~" must either be expanded to an absolute path or resolved against a base URL


### PR DESCRIPTION
Cleans up many uses of `#if FOUNDATION_FRAMEWORK` and `FOUNDATION_FRAMEWORK_NSURL`.