### PR TITLE
Increase package deployment target to macOS 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,9 +86,7 @@ FetchContent_MakeAvailable(SwiftFoundationICU SwiftCollections)
 list(APPEND CMAKE_MODULE_PATH ${SwiftFoundation_SOURCE_DIR}/cmake/modules)
 
 # Availability Macros (only applies to FoundationEssentials and FoundationInternationalization)
-set(_SwiftFoundation_BaseAvailability "macOS 13.3, iOS 16.4, tvOS 16.4, watchOS 9.4")
-set(_SwiftFoundation_macOS14Availability "macOS 14, iOS 17, tvOS 17, watchOS 10")
-set(_SwiftFoundation_macOS15Availability "macOS 15, iOS 18, tvOS 18, watchOS 11")
+set(_SwiftFoundation_BaseAvailability "macOS 15, iOS 18, tvOS 18, watchOS 11")
 set(_SwiftFoundation_FutureAvailability "macOS 10000, iOS 10000, tvOS 10000, watchOS 10000")
 
 # All versions to define for each availability name
@@ -111,8 +109,8 @@ list(APPEND _SwiftFoundation_availability_names
 # The aligned availability for each name (in the same order)
 list(APPEND _SwiftFoundation_availability_releases
     ${_SwiftFoundation_BaseAvailability}
-    ${_SwiftFoundation_macOS14Availability}
-    ${_SwiftFoundation_macOS15Availability})
+    ${_SwiftFoundation_BaseAvailability}
+    ${_SwiftFoundation_BaseAvailability})
 
 foreach(version ${_SwiftFoundation_versions})
     foreach(name release IN ZIP_LISTS _SwiftFoundation_availability_names _SwiftFoundation_availability_releases)

--- a/Package.swift
+++ b/Package.swift
@@ -8,17 +8,15 @@ import CompilerPluginSupport
 
 let availabilityTags: [_Availability] = [
     _Availability("FoundationPreview"), // Default FoundationPreview availability,
-    _Availability("FoundationPredicate", availability: .macOS14_0), // Predicate relies on pack parameter runtime support
-    _Availability("FoundationPredicateRegex", availability: .macOS15_0) // Predicate regexes rely on new stdlib APIs
+    _Availability("FoundationPredicate"), // Predicate relies on pack parameter runtime support
+    _Availability("FoundationPredicateRegex") // Predicate regexes rely on new stdlib APIs
 ]
 let versionNumbers = ["0.1", "0.2", "0.3", "0.4", "6.0.2", "6.1", "6.2"]
 
 // Availability Macro Utilities
 
 enum _OSAvailability: String {
-    case alwaysAvailable = "macOS 13.3, iOS 16.4, tvOS 16.4, watchOS 9.4" // This should match the package's deployment target
-    case macOS14_0 = "macOS 14, iOS 17, tvOS 17, watchOS 10"
-    case macOS15_0 = "macOS 15, iOS 18, tvOS 18, watchOS 11"
+    case alwaysAvailable = "macOS 15, iOS 18, tvOS 18, watchOS 11" // This should match the package's deployment target
     // Use 10000 for future availability to avoid compiler magic around the 9999 version number but ensure it is greater than 9999
     case future = "macOS 10000, iOS 10000, tvOS 10000, watchOS 10000"
 }
