### PR TITLE
Ensure that FileManager.copyItem cannot copy directory metadata to files

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -948,7 +948,7 @@ enum _FileOperations {
         #endif
     }
     #endif
-
+    
     #if !canImport(Darwin)
     private static func _copyDirectoryMetadata(srcFD: CInt, srcPath: @autoclosure () -> String, dstFD: CInt, dstPath: @autoclosure () -> String, delegate: some LinkOrCopyDelegate) throws {
         // Copy extended attributes

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -495,7 +495,7 @@ final class FileManagerTests : XCTestCase {
     func testCopyItemAtPathToPath() throws {
         let data = randomData()
         try FileManagerPlayground {
-            Directory("dir") {
+            Directory("dir", attributes: [.posixPermissions : 0o777]) {
                 File("foo", contents: data)
                 "bar"
             }
@@ -511,7 +511,7 @@ final class FileManagerTests : XCTestCase {
 #else
             XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")])
 #endif
-
+            XCTAssertEqual(try $0.attributesOfItem(atPath: "dir2")[.posixPermissions] as? UInt, 0o777)
             XCTAssertThrowsError(try $0.copyItem(atPath: "does_not_exist", toPath: "dir3")) {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
             }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -510,8 +510,10 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/bar", "dir2/bar"), .init("dir/foo", "dir2/foo")])
 #else
             XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")])
-#endif
+            
+            // Specifically for non-Windows (where copying directory metadata takes a special path) double check that the metadata was copied exactly
             XCTAssertEqual(try $0.attributesOfItem(atPath: "dir2")[.posixPermissions] as? UInt, 0o777)
+#endif
             XCTAssertThrowsError(try $0.copyItem(atPath: "does_not_exist", toPath: "dir3")) {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
             }


### PR DESCRIPTION
`FileManager.copyItem(atPath:toPath:)` has a TOCTOU bug due to how it recursively copies directories. As we recursively copy directories, we copy the directory itself with default metadata/permissions, copy the contents of the directory, then copy the metadata over (which may change permissions on the directory, including potentially making it read-only). This TOCTOU bug allows another process with write access to the source directory to (with the right timing) cause a process that uses `FileManager.copyItem` to copy and apply metadata to a file rather than a directory.

To fix the TOCTOU issue, the post-order traversal which copies the metadata now:

- Opens a file descriptor to both the source and destination directories
- `fstats` the source and destination directories to validate that they are directories (and not files)
- Then copies metadata from one open file descriptor to the other
    - This uses `fcopyfile` on Darwin, and a custom function on Linux where `fcopyfile` does not exist

This ensures that we only copy metadata between directories and cannot accidentally apply metadata to a file.