### PR TITLE
(142076445) Allow URL.standardized to return an empty string URL

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1847,7 +1847,7 @@ public struct URL: Equatable, Sendable, Hashable {
         var components = URLComponents(parseInfo: _parseInfo)
         let newPath = components.percentEncodedPath.removingDotSegments
         components.percentEncodedPath = newPath
-        return components.url(relativeTo: baseURL)!
+        return components.url(relativeTo: baseURL) ?? self
     }
 
     /// Standardizes the path of a file URL by removing dot segments.

--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -676,7 +676,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             return CFURLCreateWithString(kCFAllocatorDefault, string as CFString, nil) as URL?
         }
         #endif
-        return URL(string: string)
+        return URL(string: string, relativeTo: nil)
     }
 
     /// Returns a URL created from the URLComponents relative to a base URL.

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1405,6 +1405,12 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(comp.path, "/my\u{0}path")
     }
 
+    func testURLStandardizedEmptyString() {
+        let url = URL(string: "../../../")!
+        let standardized = url.standardized
+        XCTAssertTrue(standardized.path().isEmpty)
+    }
+
 #if FOUNDATION_FRAMEWORK
     func testURLComponentsBridging() {
         var nsURLComponents = NSURLComponents(


### PR DESCRIPTION
Calling `URL.standardized` on a URL like `../../../../` removes the dot segments and produces an empty string. `NSURL` allows the empty string, and in the old implementation, this would return a `URL` that wraps an empty string `NSURL`.

In the new implementation, we ultimately call `URL(string: "")` when initializing this standardized URL, which returns `nil` again after #1103. Since `URL.standardized` returns a non-nil `URL`, this would crash when unwrapped.

We can allow `URL.standardized` (and other methods that call `URLComponents.url`) to return an empty string `URL` as they did previously by using `URL(string:relativeTo:)` instead.