### PR TITLE
Include String+Bridging.swift in CMakeLists.txt

### DIFF
--- a/Sources/FoundationEssentials/String/CMakeLists.txt
+++ b/Sources/FoundationEssentials/String/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(FoundationEssentials PRIVATE
     BidirectionalCollection.swift
     BuiltInUnicodeScalarSet.swift
     RegexPatternCache.swift
+    String+Bridging.swift
     String+Comparison.swift
     String+Encoding.swift
     String+EndianAdaptorSequence.swift


### PR DESCRIPTION
This PR includes the new `String+Bridging.swift` file in `CMakeLists.txt` to ensure `swift-foundation` builds correctly.