@@ -77,7 +75,7 @@ let wasiLibcCSettings: [CSetting] = [
 
 let package = Package(
     name: "swift-foundation",
-    platforms: [.macOS("13.3"), .iOS("16.4"), .tvOS("16.4"), .watchOS("9.4")],
+    platforms: [.macOS("15"), .iOS("18"), .tvOS("18"), .watchOS("11")],
     products: [
         .library(name: "FoundationEssentials", targets: ["FoundationEssentials"]),
         .library(name: "FoundationInternationalization", targets: ["FoundationInternationalization"]),

--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -70,7 +70,6 @@ final class DateTests : XCTestCase {
                               3600.0 * 24 * 365 * 100) /* ~1 century in seconds */
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func test_now() {
         let date1 : Date = .now
         let date2 : Date = .now

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -571,53 +571,50 @@ final class FileManagerTests : XCTestCase {
 
         #if canImport(Darwin)
         // not supported on linux as the test depends on FileManager.removeItem calling removefile(3)
-        // not supported on older versions of Darwin where removefile would return ENOENT instead of ENAMETOOLONG
-        if #available(macOS 14.4, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-            try FileManagerPlayground {
-            }.test {
-                // Create hierarchy in which the leaf is a long path (length > PATH_MAX)
-                let rootDir = $0.currentDirectoryPath
-                let aas = Array(repeating: "a", count: Int(NAME_MAX) - 3).joined()
-                let bbs = Array(repeating: "b", count: Int(NAME_MAX) - 3).joined()
-                let ccs = Array(repeating: "c", count: Int(NAME_MAX) - 3).joined()
-                let dds = Array(repeating: "d", count: Int(NAME_MAX) - 3).joined()
-                let ees = Array(repeating: "e", count: Int(NAME_MAX) - 3).joined()
-                let leaf = "longpath"
-                
-                try $0.createDirectory(atPath: aas, withIntermediateDirectories: true)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
-                try $0.createDirectory(atPath: bbs, withIntermediateDirectories: true)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
-                try $0.createDirectory(atPath: ccs, withIntermediateDirectories: true)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
-                try $0.createDirectory(atPath: dds, withIntermediateDirectories: true)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
-                try $0.createDirectory(atPath: ees, withIntermediateDirectories: true)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(ees))
-                try $0.createDirectory(atPath: leaf, withIntermediateDirectories: true)
-                
-                XCTAssertTrue($0.changeCurrentDirectoryPath(rootDir))
-                let fullPath = "\(aas)/\(bbs)/\(ccs)/\(dds)/\(ees)/\(leaf)"
-                XCTAssertThrowsError(try $0.removeItem(atPath: fullPath)) {
-                    let underlyingPosixError = ($0 as? CocoaError)?.underlying as? POSIXError
-                    XCTAssertEqual(underlyingPosixError?.code, .ENAMETOOLONG, "removeItem didn't fail with ENAMETOOLONG; produced error: \($0)")
-                }
-                
-                // Clean up
-                XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
-                XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
-                XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
-                XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
-                try $0.removeItem(atPath: ees)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
-                try $0.removeItem(atPath: dds)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
-                try $0.removeItem(atPath: ccs)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
-                try $0.removeItem(atPath: bbs)
-                XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
-                try $0.removeItem(atPath: aas)
+        try FileManagerPlayground {
+        }.test {
+            // Create hierarchy in which the leaf is a long path (length > PATH_MAX)
+            let rootDir = $0.currentDirectoryPath
+            let aas = Array(repeating: "a", count: Int(NAME_MAX) - 3).joined()
+            let bbs = Array(repeating: "b", count: Int(NAME_MAX) - 3).joined()
+            let ccs = Array(repeating: "c", count: Int(NAME_MAX) - 3).joined()
+            let dds = Array(repeating: "d", count: Int(NAME_MAX) - 3).joined()
+            let ees = Array(repeating: "e", count: Int(NAME_MAX) - 3).joined()
+            let leaf = "longpath"
+            
+            try $0.createDirectory(atPath: aas, withIntermediateDirectories: true)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
+            try $0.createDirectory(atPath: bbs, withIntermediateDirectories: true)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
+            try $0.createDirectory(atPath: ccs, withIntermediateDirectories: true)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
+            try $0.createDirectory(atPath: dds, withIntermediateDirectories: true)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
+            try $0.createDirectory(atPath: ees, withIntermediateDirectories: true)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(ees))
+            try $0.createDirectory(atPath: leaf, withIntermediateDirectories: true)
+            
+            XCTAssertTrue($0.changeCurrentDirectoryPath(rootDir))
+            let fullPath = "\(aas)/\(bbs)/\(ccs)/\(dds)/\(ees)/\(leaf)"
+            XCTAssertThrowsError(try $0.removeItem(atPath: fullPath)) {
+                let underlyingPosixError = ($0 as? CocoaError)?.underlying as? POSIXError
+                XCTAssertEqual(underlyingPosixError?.code, .ENAMETOOLONG, "removeItem didn't fail with ENAMETOOLONG; produced error: \($0)")
             }
+            
+            // Clean up
+            XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
+            XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
+            XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
+            XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
+            try $0.removeItem(atPath: ees)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+            try $0.removeItem(atPath: dds)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+            try $0.removeItem(atPath: ccs)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+            try $0.removeItem(atPath: bbs)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+            try $0.removeItem(atPath: aas)
         }
         #endif
     }

--- a/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
@@ -43,17 +43,13 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
         check(type: Int16.self, min: "-32768", max: "32767")
         check(type: Int32.self, min: "-2147483648", max: "2147483647")
         check(type: Int64.self, min: "-9223372036854775808", max: "9223372036854775807")
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            check(type: Int128.self, min: "-170141183460469231731687303715884105728", max: "170141183460469231731687303715884105727")
-        }
+        check(type: Int128.self, min: "-170141183460469231731687303715884105728", max: "170141183460469231731687303715884105727")
 
         check(type: UInt8.self, min: "0", max: "255")
         check(type: UInt16.self, min: "0", max: "65535")
         check(type: UInt32.self, min: "0", max: "4294967295")
         check(type: UInt64.self, min: "0", max: "18446744073709551615")
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            check(type: UInt128.self, min: "0", max: "340282366920938463463374607431768211455")
-        }
+        check(type: UInt128.self, min: "0", max: "340282366920938463463374607431768211455")
     }
 
     func testNumericStringRepresentation_builtinIntegersAroundDecimalMagnitude() throws {

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
@@ -185,7 +185,6 @@ result  : \(parsed != nil ? parsed!.debugDescription : "nil") \(parsed != nil ? 
 #endif
 }
 
-@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
 
     func _matchFullRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -20,7 +20,6 @@ import TestSupport
 @testable import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
-@available(FoundationPreview 0.4, *)
 final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
     /// A Gregorian calendar in GMT with no time zone changes
     var gregorian: Calendar = {

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -105,7 +105,6 @@ final class JSONEncoderTests : XCTestCase {
         XCTAssertEqual(result2, "[]")
     }
     
-    @available(FoundationPreview 0.1, *)
     func testEncodingTopLevelWithConfiguration() throws {
         // CodableTypeWithConfiguration is a struct that conforms to CodableWithConfiguration
         let value = CodableTypeWithConfiguration.testValue
@@ -651,17 +650,13 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int16].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int32].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int64].self)
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int128].self)
-        }
+        _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int128].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt8].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt16].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt32].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt64].self)
-         if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt128].self)
-        }
+        _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt128].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Float].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Double].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int], as: [Bool].self)
@@ -669,17 +664,13 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int16], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int32], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int64], as: [Bool].self)
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-          _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int128], as: [Bool].self)
-        }
+        _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int128], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt8], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt16], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt32], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt64], as: [Bool].self)
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-          _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt128], as: [Bool].self)
-        }
+        _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt128], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Float], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Double], as: [Bool].self)
     }
