### PR TITLE
Fix WASI build of `_copyDirectoryMetadata`

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -951,6 +951,7 @@ enum _FileOperations {
     
     #if !canImport(Darwin)
     private static func _copyDirectoryMetadata(srcFD: CInt, srcPath: @autoclosure () -> String, dstFD: CInt, dstPath: @autoclosure () -> String, delegate: some LinkOrCopyDelegate) throws {
+        #if !os(WASI)
         // Copy extended attributes
         var size = flistxattr(srcFD, nil, 0)
         if size > 0 {
@@ -976,6 +977,7 @@ enum _FileOperations {
                 }
             }
         }
+        #endif
         var statInfo = stat()
         if fstat(srcFD, &statInfo) == 0 {
             // Copy owner/group


### PR DESCRIPTION
Extended attributes don't exist in WASI, so we need to exclude the use of xattr-related APIs including `flistxattr`.