### PR TITLE
Correct buffer size logic when calling `confstr`

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -560,17 +560,12 @@ extension String {
         // If it fails, we should also silently ignore the error and continue on below. This API can fail for non-programmer reasons such as the device being out of storage space when libSystem attempts to create the directory
         let length: Int = confstr(_CS_DARWIN_USER_TEMP_DIR, nil, 0)
         if length > 0 {
-            let result: String? = withUnsafeTemporaryAllocation(of: UInt8.self, capacity: length) { buffer in
+            return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: length) { buffer in
+                buffer.initialize(repeating: 0)
+                defer { buffer.deinitialize() }
                 let finalLength = confstr(_CS_DARWIN_USER_TEMP_DIR, buffer.baseAddress!, buffer.count)
                 assert(length == finalLength, "Value of _CS_DARWIN_USER_TEMP_DIR changed?")
-                if length > 0 && length < buffer.count {
-                    return String(decoding: buffer, as: UTF8.self)
-                }
-                return nil
-            }
-            
-            if let result {
-                return result
+                return String(cString: buffer.baseAddress!)
             }
         }
         #endif // canImport(Darwin)


### PR DESCRIPTION
Temporary directory lookup has faulty logic on Darwin:

```swift
if length > 0 && length < buffer.count {
    return String(decoding: buffer, as: UTF8.self)
}
```

1. We already checked 1length > 0` above, so we can eliminate that check
2. `length < buffer.count` will never be true, since we pass `capacity: length` to the `withUnsafeTemporaryAllocation` call which means that `buffer.count` will always be `length`
3. Since `buffer.count == length == finalLength`, `buffer.count` includes the null terminator but `String(decoding:)` does not stop at null terminators (in other words, the resulting string would contain a null byte at the end

This means we never actually read the value from `confstr` and always fell back to `TMPDIR`. To fix it, we just remove the unnecessary checks and switch to `String(cString:)` (and initialize the buffer to `0`s) since `confstr` is guaranteed to always copy a null-terminated string.