@@ -1403,90 +1394,82 @@ final class JSONEncoderTests : XCTestCase {
     }
   
     func test_roundTrippingInt128() {
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            let values = [
-                Int128.min,
-                Int128.min + 1,
-                -0x1_0000_0000_0000_0000,
-                0x0_8000_0000_0000_0000,
-                -1,
-                0,
-                0x7fff_ffff_ffff_ffff,
-                0x8000_0000_0000_0000,
-                0xffff_ffff_ffff_ffff,
-                0x1_0000_0000_0000_0000,
-                .max
-            ]
-            for i128 in values {
-                _testRoundTrip(of: i128)
-            }
+        let values = [
+            Int128.min,
+            Int128.min + 1,
+            -0x1_0000_0000_0000_0000,
+            0x0_8000_0000_0000_0000,
+            -1,
+            0,
+            0x7fff_ffff_ffff_ffff,
+            0x8000_0000_0000_0000,
+            0xffff_ffff_ffff_ffff,
+            0x1_0000_0000_0000_0000,
+            .max
+        ]
+        for i128 in values {
+            _testRoundTrip(of: i128)
         }
     }
     
     func test_Int128SlowPath() {
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            let decoder = JSONDecoder()
-            let work: [Int128] = [18446744073709551615, -18446744073709551615]
-            for value in work {
-                // force the slow-path by appending ".0"
-                let json = "\(value).0".data(using: String._Encoding.utf8)!
-                XCTAssertEqual(value, try? decoder.decode(Int128.self, from: json))
-            }
-            // These should work, but making them do so probably requires
-            // rewriting the slow path to use a dedicated parser. For now,
-            // we ensure that they throw instead of returning some bogus
-            // result.
-            let shouldWorkButDontYet: [Int128] = [
-                .min, -18446744073709551616, 18446744073709551616, .max
-            ]
-            for value in shouldWorkButDontYet {
-                // force the slow-path by appending ".0"
-                let json = "\(value).0".data(using: String._Encoding.utf8)!
-                XCTAssertThrowsError(try decoder.decode(Int128.self, from: json))
-            }
+        let decoder = JSONDecoder()
+        let work: [Int128] = [18446744073709551615, -18446744073709551615]
+        for value in work {
+            // force the slow-path by appending ".0"
+            let json = "\(value).0".data(using: String._Encoding.utf8)!
+            XCTAssertEqual(value, try? decoder.decode(Int128.self, from: json))
+        }
+        // These should work, but making them do so probably requires
+        // rewriting the slow path to use a dedicated parser. For now,
+        // we ensure that they throw instead of returning some bogus
+        // result.
+        let shouldWorkButDontYet: [Int128] = [
+            .min, -18446744073709551616, 18446744073709551616, .max
+        ]
+        for value in shouldWorkButDontYet {
+            // force the slow-path by appending ".0"
+            let json = "\(value).0".data(using: String._Encoding.utf8)!
+            XCTAssertThrowsError(try decoder.decode(Int128.self, from: json))
         }
     }
     
     func test_roundTrippingUInt128() {
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            let values = [
-                UInt128.zero,
-                1,
-                0x0000_0000_0000_0000_7fff_ffff_ffff_ffff,
-                0x0000_0000_0000_0000_8000_0000_0000_0000,
-                0x0000_0000_0000_0000_ffff_ffff_ffff_ffff,
-                0x0000_0000_0000_0001_0000_0000_0000_0000,
-                0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
-                0x8000_0000_0000_0000_0000_0000_0000_0000,
-                .max
-            ]
-            for u128 in values {
-                _testRoundTrip(of: u128)
-            }
+        let values = [
+            UInt128.zero,
+            1,
+            0x0000_0000_0000_0000_7fff_ffff_ffff_ffff,
+            0x0000_0000_0000_0000_8000_0000_0000_0000,
+            0x0000_0000_0000_0000_ffff_ffff_ffff_ffff,
+            0x0000_0000_0000_0001_0000_0000_0000_0000,
+            0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
+            0x8000_0000_0000_0000_0000_0000_0000_0000,
+            .max
+        ]
+        for u128 in values {
+            _testRoundTrip(of: u128)
         }
     }
     
     func test_UInt128SlowPath() {
-        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            let decoder = JSONDecoder()
-            let work: [UInt128] = [18446744073709551615]
-            for value in work {
-                // force the slow-path by appending ".0"
-                let json = "\(value).0".data(using: String._Encoding.utf8)!
-                XCTAssertEqual(value, try? decoder.decode(UInt128.self, from: json))
-            }
-            // These should work, but making them do so probably requires
-            // rewriting the slow path to use a dedicated parser. For now,
-            // we ensure that they throw instead of returning some bogus
-            // result.
-            let shouldWorkButDontYet: [UInt128] = [
-                18446744073709551616, .max
-            ]
-            for value in shouldWorkButDontYet {
-                // force the slow-path by appending ".0"
-                let json = "\(value).0".data(using: String._Encoding.utf8)!
-                XCTAssertThrowsError(try decoder.decode(UInt128.self, from: json))
-            }
+        let decoder = JSONDecoder()
+        let work: [UInt128] = [18446744073709551615]
+        for value in work {
+            // force the slow-path by appending ".0"
+            let json = "\(value).0".data(using: String._Encoding.utf8)!
+            XCTAssertEqual(value, try? decoder.decode(UInt128.self, from: json))
+        }
+        // These should work, but making them do so probably requires
+        // rewriting the slow path to use a dedicated parser. For now,
+        // we ensure that they throw instead of returning some bogus
+        // result.
+        let shouldWorkButDontYet: [UInt128] = [
+            18446744073709551616, .max
+        ]
+        for value in shouldWorkButDontYet {
+            // force the slow-path by appending ".0"
+            let json = "\(value).0".data(using: String._Encoding.utf8)!
+            XCTAssertThrowsError(try decoder.decode(UInt128.self, from: json))
         }
     }
 

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -239,7 +239,7 @@ final class JSONEncoderTests : XCTestCase {
                        dateDecodingStrategy: .custom(decode))
 
         // So should wrapped dates.
