### PR TITLE
Compatibility behaviors for Swift URL

### DIFF
--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -676,7 +676,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             return CFURLCreateWithString(kCFAllocatorDefault, string as CFString, nil) as URL?
         }
         #endif
-        return URL(string: string, relativeTo: nil)
+        return URL(stringOrEmpty: string, relativeTo: nil)
     }
 
     /// Returns a URL created from the URLComponents relative to a base URL.
@@ -690,7 +690,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             return CFURLCreateWithString(kCFAllocatorDefault, string as CFString, base as CFURL) as URL?
         }
         #endif
-        return URL(string: string, relativeTo: base)
+        return URL(stringOrEmpty: string, relativeTo: base)
     }
 
     /// Returns a URL string created from the URLComponents.


### PR DESCRIPTION
This PR addresses main behavioral differences of the new Swift `URL` implementation in order to preserve bincompat.

- Adds a compatibility path to the parser allowing the scheme to be empty for `URL`. This was the behavior in the old implementation, and can cause `URL` to return different components for URL strings starting with `:`.
- Returns `nil` host for URLs like `https:///` instead of returning empty string. RFC 3986 suggests this should be an empty string, but I don't think this conformance outweighs compatibility here.
- Linked-on-or-after-check where `URL(filePath:)` will check for full `file:` and `http:` URL strings that were incorrectly passed. It drops the `file:` scheme or passes the `http:` string to `URL(string:)` instead. It also logs an "API MISUSE" fault in these cases. This fixes apps that rely on old buggy behavior where passing a full URL string as `filePath` could happen to work itself out if a different API like `.appendingPathComponent(_:)` is called immediately after.
- Makes `.appending(component:)` behave like `.appending(path:)` for file URLs, so that it does not percent-encode `/` to `%2F`. The old implementation had a bug where this actually didn't happen for file URLs, so we should maintain that old behavior to prevent breakage.
- Restores `URL(string:relativeTo:)` returning `nil` for empty string and instead uses an internal `URL(stringOrEmpty:relativeTo:)` in cases where we do need to initialize with the empty string, such as when `.deletingLastPathComponent()` of a single-component path. We can still pass the empty string RFC tests using `URL(stringOrEmpty:relativeTo:)`.
- Restores file path initializers' behavior of replacing an empty input path with `./` or `.`