### PR TITLE
Darwin SearchPaths without expanding tilde produce non-tilde-based paths

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1049,6 +1049,16 @@ final class FileManagerTests : XCTestCase {
         XCTAssertEqual(FileManager.default.homeDirectory(forUser: UUID().uuidString), fallbackPath)
         #endif
     }
+    
+    func testSearchPathsWithoutExpandingTilde() throws {
+        #if !canImport(Darwin)
+        throw XCTSkip("This test is not applicable for this platform")
+        #else
+        for path in _DarwinSearchPaths(for: .libraryDirectory, in: .userDomainMask, expandTilde: false) {
+            XCTAssertTrue(path.starts(with: "~/"), "Path '\(path)' did not start with ~/ as expected")
+        }
+        #endif
+    }
 
     func testWindowsDirectoryCreationCrash() throws {
         try FileManagerPlayground {


### PR DESCRIPTION
The `String`, ObjC-based search path enumeration calls the Swift implementation which produces a `URL` and then converts each URL back to a `String` path. This process is actually making paths absolute which is fine for Swift use cases, but the ObjC API has an option to prevent expansion of the tilde directory. By passing those unexpanded paths through `URL`, we end up with paths like `/Users/USER/Library` which are incorrect because the tilde is expanded.

To avoid these behaviors and maintain support for the "legacy" ObjC behavior for string paths, I shuffled the functions around just a bit so that the implementation creates `String`s instead of `URL`s and only converts to `URL` for the Swift API. This also allows us to test the `String` results directly in our unit tests to add a test that validates this behavior even in non-`FOUNDATION_FRAMEWORK` builds.