-        let expectedJSON_array = "[42]".data(using: .utf8)!
+        let expectedJSON_array = "[42]".data(using: String._Encoding.utf8)!
         _testRoundTrip(of: TopLevelArrayWrapper(timestamp),
                        expectedJSON: expectedJSON_array,
                        dateEncodingStrategy: .custom(encode),

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -57,7 +57,6 @@ extension PredicateExpressions {
     }
 }
 
-@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 final class PredicateCodableTests: XCTestCase {
     
     struct Object : Equatable, PredicateCodableKeyPathProviding {

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -55,7 +55,6 @@ final class PredicateTests: XCTestCase {
         var a: Bool
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testBasic() throws {
         let compareTo = 2
         let predicate = #Predicate<Object> {
@@ -65,7 +64,6 @@ final class PredicateTests: XCTestCase {
         try XCTAssertTrue(predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testVariadic() throws {
         let predicate = #Predicate<Object, Int> {
             $0.a == $1 + 1
@@ -73,7 +71,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 3, b: "", c: 0, d: 0, e: "c", f: true, g: []), 2))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testArithmetic() throws {
         let predicate = #Predicate<Object> {
             $0.a + 2 == 4
@@ -81,7 +78,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testDivision() throws {
         let predicate = #Predicate<Object> {
             $0.a / 2 == 3
@@ -93,7 +89,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate2.evaluate(Object(a: 2, b: "", c: 6.0, d: 0, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testBuildDivision() throws {
         let predicate = #Predicate<Object> {
             $0.a / 2 == 3
@@ -101,7 +96,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 6, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testUnaryMinus() throws {
         let predicate = #Predicate<Object> {
             -$0.a == 17
@@ -109,7 +103,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: -17, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testCount() throws {
         let predicate = #Predicate<Object> {
             $0.g.count == 5
@@ -117,7 +110,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 0, b: "", c: 0, d: 0, e: "c", f: true, g: [2, 3, 5, 7, 11])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testFilter() throws {
         let predicate = #Predicate<Object> { object in
             !object.g.filter {
@@ -127,7 +119,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 0, b: "", c: 0.0, d: 17, e: "c", f: true, g: [3, 5, 7, 11, 13, 17, 19])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testContains() throws {
         let predicate = #Predicate<Object> {
             $0.g.contains($0.a)
@@ -135,7 +126,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 13, b: "", c: 0.0, d: 0, e: "c", f: true, g: [2, 3, 5, 11, 13, 17])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testContainsWhere() throws {
         let predicate = #Predicate<Object> { object in
             object.g.contains {
@@ -145,7 +135,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 2, b: "", c: 0.0, d: 0, e: "c", f: true, g: [3, 5, 7, 2, 11, 13])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testAllSatisfy() throws {
         let predicate = #Predicate<Object> { object in
             object.g.allSatisfy {
@@ -155,7 +144,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(Object(a: 0, b: "", c: 0.0, d: 2, e: "c", f: true, g: [3, 5, 7, 11, 13, 17, 19])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testOptional() throws {
         struct Wrapper<T> {
             let wrapped: T?
@@ -179,7 +167,6 @@ final class PredicateTests: XCTestCase {
         XCTAssertTrue(try predicate3.evaluate(Wrapper(wrapped: nil)))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testConditional() throws {
         let predicate = #Predicate<Bool, String, String> {
             ($0 ? $1 : $2) == "if branch"
@@ -187,7 +174,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate.evaluate(true, "if branch", "else branch"))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testClosedRange() throws {
         let predicate = #Predicate<Object> {
             (3...5).contains($0.a)
@@ -199,7 +185,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testRange() throws {
         let predicate = #Predicate<Object> {
             (3 ..< 5).contains($0.a)
@@ -212,7 +197,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testRangeContains() throws {
         let date = Date.distantPast
         let predicate = #Predicate<Object> {
@@ -222,7 +206,6 @@ final class PredicateTests: XCTestCase {
         XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testTypes() throws {
         let predicate = #Predicate<Object> {
             ($0.i as? Int).flatMap { $0 == 3 } ?? false
@@ -234,7 +217,6 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testSubscripts() throws {
         var predicate = #Predicate<Object> {
             $0.g[0] == 0
@@ -254,7 +236,6 @@ final class PredicateTests: XCTestCase {
         XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testLazyDefaultValueSubscript() throws {
         struct Foo : Codable, Sendable {
             var property: Int {
@@ -269,7 +250,6 @@ final class PredicateTests: XCTestCase {
         XCTAssertFalse(try predicate.evaluate(["key" : 2]))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testStaticValues() throws {
         func assertPredicate<T>(_ pred: Predicate<T>, value: T, expected: Bool) throws {
             XCTAssertEqual(try pred.evaluate(value), expected)
@@ -279,7 +259,6 @@ final class PredicateTests: XCTestCase {
         try assertPredicate(.false, value: "Hello", expected: false)
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testMaxMin() throws {
         var predicate = #Predicate<Object> {
             $0.g.max() == 2
@@ -296,7 +275,6 @@ final class PredicateTests: XCTestCase {
     
     #if FOUNDATION_FRAMEWORK
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testCaseInsensitiveCompare() throws {
         let equal = ComparisonResult.orderedSame
         let predicate = #Predicate<Object> {
@@ -308,7 +286,6 @@ final class PredicateTests: XCTestCase {
     
     #endif
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testBuildDynamically() throws {
         func _build(_ equal: Bool) -> Predicate<Int> {
             Predicate<Int> {
@@ -330,7 +307,6 @@ final class PredicateTests: XCTestCase {
         XCTAssertFalse(try _build(false).evaluate(1))
     }
     
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testResilientKeyPaths() {
         // Local, non-resilient type
         struct Foo {

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -23,6 +23,9 @@ import RegexBuilder
 @freestanding(expression)
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 macro Predicate<each Input>(_ body: (repeat each Input) -> Bool) -> Predicate<repeat each Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
+@freestanding(expression)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+macro Expression<each Input, Output>(_ body: (repeat each Input) -> Output) -> Expression<repeat each Input, Output> = #externalMacro(module: "FoundationMacros", type: "ExpressionMacro")
 #endif
 
 // Work around an issue issue on older Swift compilers

--- a/Tests/FoundationEssentialsTests/SortComparatorTests.swift
+++ b/Tests/FoundationEssentialsTests/SortComparatorTests.swift
@@ -20,7 +20,6 @@ import TestSupport
 @testable import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
-@available(FoundationPreview 0.1, *)
 class SortComparatorTests: XCTestCase {
     func test_comparable_descriptors() {
         let intDesc: ComparableComparator<Int> = ComparableComparator<Int>()

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -1009,7 +1009,7 @@ final class StringTests : XCTestCase {
     func test_dataUsingEncoding_preservingBOM() {
         func roundTrip(_ data: Data) -> Bool {
             let str = String(data: data, encoding: .utf8)!
-            let strAsUTF16BE = str.data(using: .utf16BigEndian)!
+            let strAsUTF16BE = str.data(using: String._Encoding.utf16BigEndian)!
             let strRoundTripUTF16BE = String(data: strAsUTF16BE, encoding: .utf16BigEndian)!
             return strRoundTripUTF16BE == str
         }
@@ -1026,8 +1026,8 @@ final class StringTests : XCTestCase {
     func test_dataUsingEncoding_ascii() {
         XCTAssertEqual("abc".data(using: .ascii), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
         XCTAssertEqual("abc".data(using: .nonLossyASCII), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
-        XCTAssertEqual("e\u{301}\u{301}f".data(using: .ascii), nil)
-        XCTAssertEqual("e\u{301}\u{301}f".data(using: .nonLossyASCII), nil)
+        XCTAssertEqual("e\u{301}\u{301}f".data(using: String._Encoding.ascii), nil)
+        XCTAssertEqual("e\u{301}\u{301}f".data(using: String._Encoding.nonLossyASCII), nil)
         
         XCTAssertEqual("abc".data(using: .ascii, allowLossyConversion: true), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
         XCTAssertEqual("abc".data(using: .nonLossyASCII, allowLossyConversion: true), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
@@ -1326,7 +1326,7 @@ final class StringTests : XCTestCase {
             XCTAssertNotNil(String(data: data, encoding: encoding), "Failed to decode \(data) (\(string.debugDescription))", file: file, line: line)
         }
         for string in invalid {
-            XCTAssertNil(string.data(using: .macOSRoman), "Incorrectly successfully encoded \(string.debugDescription)", file: file, line: line)
+            XCTAssertNil(string.data(using: String._Encoding.macOSRoman), "Incorrectly successfully encoded \(string.debugDescription)", file: file, line: line)
         }
     }
     

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -1118,14 +1118,6 @@ final class StringTests : XCTestCase {
             } catch {
                 XCTFail(error.localizedDescription)
             }
-
-            let usedEncoding: String._Encoding = String._Encoding(rawValue: 0)
-            do {
-                _ = try String(contentsOfFile: nonExistentURL.path())
-                XCTFail()
-            } catch {
-                expectEqual(0, usedEncoding.rawValue)
-            }
         }
 
     }

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -546,7 +546,6 @@ final class URLTests : XCTestCase {
         try FileManager.default.removeItem(at: builder(tempDirectory))
     }
 
-    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     func testURLEncodingInvalidCharacters() throws {
         let urlStrings = [
             " ",

--- a/Tests/FoundationEssentialsTests/UUIDTests.swift
+++ b/Tests/FoundationEssentialsTests/UUIDTests.swift
@@ -90,7 +90,6 @@ final class UUIDTests : XCTestCase {
         XCTAssertEqual(String(reflecting: uuid), "89E90DC6-5EBA-41A8-A64D-81D3576EE46E")
     }
 
-    @available(FoundationPreview 0.1, *)
     func test_UUID_Comparable() throws {
         var uuid1 = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
         var uuid2 = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000002"))

--- a/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
@@ -21,7 +21,6 @@ import TestSupport
 @testable import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
-@available(FoundationPreview 0.4, *)
 final class CalendarRecurrenceRuleTests: XCTestCase {
     /// A Gregorian calendar with a time zone set to California
     var gregorian: Calendar = {

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -728,7 +728,6 @@ final class CalendarTests : XCTestCase {
         XCTAssertEqual(weekend, weekendForNilLocale)
     }
     
-    @available(FoundationPreview 0.4, *)
     func test_datesAdding_range() {
         let startDate = Date(timeIntervalSinceReferenceDate: 689292158.712307) // 2022-11-04 22:02:38 UTC
         let endDate = startDate + (86400 * 3) + (3600 * 2) // 3 days + 2 hours later - cross a DST boundary which adds a day with an additional hour in it
@@ -741,7 +740,6 @@ final class CalendarTests : XCTestCase {
         XCTAssertEqual(numberOfDays, 3)
     }
     
-    @available(FoundationPreview 0.4, *)
     func test_datesAdding_year() {
         // Verify that adding 12 months once is the same as adding 1 month 12 times
         let startDate = Date(timeIntervalSinceReferenceDate: 688946558.712307) // 2022-10-31 22:02:38 UTC
@@ -754,7 +752,6 @@ final class CalendarTests : XCTestCase {
         XCTAssertEqual(oneYearOnce, oneYearTwelve)
     }
     
-    @available(FoundationPreview 0.4, *)
     func test_datesMatching_simpleExample() {
         let cal = Calendar(identifier: .gregorian)
         // August 22, 2022 at 3:02:38 PM PDT
@@ -773,7 +770,6 @@ final class CalendarTests : XCTestCase {
         }
     }
 
-    @available(FoundationPreview 0.4, *)
     func test_datesMatching() {
         let startDate = Date(timeIntervalSinceReferenceDate: 682898558.712307) // 2022-08-22 22:02:38 UTC
         let endDate = startDate + (86400 * 3)
@@ -804,7 +800,6 @@ final class CalendarTests : XCTestCase {
         XCTAssertTrue(unboundedBackward.first! > unboundedBackward.last!)
     }
     
-    @available(FoundationPreview 0.4, *)
     func test_dayOfYear_bounds() {
         let date = Date(timeIntervalSinceReferenceDate: 682898558.712307) // 2022-08-22 22:02:38 UTC, day 234
         var cal = Calendar(identifier: .gregorian)
@@ -840,7 +835,6 @@ final class CalendarTests : XCTestCase {
         XCTAssertEqual(previousDayComps, previousDayExpectationComps)
     }
     
-    @available(FoundationPreview 0.4, *)
     func test_dayOfYear() {
         // An arbitrary date, for which we know the answers
         let date = Date(timeIntervalSinceReferenceDate: 682898558.712307) // 2022-08-22 22:02:38 UTC, day 234

--- a/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
@@ -14,7 +14,6 @@
 import TestSupport
 #endif
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 final class ByteCountFormatStyleTests : XCTestCase {
     let locales = [Locale(identifier: "en_US"), .init(identifier: "fr_FR"), .init(identifier: "zh_TW"), .init(identifier: "zh_CN"), .init(identifier: "ar")]
 

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -23,7 +23,6 @@ import TestSupport
 @testable import Foundation
 #endif
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 final class DateFormatStyleTests : XCTestCase {
     let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
 
@@ -584,7 +583,6 @@ final class DateFormatStyleTests : XCTestCase {
         }
     }
 
-    @available(FoundationPreview 0.4, *)
     func testRemovingFields() {
         var format: Date.FormatStyle = .init(calendar: .init(identifier: .gregorian), timeZone: .gmt).locale(Locale(identifier: "en_US"))
         func verifyWithFormat(_ date: Date, expected: String, file: StaticString = #filePath, line: UInt = #line) {
@@ -1068,7 +1066,6 @@ final class DateVerbatimFormatStyleTests : XCTestCase {
     }
 }
 
-@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 final class MatchConsumerAndSearcherTests : XCTestCase {
 
     let enUS = Locale(identifier: "en_US")
@@ -1358,7 +1355,6 @@ extension DateFormatStyleTests {
 
 // MARK: DiscreteFormatStyle conformance test
 
-@available(FoundationPreview 0.4, *)
 final class TestDateStyleDiscreteConformance : XCTestCase {
     let enUSLocale = Locale(identifier: "en_US")
     var calendar = Calendar(identifier: .gregorian)
@@ -1602,7 +1598,6 @@ final class TestDateStyleDiscreteConformance : XCTestCase {
     }
 }
 
-@available(FoundationPreview 0.4, *)
 final class TestDateVerbatimStyleDiscreteConformance : XCTestCase {
     let enUSLocale = Locale(identifier: "en_US")
     var calendar = Calendar(identifier: .gregorian)

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -644,7 +644,7 @@ final class DateAttributedFormatStyleTests : XCTestCase {
         ]
 
         for (style, expectation) in expectations {
-            let formatted = style.attributed.format(date)
+            let formatted = style.attributedStyle.format(date)
             XCTAssertEqual(formatted, expectation.attributedString)
         }
     }
@@ -669,7 +669,7 @@ final class DateAttributedFormatStyleTests : XCTestCase {
         ]
 
         for (style, expectation) in expectations {
-            let formatted = style.attributed.format(date)
+            let formatted = style.attributedStyle.format(date)
             XCTAssertEqual(formatted, expectation.attributedString)
         }
     }
@@ -700,11 +700,11 @@ final class DateAttributedFormatStyleTests : XCTestCase {
         var format = Date.FormatStyle.dateTime
         format.timeZone = .gmt
 
-        test(date.formatted(format.weekday().locale(enUSLocale).attributed), [("Mon", .weekday)])
-        test(date.formatted(format.weekday().locale(zhTW).attributed), [("週一", .weekday)])
+        test(date.formatted(format.weekday().locale(enUSLocale).attributedStyle), [("Mon", .weekday)])
+        test(date.formatted(format.weekday().locale(zhTW).attributedStyle), [("週一", .weekday)])
 
-        test(date.formatted(format.weekday().attributed.locale(enUSLocale)), [("Mon", .weekday)])
-        test(date.formatted(format.weekday().attributed.locale(zhTW)),  [("週一", .weekday)])
+        test(date.formatted(format.weekday().attributedStyle.locale(enUSLocale)), [("Mon", .weekday)])
+        test(date.formatted(format.weekday().attributedStyle.locale(zhTW)),  [("週一", .weekday)])
     }
 
 #if FOUNDATION_FRAMEWORK
@@ -980,7 +980,7 @@ final class DateVerbatimFormatStyleTests : XCTestCase {
         // dateFormatter.date(from: "2021-01-23 14:51:20")!
         let date = Date(timeIntervalSinceReferenceDate: 633106280.0)
         func verify(_ f: Date.FormatString, expected: [Segment], file: StaticString = #filePath, line: UInt = #line) {
-            let s = date.formatted(Date.VerbatimFormatStyle.verbatim(f, locale:Locale(identifier: "en_US"), timeZone: utcTimeZone, calendar: Calendar(identifier: .gregorian)).attributed)
+            let s = date.formatted(Date.VerbatimFormatStyle.verbatim(f, locale:Locale(identifier: "en_US"), timeZone: utcTimeZone, calendar: Calendar(identifier: .gregorian)).attributedStyle)
             XCTAssertEqual(s, expected.attributedString, file: file, line: line)
         }
         verify("\(year: .twoDigits)_\(month: .defaultDigits)_\(day: .defaultDigits)", expected:

--- a/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
@@ -328,7 +328,6 @@ final class DateRelativeFormatStyleTests: XCTestCase {
         XCTAssertNotEqual(formattedSpanish, formattedEnglish)
     }
 
-    @available(FoundationPreview 0.4, *)
     func testAllowedFieldsNamed() throws {
         var named = Date.RelativeFormatStyle(presentation: .named, locale: enUSLocale, calendar: calendar)
 
@@ -362,7 +361,6 @@ final class DateRelativeFormatStyleTests: XCTestCase {
         _verifyStyle("2021-06-11T07:00:00Z", relativeTo: "2021-06-10T12:00:00Z", expected: "tomorrow")
     }
 
-    @available(FoundationPreview 0.4, *)
     func testAllowedFieldsNumeric() throws {
         var named = Date.RelativeFormatStyle(presentation: .numeric, locale: enUSLocale, calendar: calendar)
 
@@ -395,7 +393,6 @@ final class DateRelativeFormatStyleTests: XCTestCase {
 
 // MARK: DiscreteFormatStyle conformance test
 
-@available(FoundationPreview 0.4, *)
 final class TestDateAnchoredRelativeDiscreteConformance : XCTestCase {
     let enUSLocale = Locale(identifier: "en_US")
     var calendar = Calendar(identifier: .gregorian)

--- a/Tests/FoundationInternationalizationTests/Formatting/DiscreteFormatStyleTestUtilities.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DiscreteFormatStyleTestUtilities.swift
@@ -22,7 +22,6 @@ import TestSupport
 @testable import FoundationInternationalization
 #endif
 
-@available(FoundationPreview 0.4, *)
 extension DiscreteFormatStyle where FormatInput : Comparable {
     /// Produces a sequence that generates all outputs of a discrete format style from a given start to a given end.
     func evaluate(from initialInput: FormatInput, to end: FormatInput, _ advance: @escaping (FormatInput, FormatInput) -> FormatInput? = { prev, next in next }) -> LazySequence<DiscreteFormatStyleSequence<Self>> {
@@ -30,7 +29,6 @@ extension DiscreteFormatStyle where FormatInput : Comparable {
     }
 }
 
-@available(FoundationPreview 0.4, *)
 extension DiscreteFormatStyle {
     /// Produces a sequence that generates all outputs of a discrete format style from a given start to a given end.
     func evaluate(from initialInput: FormatInput, to end: FormatInput, _ advance: @escaping (FormatInput, FormatInput) -> FormatInput? = { prev, next in next }, isLower: @escaping (FormatInput, FormatInput) -> Bool) -> LazySequence<DiscreteFormatStyleSequence<Self>> {
@@ -39,7 +37,6 @@ extension DiscreteFormatStyle {
 }
 
 /// A sequence that generates all outputs of a discrete format style from a given start to a given end.
-@available(FoundationPreview 0.4, *)
 struct DiscreteFormatStyleSequence<Style: DiscreteFormatStyle> : Sequence, IteratorProtocol {
     private let style: Style
     private var input: Style.FormatInput
@@ -139,7 +136,6 @@ func verify<T: Equatable>(
 /// `discreteInput(before:)` and `discreteInput(after:)` are shorter than they could
 /// be, i.e. `style.format(style.discreteInput(after: sample)) == style.format(sample)`.
 /// - Parameter samples: The number of random samples to verify.
-@available(FoundationPreview 0.4, *)
 func verifyDiscreteFormatStyleConformance<Style: DiscreteFormatStyle>(
     _ style: Style,
     strict: Bool = false,
@@ -178,7 +174,6 @@ func verifyDiscreteFormatStyleConformance<Style: DiscreteFormatStyle>(
 /// be, i.e. `style.format(style.discreteInput(after: sample)) == style.format(sample)`.
 /// - Parameter samples: The number of random samples to verify.
 /// ````
-@available(FoundationPreview 0.4, *)
 func verifyDiscreteFormatStyleConformance<Style: DiscreteFormatStyle>(
     _ style: Style,
     strict: Bool = false,
@@ -220,7 +215,6 @@ func verifyDiscreteFormatStyleConformance<Style: DiscreteFormatStyle>(
 /// be, i.e. `style.format(style.discreteInput(after: sample)) == style.format(sample)`.
 /// - Parameter samples: The number of random samples to verify.
 /// ````
-@available(FoundationPreview 0.4, *)
 func verifyDiscreteFormatStyleConformance(
     _ style: Date.ComponentsFormatStyle,
     strict: Bool = false,
@@ -289,7 +283,6 @@ func verifyDiscreteFormatStyleConformance(
 /// `discreteInput(before:)` and `discreteInput(after:)` are shorter than they could
 /// be, i.e. `style.format(style.discreteInput(after: sample)) == style.format(sample)`.
 /// - Parameter samples: The number of random samples to verify.
-@available(FoundationPreview 0.4, *)
 func verifyDiscreteFormatStyleConformance<Style: DiscreteFormatStyle>(
     _ style: Style,
     strict: Bool = false,

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
@@ -555,7 +555,6 @@ final class DurationTimeAttributedStyleTests : XCTestCase {
 
 // MARK: DiscreteFormatStyle conformance test
 
-@available(FoundationPreview 0.4, *)
 final class TestDurationTimeDiscreteConformance : XCTestCase {
     func testBasics() throws {
         var style: Duration._TimeFormatStyle

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
@@ -1115,7 +1115,6 @@ final class DurationUnitAttributedFormatStyleTests : XCTestCase {
 
 // MARK: DiscreteFormatStyle conformance test
 
-@available(FoundationPreview 0.4, *)
 final class TestDurationUnitsDiscreteConformance : XCTestCase {
     func testBasics() throws {
         var style: Duration._UnitsFormatStyle

--- a/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
@@ -23,7 +23,6 @@ import TestSupport
 @testable import Foundation
 #endif
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 class ListFormatStyleTests : XCTestCase {
     func test_orList() {
         var style: ListFormatStyle<StringStyle, [String]> = .list(type: .or, width: .standard)

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -615,7 +615,7 @@ final class NumberFormatStyleTests: XCTestCase {
                 "identifier": "en_US"
             }
         }
-        """.data(using: .utf8)
+        """.data(using: String._Encoding.utf8)
 
         guard let previouslyEncoded else {
             XCTFail()

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -1816,7 +1816,6 @@ class TestNumberAttributeFormatStyle: XCTestCase {
 }
 
 // MARK: Pattern Matching
-@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 final class FormatStylePatternMatchingTests : XCTestCase {
     let frFR = Locale(identifier: "fr_FR")
     let enUS = Locale(identifier: "en_US")

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -227,7 +227,7 @@ final class NumberParseStrategyTests : XCTestCase {
             {"formatStyle":{"locale":{"current":0,"identifier":"en_US"},"collection":{"presentation":{"option":1}},"currencyCode":"USD"},"numberFormatType":{"currency":{"_0":{"presentation":{"option":1}}}},"lenient":true,"locale":{"identifier":"en_US","current":0}}
         """
 
-        guard let existingData = existingSerializedParseStrategy.data(using: .utf8) else {
+        guard let existingData = existingSerializedParseStrategy.data(using: String._Encoding.utf8) else {
             XCTFail("Unable to get data from JSON string")
             return
         }
@@ -246,7 +246,7 @@ final class NumberParseStrategyTests : XCTestCase {
             {"formatStyle":{"collection":{"presentation":{"option":1}},"locale":{"current":0,"identifier":"en_US"},"currencyCode":"GBP"},"lenient":true,"locale":{"current":0,"identifier":"en_US"},"numberFormatType":{"currency":{"_0":{"presentation":{"option":1}}}}}
         """
 
-        guard let existingData = existingSerializedParseStrategy.data(using: .utf8) else {
+        guard let existingData = existingSerializedParseStrategy.data(using: String._Encoding.utf8) else {
             XCTFail("Unable to get data from JSON string")
             return
         }

--- a/Tests/FoundationInternationalizationTests/PredicateInternationalizationTests.swift
+++ b/Tests/FoundationInternationalizationTests/PredicateInternationalizationTests.swift
@@ -14,7 +14,6 @@
 import TestSupport
 #endif
 
-@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 final class PredicateInternationalizationTests: XCTestCase {
     
     struct Object {

--- a/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
@@ -28,7 +28,6 @@ class Hello {
 @available(*, unavailable)
 extension Hello : Sendable {}
 
-@available(FoundationPreview 0.1, *)
 final class SortDescriptorTests: XCTestCase {
     struct NonNSObjectRoot {
         enum Gadget: Int, Comparable {


### PR DESCRIPTION
As we add new APIs and features to Foundation, we plan to adopt new APIs from the Swift standard library that were introduced in the macOS 15-aligned releases. Using these features requires that we increase the minimum deployment target of the SwiftPM build (used for ease of at-desk to macOS 15). This increases the deployment target accordingly so that we can begin to adopt these new APIs without guarding for macOS 15 availability.

In order to bumping the deployment target version, this change also:
- Updates some code in a handful of unit tests to deal with new ambiguity discovered by the compiler (these ambiguity issues stem from new APIs added to Foundation.framework in macOS 15 that were previously disfavored due to lacking matching availability but are now equally favored due to the increased deployment target).
- Resolves new deprecation warnings caused by uses of APIs deprecated between the old deployment target and the new one
- Removes now unnecessarily availability checks/annotations in the unit tests for versions lower than the new deployment target