### PR TITLE
[6.1] Implement LockedState for Musl

### DIFF
--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -46,17 +46,19 @@ package struct LockedState<State> {
         fileprivate static func initialize(_ platformLock: PlatformLock) {
 #if canImport(os)
             platformLock.initialize(to: os_unfair_lock())
-#elseif canImport(Bionic) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_mutex_init(platformLock, nil)
 #elseif canImport(WinSDK)
             InitializeSRWLock(platformLock)
 #elseif os(WASI)
             // no-op
+#else
+#error("LockedState._Lock.initialize is unimplemented on this platform")
 #endif
         }
 
         fileprivate static func deinitialize(_ platformLock: PlatformLock) {
-#if canImport(Bionic) || canImport(Glibc)
+#if canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_mutex_destroy(platformLock)
 #endif
             platformLock.deinitialize(count: 1)
@@ -65,24 +67,28 @@ package struct LockedState<State> {
         static fileprivate func lock(_ platformLock: PlatformLock) {
 #if canImport(os)
             os_unfair_lock_lock(platformLock)
-#elseif canImport(Bionic) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_mutex_lock(platformLock)
 #elseif canImport(WinSDK)
             AcquireSRWLockExclusive(platformLock)
 #elseif os(WASI)
             // no-op
+#else
+#error("LockedState._Lock.lock is unimplemented on this platform")
 #endif
         }
 
         static fileprivate func unlock(_ platformLock: PlatformLock) {
 #if canImport(os)
             os_unfair_lock_unlock(platformLock)
-#elseif canImport(Bionic) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_mutex_unlock(platformLock)
 #elseif canImport(WinSDK)
             ReleaseSRWLockExclusive(platformLock)
 #elseif os(WASI)
             // no-op
+#else
+#error("LockedState._Lock.unlock is unimplemented on this platform")
 #endif
         }
     }


### PR DESCRIPTION
  - **Explanation**: Implements locking behavior for the internal `LockedState` type for the static linux SDK build
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Impacts synchronization primitives in FoundationEssentials/FoundationInternationalization in the static linux SDK
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: https://github.com/swiftlang/swift-foundation/issues/1100
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift-foundation/pull/1101
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low - changed code is minimal and makes `Musl` perform the equivalent to `Glibc`
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: local testing with sample code
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @itingliu @parkera @iCharlesHu 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->
