### PR TITLE
URLComponents.string should percent-encode colons in first path segment if needed

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1498,7 +1498,7 @@ public struct URL: Equatable, Sendable, Hashable {
         }
         #endif
         if _baseParseInfo != nil {
-            return absoluteURL.path(percentEncoded: percentEncoded)
+            return absoluteURL.relativePath(percentEncoded: percentEncoded)
         }
         if percentEncoded {
             return String(_parseInfo.path)

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1327,6 +1327,19 @@ final class URLTests : XCTestCase {
         comp = try XCTUnwrap(URLComponents(string: legalURLString))
         XCTAssertEqual(comp.string, legalURLString)
         XCTAssertEqual(comp.percentEncodedPath, colonFirstPath)
+
+        // Colons should be percent-encoded by URLComponents.string if
+        // they could be misinterpreted as a scheme separator.
+
+        comp = URLComponents()
+        comp.percentEncodedPath = "not%20a%20scheme:"
+        XCTAssertEqual(comp.string, "not%20a%20scheme%3A")
+
+        // These would fail if we did not percent-encode the colon.
+        // .string should always produce a valid URL string, or nil.
+
+        XCTAssertNotNil(URL(string: comp.string!))
+        XCTAssertNotNil(URLComponents(string: comp.string!))
     }
 
     func testURLComponentsInvalidPaths() {


### PR DESCRIPTION
The following code can recursively call `.path()`, causing an infinite loop.

```
let str = "./not a scheme:"
let baseStr = "base"
let base = URL(string: baseStr)!
let url = URL(string: str, relativeTo: base)!
print(url.path()) // Infinite loop
```

The issue is that `self.path()` calls `.absoluteURL.path()` if `self` has a base URL. `.absoluteURL` _should_ never have a base URL, so this shouldn't recurse. However, if `URL(string: absoluteString)` fails like it does in this example, then `.absoluteURL` returns `self`, causing the recursion.

In the example above, merging the relative and base paths gives us `./not%20a%20scheme:` since they are both relative. Then, we remove the dot segments as specified by the RFC algorithm, giving us `not%20a%20scheme:`. We assign this to a `urlComponents.percentEncodedPath`, then when we're finished building the components, we call `urlComponents.string` to get the absolute string.

`URLComponents.string` should always return a parsable URL string, or `nil`. In this case, the string that's returned is `not%20a%20scheme:`, which is not valid.

This PR fixes the issue by:
1. Percent-encoding colons in the first path segment when generating `URLComponents.string`, but only if the colons could be mistaken as a scheme separator.
2. Calling `absoluteURL.relativePath()` instead to ensure that we never recurse.