### PR TITLE
Prevent potential buffer over-reads of file system representations

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -220,6 +220,13 @@ extension UnsafeBufferPointer {
         var decoder = T()
         var iterator = self.makeIterator()
         
+        defer {
+            if nullTerminated {
+                // Ensure buffer is always null-terminated even on failure to prevent buffer over-reads
+                buffer[buffer.count - 1] = 0
+            }
+        }
+        
         func appendOutput(_ values: some Collection<UInt8>) throws {
             let bufferPortion = UnsafeMutableBufferPointer(start: buffer.baseAddress!.advanced(by: bufferIdx), count: bufferLength - bufferIdx)
             guard bufferPortion.count >= values.count else {
@@ -324,6 +331,10 @@ extension NSString {
             } else if self.fastestEncoding == NSASCIIStringEncoding, let fastUTF8 = self._fastCStringContents(false) {
                 // If we have quick access to ASCII contents, no need to decompose
                 let utf8Buffer = UnsafeBufferPointer(start: fastUTF8, count: self.length)
+                defer {
+                    // Ensure buffer is always null-terminated even on failure to prevent buffer over-reads
+                    buffer[buffer.count - 1] = 0
+                }
                 
                 // We only allow embedded nulls if there are no non-null characters following the first null character
                 if let embeddedNullIdx = utf8Buffer.firstIndex(of: 0) {

--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -223,7 +223,9 @@ extension UnsafeBufferPointer {
         defer {
             if nullTerminated {
                 // Ensure buffer is always null-terminated even on failure to prevent buffer over-reads
-                buffer[buffer.count - 1] = 0
+                if !buffer.isEmpty {
+                    buffer[buffer.count - 1] = 0
+                }
             }
         }
         
@@ -333,7 +335,9 @@ extension NSString {
                 let utf8Buffer = UnsafeBufferPointer(start: fastUTF8, count: self.length)
                 defer {
                     // Ensure buffer is always null-terminated even on failure to prevent buffer over-reads
-                    buffer[buffer.count - 1] = 0
+                    if !buffer.isEmpty {
+                        buffer[buffer.count - 1] = 0
+                    }
                 }
                 
                 // We only allow embedded nulls if there are no non-null characters following the first null character


### PR DESCRIPTION
The CoreFoundation-level file system representation APIs allow for filling a provided buffer and returning a boolean value indicating success or failure. In some cases, we've seen clients partially filling a buffer, failing, and then reading the buffer despite the `false` return value. We can't avoid writing partial results to the buffer (as some clients depend on the partial results) but we can ensure that the buffer ends with a null terminator even in cases of failure. While the buffer may contain incorrect values, it will at least prevent simple buffer over-reads caused by immediate calls to functions like `strlen` on the return value.