### PR TITLE
Don't try to set extended attributes on Android

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -951,7 +951,7 @@ enum _FileOperations {
     
     #if !canImport(Darwin)
     private static func _copyDirectoryMetadata(srcFD: CInt, srcPath: @autoclosure () -> String, dstFD: CInt, dstPath: @autoclosure () -> String, delegate: some LinkOrCopyDelegate) throws {
-        #if !os(WASI)
+        #if !os(WASI) && !os(Android)
         // Copy extended attributes
         var size = flistxattr(srcFD, nil, 0)
         if size > 0 {


### PR DESCRIPTION
Normal users don't have permission to change these, even for their own files.

@jmschonfeld, as [done previously for Android](https://github.com/swiftlang/swift-foundation/pull/871#discussion_r1722073325).