### PR TITLE
Add an HTTP format style for both `Date` and `DateComponents`

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -608,6 +608,19 @@ public struct Calendar : Hashable, Equatable, Sendable {
         return dc
     }
 
+    /// Same as `dateComponents:from:` but uses the more efficient bitset form of ComponentSet.
+    /// Prefixed with `_` to avoid ambiguity at call site with the `Set<Component>` method.
+    internal func _dateComponents(_ components: ComponentSet, from date: Date, in timeZone: TimeZone) -> DateComponents {
+        var dc = _calendar.dateComponents(components, from: date.capped, in: timeZone)
+
+        // Fill out the Calendar field of dateComponents, if requested.
+        if components.contains(.calendar) {
+            dc.calendar = self
+        }
+
+        return dc
+    }
+
     /// Returns all the date components of a date, as if in a given time zone (instead of the `Calendar` time zone).
     ///
     /// The time zone overrides the time zone of the `Calendar` for the purposes of this calculation.

--- a/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
+++ b/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
@@ -55,3 +55,47 @@ extension Date {
     }
 #endif // FOUNDATION_FRAMEWORK
 }
+
+@available(FoundationPreview 6.2, *)
+extension DateComponents {
+    /// Converts `self` to its textual representation.
+    /// - Parameter format: The format for formatting `self`.
+    /// - Returns: A representation of `self` using the given `format`. The type of the representation is specified by `FormatStyle.FormatOutput`.
+#if FOUNDATION_FRAMEWORK
+    public func formatted<F: Foundation.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == DateComponents {
+        format.format(self)
+    }
+#else
+    public func formatted<F: FoundationEssentials.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == DateComponents {
+        format.format(self)
+    }
+#endif // FOUNDATION_FRAMEWORK
+    
+    // Parsing
+    /// Creates a new `Date` by parsing the given representation.
+    /// - Parameter value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
+    /// - Parameters:
+    ///   - value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
+    ///   - strategy: The parse strategy to parse `value` whose `ParseOutput` is `Date`.
+#if FOUNDATION_FRAMEWORK
+    public init<T: Foundation.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
+        self = try strategy.parse(value)
+    }
+#else
+    public init<T: FoundationEssentials.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
+        self = try strategy.parse(value)
+    }
+#endif // FOUNDATION_FRAMEWORK
+    /// Creates a new `Date` by parsing the given string representation.
+#if FOUNDATION_FRAMEWORK
+    @_disfavoredOverload
+    public init<T: Foundation.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
+        self = try strategy.parse(String(value))
+    }
+#else
+    @_disfavoredOverload
+    public init<T: FoundationEssentials.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
+        self = try strategy.parse(String(value))
+    }
+#endif // FOUNDATION_FRAMEWORK
+}

--- a/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
+++ b/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
@@ -72,11 +72,11 @@ extension DateComponents {
 #endif // FOUNDATION_FRAMEWORK
     
     // Parsing
-    /// Creates a new `Date` by parsing the given representation.
+    /// Creates a new `DateComponents` by parsing the given representation.
     /// - Parameter value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
     /// - Parameters:
     ///   - value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
-    ///   - strategy: The parse strategy to parse `value` whose `ParseOutput` is `Date`.
+    ///   - strategy: The parse strategy to parse `value` whose `ParseOutput` is `DateComponents`.
 #if FOUNDATION_FRAMEWORK
     public init<T: Foundation.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
         self = try strategy.parse(value)
@@ -86,7 +86,7 @@ extension DateComponents {
         self = try strategy.parse(value)
     }
 #endif // FOUNDATION_FRAMEWORK
-    /// Creates a new `Date` by parsing the given string representation.
+    /// Creates a new `DateComponents` by parsing the given string representation.
 #if FOUNDATION_FRAMEWORK
     @_disfavoredOverload
     public init<T: Foundation.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {

--- a/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
+++ b/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
@@ -61,15 +61,9 @@ extension DateComponents {
     /// Converts `self` to its textual representation.
     /// - Parameter format: The format for formatting `self`.
     /// - Returns: A representation of `self` using the given `format`. The type of the representation is specified by `FormatStyle.FormatOutput`.
-#if FOUNDATION_FRAMEWORK
-    public func formatted<F: Foundation.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == DateComponents {
+    public func formatted<F: FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == DateComponents {
         format.format(self)
     }
-#else
-    public func formatted<F: FoundationEssentials.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == DateComponents {
-        format.format(self)
-    }
-#endif // FOUNDATION_FRAMEWORK
     
     // Parsing
     /// Creates a new `DateComponents` by parsing the given representation.
@@ -77,25 +71,13 @@ extension DateComponents {
     /// - Parameters:
     ///   - value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
     ///   - strategy: The parse strategy to parse `value` whose `ParseOutput` is `DateComponents`.
-#if FOUNDATION_FRAMEWORK
-    public init<T: Foundation.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
+    public init<T: ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
         self = try strategy.parse(value)
     }
-#else
-    public init<T: FoundationEssentials.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
-        self = try strategy.parse(value)
-    }
-#endif // FOUNDATION_FRAMEWORK
+
     /// Creates a new `DateComponents` by parsing the given string representation.
-#if FOUNDATION_FRAMEWORK
     @_disfavoredOverload
-    public init<T: Foundation.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
+    public init<T: ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
         self = try strategy.parse(String(value))
     }
-#else
-    @_disfavoredOverload
-    public init<T: FoundationEssentials.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
-        self = try strategy.parse(String(value))
-    }
-#endif // FOUNDATION_FRAMEWORK
 }

