### PR TITLE
Fix parsing foreign currency strings

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
@@ -54,7 +54,7 @@ extension Decimal.ParseStrategy {
             numberFormatType = .percent(format.collection)
             locale = format.locale
         } else if let format = formatStyle as? Decimal.FormatStyle.Currency {
-            numberFormatType = .currency(format.collection, format.currencyCode)
+            numberFormatType = .currency(format.collection, currencyCode: format.currencyCode)
             locale = format.locale
         } else {
             // For some reason we've managed to accept a format style of a type that we don't own, which shouldn't happen. Fallback to the default decimal style and try anyways.

--- a/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
@@ -54,7 +54,7 @@ extension Decimal.ParseStrategy {
             numberFormatType = .percent(format.collection)
             locale = format.locale
         } else if let format = formatStyle as? Decimal.FormatStyle.Currency {
-            numberFormatType = .currency(format.collection)
+            numberFormatType = .currency(format.collection, format.currencyCode)
             locale = format.locale
         } else {
             // For some reason we've managed to accept a format style of a type that we don't own, which shouldn't happen. Fallback to the default decimal style and try anyways.

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
@@ -418,7 +418,7 @@ extension FloatingPointFormatStyle {
 extension FloatingPointFormatStyle : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
-        FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
+        try FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
 }
 
@@ -426,7 +426,7 @@ extension FloatingPointFormatStyle : CustomConsumingRegexComponent {
 extension FloatingPointFormatStyle.Percent : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
-        FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
+        try FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
 }
 
@@ -434,7 +434,7 @@ extension FloatingPointFormatStyle.Percent : CustomConsumingRegexComponent {
 extension FloatingPointFormatStyle.Currency : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
-        FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
+        try FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
 }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
@@ -52,7 +52,7 @@ extension FloatingPointParseStrategy: ParseStrategy {
             numberFormatType = .percent(format.collection)
             locale = format.locale
         } else if let format = formatStyle as? FloatingPointFormatStyle<Format.FormatInput>.Currency {
-            numberFormatType = .currency(format.collection, format.currencyCode)
+            numberFormatType = .currency(format.collection, currencyCode: format.currencyCode)
             locale = format.locale
         } else {
             // For some reason we've managed to accept a format style of a type that we don't own, which shouldn't happen. Fallback to the default decimal style and try anyways.

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
@@ -18,8 +18,6 @@ import FoundationEssentials
 public struct FloatingPointParseStrategy<Format> : Codable, Hashable where Format : FormatStyle, Format.FormatInput : BinaryFloatingPoint {
     public var formatStyle: Format
     public var lenient: Bool
-    var numberFormatType: ICULegacyNumberFormatter.NumberFormatType
-    var locale: Locale
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -29,27 +27,42 @@ extension FloatingPointParseStrategy : Sendable where Format : Sendable {}
 extension FloatingPointParseStrategy: ParseStrategy {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func parse(_ value: String) throws -> Format.FormatInput {
-        guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
-            throw CocoaError(CocoaError.formatting, userInfo: [
-                NSDebugDescriptionErrorKey: "Cannot parse \(value), unable to create formatter" ])
-        }
-        if let v = parser.parseAsDouble(value._trimmingWhitespace()) {
-            return Format.FormatInput(v)
-        } else {
+        let trimmedString = value._trimmingWhitespace()
+        guard let result = try parse(trimmedString, startingAt: trimmedString.startIndex, in: trimmedString.startIndex..<trimmedString.endIndex) else {
             let exampleString = formatStyle.format(3.14)
             throw CocoaError(CocoaError.formatting, userInfo: [
                 NSDebugDescriptionErrorKey: "Cannot parse \(value). String should adhere to the specified format, such as \(exampleString)" ])
         }
+        return result.1
     }
 
     // Regex component utility
-    internal func parse(_ value: String, startingAt index: String.Index, in range: Range<String.Index>) -> (String.Index, Format.FormatInput)? {
+    internal func parse(_ value: String, startingAt index: String.Index, in range: Range<String.Index>) throws -> (String.Index, Format.FormatInput)? {
         guard index < range.upperBound else {
             return nil
         }
 
+        let numberFormatType: ICULegacyNumberFormatter.NumberFormatType
+        let locale: Locale
+
+        if let format = formatStyle as? FloatingPointFormatStyle<Format.FormatInput> {
+            numberFormatType = .number(format.collection)
+            locale = format.locale
+        } else if let format = formatStyle as? FloatingPointFormatStyle<Format.FormatInput>.Percent {
+            numberFormatType = .percent(format.collection)
+            locale = format.locale
+        } else if let format = formatStyle as? FloatingPointFormatStyle<Format.FormatInput>.Currency {
+            numberFormatType = .currency(format.collection, format.currencyCode)
+            locale = format.locale
+        } else {
+            // For some reason we've managed to accept a format style of a type that we don't own, which shouldn't happen. Fallback to the default decimal style and try anyways.
+            numberFormatType = .number(.init())
+            locale = .autoupdatingCurrent
+        }
+
         guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
-            return nil
+            throw CocoaError(CocoaError.formatting, userInfo: [
+                NSDebugDescriptionErrorKey: "Cannot parse \(value), unable to create formatter" ])
         }
         let substr = value[index..<range.upperBound]
         var upperBound = 0
@@ -68,8 +81,6 @@ public extension FloatingPointParseStrategy {
     init<Value>(format: Format, lenient: Bool = true) where Format == FloatingPointFormatStyle<Value> {
         self.formatStyle = format
         self.lenient = lenient
-        self.locale = format.locale
-        self.numberFormatType = .number(format.collection)
     }
 }
 
@@ -78,8 +89,6 @@ public extension FloatingPointParseStrategy {
     init<Value>(format: Format, lenient: Bool = true) where Format == FloatingPointFormatStyle<Value>.Currency {
         self.formatStyle = format
         self.lenient = lenient
-        self.locale = format.locale
-        self.numberFormatType = .currency(format.collection, format.currencyCode)
     }
 }
 
@@ -88,7 +97,5 @@ public extension FloatingPointParseStrategy {
     init<Value>(format: Format, lenient: Bool = true) where Format == FloatingPointFormatStyle<Value>.Percent {
         self.formatStyle = format
         self.lenient = lenient
-        self.locale = format.locale
-        self.numberFormatType = .percent(format.collection)
     }
 }

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
@@ -79,7 +79,7 @@ public extension FloatingPointParseStrategy {
         self.formatStyle = format
         self.lenient = lenient
         self.locale = format.locale
-        self.numberFormatType = .currency(format.collection)
+        self.numberFormatType = .currency(format.collection, format.currencyCode)
     }
 }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
@@ -123,7 +123,7 @@ internal final class ICULegacyNumberFormatter : @unchecked Sendable {
     enum NumberFormatType : Hashable, Codable {
         case number(NumberFormatStyleConfiguration.Collection)
         case percent(NumberFormatStyleConfiguration.Collection)
-        case currency(CurrencyFormatStyleConfiguration.Collection, /*currency code*/ String)
+        case currency(CurrencyFormatStyleConfiguration.Collection, currencyCode: String)
         case descriptive(DescriptiveNumberFormatConfiguration.Collection)
     }
 
@@ -143,7 +143,7 @@ internal final class ICULegacyNumberFormatter : @unchecked Sendable {
                 }
             case .percent(_):
                 icuType = .percent
-            case .currency(let config, let _):
+            case .currency(let config, _):
                 icuType = config.icuNumberFormatStyle
             case .descriptive(let config):
                 icuType = config.icuNumberFormatStyle

--- a/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
@@ -123,7 +123,7 @@ internal final class ICULegacyNumberFormatter : @unchecked Sendable {
     enum NumberFormatType : Hashable, Codable {
         case number(NumberFormatStyleConfiguration.Collection)
         case percent(NumberFormatStyleConfiguration.Collection)
-        case currency(CurrencyFormatStyleConfiguration.Collection)
+        case currency(CurrencyFormatStyleConfiguration.Collection, /*currency code*/ String)
         case descriptive(DescriptiveNumberFormatConfiguration.Collection)
     }
 
@@ -143,7 +143,7 @@ internal final class ICULegacyNumberFormatter : @unchecked Sendable {
                 }
             case .percent(_):
                 icuType = .percent
-            case .currency(let config):
+            case .currency(let config, let _):
                 icuType = config.icuNumberFormatStyle
             case .descriptive(let config):
                 icuType = config.icuNumberFormatStyle
@@ -178,12 +178,13 @@ internal final class ICULegacyNumberFormatter : @unchecked Sendable {
                     }
                 }
 
-            case .currency(let config):
+            case .currency(let config, let currencyCode):
                 setMultiplier(config.scale, formatter: formatter)
                 setPrecision(config.precision, formatter: formatter)
                 setGrouping(config.group, formatter: formatter)
                 setDecimalSeparator(config.decimalSeparatorStrategy, formatter: formatter)
                 setRoundingIncrement(config.roundingIncrement, formatter: formatter)
+                try setTextAttribute(.currencyCode, formatter: formatter, value: currencyCode)
 
                 // Currency specific attributes
                 if let sign = config.signDisplayStrategy {

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
@@ -563,7 +563,7 @@ extension IntegerFormatStyle {
 extension IntegerFormatStyle : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
-        IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
+        try IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
 }
 
@@ -571,7 +571,7 @@ extension IntegerFormatStyle : CustomConsumingRegexComponent {
 extension IntegerFormatStyle.Percent : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
-        IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
+        try IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
 }
 
@@ -579,7 +579,7 @@ extension IntegerFormatStyle.Percent : CustomConsumingRegexComponent {
 extension IntegerFormatStyle.Currency : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
-        IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
+        try IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
 }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -50,7 +50,7 @@ extension IntegerParseStrategy: ParseStrategy {
             numberFormatType = .percent(format.collection)
             locale = format.locale
         } else if let format = formatStyle as? IntegerFormatStyle<Format.FormatInput>.Currency {
-            numberFormatType = .currency(format.collection, format.currencyCode)
+            numberFormatType = .currency(format.collection, currencyCode: format.currencyCode)
             locale = format.locale
         } else {
             // For some reason we've managed to accept a format style of a type that we don't own, which shouldn't happen. Fallback to the default decimal style and try anyways.

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -103,6 +103,6 @@ public extension IntegerParseStrategy {
         self.formatStyle = format
         self.lenient = lenient
         self.locale = format.locale
-        self.numberFormatType = .currency(format.collection)
+        self.numberFormatType = .currency(format.collection, format.currencyCode)
     }
 }

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -18,8 +18,6 @@ import FoundationEssentials
 public struct IntegerParseStrategy<Format> : Codable, Hashable where Format : FormatStyle, Format.FormatInput : BinaryInteger {
     public var formatStyle: Format
     public var lenient: Bool
-    var numberFormatType: ICULegacyNumberFormatter.NumberFormatType
-    var locale: Locale
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -28,37 +26,36 @@ extension IntegerParseStrategy : Sendable where Format : Sendable {}
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerParseStrategy: ParseStrategy {
     public func parse(_ value: String) throws -> Format.FormatInput {
-        guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
-            throw CocoaError(CocoaError.formatting, userInfo: [
-                NSDebugDescriptionErrorKey: "Cannot parse \(value). Could not create parser." ])
-        }
         let trimmedString = value._trimmingWhitespace()
-        if let v = parser.parseAsInt(trimmedString) {
-            guard let exact = Format.FormatInput(exactly: v) else {
-                throw CocoaError(CocoaError.formatting, userInfo: [
-                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the valid bounds of the specified output type" ])
-            }
-            return exact
-        } else if let v = parser.parseAsDouble(trimmedString) {
-            guard v.magnitude < Double(sign: .plus, exponent: Double.significandBitCount + 1, significand: 1) else {
-                throw CocoaError(CocoaError.formatting, userInfo: [
-                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the lossless floating-point range" ])
-            }
-            guard let exact = Format.FormatInput(exactly: v) else {
-                throw CocoaError(CocoaError.formatting, userInfo: [
-                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the valid bounds of the specified output type" ])
-            }
-            return exact
-        } else {
+        guard let result = try parse(trimmedString, startingAt: trimmedString.startIndex, in: trimmedString.startIndex..<trimmedString.endIndex) else {
             let exampleString = formatStyle.format(123)
             throw CocoaError(CocoaError.formatting, userInfo: [
                 NSDebugDescriptionErrorKey: "Cannot parse \(value). String should adhere to the specified format, such as \(exampleString)" ])
         }
+        return result.1
     }
 
-    internal func parse(_ value: String, startingAt index: String.Index, in range: Range<String.Index>) -> (String.Index, Format.FormatInput)? {
+    internal func parse(_ value: String, startingAt index: String.Index, in range: Range<String.Index>) throws -> (String.Index, Format.FormatInput)? {
         guard index < range.upperBound else {
             return nil
+        }
+
+        let numberFormatType: ICULegacyNumberFormatter.NumberFormatType
+        let locale: Locale
+
+        if let format = formatStyle as? IntegerFormatStyle<Format.FormatInput> {
+            numberFormatType = .number(format.collection)
+            locale = format.locale
+        } else if let format = formatStyle as? IntegerFormatStyle<Format.FormatInput>.Percent {
+            numberFormatType = .percent(format.collection)
+            locale = format.locale
+        } else if let format = formatStyle as? IntegerFormatStyle<Format.FormatInput>.Currency {
+            numberFormatType = .currency(format.collection, format.currencyCode)
+            locale = format.locale
+        } else {
+            // For some reason we've managed to accept a format style of a type that we don't own, which shouldn't happen. Fallback to the default decimal style and try anyways.
+            numberFormatType = .number(.init())
+            locale = .autoupdatingCurrent
         }
 
         guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
@@ -67,12 +64,25 @@ extension IntegerParseStrategy: ParseStrategy {
         let substr = value[index..<range.upperBound]
         var upperBound = 0
         if let value = parser.parseAsInt(substr, upperBound: &upperBound) {
+            guard let exact = Format.FormatInput(exactly: value) else {
+                throw CocoaError(CocoaError.formatting, userInfo: [
+                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the valid bounds of the specified output type" ])
+            }
             let upperBoundInSubstr = String.Index(utf16Offset: upperBound, in: substr)
-            return (upperBoundInSubstr, Format.FormatInput(value))
-        } else if let value = parser.parseAsInt(substr, upperBound: &upperBound) {
+            return (upperBoundInSubstr, exact)
+        } else if let value = parser.parseAsDouble(substr, upperBound: &upperBound) {
+            guard value.magnitude < Double(sign: .plus, exponent: Double.significandBitCount + 1, significand: 1) else {
+                throw CocoaError(CocoaError.formatting, userInfo: [
+                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the lossless floating-point range" ])
+            }
+            guard let exact = Format.FormatInput(exactly: value) else {
+                throw CocoaError(CocoaError.formatting, userInfo: [
+                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the valid bounds of the specified output type" ])
+            }
             let upperBoundInSubstr = String.Index(utf16Offset: upperBound, in: substr)
-            return (upperBoundInSubstr, Format.FormatInput(clamping: Int64(value)))
+            return (upperBoundInSubstr, exact)
         }
+
         return nil
     }
 }
@@ -82,8 +92,6 @@ public extension IntegerParseStrategy {
     init<Value>(format: Format, lenient: Bool = true) where Format == IntegerFormatStyle<Value> {
         self.formatStyle = format
         self.lenient = lenient
-        self.locale = format.locale
-        self.numberFormatType = .number(format.collection)
     }
 }
 
@@ -92,8 +100,6 @@ public extension IntegerParseStrategy {
     init<Value>(format: Format, lenient: Bool = true) where Format == IntegerFormatStyle<Value>.Percent {
         self.formatStyle = format
         self.lenient = lenient
-        self.locale = format.locale
-        self.numberFormatType = .percent(format.collection)
     }
 }
 
@@ -102,7 +108,5 @@ public extension IntegerParseStrategy {
     init<Value>(format: Format, lenient: Bool = true) where Format == IntegerFormatStyle<Value>.Currency {
         self.formatStyle = format
         self.lenient = lenient
-        self.locale = format.locale
-        self.numberFormatType = .currency(format.collection, format.currencyCode)
     }
 }

--- a/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
@@ -109,6 +109,7 @@ extension UNumberFormatAttribute {
 
 extension UNumberFormatTextAttribute {
     static let defaultRuleSet = UNUM_DEFAULT_RULESET
+    static let currencyCode = UNUM_CURRENCY_CODE
 }
 
 extension UDateRelativeDateTimeFormatterStyle {

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -49,6 +49,8 @@ public typealias FloatingPointFormatStyle = Foundation.FloatingPointFormatStyle
 public typealias NumberFormatStyleConfiguration = Foundation.NumberFormatStyleConfiguration
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public typealias CurrencyFormatStyleConfiguration = Foundation.CurrencyFormatStyleConfiguration
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias IntegerParseStrategy = FoundationInternationalization.IntegerParseStrategy
 
 @available(FoundationPreview 0.4, *)
 public typealias DiscreteFormatStyle = Foundation.DiscreteFormatStyle
@@ -147,6 +149,8 @@ public typealias FloatingPointFormatStyle = FoundationInternationalization.Float
 public typealias NumberFormatStyleConfiguration = FoundationInternationalization.NumberFormatStyleConfiguration
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public typealias CurrencyFormatStyleConfiguration = FoundationInternationalization.CurrencyFormatStyleConfiguration
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias IntegerParseStrategy = FoundationInternationalization.IntegerParseStrategy
 
 @available(FoundationPreview 0.4, *)
 public typealias DiscreteFormatStyle = FoundationEssentials.DiscreteFormatStyle

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -50,7 +50,7 @@ public typealias NumberFormatStyleConfiguration = Foundation.NumberFormatStyleCo
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public typealias CurrencyFormatStyleConfiguration = Foundation.CurrencyFormatStyleConfiguration
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-public typealias IntegerParseStrategy = FoundationInternationalization.IntegerParseStrategy
+public typealias IntegerParseStrategy = Foundation.IntegerParseStrategy
 
 @available(FoundationPreview 0.4, *)
 public typealias DiscreteFormatStyle = Foundation.DiscreteFormatStyle

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -595,6 +595,39 @@ final class NumberFormatStyleTests: XCTestCase {
         XCTAssertEqual((-922337203685477 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)), "-$1000T")
     }
 
+    func testCurrency_Codable() throws {
+        let gbpInUS = Decimal.FormatStyle.Currency(code: "GBP", locale: enUSLocale)
+        let encoded = try JSONEncoder().encode(gbpInUS)
+        let json_gbp = String(data: encoded, encoding: String.Encoding.utf8)!
+        print(json_gbp)
+
+        let previouslyEncoded = """
+{
+    "collection":
+    {
+        "presentation":
+        {
+            "option": 1
+        }
+    },
+    "currencyCode": "GBP",
+    "locale":
+    {
+        "current": 0,
+        "identifier": "en_US"
+    }
+}
+""".data(using: .utf8)
+
+        guard let previouslyEncoded else {
+            XCTFail()
+            return
+        }
+
+        let decoded = try JSONDecoder().decode(Decimal.FormatStyle.Currency, from: previouslyEncoded)
+        XCTAssertEqual(decoded, gbpInUS)
+    }
+
     func testCurrency_scientific() throws {
         let baseStyle = Decimal.FormatStyle.Currency(code: "USD", locale: Locale(identifier: "en_US")).notation(.scientific)
 
@@ -1905,23 +1938,33 @@ final class FormatStylePatternMatchingTests : XCTestCase {
         _verifyMatching("€52,249", formatStyle: floatStyle, expectedUpperBound: nil, expectedValue: nil)
         _verifyMatching("€52,249", formatStyle: decimalStyle, expectedUpperBound: nil, expectedValue: nil)
 
-        // Different locale
         let frenchStyle: IntegerFormatStyle<Int>.Currency = .init(code: "EUR", locale: frFR)
+        let frenchPrice = frenchStyle.format(57379)
+        XCTAssertEqual(frenchPrice, "57 379,00 €")
+        _verifyMatching("57 379,00 €", formatStyle: frenchStyle, expectedUpperBound: "57 379,00 €".endIndex, expectedValue: 57379)
+        _verifyMatching("57 379 €", formatStyle: frenchStyle, expectedUpperBound: "57 379 €".endIndex, expectedValue: 57379)
+        _verifyMatching("57 379,00 € semble beaucoup", formatStyle: frenchStyle, expectedUpperBound: "57 379,00 €".endIndex, expectedValue: 57379)
 
-        let frenchPrice = "57 379 €"
-        _verifyMatching(frenchPrice, formatStyle: frenchStyle, expectedUpperBound: frenchPrice.endIndex, expectedValue: 57379)
-        _verifyMatching(frenchPrice, formatStyle: floatStyle.locale(frFR), expectedUpperBound: frenchPrice.endIndex, expectedValue: 57379)
-        _verifyMatching(frenchPrice, formatStyle: decimalStyle.locale(frFR), expectedUpperBound: frenchPrice.endIndex, expectedValue: 57379)
+        // Does not match when matching with USD style
+        _verifyMatching("57 379,00 €", formatStyle: floatStyle.locale(frFR), expectedUpperBound: nil, expectedValue: nil)
+        _verifyMatching("57 379,00 €", formatStyle: decimalStyle.locale(frFR), expectedUpperBound: nil, expectedValue: nil)
 
-        _verifyMatching("\(frenchPrice) semble beaucoup", formatStyle: frenchStyle, expectedUpperBound: frenchPrice.endIndex, expectedValue: 57379)
-        _verifyMatching("\(frenchPrice) semble beaucoup", formatStyle: floatStyle.locale(frFR), expectedUpperBound: frenchPrice.endIndex, expectedValue: 57379)
-        _verifyMatching("\(frenchPrice) semble beaucoup", formatStyle: decimalStyle.locale(frFR), expectedUpperBound: frenchPrice.endIndex, expectedValue: 57379)
+        // Mix currency and locale
+        _verifyMatching("57 379,00 $US", formatStyle: floatStyle.locale(frFR), expectedUpperBound: "57 379,00 $US".endIndex, expectedValue: 57379)
+        _verifyMatching("57 379,00 $US", formatStyle: decimalStyle.locale(frFR), expectedUpperBound: "57 379,00 $US".endIndex, expectedValue: 57379)
+        _verifyMatching("57 379,00 $US semble beaucoup", formatStyle: floatStyle.locale(frFR), expectedUpperBound: "57 379,00 $US".endIndex, expectedValue: 57379)
+        _verifyMatching("57 379,00 $US semble beaucoup", formatStyle: decimalStyle.locale(frFR), expectedUpperBound: "57 379,00 $US".endIndex, expectedValue: 57379)
 
+        // Range tests
         let newFrenchStr = "<remplir le blanc> coûte \(frenchPrice)"
         let frenchMatchRange = newFrenchStr.firstIndex(of: "5")! ..< newFrenchStr.endIndex
         _verifyMatching(newFrenchStr, formatStyle: frenchStyle, range: frenchMatchRange, expectedUpperBound: newFrenchStr.endIndex, expectedValue: 57379)
-        _verifyMatching(newFrenchStr, formatStyle: floatStyle.locale(frFR), range: frenchMatchRange, expectedUpperBound: newFrenchStr.endIndex, expectedValue: 57379)
-        _verifyMatching(newFrenchStr, formatStyle: decimalStyle.locale(frFR), range: frenchMatchRange, expectedUpperBound: newFrenchStr.endIndex, expectedValue: 57379)
+
+        // Mix currency and locale range tests
+        let newFrenchUSDStr = "<remplir le blanc> coûte 57 379,00 $US"
+        let usdPriceRange = newFrenchUSDStr.firstIndex(of: "5")! ..< newFrenchUSDStr.endIndex
+        _verifyMatching(newFrenchUSDStr, formatStyle: floatStyle.locale(frFR), range: usdPriceRange, expectedUpperBound: newFrenchUSDStr.endIndex, expectedValue: 57379)
+        _verifyMatching(newFrenchUSDStr, formatStyle: decimalStyle.locale(frFR), range: usdPriceRange, expectedUpperBound: newFrenchUSDStr.endIndex, expectedValue: 57379)
 
         // Sign tests
         let signTests = [

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -599,24 +599,22 @@ final class NumberFormatStyleTests: XCTestCase {
         let gbpInUS = Decimal.FormatStyle.Currency(code: "GBP", locale: enUSLocale)
         let encoded = try JSONEncoder().encode(gbpInUS)
         let json_gbp = String(data: encoded, encoding: String.Encoding.utf8)!
-        print(json_gbp)
-
         let previouslyEncoded = """
-{
-    "collection":
-    {
-        "presentation":
         {
-            "option": 1
+            "collection":
+            {
+                "presentation":
+                {
+                    "option": 1
+                }
+            },
+            "currencyCode": "GBP",
+            "locale":
+            {
+                "current": 0,
+                "identifier": "en_US"
+            }
         }
-    },
-    "currencyCode": "GBP",
-    "locale":
-    {
-        "current": 0,
-        "identifier": "en_US"
-    }
-}
 """.data(using: .utf8)
 
         guard let previouslyEncoded else {

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -181,7 +181,7 @@ final class NumberParseStrategyTests : XCTestCase {
         XCTAssertEqual(parsedInt, 32)
     }
 
-    func test_roundtripForeignCurrency() {
+    func test_roundtripForeignCurrency() throws {
         let testData: [Int] = [
             87650000, 8765000, 876500, 87650, 8765, 876, 87, 8, 0
         ]
@@ -189,10 +189,10 @@ final class NumberParseStrategyTests : XCTestCase {
             -87650000, -8765000, -876500, -87650, -8765, -876, -87, -8
         ]
 
-        func _verifyRoundtripCurrency(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Currency, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) {
+        func _verifyRoundtripCurrency(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Currency, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
             for value in testData {
                 let str = style.format(value)
-                let parsed = try! Int(str, strategy: style.parseStrategy)
+                let parsed = try Int(str, strategy: style.parseStrategy)
                 XCTAssertEqual(value, parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", file: file, line: line)
 
                 let nonLenientParsed = try! Int(str, format: style, lenient: false)
@@ -201,21 +201,21 @@ final class NumberParseStrategyTests : XCTestCase {
         }
 
         let currencyStyle: IntegerFormatStyle<Int>.Currency = .init(code: "EUR", locale: Locale(identifier: "en_US"))
-        _verifyRoundtripCurrency(testData, currencyStyle, "currency style")
-        _verifyRoundtripCurrency(testData, currencyStyle.sign(strategy: .always()), "currency style, sign: always")
-        _verifyRoundtripCurrency(testData, currencyStyle.grouping(.never), "currency style, grouping: never")
-        _verifyRoundtripCurrency(testData, currencyStyle.presentation(.isoCode), "currency style, presentation: iso code")
-        _verifyRoundtripCurrency(testData, currencyStyle.presentation(.fullName), "currency style, presentation: iso code")
-        _verifyRoundtripCurrency(testData, currencyStyle.presentation(.narrow), "currency style, presentation: iso code")
-        _verifyRoundtripCurrency(testData, currencyStyle.decimalSeparator(strategy: .always), "currency style, decimal display: always")
+        try _verifyRoundtripCurrency(testData, currencyStyle, "currency style")
+        try _verifyRoundtripCurrency(testData, currencyStyle.sign(strategy: .always()), "currency style, sign: always")
+        try _verifyRoundtripCurrency(testData, currencyStyle.grouping(.never), "currency style, grouping: never")
+        try _verifyRoundtripCurrency(testData, currencyStyle.presentation(.isoCode), "currency style, presentation: iso code")
+        try _verifyRoundtripCurrency(testData, currencyStyle.presentation(.fullName), "currency style, presentation: iso code")
+        try _verifyRoundtripCurrency(testData, currencyStyle.presentation(.narrow), "currency style, presentation: iso code")
+        try _verifyRoundtripCurrency(testData, currencyStyle.decimalSeparator(strategy: .always), "currency style, decimal display: always")
 
-        _verifyRoundtripCurrency(negativeData, currencyStyle, "currency style")
-        _verifyRoundtripCurrency(negativeData, currencyStyle.sign(strategy: .accountingAlways()), "currency style, sign: always")
-        _verifyRoundtripCurrency(negativeData, currencyStyle.grouping(.never), "currency style, grouping: never")
-        _verifyRoundtripCurrency(negativeData, currencyStyle.presentation(.isoCode), "currency style, presentation: iso code")
-        _verifyRoundtripCurrency(negativeData, currencyStyle.presentation(.fullName), "currency style, presentation: iso code")
-        _verifyRoundtripCurrency(negativeData, currencyStyle.presentation(.narrow), "currency style, presentation: iso code")
-        _verifyRoundtripCurrency(negativeData, currencyStyle.decimalSeparator(strategy: .always), "currency style, decimal display: always")
+        try _verifyRoundtripCurrency(negativeData, currencyStyle, "currency style")
+        try _verifyRoundtripCurrency(negativeData, currencyStyle.sign(strategy: .accountingAlways()), "currency style, sign: always")
+        try _verifyRoundtripCurrency(negativeData, currencyStyle.grouping(.never), "currency style, grouping: never")
+        try _verifyRoundtripCurrency(negativeData, currencyStyle.presentation(.isoCode), "currency style, presentation: iso code")
+        try _verifyRoundtripCurrency(negativeData, currencyStyle.presentation(.fullName), "currency style, presentation: iso code")
+        try _verifyRoundtripCurrency(negativeData, currencyStyle.presentation(.narrow), "currency style, presentation: iso code")
+        try _verifyRoundtripCurrency(negativeData, currencyStyle.decimalSeparator(strategy: .always), "currency style, decimal display: always")
     }
 
     let testNegativePositiveDecimalData: [Decimal] = [  Decimal(string:"87650")!, Decimal(string:"8765")!,

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -195,7 +195,7 @@ final class NumberParseStrategyTests : XCTestCase {
                 let parsed = try Int(str, strategy: style.parseStrategy)
                 XCTAssertEqual(value, parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", file: file, line: line)
 
-                let nonLenientParsed = try! Int(str, format: style, lenient: false)
+                let nonLenientParsed = try Int(str, format: style, lenient: false)
                 XCTAssertEqual(value, nonLenientParsed, file: file, line: line)
             }
         }


### PR DESCRIPTION
Currently parsing a currency string would fail if the currency code does not match `FormatStyle`'s locale region. 

For example,
```swift
let style = Decimal.FormatStyle.Currency(code: "GBP", locale: .init(identifier: "en_US")).presentation(.isoCode)
```
    
This formats 3.14 into `"GBP\u{0xa0}3.14"`, but parsing such string fails. 

Fix this by always set the ICU formatter's currency code.
    
Resolves rdar://138179737
