### PR TITLE
FreeBSD platform specific fixes

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -34,6 +34,8 @@ import WASILibc
 func _fgetxattr(_ fd: Int32, _ name: UnsafePointer<CChar>!, _ value: UnsafeMutableRawPointer!, _ size: Int, _ position: UInt32, _ options: Int32) -> Int {
 #if canImport(Darwin)
     return fgetxattr(fd, name, value, size, position, options)
+#elseif os(FreeBSD)
+    return extattr_get_fd(fd, EXTATTR_NAMESPACE_USER, name, value, size)
 #elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
     return fgetxattr(fd, name, value, size)
 #else

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -606,6 +606,8 @@ private func writeExtendedAttributes(fd: Int32, attributes: [String : Data]) {
             // Returns non-zero on error, but we ignore them
 #if canImport(Darwin)
             _ = fsetxattr(fd, key, valueBuf.baseAddress!, valueBuf.count, 0, 0)
+#elseif os(FreeBSD)
+            _ = extattr_set_fd(fd, EXTATTR_NAMESPACE_USER, key, valueBuf.baseAddress!, valueBuf.count)
 #elseif canImport(Glibc) || canImport(Musl)
             _ = fsetxattr(fd, key, valueBuf.baseAddress!, valueBuf.count, 0)
 #endif

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -623,7 +623,7 @@ extension POSIXError {
         return .EMULTIHOP
     }
 
-    #if !os(WASI)
+    #if !os(WASI) && !os(FreeBSD)
     /// No message available on STREAM.
     public static var ENODATA: POSIXErrorCode {
         return .ENODATA
@@ -635,7 +635,7 @@ extension POSIXError {
         return .ENOLINK
     }
 
-    #if !os(WASI)
+    #if !os(WASI) && !os(FreeBSD)
     /// No STREAM resources.
     public static var ENOSR: POSIXErrorCode {
         return .ENOSR
@@ -653,7 +653,7 @@ extension POSIXError {
         return .EPROTO
     }
 
-    #if !os(OpenBSD) && !os(WASI)
+    #if !os(OpenBSD) && !os(WASI) && !os(FreeBSD)
     /// STREAM ioctl timeout.
     public static var ETIME: POSIXErrorCode {
         return .ETIME

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -486,6 +486,8 @@ extension _FileManagerImpl {
     private func _extendedAttribute(_ key: UnsafePointer<CChar>, at path: UnsafePointer<CChar>, followSymlinks: Bool) throws -> Data? {
         #if canImport(Darwin)
         var size = getxattr(path, key, nil, 0, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
+        #elseif os(FreeBSD) || os(NetBSD)
+        var size = (followSymlinks ? extattr_get_file : extattr_get_link)(path, EXTATTR_NAMESPACE_USER, key, nil, 0)
         #else
         var size = followSymlinks ? getxattr(path, key, nil, 0) : lgetxattr(path, key, nil, 0)
         #endif
@@ -498,6 +500,8 @@ extension _FileManagerImpl {
         let buffer = malloc(size)!
         #if canImport(Darwin)
         size = getxattr(path, key, buffer, size, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
+        #elseif os(FreeBSD) || os(NetBSD)
+        size = (followSymlinks ? extattr_get_file : extattr_get_link)(path, EXTATTR_NAMESPACE_USER, key, buffer, size)
         #else
         size = followSymlinks ? getxattr(path, key, buffer, size) : lgetxattr(path, key, buffer, size)
         #endif
@@ -516,6 +520,8 @@ extension _FileManagerImpl {
     private func _extendedAttributes(at path: UnsafePointer<CChar>, followSymlinks: Bool) throws -> [String : Data]? {
         #if canImport(Darwin)
         var size = listxattr(path, nil, 0, 0)
+        #elseif os(FreeBSD) || os(NetBSD)
+        var size = (followSymlinks ? extattr_list_file : extattr_list_link)(path, EXTATTR_NAMESPACE_USER, nil, 0)
         #else
         var size = listxattr(path, nil, 0)
         #endif
@@ -524,6 +530,8 @@ extension _FileManagerImpl {
         defer { keyList.deallocate() }
         #if canImport(Darwin)
         size = listxattr(path, keyList.baseAddress!, size, 0)
+        #elseif os(FreeBSD) || os(NetBSD)
+        size = (followSymlinks ? extattr_list_file : extattr_list_link)(path, EXTATTR_NAMESPACE_USER, nil, 0)
         #else
         size = listxattr(path, keyList.baseAddress!, size)
         #endif

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -185,6 +185,14 @@ extension _FileManagerImpl {
             let result = setxattr(path, key, buffer.baseAddress!, buffer.count, 0, followSymLinks ? 0 : XATTR_NOFOLLOW)
             #else
             var result: Int32
+            #endif
+            #if os(FreeBSD)
+            if followSymLinks {
+                result = Int32(extattr_set_file(path, EXTATTR_NAMESPACE_USER, key, buffer.baseAddress!, buffer.count))
+            } else {
+                result = Int32(extattr_set_link(path, EXTATTR_NAMESPACE_USER, key, buffer.baseAddress!, buffer.count))
+            }
+            #else
             if followSymLinks {
                 result = lsetxattr(path, key, buffer.baseAddress!, buffer.count, 0)
             } else {

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -354,9 +354,15 @@ struct _POSIXDirectoryContentsSequence: Sequence {
                     continue
                 }
                 #endif
+                #if os(FreeBSD)
+                guard dent.pointee.d_fileno != 0 else {
+                    continue
+                }
+                #else
                 guard dent.pointee.d_ino != 0 else {
                     continue
                 }
+                #endif
                 // Use name
                 let fileName: String
                 #if os(WASI)

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -900,10 +900,17 @@ enum _FileOperations {
         }
         #else
         while current < total {
+            #if os(FreeBSD)
+            guard copy_file_range(srcfd, &current, dstfd, nil, total - Int(current), 0) != -1 else {
+                try delegate.throwIfNecessary(errno, String(cString: srcPtr), String(cString: dstPtr))
+                return
+            }
+            #else
             guard sendfile(dstfd, srcfd, &current, Swift.min(total - Int(current), chunkSize)) != -1 else {
                 try delegate.throwIfNecessary(errno, String(cString: srcPtr), String(cString: dstPtr))
                 return
             }
+            #endif
         }
         #endif
     }

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -31,6 +31,8 @@ package struct LockedState<State> {
     private struct _Lock {
 #if canImport(os)
         typealias Primitive = os_unfair_lock
+#elseif os(FreeBSD)
+        typealias Primitive = pthread_mutex_t?
 #elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
         typealias Primitive = pthread_mutex_t
 #elseif canImport(WinSDK)

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -142,7 +142,11 @@ final class _ProcessInfo: Sendable {
         let time: UInt64 = ullTime
 #else
         var ts: timespec = timespec()
+#if os(Linux)
         clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
+#else
+        clock_gettime(CLOCK_MONOTONIC, &ts)
+#endif
         let time: UInt64 = UInt64(ts.tv_sec) * 1000000000 + UInt64(ts.tv_nsec)
 #endif
         let timeString = String(time, radix: 16, uppercase: true)

--- a/Sources/_FoundationCShims/include/_CStdlib.h
+++ b/Sources/_FoundationCShims/include/_CStdlib.h
@@ -148,7 +148,7 @@
 #include <tzfile.h>
 #else
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
 #ifndef TZDIR
 #define TZDIR    "/usr/share/zoneinfo/" /* Time zone object file directory */
 #endif /* !defined TZDIR */
@@ -156,7 +156,7 @@
 #ifndef TZDEFAULT
 #define TZDEFAULT    "/etc/localtime"
 #endif /* !defined TZDEFAULT */
-#endif /* TARGET_OS_MAC || TARGET_OS_LINUX */
+#endif /* TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD */
 
 #endif
 


### PR DESCRIPTION
- Use "/usr/share/zoneinfo" like other platforms
- Use platform specific types and values
- Implement extattr ops for FreeBSD
- Use copy_file_range(2) for file cloning
   * all supported FreeBSD (13+) supports it for regular file, and allows for file system level offloading (e.g. ZFS block-cloning, NFS server side copying)