### PR TITLE
Implement LockedState for Musl

### DIFF
--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -46,17 +46,19 @@ package struct LockedState<State> {
         fileprivate static func initialize(_ platformLock: PlatformLock) {
 #if canImport(os)
             platformLock.initialize(to: os_unfair_lock())
-#elseif canImport(Bionic) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_mutex_init(platformLock, nil)
 #elseif canImport(WinSDK)
             InitializeSRWLock(platformLock)
 #elseif os(WASI)
             // no-op
+#else
+#error("LockedState._Lock.initialize is unimplemented on this platform")
 #endif
         }
 
         fileprivate static func deinitialize(_ platformLock: PlatformLock) {
-#if canImport(Bionic) || canImport(Glibc)
+#if canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_mutex_destroy(platformLock)
 #endif
             platformLock.deinitialize(count: 1)
@@ -65,24 +67,28 @@ package struct LockedState<State> {
         static fileprivate func lock(_ platformLock: PlatformLock) {
 #if canImport(os)
             os_unfair_lock_lock(platformLock)
-#elseif canImport(Bionic) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_mutex_lock(platformLock)
 #elseif canImport(WinSDK)
             AcquireSRWLockExclusive(platformLock)
 #elseif os(WASI)
             // no-op
+#else
+#error("LockedState._Lock.lock is unimplemented on this platform")
 #endif
         }
 
         static fileprivate func unlock(_ platformLock: PlatformLock) {
 #if canImport(os)
             os_unfair_lock_unlock(platformLock)
-#elseif canImport(Bionic) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_mutex_unlock(platformLock)
 #elseif canImport(WinSDK)
             ReleaseSRWLockExclusive(platformLock)
 #elseif os(WASI)
             // no-op
+#else
+#error("LockedState._Lock.unlock is unimplemented on this platform")
 #endif
         }
     }


### PR DESCRIPTION
Unfortunately, we're missing a few conditionals in the `LockedState` implementation that left `LockedState` acting as a no-op for the static linux SDK. This results in the lack of synchronization of caches in swift-foundation for that platform. I went ahead and added the right conditionals for Musl (same as Glibc) and also added an explicit `#else` case with a `#error` so that we can more quickly and easily detect platforms for which we have not implemented synchronization primitives here.

I've confirmed that running the sample program in the linked issue produces the segmentation fault but with this change the fault no longer occurs.

Resolves https://github.com/swiftlang/swift-foundation/issues/1100