### PR TITLE
Fix FreeBSD date formatting

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -259,7 +259,7 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
         // NSDate uses the constant format `uuuu-MM-dd HH:mm:ss '+0000'`
 
         // Glibc needs a non-standard format option to pad %Y to 4 digits
-#if canImport(Glibc)
+#if canImport(Glibc) && !os(FreeBSD)
         let format = "%4Y-%m-%d %H:%M:%S +0000"
 #else
         let format = "%Y-%m-%d %H:%M:%S +0000"


### PR DESCRIPTION
Unlike other `import Glibc` platforms, FreeBSD needs to standard format to produce correct output. Otherwise, the year components is set to the `4Y` constant.