### PR TITLE
Don't encode colon if URLComponents path starts with colon

### DIFF
--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1355,6 +1355,16 @@ final class URLTests : XCTestCase {
 
         XCTAssertNotNil(URL(string: comp.string!))
         XCTAssertNotNil(URLComponents(string: comp.string!))
+
+        // In rare cases, an app might rely on URL allowing an empty scheme,
+        // but then take that string and pass it to URLComponents to modify
+        // other components of the URL. We shouldn't percent-encode the colon
+        // in these cases.
+
+        let url = try XCTUnwrap(URL(string: "://host/path"))
+        comp = try XCTUnwrap(URLComponents(string: url.absoluteString))
+        comp.query = "key=value"
+        XCTAssertEqual(comp.string, "://host/path?key=value")
     }
 
     func testURLComponentsInvalidPaths() {


### PR DESCRIPTION
Apps can take a URL string like

```
://host/path
```

which `URL` now allows (after the compatibility change to go back to allowing an empty scheme), and pass it to `URLComponents(string:)`. `URLComponents` follows RFC 3986, which says a scheme cannot be empty, so it interprets the whole string as a path. The app could then use `components.queryItems = ...` to assign query items and call `components.url`, which needs to generate the new `.string`.

During string generation, `URLComponents` percent encodes the colon at the beginning of the path, so the `URL` returned does not have the scheme, host, and path it started out with. We can fix this by not percent-encoding any colons in the first path segment if the colon is the first character in the string.

This still preserves the behaviors of both `URL` and `URLComponents`: `URL` can interpret the colon as an empty scheme like before, and `URLComponents`, knowing that a scheme cannot be empty according to RFC 3986, can still interpret the string as a relative path.