### PR TITLE
Home directory for non-existent user should not fall back to /var/empty or %ALLUSERSPROFILE%

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -48,7 +48,13 @@ extension _FileManagerImpl {
     }
     
     func homeDirectory(forUser userName: String?) -> URL? {
-        URL(filePath:  String.homeDirectoryPath(forUser: userName), directoryHint: .isDirectory)
+        guard let userName else {
+            return homeDirectoryForCurrentUser
+        }
+        guard let path = String.homeDirectoryPath(forUser: userName) else {
+            return nil
+        }
+        return URL(filePath: path, directoryHint: .isDirectory)
     }
     
     var temporaryDirectory: URL {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1039,14 +1039,8 @@ final class FileManagerTests : XCTestCase {
         #if canImport(Darwin) && !os(macOS)
         throw XCTSkip("This test is not applicable on this platform")
         #else
-        #if os(Windows)
-        let fallbackPath = URL(filePath: try XCTUnwrap(ProcessInfo.processInfo.environment["ALLUSERSPROFILE"]), directoryHint: .isDirectory)
-        #else
-        let fallbackPath = URL(filePath: "/var/empty", directoryHint: .isDirectory)
-        #endif
-        
-        XCTAssertEqual(FileManager.default.homeDirectory(forUser: ""), fallbackPath)
-        XCTAssertEqual(FileManager.default.homeDirectory(forUser: UUID().uuidString), fallbackPath)
+        XCTAssertNil(FileManager.default.homeDirectory(forUser: ""))
+        XCTAssertNil(FileManager.default.homeDirectory(forUser: UUID().uuidString))
         #endif
     }
     


### PR DESCRIPTION
When porting `FileManager` to swift-foundation, I made the mistake of changing the underlying home directory lookup behavior for non-existent users to fallback to `/var/empty`. I also synced this behavior to Windows where it now falls back to `%ALLUSERSPROFILE%` and updated unit tests to match this behavior. However, this behavior is incorrect. Falling back to `/var/empty` or `%ALLUSERSPROFILE%` is an alright choice for the current user, but for an arbitrary other user, we should instead return `nil` as these APIs return optional values. This PR splits the user home directory implementation into two: one for the current user that falls back to `/var/empty`/`%ALLUSERSPROFILE%` and one for a specific user that returns `nil` on failure.