### PR TITLE
Allow URLParser to be called directly from ObjC

### DIFF
--- a/Sources/FoundationEssentials/URL/URLComponents_ObjC.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents_ObjC.swift
@@ -33,6 +33,10 @@ extension NSURLComponents {
         guard let components = URLComponents(string: string, encodingInvalidCharacters: encodingInvalidCharacters) else { return nil }
         return _NSSwiftURLComponents(components: components)
     }
+
+    static func _parseString(_ string: String, encodingInvalidCharacters: Bool, compatibility: URLParserCompatibility.RawValue) -> String? {
+        return RFC3986Parser.parse(urlString: string, encodingInvalidCharacters: encodingInvalidCharacters, compatibility: .init(rawValue: compatibility))?.urlString
+    }
 }
 
 #if canImport(_FoundationICU)

--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -699,7 +699,7 @@ internal struct RFC3986Parser: URLParserProtocol {
             }
         }
 
-        return parse(urlString: finalURLString)
+        return parse(urlString: finalURLString, compatibility: compatibility)
     }
 
     /// Parses a URL string into its component parts and stores these ranges in a `URLParseInfo`.


### PR DESCRIPTION
Allow compatibility-mode Swift URL parsing to be called directly from ObjC, saving an `NSURLComponents` allocation and improving performance.