### PR TITLE
[6.1][android] fix 32-bit build (#1086)

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -960,7 +960,7 @@ enum _FileOperations {
             
             #if !os(WASI) // WASI doesn't have fchmod for now
             // Copy permissions
-            if fchmod(dstFD, statInfo.st_mode) != 0 {
+            if fchmod(dstFD, mode_t(statInfo.st_mode)) != 0 {
                 try delegate.throwIfNecessary(errno, srcPath(), dstPath())
             }
             #endif


### PR DESCRIPTION
__Explanation:__ A single type conversion that @hyp added after bb3fccfa3 to get Android armv7 building again, this is [the last patch I apply on my Android CI for this repo for 6.1](https://github.com/finagolfin/swift-android-sdk/blob/main/swift-android-foundation-devel.patch).

__Scope:__ Should do nothing on most platforms

__Issue:__ None

__Original PR:__ #1086

__Risk:__ very low

__Testing:__ Passed all CI on trunk and my Android CI for the last month

__Reviewer:__ @compnerd