### PR TITLE
Allow non-numeric port when bridging from CFURL

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -2116,7 +2116,7 @@ public struct URL: Equatable, Sendable, Hashable {
             return
         }
         #endif
-        if let parseInfo = URL.parse(urlString: _url.relativeString) {
+        if let parseInfo = RFC3986Parser.parse(urlString: _url.relativeString, encodingInvalidCharacters: true, compatibility: [.allowEmptyScheme, .allowAnyPort]) {
             _parseInfo = parseInfo
         } else {
             // Go to compatibility jail (allow `URL` as a dummy string container for `NSURL` instead of crashing)


### PR DESCRIPTION
`CFURL` historically allowed URLs such as `scheme://host:port-string` as long as the port string only contained valid URL characters (characters that can exist in at least some part of a URL string). RFC 3986 only allows digits in the port, so this breaks that use case when a `CFURL` is bridged to `URL`. This PR allows `URL` to have non-numeric ports with valid URL characters, but only in the case of bridging.