### PR TITLE
[6.1] URL.appendingPathExtension("") appends a trailing dot

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -207,7 +207,7 @@ extension String {
     }
 
     internal func appendingPathExtension(_ pathExtension: String) -> String {
-        guard validatePathExtension(pathExtension) else {
+        guard !pathExtension.isEmpty, validatePathExtension(pathExtension) else {
             return self
         }
         var result = self._droppingTrailingSlashes

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1754,7 +1754,7 @@ public struct URL: Equatable, Sendable, Hashable {
             return result
         }
         #endif
-        guard !relativePath().isEmpty else { return self }
+        guard !pathExtension.isEmpty, !relativePath().isEmpty else { return self }
         var components = URLComponents(parseInfo: _parseInfo)
         // pathExtension might need to be percent-encoded, so use .path
         let newPath = components.path.appendingPathExtension(pathExtension)

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -913,6 +913,15 @@ final class URLTests : XCTestCase {
         url.deletePathExtension()
         // Old behavior only searches the last empty component, so the extension isn't actually removed
         checkBehavior(url.path(), new: "/path/", old: "/path.foo///")
+
+        url = URL(filePath: "/tmp/x")
+        url.appendPathExtension("")
+        XCTAssertEqual(url.path(), "/tmp/x")
+        XCTAssertEqual(url, url.deletingPathExtension().appendingPathExtension(url.pathExtension))
+
+        url = URL(filePath: "/tmp/x.")
+        url.deletePathExtension()
+        XCTAssertEqual(url.path(), "/tmp/x.")
     }
 
     func testURLAppendingToEmptyPath() throws {


### PR DESCRIPTION
**Explanation:** Prevents a trailing dot from being appended for an empty path extension.
**Scope:** Only impacts `URL.appendingPathExtension(_:)` when the input is an empty string.
**Original PR:** #1082 
**Risk:** Low - empty string check, restores previous behavior
**Testing:** Added unit test, swift-ci
**Reviewer:** @jmschonfeld   

Resolves https://github.com/swiftlang/swift-foundation/issues/1080 for `release/6.1`