--- a/Sources/FoundationEssentials/Formatting/Date+HTTPFormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+HTTPFormatStyle.swift
@@ -152,7 +152,7 @@ extension DateComponents.HTTPFormatStyle : ParseStrategy {
 extension DateComponents {
     /// Converts `DateComponents` into RFC 9110-compatible "HTTP date" `String`, and parses in the reverse direction.
     /// This parser does not do validation on the individual values of the components. An optional date can be created from the result using `Calendar(identifier: .gregorian).date(from: ...)`.
-    /// When formatting, missing or invalid fields are filled with default values: `Sun`, `01`, `Jan`, `2000`, `00:00:00`, `GMT`. Note that missing fields may result in an invalid date or time.
+    /// When formatting, missing or invalid fields are filled with default values: `Sun`, `01`, `Jan`, `2000`, `00:00:00`, `GMT`. Note that missing fields may result in an invalid date or time. Other values in the `DateComponents` are ignored.
     public struct HTTPFormatStyle : Sendable, Hashable, Codable, ParseableFormatStyle {
         public init() {
         }
@@ -431,8 +431,9 @@ extension DateComponents {
             if second < 0 || second > 60 {
                 throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Second \(second) is out of bounds")
             }
+            // Foundation does not support leap seconds. We convert 60 seconds into 59 seconds.
             if second == 60 {
-                dc.second = 0
+                dc.second = 59
             } else {
                 dc.second = second
             }

--- a/Sources/FoundationEssentials/Formatting/Date+HTTPFormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+HTTPFormatStyle.swift
@@ -115,13 +115,6 @@ extension RegexComponent where Self == Date.HTTPFormatStyle {
 // MARK: - Components
 
 @available(FoundationPreview 6.2, *)
-extension DateComponents {
-    public func HTTPComponentsFormat(_ style: HTTPFormatStyle = .init()) -> String {
-        return style.format(self)
-    }
-}
-
-@available(FoundationPreview 6.2, *)
 public extension FormatStyle where Self == DateComponents.HTTPFormatStyle {
     static var http: Self {
         return DateComponents.HTTPFormatStyle()
@@ -338,7 +331,7 @@ extension DateComponents {
                 throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now))
             }
             
-            if maybeWeekday1 >= UInt8(ascii: "0") && maybeWeekday1 <= UInt8(ascii: "9") {
+            if isASCIIDigit(maybeWeekday1) {
                 // This is the first digit of the day. Weekday is not present.
             } else {
                 // Anything else must be a day-name (Mon, Tue, ... Sun)
@@ -366,8 +359,8 @@ extension DateComponents {
                 }
                 
                 // Move past , and space to weekday
-                try it.expectCharacter(UInt8(ascii: ","), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
-                try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+                try it.expectCharacter(UInt8(ascii: ","), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing , after weekday")
+                try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing space after weekday")
             }
 
             dc.day = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing or malformed day")
@@ -427,7 +420,7 @@ extension DateComponents {
             
             try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
             let second = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
-            // second '60' is supported in the spec for leap seconds, but Foundation does not support leap seconds. 60 is adjusted to 0.
+            // second '60' is supported in the spec for leap seconds, but Foundation does not support leap seconds. 60 is adjusted to 59.
             if second < 0 || second > 60 {
                 throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Second \(second) is out of bounds")
             }

--- a/Sources/FoundationEssentials/Formatting/Date+HTTPFormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+HTTPFormatStyle.swift
@@ -1,0 +1,455 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(FoundationPreview 6.2, *)
+public extension FormatStyle where Self == Date.HTTPFormatStyle {
+    static var http: Self {
+        return Date.HTTPFormatStyle()
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+public extension ParseableFormatStyle where Self == Date.HTTPFormatStyle {
+    static var http: Self { .init() }
+}
+
+@available(FoundationPreview 6.2, *)
+public extension ParseStrategy where Self == Date.HTTPFormatStyle {
+    @_disfavoredOverload
+    static var http: Self { .init() }
+}
+
+@available(FoundationPreview 6.2, *)
+extension Date.HTTPFormatStyle : ParseStrategy {
+    public var parseStrategy: Date.HTTPFormatStyle { self }
+}
+
+@available(FoundationPreview 6.2, *)
+extension Date.HTTPFormatStyle : FormatStyle {
+}
+
+@available(FoundationPreview 6.2, *)
+extension Date {
+    /// Options for generating and parsing string representations of dates following the HTTP date format from [RFC 9110 § 5.6.7](https://www.rfc-editor.org/rfc/rfc9110.html#http.date).
+    public struct HTTPFormatStyle : Sendable, Hashable, Codable, ParseableFormatStyle {
+        let componentsStyle = DateComponents.HTTPFormatStyle()
+
+        public init() {}
+        public init(from decoder: any Decoder) throws {}
+        
+        public func format(_ date: Date) -> String {
+            // <day-name>, <day> <month> <year> <hour>:<minute>:<second> GMT
+            let components = Calendar(identifier: .gregorian)._dateComponents([.weekday, .day, .month, .year, .hour, .minute, .second], from: date, in: .gmt)
+            return componentsStyle.format(components)
+        }
+                
+        public func parse(_ value: String) throws -> Date {
+            guard let (_, date) = parse(value, in: value.startIndex..<value.endIndex) else {
+                throw parseError(value, exampleFormattedString: self.format(Date.now))
+            }
+            return date
+        }
+
+        fileprivate func parse(_ value: String, in range: Range<String.Index>) -> (String.Index, Date)? {
+            var v = value[range]
+            guard !v.isEmpty else {
+                return nil
+            }
+            
+            let result = v.withUTF8 { buffer -> (Int, Date)? in
+                let view = BufferView(unsafeBufferPointer: buffer)!
+
+                guard let comps = try? componentsStyle.components(from: value, in: view) else {
+                    return nil
+                }
+                
+                // HTTP dates are always GMT
+                guard let date = Calendar(identifier: .gregorian).date(from: comps.components) else {
+                    return nil
+                }
+                    
+                return (comps.consumed, date)
+            }
+            
+            guard let result else {
+                return nil
+            }
+            
+            let endIndex = value.utf8.index(v.startIndex, offsetBy: result.0)
+            return (endIndex, result.1)
+        }
+    }
+}
+
+// MARK: - Regex
+
+@available(FoundationPreview 6.2, *)
+extension Date.HTTPFormatStyle : CustomConsumingRegexComponent {
+    public typealias RegexOutput = Date
+    public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Date)? {
+        guard index < bounds.upperBound else {
+            return nil
+        }
+        // It's important to return nil from parse in case of a failure, not throw. That allows things like the firstMatch regex to work.
+        return self.parse(input, in: index..<bounds.upperBound)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension RegexComponent where Self == Date.HTTPFormatStyle {
+    /// Creates a regex component to match an HTTP date and time, such as "2015-11-14'T'15:05:03'Z'", and capture the string as a `Date` using the time zone as specified in the string.
+    public static var http: Date.HTTPFormatStyle {
+        return Date.HTTPFormatStyle()
+    }
+}
+
+// MARK: - Components
+
+@available(FoundationPreview 6.2, *)
+extension DateComponents {
+    public func HTTPComponentsFormat(_ style: HTTPFormatStyle = .init()) -> String {
+        return style.format(self)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+public extension FormatStyle where Self == DateComponents.HTTPFormatStyle {
+    static var http: Self {
+        return DateComponents.HTTPFormatStyle()
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+public extension ParseableFormatStyle where Self == DateComponents.HTTPFormatStyle {
+    static var http: Self { .init() }
+}
+
+@available(FoundationPreview 6.2, *)
+public extension ParseStrategy where Self == DateComponents.HTTPFormatStyle {
+    @_disfavoredOverload
+    static var http: Self { .init() }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DateComponents.HTTPFormatStyle : FormatStyle {
+}
+
+@available(FoundationPreview 6.2, *)
+extension DateComponents.HTTPFormatStyle : ParseStrategy {
+    public var parseStrategy: DateComponents.HTTPFormatStyle { self }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DateComponents {
+    /// Converts `DateComponents` into RFC 9110-compatible "HTTP date" `String`, and parses in the reverse direction.
+    /// This parser does not do validation on the individual values of the components. An optional date can be created from the result using `Calendar(identifier: .gregorian).date(from: ...)`.
+    public struct HTTPFormatStyle : Sendable, Hashable, Codable, ParseableFormatStyle {
+        public init() {
+        }
+        
+        // MARK: - Format
+        
+        public func format(_ components: DateComponents) -> String {
+            let capacity = 32 // It is believed no HTTP date can exceed this size (max should be 26)
+            return withUnsafeTemporaryAllocation(of: CChar.self, capacity: capacity + 1) { _buffer in
+                var buffer = OutputBuffer(initializing: _buffer.baseAddress!, capacity: _buffer.count)
+                
+                switch components.weekday {
+                case 1:
+                    buffer.appendElement(CChar(UInt8(ascii: "S")))
+                    buffer.appendElement(CChar(UInt8(ascii: "u")))
+                    buffer.appendElement(CChar(UInt8(ascii: "n")))
+                case 2:
+                    buffer.appendElement(CChar(UInt8(ascii: "M")))
+                    buffer.appendElement(CChar(UInt8(ascii: "o")))
+                    buffer.appendElement(CChar(UInt8(ascii: "n")))
+                case 3:
+                    buffer.appendElement(CChar(UInt8(ascii: "T")))
+                    buffer.appendElement(CChar(UInt8(ascii: "u")))
+                    buffer.appendElement(CChar(UInt8(ascii: "e")))
+                case 4:
+                    buffer.appendElement(CChar(UInt8(ascii: "W")))
+                    buffer.appendElement(CChar(UInt8(ascii: "e")))
+                    buffer.appendElement(CChar(UInt8(ascii: "d")))
+                case 5:
+                    buffer.appendElement(CChar(UInt8(ascii: "T")))
+                    buffer.appendElement(CChar(UInt8(ascii: "h")))
+                    buffer.appendElement(CChar(UInt8(ascii: "u")))
+                case 6:
+                    buffer.appendElement(CChar(UInt8(ascii: "F")))
+                    buffer.appendElement(CChar(UInt8(ascii: "r")))
+                    buffer.appendElement(CChar(UInt8(ascii: "i")))
+                case 7:
+                    buffer.appendElement(CChar(UInt8(ascii: "S")))
+                    buffer.appendElement(CChar(UInt8(ascii: "a")))
+                    buffer.appendElement(CChar(UInt8(ascii: "t")))
+                default:
+                    preconditionFailure("Invalid weekday \(String(describing: components.weekday))")
+                }
+                
+                buffer.appendElement(CChar(UInt8(ascii: ",")))
+                buffer.appendElement(CChar(UInt8(ascii: " ")))
+                
+                let day = components.day ?? 1
+                buffer.append(day, zeroPad: 2)
+                buffer.appendElement(CChar(UInt8(ascii: " ")))
+                
+                switch components.month {
+                case 1:
+                    buffer.appendElement(CChar(UInt8(ascii: "J")))
+                    buffer.appendElement(CChar(UInt8(ascii: "a")))
+                    buffer.appendElement(CChar(UInt8(ascii: "n")))
+                case 2:
+                    buffer.appendElement(CChar(UInt8(ascii: "F")))
+                    buffer.appendElement(CChar(UInt8(ascii: "e")))
+                    buffer.appendElement(CChar(UInt8(ascii: "b")))
+                case 3:
+                    buffer.appendElement(CChar(UInt8(ascii: "M")))
+                    buffer.appendElement(CChar(UInt8(ascii: "a")))
+                    buffer.appendElement(CChar(UInt8(ascii: "r")))
+                case 4:
+                    buffer.appendElement(CChar(UInt8(ascii: "A")))
+                    buffer.appendElement(CChar(UInt8(ascii: "p")))
+                    buffer.appendElement(CChar(UInt8(ascii: "r")))
+                case 5:
+                    buffer.appendElement(CChar(UInt8(ascii: "M")))
+                    buffer.appendElement(CChar(UInt8(ascii: "a")))
+                    buffer.appendElement(CChar(UInt8(ascii: "y")))
+                case 6:
+                    buffer.appendElement(CChar(UInt8(ascii: "J")))
+                    buffer.appendElement(CChar(UInt8(ascii: "u")))
+                    buffer.appendElement(CChar(UInt8(ascii: "n")))
+                case 7:
+                    buffer.appendElement(CChar(UInt8(ascii: "J")))
+                    buffer.appendElement(CChar(UInt8(ascii: "u")))
+                    buffer.appendElement(CChar(UInt8(ascii: "l")))
+                case 8:
+                    buffer.appendElement(CChar(UInt8(ascii: "A")))
+                    buffer.appendElement(CChar(UInt8(ascii: "u")))
+                    buffer.appendElement(CChar(UInt8(ascii: "g")))
+                case 9:
+                    buffer.appendElement(CChar(UInt8(ascii: "S")))
+                    buffer.appendElement(CChar(UInt8(ascii: "e")))
+                    buffer.appendElement(CChar(UInt8(ascii: "p")))
+                case 10:
+                    buffer.appendElement(CChar(UInt8(ascii: "O")))
+                    buffer.appendElement(CChar(UInt8(ascii: "c")))
+                    buffer.appendElement(CChar(UInt8(ascii: "t")))
+                case 11:
+                    buffer.appendElement(CChar(UInt8(ascii: "N")))
+                    buffer.appendElement(CChar(UInt8(ascii: "o")))
+                    buffer.appendElement(CChar(UInt8(ascii: "v")))
+                case 12:
+                    buffer.appendElement(CChar(UInt8(ascii: "D")))
+                    buffer.appendElement(CChar(UInt8(ascii: "e")))
+                    buffer.appendElement(CChar(UInt8(ascii: "c")))
+                default:
+                    preconditionFailure("Invalid month \(String(describing: components.month))")
+                }
+                buffer.appendElement(CChar(UInt8(ascii: " ")))
+                
+                let year = components.year ?? 2000
+                buffer.append(year, zeroPad: 4)
+                buffer.appendElement(CChar(UInt8(ascii: " ")))
+                
+                let h = components.hour!
+                let m = components.minute!
+                let s = components.second!
+                
+                buffer.append(h, zeroPad: 2)
+                buffer.appendElement(CChar(UInt8(ascii: ":")))
+                buffer.append(m, zeroPad: 2)
+                buffer.appendElement(CChar(UInt8(ascii: ":")))
+                buffer.append(s, zeroPad: 2)
+                
+                buffer.appendElement(CChar(UInt8(ascii: " ")))
+                buffer.appendElement(CChar(UInt8(ascii: "G")))
+                buffer.appendElement(CChar(UInt8(ascii: "M")))
+                buffer.appendElement(CChar(UInt8(ascii: "T")))
+                
+                // Null-terminate
+                buffer.appendElement(CChar(0))
+                
+                // Make a string
+                let initialized = buffer.relinquishBorrowedMemory()
+                return String(validatingUTF8: initialized.baseAddress!)!
+            }
+        }
+        
+        // MARK: - Parse
+        
+        fileprivate struct ComponentsParseResult {
+            var consumed: Int
+            var components: DateComponents
+        }
+        
+        public func parse(_ value: String) throws -> DateComponents {
+            guard let (_, components) = parse(value, in: value.startIndex..<value.endIndex) else {
+                throw parseError(value, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now))
+            }
+            return components
+        }
+
+        private func parse(_ value: String, in range: Range<String.Index>) -> (String.Index, DateComponents)? {
+            var v = value[range]
+            guard !v.isEmpty else {
+                return nil
+            }
+            
+            let result = v.withUTF8 { buffer -> (Int, DateComponents)? in
+                let view = BufferView(unsafeBufferPointer: buffer)!
+
+                guard let comps = try? components(from: value, in: view) else {
+                    return nil
+                }
+                    
+                return (comps.consumed, comps.components)
+            }
+            
+            guard let result else {
+                return nil
+            }
+            
+            let endIndex = value.utf8.index(v.startIndex, offsetBy: result.0)
+            return (endIndex, result.1)
+        }
+        
+        fileprivate func components(from inputString: String, in view: borrowing BufferView<UInt8>) throws -> ComponentsParseResult {
+            // https://www.rfc-editor.org/rfc/rfc9110.html#http.date
+            // <day-name>, <day> <month> <year> <hour>:<minute>:<second> GMT
+
+            var it = view.makeIterator()
+            var dc = DateComponents()
+            
+            // Despite the spec, we allow the weekday name to be optional.
+            guard let maybeWeekday1 = it.peek() else {
+                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now))
+            }
+            
+            if maybeWeekday1 >= UInt8(ascii: "0") && maybeWeekday1 <= UInt8(ascii: "9") {
+                // This is the first digit of the day. Weekday is not present.
+            } else {
+                // Anything else must be a day-name (Mon, Tue, ... Sun)
+                guard let weekday1 = it.next(), let weekday2 = it.next(), let weekday3 = it.next() else {
+                    throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now))
+                }
+                
+                dc.weekday = switch (weekday1, weekday2, weekday3) {
+                case (UInt8(ascii: "S"), UInt8(ascii: "u"), UInt8(ascii: "n")):
+                    1
+                case (UInt8(ascii: "M"), UInt8(ascii: "o"), UInt8(ascii: "n")):
+                    2
+                case (UInt8(ascii: "T"), UInt8(ascii: "u"), UInt8(ascii: "e")):
+                    3
+                case (UInt8(ascii: "W"), UInt8(ascii: "e"), UInt8(ascii: "d")):
+                    4
+                case (UInt8(ascii: "T"), UInt8(ascii: "h"), UInt8(ascii: "u")):
+                    5
+                case (UInt8(ascii: "F"), UInt8(ascii: "r"), UInt8(ascii: "i")):
+                    6
+                case (UInt8(ascii: "S"), UInt8(ascii: "a"), UInt8(ascii: "t")):
+                    7
+                default:
+                    throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Malformed weekday name")
+                }
+                
+                // Move past , and space to weekday
+                try it.expectCharacter(UInt8(ascii: ","), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+                try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            }
+
+            dc.day = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing or malformed day")
+            try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+
+            // month-name (Jan, Feb, ... Dec)
+            guard let month1 = it.next(), let month2 = it.next(), let month3 = it.next() else {
+                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing month")
+            }
+            
+            dc.month = switch (month1, month2, month3) {
+            case (UInt8(ascii: "J"), UInt8(ascii: "a"), UInt8(ascii: "n")):
+                1
+            case (UInt8(ascii: "F"), UInt8(ascii: "e"), UInt8(ascii: "b")):
+                2
+            case (UInt8(ascii: "M"), UInt8(ascii: "a"), UInt8(ascii: "r")):
+                3
+            case (UInt8(ascii: "A"), UInt8(ascii: "p"), UInt8(ascii: "r")):
+                4
+            case (UInt8(ascii: "M"), UInt8(ascii: "a"), UInt8(ascii: "y")):
+                5
+            case (UInt8(ascii: "J"), UInt8(ascii: "u"), UInt8(ascii: "n")):
+                6
+            case (UInt8(ascii: "J"), UInt8(ascii: "u"), UInt8(ascii: "l")):
+                7
+            case (UInt8(ascii: "A"), UInt8(ascii: "u"), UInt8(ascii: "g")):
+                8
+            case (UInt8(ascii: "S"), UInt8(ascii: "e"), UInt8(ascii: "p")):
+                9
+            case (UInt8(ascii: "O"), UInt8(ascii: "c"), UInt8(ascii: "t")):
+                10
+            case (UInt8(ascii: "N"), UInt8(ascii: "o"), UInt8(ascii: "v")):
+                11
+            case (UInt8(ascii: "D"), UInt8(ascii: "e"), UInt8(ascii: "c")):
+                12
+            default:
+                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Month \(String(describing: dc.month)) is out of bounds")
+            }
+
+            try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+
+            dc.year = try it.digits(minDigits: 4, maxDigits: 4, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+
+            let hour = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            if hour < 0 || hour > 23 {
+                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Hour \(hour) is out of bounds")
+            }
+            dc.hour = hour
+            
+            try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            let minute = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            if minute < 0 || minute > 59 {
+                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Minute \(minute) is out of bounds")
+            }
+            dc.minute = minute
+            
+            try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            let second = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            // second '60' is supported in the spec for leap seconds, but Foundation does not support leap seconds. 60 is adjusted to 0.
+            if second < 0 || second > 60 {
+                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Second \(second) is out of bounds")
+            }
+            if second == 60 {
+                dc.second = 0
+            } else {
+                dc.second = second
+            }
+            try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+
+            // "GMT"
+            try it.expectCharacter(UInt8(ascii: "G"), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing GMT time zone")
+            try it.expectCharacter(UInt8(ascii: "M"), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing GMT time zone")
+            try it.expectCharacter(UInt8(ascii: "T"), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing GMT time zone")
+
+            // Time zone is always GMT, calendar is always Gregorian
+            dc.timeZone = .gmt
+            dc.calendar = Calendar(identifier: .gregorian)
+
+            // Would be nice to see this functionality on BufferView, but for now we calculate it ourselves.
+            let utf8CharactersRead = it.curPointer - view.startIndex._rawValue
+            
+            return ComponentsParseResult(consumed: utf8CharactersRead, components: dc)
+        }
+
+    }
+}
+

--- a/Sources/FoundationEssentials/Formatting/FormatParsingUtilities.swift
+++ b/Sources/FoundationEssentials/Formatting/FormatParsingUtilities.swift
@@ -10,13 +10,136 @@
 //
 //===----------------------------------------------------------------------===//
 
-package func parseError(_ value: String, exampleFormattedString: String?) -> CocoaError {
+package func parseError(_ value: String, exampleFormattedString: String?, extendedDescription: String? = nil) -> CocoaError {
     let errorStr: String
     if let exampleFormattedString = exampleFormattedString {
-        errorStr = "Cannot parse \(value). String should adhere to the preferred format of the locale, such as \(exampleFormattedString)."
+        errorStr = "Cannot parse \(value)\(extendedDescription.map({ ": \($0)." }) ?? ".") String should adhere to the preferred format of the locale, such as \(exampleFormattedString)."
     } else {
-        errorStr = "Cannot parse \(value)."
+        errorStr = "Cannot parse \(value)\(extendedDescription.map({ ": \($0)." }) ?? ".")"
     }
     return CocoaError(CocoaError.formatting, userInfo: [ NSDebugDescriptionErrorKey: errorStr ])
+}
+
+func isASCIIDigit(_ x: UInt8) -> Bool {
+    x >= UInt8(ascii: "0") && x <= UInt8(ascii: "9")
+}
+
+extension BufferViewIterator<UInt8> {
+    mutating func expectCharacter(_ expected: UInt8, input: String, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws {
+        guard let parsed = next(), parsed == expected else {
+            throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
+        }
+    }
+    
+    mutating func expectOneOrMoreCharacters(_ expected: UInt8, input: String, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws {
+        guard let parsed = next(), parsed == expected else {
+            throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
+        }
+        
+        while let parsed = peek(), parsed == expected {
+            advance()
+        }
+    }
+    
+    mutating func expectZeroOrMoreCharacters(_ expected: UInt8) {
+        while let parsed = peek(), parsed == expected {
+            advance()
+        }
+    }
+            
+    mutating func digits(minDigits: Int? = nil, maxDigits: Int? = nil, nanoseconds: Bool = false, input: String, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws -> Int {
+        // Consume all leading zeros, parse until we no longer see a digit
+        var result = 0
+        var count = 0
+        // Cap at 10 digits max to avoid overflow
+        let max = min(maxDigits ?? 10, 10)
+        while let next = peek(), isASCIIDigit(next) {
+            let digit = Int(next - UInt8(ascii: "0"))
+            result *= 10
+            result += digit
+            advance()
+            count += 1
+            if count >= max { break }
+        }
+        
+        guard count > 0 else {
+            // No digits actually found
+            throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
+        }
+        
+        if let minDigits, count < minDigits {
+            // Too few digits found
+            throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
+        }
+        
+        if nanoseconds {
+            // Keeps us in the land of integers
+            if count == 1 { return result * 100_000_000 }
+            if count == 2 { return result * 10_000_000 }
+            if count == 3 { return result * 1_000_000 }
+            if count == 4 { return result * 100_000 }
+            if count == 5 { return result * 10_000 }
+            if count == 6 { return result * 1_000 }
+            if count == 7 { return result * 100 }
+            if count == 8 { return result * 10 }
+            if count == 9 { return result }
+            throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
+        }
+
+        return result
+    }
+    
+
+}
+
+// Formatting helpers
+extension OutputBuffer<CChar> {
+    static let asciiZero = CChar(48)
+
+    mutating func append(_ i: Int, zeroPad: Int) {
+        if i < 10 {
+            if zeroPad - 1 > 0 {
+                for _ in 0..<zeroPad-1 { appendElement(Self.asciiZero) }
+            }
+            appendElement(Self.asciiZero + CChar(i))
+        } else if i < 100 {
+            if zeroPad - 2 > 0 {
+                for _ in 0..<zeroPad-2 { appendElement(Self.asciiZero) }
+            }
+            let (tens, ones) = i.quotientAndRemainder(dividingBy: 10)
+            appendElement(Self.asciiZero + CChar(tens))
+            appendElement(Self.asciiZero + CChar(ones))
+        } else if i < 1000 {
+            if zeroPad - 3 > 0 {
+                for _ in 0..<zeroPad-3 { appendElement(Self.asciiZero) }
+            }
+            let (hundreds, remainder) = i.quotientAndRemainder(dividingBy: 100)
+            let (tens, ones) = remainder.quotientAndRemainder(dividingBy: 10)
+            appendElement(Self.asciiZero + CChar(hundreds))
+            appendElement(Self.asciiZero + CChar(tens))
+            appendElement(Self.asciiZero + CChar(ones))
+        } else if i < 10000 {
+            if zeroPad - 4 > 0 {
+                for _ in 0..<zeroPad-4 { appendElement(Self.asciiZero) }
+            }
+            let (thousands, remainder) = i.quotientAndRemainder(dividingBy: 1000)
+            let (hundreds, remainder2) = remainder.quotientAndRemainder(dividingBy: 100)
+            let (tens, ones) = remainder2.quotientAndRemainder(dividingBy: 10)
+            appendElement(Self.asciiZero + CChar(thousands))
+            appendElement(Self.asciiZero + CChar(hundreds))
+            appendElement(Self.asciiZero + CChar(tens))
+            appendElement(Self.asciiZero + CChar(ones))
+        } else {
+            // Special case - we don't do zero padding
+            var desc = i.numericStringRepresentation
+            desc.withUTF8 {
+                $0.withMemoryRebound(to: CChar.self) { buf in
+                    append(fromContentsOf: buf)
+                }
+            }
+        }
+    }
+
+    
 }
 

--- a/Tests/FoundationEssentialsTests/Formatting/HTTPFormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/HTTPFormatStyleFormattingTests.swift
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if canImport(FoundationEssentials)
+@testable import FoundationEssentials
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#endif
+
+final class HTTPFormatStyleFormattingTests: XCTestCase {
+    
+    func test_HTTPFormat() throws {
+        let date = Date.now
+        
+        let formatted = date.formatted(.http) // e.g.  "Fri, 17 Jan 2025 19:03:05 GMT"
+        let parsed = try? Date(formatted, strategy: .http)
+        
+        let result = try XCTUnwrap(parsed)
+        XCTAssertEqual(date.timeIntervalSinceReferenceDate, result.timeIntervalSinceReferenceDate, accuracy: 1.0)
+    }
+    
+    func test_HTTPFormat_components() throws {
+        let date = Date.now
+        let formatted = date.formatted(.http) // e.g.  "Fri, 17 Jan 2025 19:03:05 GMT"
+        
+        let parsed = try? DateComponents(formatted, strategy: .http)
+        
+        let result = try XCTUnwrap(parsed)
+        
+        let resultDate = Calendar(identifier: .gregorian).date(from: result)
+        let resultDateUnwrapped = try XCTUnwrap(resultDate)
+        
+        XCTAssertEqual(date.timeIntervalSinceReferenceDate, resultDateUnwrapped.timeIntervalSinceReferenceDate, accuracy: 1.0)
+    }
+    
+    func test_HTTPFormat_variousInputs() throws {
+        let tests = [
+            "Mon, 20 Jan 2025 01:02:03 GMT",
+            "Tue, 20 Jan 2025 10:02:03 GMT",
+            "Wed, 20 Jan 2025 23:02:03 GMT",
+            "Thu, 20 Jan 2025 01:10:03 GMT",
+            "Fri, 20 Jan 2025 01:50:59 GMT",
+            "Sat, 20 Jan 2025 01:50:60 GMT", // 60 is valid, treated as 0
+            "Sun, 20 Jan 2025 01:03:03 GMT",
+            "20 Jan 2025 01:02:03 GMT", // Missing weekdays is ok
+            "20 Jan 2025 10:02:03 GMT",
+            "20 Jan 2025 23:02:03 GMT",
+            "20 Jan 2025 01:10:03 GMT",
+            "20 Jan 2025 01:50:59 GMT",
+            "20 Jan 2025 01:50:60 GMT",
+            "20 Jan 2025 01:03:03 GMT",
+            "Mon, 20 Jan 2025 01:03:03 GMT",
+            "Mon, 03 Feb 2025 01:03:03 GMT",
+            "Mon, 03 Mar 2025 01:03:03 GMT",
+            "Mon, 14 Apr 2025 01:03:03 GMT",
+            "Mon, 05 May 2025 01:03:03 GMT",
+            "Mon, 21 Jul 2025 01:03:03 GMT",
+            "Mon, 04 Aug 2025 01:03:03 GMT",
+            "Mon, 22 Sep 2025 01:03:03 GMT",
+            "Mon, 30 Oct 2025 01:03:03 GMT",
+            "Mon, 24 Nov 2025 01:03:03 GMT",
+            "Mon, 22 Dec 2025 01:03:03 GMT",
+            "Tue, 29 Feb 2028 01:03:03 GMT", // leap day
+        ]
+        
+        for good in tests {
+            XCTAssertNotNil(try? Date(good, strategy: .http), "Input \(good) was nil")
+            XCTAssertNotNil(try? DateComponents(good, strategy: .http), "Input \(good) was nil")
+        }
+    }
+    
+    func test_HTTPFormat_badInputs() throws {
+        let tests = [
+            "Xri, 17 Jan 2025 19:03:05 GMT",
+            "Fri, 17 Janu 2025 19:03:05 GMT",
+            "Fri, 17Jan 2025 19:03:05 GMT",
+            "Fri, 17 Xrz 2025 19:03:05 GMT",
+            "Fri, 17 Jan 2025 19:03:05", // missing GMT
+            "Fri, 1 Jan 2025 19:03:05 GMT",
+            "Fri, 17 Jan 2025 1:03:05 GMT",
+            "Fri, 17 Jan 2025 19:3:05 GMT",
+            "Fri, 17 Jan 2025 19:03:5 GMT",
+            "Fri, 17 Jan 2025 19:03:05 GmT",
+            "Fri, 17 Jan 20252 19:03:05 GMT",
+            "Fri, 17 Jan 252 19:03:05 GMT",
+            "fri, 17 Jan 2025 19:03:05 GMT", // miscapitalized
+            "Fri, 17 jan 2025 19:03:05 GMT",
+            "Fri, 16 Jan 2025 25:03:05 GMT", // nonsense date
+            "Fri, 30 Feb 2025 25:03:05 GMT", // nonsense date
+        ]
+        
+        for bad in tests {
+            XCTAssertNil(try? Date(bad, strategy: .http), "Input \(bad) was not nil")
+            XCTAssertNil(try? DateComponents(bad, strategy: .http), "Input \(bad) was not nil")
+        }
+    }
+    
+    func test_HTTPComponentsFormat() throws {
+        let input = "Fri, 17 Jan 2025 19:03:05 GMT"
+        let parsed = try? DateComponents(input, strategy: .http)
+        
+        XCTAssertEqual(parsed?.weekday, 6)
+        XCTAssertEqual(parsed?.day, 17)
+        XCTAssertEqual(parsed?.month, 1)
+        XCTAssertEqual(parsed?.year, 2025)
+        XCTAssertEqual(parsed?.hour, 19)
+        XCTAssertEqual(parsed?.minute, 3)
+        XCTAssertEqual(parsed?.second, 5)
+        XCTAssertEqual(parsed?.timeZone, TimeZone.gmt)
+    }
+    
+    func test_validatingResultOfParseVsString() throws {
+        // This date will parse correctly, but of course the value of 99 does not correspond to the actual day.
+        let strangeDate = "Mon, 99 Jan 2025 19:03:05 GMT"
+        let date = try XCTUnwrap(Date(strangeDate, strategy: .http))
+        let components = try XCTUnwrap(DateComponents(strangeDate, strategy: .http))
+        
+        let actualDay = Calendar(identifier: .gregorian).component(.day, from: date)
+        let componentDay = try XCTUnwrap(components.day)
+        XCTAssertNotEqual(actualDay, componentDay)
+    }
+}
+


### PR DESCRIPTION
Adds a prototype HTTP format style for `Date` and `DateComponents`.

(https://forums.swift.org/t/pitch-http-date-format-style/76783)