### PR TITLE
URL.absoluteString crashes if baseURL starts with colon

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1123,7 +1123,9 @@ public struct URL: Equatable, Sendable, Hashable {
         }
 
         if let baseScheme = _baseParseInfo.scheme {
-            result.scheme = String(baseScheme)
+            // Scheme might be empty, which URL allows for compatibility,
+            // but URLComponents does not, so we force it internally.
+            result.forceScheme(String(baseScheme))
         }
 
         if hasAuthority {
@@ -1498,7 +1500,7 @@ public struct URL: Equatable, Sendable, Hashable {
         }
         #endif
         if _baseParseInfo != nil {
-            return absoluteURL.path(percentEncoded: percentEncoded)
+            return absoluteURL.relativePath(percentEncoded: percentEncoded)
         }
         if percentEncoded {
             return String(_parseInfo.path)

--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -142,10 +142,12 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             return nil
         }
 
-        mutating func setScheme(_ newValue: String?) throws {
+        mutating func setScheme(_ newValue: String?, force: Bool = false) throws {
             reset(.scheme)
-            guard Parser.validate(newValue, component: .scheme) else {
-                throw InvalidComponentError.scheme
+            if !force {
+                guard Parser.validate(newValue, component: .scheme) else {
+                    throw InvalidComponentError.scheme
+                }
             }
             _scheme = newValue
             if encodedHost != nil {
@@ -714,6 +716,11 @@ public struct URLComponents: Hashable, Equatable, Sendable {
                 fatalError("Attempting to set scheme with invalid characters")
             }
         }
+    }
+
+    /// Used by `URL` to allow empty scheme for compatibility.
+    internal mutating func forceScheme(_ scheme: String) {
+        try? components.setScheme(scheme, force: true)
     }
 
 #if FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -946,6 +946,21 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(schemeOnly.absoluteString, "scheme:foo")
     }
 
+    func testURLEmptySchemeCompatibility() throws {
+        var url = try XCTUnwrap(URL(string: ":memory:"))
+        XCTAssertEqual(url.scheme, "")
+
+        let base = try XCTUnwrap(URL(string: "://home"))
+        XCTAssertEqual(base.host(), "home")
+
+        url = try XCTUnwrap(URL(string: "/path", relativeTo: base))
+        XCTAssertEqual(url.scheme, "")
+        XCTAssertEqual(url.host(), "home")
+        XCTAssertEqual(url.path, "/path")
+        XCTAssertEqual(url.absoluteString, "://home/path")
+        XCTAssertEqual(url.absoluteURL.scheme, "")
+    }
+
     func testURLComponentsPercentEncodedUnencodedProperties() throws {
         var comp = URLComponents()
 


### PR DESCRIPTION
Recent regression from reverting to compatibility `URL` behaviors in #1113.

`URL.absoluteString` uses `URLComponents` to build the string from the correct parts of the relative and base URLs. After allowing `URL` to have an empty scheme for compatibility in #1113, `URL.absoluteString` would crash if we used an empty scheme from the base URL. The crash occurs when we assign `components.scheme = ""` since `URLComponents` does not consider an empty scheme valid.

Since we are only using `URLComponents` to produce an absolute string, we can bypass the scheme validation with an internal function, since the scheme used for the URL's `absoluteString` has already been validated by the base `URL`.