### PR TITLE
Do not cache NSLocale.current if we fail to fetch preferences

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -34,30 +34,30 @@ dynamic package func _localeICUClass() -> _LocaleProtocol.Type {
 /// Singleton which listens for notifications about preference changes for Locale and holds cached singletons.
 struct LocaleCache : Sendable, ~Copyable {
     // MARK: - State
-    
+
     struct State {
-        
+
         init() {
 #if FOUNDATION_FRAMEWORK
             // For Foundation.framework, we listen for system notifications about the system Locale changing from the Darwin notification center.
             _CFNotificationCenterInitializeDependentNotificationIfNecessary(CFNotificationName.cfLocaleCurrentLocaleDidChange!.rawValue)
 #endif
         }
-        
+
         private var cachedFixedLocales: [String : any _LocaleProtocol] = [:]
         private var cachedFixedComponentsLocales: [Locale.Components : any _LocaleProtocol] = [:]
 
 #if FOUNDATION_FRAMEWORK
         private var cachedFixedIdentifierToNSLocales: [String : _NSSwiftLocale] = [:]
-        
+
         struct IdentifierAndPrefs : Hashable {
             let identifier: String
             let prefs: LocalePreferences?
         }
-        
+
         private var cachedFixedLocaleToNSLocales: [IdentifierAndPrefs : _NSSwiftLocale] = [:]
 #endif
-                
+
         mutating func fixed(_ id: String) -> any _LocaleProtocol {
             // Note: Even if the currentLocale's identifier is the same, currentLocale may have preference overrides which are not reflected in the identifier itself.
             if let locale = cachedFixedLocales[id] {
@@ -81,7 +81,7 @@ struct LocaleCache : Sendable, ~Copyable {
                 return locale
             }
         }
-        
+
 #if canImport(_FoundationICU)
         mutating func fixedNSLocale(_ locale: _LocaleICU) -> _NSSwiftLocale {
             let id = IdentifierAndPrefs(identifier: locale.identifier, prefs: locale.prefs)
@@ -102,13 +102,13 @@ struct LocaleCache : Sendable, ~Copyable {
         func fixedComponents(_ comps: Locale.Components) -> (any _LocaleProtocol)? {
             cachedFixedComponentsLocales[comps]
         }
-        
+
         mutating func fixedComponentsWithCache(_ comps: Locale.Components) -> any _LocaleProtocol {
             if let l = fixedComponents(comps) {
                 return l
             } else {
                 let new = _localeICUClass().init(components: comps)
-                
+
                 cachedFixedComponentsLocales[comps] = new
                 return new
             }
@@ -116,19 +116,19 @@ struct LocaleCache : Sendable, ~Copyable {
     }
 
     let lock: LockedState<State>
-    
+
     static let cache = LocaleCache()
     private let _currentCache = LockedState<(any _LocaleProtocol)?>(initialState: nil)
-    
+
 #if FOUNDATION_FRAMEWORK
     private var _currentNSCache = LockedState<_NSSwiftLocale?>(initialState: nil)
 #endif
-    
+
     fileprivate init() {
         lock = LockedState(initialState: State())
     }
 
-    
+
     /// For testing of `autoupdatingCurrent` only. If you want to test `current`, create a custom `Locale` with the appropriate settings using `localeAsIfCurrent(name:overrides:disableBundleMatching:)` and use that instead.
     /// This mutates global state of the current locale, so it is not safe to use in concurrent testing.
     func resetCurrent(to preferences: LocalePreferences) {
@@ -150,32 +150,36 @@ struct LocaleCache : Sendable, ~Copyable {
     }
 
     var current: any _LocaleProtocol {
+        return _currentAndCache.locale
+    }
+
+    fileprivate var _currentAndCache: (locale: any _LocaleProtocol, doCache: Bool) {
         if let result = _currentCache.withLock({ $0 }) {
-            return result
+            return (result, true)
         }
-        
+
         // We need to fetch prefs and try again
         let (preferences, doCache) = preferences()
         let locale = _localeICUClass().init(name: nil, prefs: preferences, disableBundleMatching: false)
-        
+
         // It's possible this was an 'incomplete locale', in which case we will want to calculate it again later.
         if doCache {
             return _currentCache.withLock {
                 if let current = $0 {
                     // Someone beat us to setting it - use existing one
-                    return current
+                    return (current, true)
                 } else {
                     $0 = locale
-                    return locale
+                    return (locale, true)
                 }
             }
+        } else {
+            return (locale, false)
         }
-        
-        return locale
     }
-    
+
     // MARK: Singletons
-    
+
     // This value is immutable, so we can share one instance for the whole process.
     static let unlocalized = _LocaleUnlocalized(identifier: "en_001")
 
@@ -185,19 +189,19 @@ struct LocaleCache : Sendable, ~Copyable {
     static let system : any _LocaleProtocol = {
         _localeICUClass().init(identifier: "", prefs: nil)
     }()
-    
+
 #if FOUNDATION_FRAMEWORK
     static let autoupdatingCurrentNSLocale : _NSSwiftLocale = {
         _NSSwiftLocale(Locale(inner: autoupdatingCurrent))
     }()
-    
+
     static let systemNSLocale : _NSSwiftLocale = {
         _NSSwiftLocale(Locale(inner: system))
     }()
 #endif
-    
+
     // MARK: -
-    
+
     func fixed(_ id: String) -> any _LocaleProtocol {
         lock.withLock {
             $0.fixed(id)
@@ -219,19 +223,25 @@ struct LocaleCache : Sendable, ~Copyable {
         if let result = _currentNSCache.withLock({ $0 }) {
             return result
         }
-        
+
         // Create the current _NSSwiftLocale, based on the current Swift Locale.
+        // n.b. do not call just `current` here; instead, use `_currentAndCache`
+        // so that the caching status is honored
+        let (current, doCache) = _currentAndCache
         let nsLocale = _NSSwiftLocale(Locale(inner: current))
-            
-        // TODO: The current locale has an idea of not caching, which we have never honored here in the NSLocale cache
-        return _currentNSCache.withLock {
-            if let current = $0 {
-                // Someone beat us to setting it, use that one
-                return current
-            } else {
-                $0 = nsLocale
-                return nsLocale
+
+        if doCache {
+            return _currentNSCache.withLock {
+                if let current = $0 {
+                    // Someone beat us to setting it, use that one
+                    return current
+                } else {
+                    $0 = nsLocale
+                    return nsLocale
+                }
             }
+        } else {
+            return nsLocale
         }
     }
 
@@ -240,7 +250,7 @@ struct LocaleCache : Sendable, ~Copyable {
     func fixedComponents(_ comps: Locale.Components) -> any _LocaleProtocol {
         lock.withLock { $0.fixedComponentsWithCache(comps) }
     }
-    
+
 #if FOUNDATION_FRAMEWORK && !NO_CFPREFERENCES
     func preferences() -> (LocalePreferences, Bool) {
         // On Darwin, we check the current user preferences for Locale values
@@ -249,7 +259,7 @@ struct LocaleCache : Sendable, ~Copyable {
 
         var prefs = LocalePreferences()
         prefs.apply(cfPrefs)
-        
+
         if wouldDeadlock.boolValue {
             // Don't cache a locale built with incomplete prefs
             return (prefs, false)
@@ -257,7 +267,7 @@ struct LocaleCache : Sendable, ~Copyable {
             return (prefs, true)
         }
     }
-    
+
     func preferredLanguages(forCurrentUser: Bool) -> [String] {
         var languages: [String] = []
         if forCurrentUser {
@@ -265,12 +275,12 @@ struct LocaleCache : Sendable, ~Copyable {
         } else {
             languages = CFPreferencesCopyAppValue("AppleLanguages" as CFString, kCFPreferencesCurrentApplication) as? [String] ?? []
         }
-        
+
         return languages.compactMap {
             Locale.canonicalLanguageIdentifier(from: $0)
         }
     }
-    
+
     func preferredLocale() -> String? {
         guard let preferredLocaleID = CFPreferencesCopyAppValue("AppleLocale" as CFString, kCFPreferencesCurrentApplication) as? String else {
             return nil
@@ -288,29 +298,29 @@ struct LocaleCache : Sendable, ~Copyable {
     func preferredLanguages(forCurrentUser: Bool) -> [String] {
         [Locale.canonicalLanguageIdentifier(from: "en-001")]
     }
-    
+
     func preferredLocale() -> String? {
         "en_001"
     }
 #endif
-    
+
 #if FOUNDATION_FRAMEWORK && !NO_CFPREFERENCES
     /// This returns an instance of `Locale` that's set up exactly like it would be if the user changed the current locale to that identifier, set the preferences keys in the overrides dictionary, then called `current`.
     func localeAsIfCurrent(name: String?, cfOverrides: CFDictionary? = nil, disableBundleMatching: Bool = false) -> Locale {
-        
+
         var (prefs, _) = preferences()
         if let cfOverrides { prefs.apply(cfOverrides) }
-        
+
         let inner = _LocaleICU(name: name, prefs: prefs, disableBundleMatching: disableBundleMatching)
         return Locale(inner: inner)
     }
 #endif
-    
+
     /// This returns an instance of `Locale` that's set up exactly like it would be if the user changed the current locale to that identifier, set the preferences keys in the overrides dictionary, then called `current`.
     func localeAsIfCurrent(name: String?, overrides: LocalePreferences? = nil, disableBundleMatching: Bool = false) -> Locale {
         var (prefs, _) = preferences()
         if let overrides { prefs.apply(overrides) }
-        
+
         let inner = _localeICUClass().init(name: name, prefs: prefs, disableBundleMatching: disableBundleMatching)
         return Locale(inner: inner)
     }
@@ -334,7 +344,7 @@ struct LocaleCache : Sendable, ~Copyable {
 
         let preferredLanguages = preferredLanguages(forCurrentUser: false)
         guard let preferredLocaleID = preferredLocale() else { return nil }
-        
+
         let canonicalizedLocalizations = availableLocalizations.compactMap { Locale.canonicalLanguageIdentifier(from: $0) }
         let identifier = Locale.localeIdentifierForCanonicalizedLocalizations(canonicalizedLocalizations, preferredLanguages: preferredLanguages, preferredLocaleID: preferredLocaleID)
         guard let identifier else {


### PR DESCRIPTION
Currently, we do not cache the current Swift locale if we cannot fetch proper preferences. This allows us to update the cached value if subsequent access succeeds.

We should be doing that for `currentNSLocale` too, but we are not. Fix the logic so that the behaviors match.

Resolves rdar://142699797