### PR TITLE
Guard macro declarations behind `hasFeature(Macros)`

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -27,6 +27,8 @@ public struct Expression<each Input, Output> : Sendable {
     }
 }
 
+#if hasFeature(Macros)
 @freestanding(expression)
 @available(FoundationPredicate 0.4, *)
 public macro Expression<each Input, Output>(_ body: (repeat each Input) -> Output) -> Expression<repeat each Input, Output> = #externalMacro(module: "FoundationMacros", type: "ExpressionMacro")
+#endif

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -27,9 +27,11 @@ public struct Predicate<each Input> : Sendable {
     }
 }
 
+#if hasFeature(Macros)
 @freestanding(expression)
 @available(FoundationPredicate 0.1, *)
 public macro Predicate<each Input>(_ body: (repeat each Input) -> Bool) -> Predicate<repeat each Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
+#endif
 
 @available(FoundationPredicate 0.1, *)
 extension Predicate {


### PR DESCRIPTION
To enable building this package with a "minimal" Swift toolchain whose compiler does not have support for macros, guard the macro declarations behind `#if hasFeature(Macros)`. This has no effect on anything but the toolchain bootstrap process.