### PR TITLE
Fix FreeBSD tests

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -34,7 +34,7 @@ extension FileManager {
 }
 
 private struct DelegateCaptures : Equatable, Sendable {
-    struct Operation : Equatable, CustomStringConvertible {
+    struct Operation : Equatable, CustomStringConvertible, Comparable {
         let src: String
         let dst: String?
         
@@ -44,6 +44,10 @@ private struct DelegateCaptures : Equatable, Sendable {
             } else {
                 "'\(src)'"
             }
+        }
+
+        static func <(lhs: Operation, rhs: Operation) -> Bool {
+          lhs.src < rhs.src || lhs.dst == nil || (rhs.dst != nil && lhs.dst! < rhs.dst!)
         }
         
         init(_ src: String, _ dst: String? = nil) {
@@ -507,9 +511,9 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual($0.contents(atPath: "dir/foo"), data)
             XCTAssertEqual($0.contents(atPath: "dir2/foo"), data)
 #if os(Windows)
-            XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/bar", "dir2/bar"), .init("dir/foo", "dir2/foo")])
+            XCTAssertEqual($0.delegateCaptures.shouldCopy.sorted(), [.init("dir", "dir2"), .init("dir/bar", "dir2/bar"), .init("dir/foo", "dir2/foo")].sorted())
 #else
-            XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")])
+            XCTAssertEqual($0.delegateCaptures.shouldCopy.sorted(), [.init("dir", "dir2"), .init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")].sorted())
             
             // Specifically for non-Windows (where copying directory metadata takes a special path) double check that the metadata was copied exactly
             XCTAssertEqual(try $0.attributesOfItem(atPath: "dir2")[.posixPermissions] as? UInt, 0o777)

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -511,9 +511,11 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual($0.contents(atPath: "dir/foo"), data)
             XCTAssertEqual($0.contents(atPath: "dir2/foo"), data)
 #if os(Windows)
-            XCTAssertEqual($0.delegateCaptures.shouldCopy.sorted(), [.init("dir", "dir2"), .init("dir/bar", "dir2/bar"), .init("dir/foo", "dir2/foo")].sorted())
+            XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/bar", "dir2/bar"), .init("dir/foo", "dir2/foo")])
 #else
-            XCTAssertEqual($0.delegateCaptures.shouldCopy.sorted(), [.init("dir", "dir2"), .init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")].sorted())
+            var shouldCopy = $0.delegateCaptures.shouldCopy
+            XCTAssertEqual(shouldCopy.removeFirst(), .init("dir", "dir2"))
+            XCTAssertEqual(shouldCopy.sorted(), [.init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")].sorted())
             
             // Specifically for non-Windows (where copying directory metadata takes a special path) double check that the metadata was copied exactly
             XCTAssertEqual(try $0.attributesOfItem(atPath: "dir2")[.posixPermissions] as? UInt, 0o777)

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -171,7 +171,7 @@ final class ProcessInfoTests : XCTestCase {
     func testProcessName() {
 #if FOUNDATION_FRAMEWORK
         let targetName = "TestHost"
-#elseif os(Linux) || os(Windows) || os(Android)
+#elseif os(Linux) || os(Windows) || os(Android) || os(FreeBSD)
         let targetName = "swift-foundationPackageTests.xctest"
 #else
         let targetName = "xctest"


### PR DESCRIPTION
Apart from a trivial change for `ProcessInfoTests`. This PR make `FileManagerTests` to compare the sorted output instead since this test sometimes fails due to the ordering of elements in the array.