### PR TITLE
[Windows] Include variant in file path errors

### DIFF
--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -155,7 +155,7 @@ extension CocoaError {
     }
     
     static func errorWithFilePath(_ path: String? = nil, win32 dwError: DWORD, reading: Bool, variant: String? = nil, source: String? = nil, destination: String? = nil) -> CocoaError {
-        return CocoaError(.init(win32: dwError, reading: reading, emptyPath: path?.isEmpty), path: path, underlying: Win32Error(dwError), source: source, destination: destination)
+        return CocoaError(.init(win32: dwError, reading: reading, emptyPath: path?.isEmpty), path: path, underlying: Win32Error(dwError), variant: variant, source: source, destination: destination)
     }
 }
 #endif


### PR DESCRIPTION
A small typo causes file path errors on Windows to not include the variant of the API that produced the error. This patch ensures we pass the variant down to the error constructor

Resolves https://github.com/swiftlang/swift-foundation/issues/1084