### PR TITLE
[6.1] Fix WASI build of `_copyDirectoryMetadata`

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -911,6 +911,7 @@ enum _FileOperations {
     
     #if !canImport(Darwin)
     private static func _copyDirectoryMetadata(srcFD: CInt, srcPath: @autoclosure () -> String, dstFD: CInt, dstPath: @autoclosure () -> String, delegate: some LinkOrCopyDelegate) throws {
+        #if !os(WASI)
         // Copy extended attributes
         var size = flistxattr(srcFD, nil, 0)
         if size > 0 {
@@ -936,6 +937,7 @@ enum _FileOperations {
                 }
             }
         }
+        #endif
         var statInfo = stat()
         if fstat(srcFD, &statInfo) == 0 {
             // Copy owner/group

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -911,7 +911,7 @@ enum _FileOperations {
     
     #if !canImport(Darwin)
     private static func _copyDirectoryMetadata(srcFD: CInt, srcPath: @autoclosure () -> String, dstFD: CInt, dstPath: @autoclosure () -> String, delegate: some LinkOrCopyDelegate) throws {
-        #if !os(WASI)
+        #if !os(WASI) && !os(Android)
         // Copy extended attributes
         var size = flistxattr(srcFD, nil, 0)
         if size > 0 {

--- a/Sources/FoundationEssentials/WASILibc+Extensions.swift
+++ b/Sources/FoundationEssentials/WASILibc+Extensions.swift
@@ -49,5 +49,14 @@ internal var O_TRUNC: Int32 {
 internal var O_WRONLY: Int32 {
     return _platform_shims_O_WRONLY()
 }
+internal var O_RDONLY: Int32 {
+    return _platform_shims_O_RDONLY()
+}
+internal var O_DIRECTORY: Int32 {
+    return _platform_shims_O_DIRECTORY()
+}
+internal var O_NOFOLLOW: Int32 {
+    return _platform_shims_O_NOFOLLOW()
+}
 
 #endif // os(WASI)

--- a/Sources/_FoundationCShims/include/platform_shims.h
+++ b/Sources/_FoundationCShims/include/platform_shims.h
@@ -102,6 +102,10 @@ static inline int32_t _platform_shims_O_CREAT(void) { return O_CREAT; }
 static inline int32_t _platform_shims_O_EXCL(void) { return O_EXCL; }
 static inline int32_t _platform_shims_O_TRUNC(void) { return O_TRUNC; }
 static inline int32_t _platform_shims_O_WRONLY(void) { return O_WRONLY; }
+static inline int32_t _platform_shims_O_RDONLY(void) { return O_RDONLY; }
+static inline int32_t _platform_shims_O_DIRECTORY(void) { return O_DIRECTORY; }
+static inline int32_t _platform_shims_O_NOFOLLOW(void) { return O_NOFOLLOW; }
+
 #endif
 
 #endif /* CSHIMS_PLATFORM_SHIMS */


### PR DESCRIPTION
**Explanation:** Fix build issues in WASI platform, which are introduced in https://github.com/swiftlang/swift-foundation/pull/1083
**Scope:** Impacts FileManager.copyItem(atPath:toPath:) on non-Windows platforms
**Original PR:** https://github.com/swiftlang/swift-foundation/pull/1094 and https://github.com/swiftlang/swift-foundation/pull/1095
**Risk:** Low - replace a legacy libc function call with a modern one, gate a few parts behind `os(WASI)`
**Testing:** swift-ci testing
**Reviewer:** @jmschonfeld