### PR TITLE
AttributedString APIs for operations over noncontiguous ranges

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -105,9 +105,9 @@ extension AttributedString.Guts {
         if left._guts === right._guts, left._strBounds == right._strBounds { return true }
 
         guard left.count == right.count else { return false }
+        guard !left.isEmpty else { return true }
 
-        var leftIndex = left._strBounds.lowerBound
-        var rightIndex = right._strBounds.lowerBound
+        guard var leftIndex = left._strBounds.ranges.first?.lowerBound, var rightIndex = right._strBounds.ranges.first?.lowerBound else { return false }
 
         var it1 = left.makeIterator()
         var it2 = right.makeIterator()
@@ -135,8 +135,8 @@ extension AttributedString.Guts {
                 return false
             }
         }
-        assert(leftIndex == left._strBounds.upperBound)
-        assert(rightIndex == right._strBounds.upperBound)
+        assert(leftIndex == left._strBounds.ranges.last?.upperBound)
+        assert(rightIndex == right._strBounds.ranges.last?.upperBound)
         return true
     }
 
@@ -159,6 +159,10 @@ extension AttributedString.Guts {
 
 extension AttributedString.Guts {
     internal func description(in range: Range<BigString.Index>) -> String {
+        self.description(in: RangeSet(range))
+    }
+    
+    internal func description(in range: RangeSet<BigString.Index>) -> String {
         var result = ""
         let runs = Runs(self, in: range)
         for run in runs {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -50,10 +50,32 @@ extension AttributedString.Runs {
                 if _index == _slice.endIndex {
                     return nil
                 }
-                let run = _slice.runs[_index]
-                let next = _slice.index(after: _index)
-                let range = _index ..< next
-                _index = next
+                
+                var run: AttributedString.Runs.Run
+                var range: Range<AttributedString.Index>
+                if _slice.runs._isDiscontiguous {
+                    // Need to find the end of the current run (which may not be the same as the start of the next since it's discontiguous)
+                    run = _slice.runs[_index]
+                    let end = _slice.runs._slicedRunBoundary(
+                        after: _index,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: true)
+                    let next = _slice.runs._slicedRunBoundary(
+                        after: end,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: false)
+                    range = _index ..< end
+                    _index = next
+                } else {
+                    // Contiguous runs ensures that the next index is the end of our run, which we can cache as the start of the next
+                    run = _slice.runs[_index]
+                    let next = _slice.index(after: _index)
+                    range = _index ..< next
+                    _index = next
+                }
+                
                 return (run._attributes[T.self], range)
             }
         }
@@ -63,25 +85,29 @@ extension AttributedString.Runs {
         }
 
         public var startIndex: Index {
-            Index(runs._strBounds.lowerBound)
+            Index(runs.startIndex._stringIndex!)
         }
 
         public var endIndex: Index {
-            Index(runs._strBounds.upperBound)
+            Index(runs.endIndex._stringIndex!)
         }
 
         public func index(before i: Index) -> Index {
             runs._slicedRunBoundary(
                 before: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfPrevious: false
+            )
         }
 
         public func index(after i: Index) -> Index {
             runs._slicedRunBoundary(
                 after: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfCurrent: false
+            )
         }
 
         public subscript(position: AttributedString.Index) -> Element {
@@ -89,7 +115,12 @@ extension AttributedString.Runs {
                 roundingDown: position,
                 attributeNames: _names,
                 constraints: _constraints)
-            let end = self.index(after: position)
+            let end = runs._slicedRunBoundary(
+                after: position,
+                attributeNames: _names,
+                constraints: _constraints,
+                endOfCurrent: true
+            )
             let attributes = runs._guts.runs[runIndex].attributes
             return (attributes[T.self], start ..< end)
         }
@@ -157,10 +188,32 @@ extension AttributedString.Runs {
                 if _index == _slice.endIndex {
                     return nil
                 }
-                let run = _slice.runs[_index]
-                let next = _slice.index(after: _index)
-                let range = _index ..< next
-                _index = next
+                
+                var run: AttributedString.Runs.Run
+                var range: Range<AttributedString.Index>
+                if _slice.runs._isDiscontiguous {
+                    // Need to find the end of the current run (which may not be the same as the start of the next since it's discontiguous)
+                    run = _slice.runs[_index]
+                    let end = _slice.runs._slicedRunBoundary(
+                        after: _index,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: true)
+                    let next = _slice.runs._slicedRunBoundary(
+                        after: end,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: false)
+                    range = _index ..< end
+                    _index = next
+                } else {
+                    // Contiguous runs ensures that the next index is the end of our run, which we can cache as the start of the next
+                    run = _slice.runs[_index]
+                    let next = _slice.index(after: _index)
+                    range = _index ..< next
+                    _index = next
+                }
+                
                 return (run._attributes[T.self], run._attributes[U.self], range)
             }
         }
@@ -168,27 +221,31 @@ extension AttributedString.Runs {
         public func makeIterator() -> Iterator {
             Iterator(self)
         }
-
+        
         public var startIndex: Index {
-            Index(runs._strBounds.lowerBound)
+            Index(runs.startIndex._stringIndex!)
         }
-
+        
         public var endIndex: Index {
-            Index(runs._strBounds.upperBound)
+            Index(runs.endIndex._stringIndex!)
         }
 
         public func index(before i: Index) -> Index {
             runs._slicedRunBoundary(
                 before: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfPrevious: false
+            )
         }
 
         public func index(after i: Index) -> Index {
             runs._slicedRunBoundary(
                 after: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfCurrent: false
+            )
         }
 
         public subscript(position: AttributedString.Index) -> Element {
@@ -196,7 +253,12 @@ extension AttributedString.Runs {
                 roundingDown: position,
                 attributeNames: _names,
                 constraints: _constraints)
-            let end = self.index(after: position)
+            let end = runs._slicedRunBoundary(
+                after: position,
+                attributeNames: _names,
+                constraints: _constraints,
+                endOfCurrent: true
+            )
             let attributes = runs._guts.runs[runIndex].attributes
             return (attributes[T.self], attributes[U.self], start ..< end)
         }
@@ -284,10 +346,32 @@ extension AttributedString.Runs {
                 if _index == _slice.endIndex {
                     return nil
                 }
-                let run = _slice.runs[_index]
-                let next = _slice.index(after: _index)
-                let range = _index ..< next
-                _index = next
+                
+                var run: AttributedString.Runs.Run
+                var range: Range<AttributedString.Index>
+                if _slice.runs._isDiscontiguous {
+                    // Need to find the end of the current run (which may not be the same as the start of the next since it's discontiguous)
+                    run = _slice.runs[_index]
+                    let end = _slice.runs._slicedRunBoundary(
+                        after: _index,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: true)
+                    let next = _slice.runs._slicedRunBoundary(
+                        after: end,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: false)
+                    range = _index ..< end
+                    _index = next
+                } else {
+                    // Contiguous runs ensures that the next index is the end of our run, which we can cache as the start of the next
+                    run = _slice.runs[_index]
+                    let next = _slice.index(after: _index)
+                    range = _index ..< next
+                    _index = next
+                }
+                
                 return (
                     run._attributes[T.self],
                     run._attributes[U.self],
@@ -299,27 +383,31 @@ extension AttributedString.Runs {
         public func makeIterator() -> Iterator {
             Iterator(self)
         }
-
+        
         public var startIndex: Index {
-            Index(runs._strBounds.lowerBound)
+            Index(runs.startIndex._stringIndex!)
         }
-
+        
         public var endIndex: Index {
-            Index(runs._strBounds.upperBound)
+            Index(runs.endIndex._stringIndex!)
         }
 
         public func index(before i: Index) -> Index {
             runs._slicedRunBoundary(
                 before: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfPrevious: false
+            )
         }
 
         public func index(after i: Index) -> Index {
             runs._slicedRunBoundary(
                 after: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfCurrent: false
+            )
         }
 
         public subscript(position: AttributedString.Index) -> Element {
@@ -327,7 +415,12 @@ extension AttributedString.Runs {
                 roundingDown: position,
                 attributeNames: _names,
                 constraints: _constraints)
-            let end = self.index(after: position)
+            let end = runs._slicedRunBoundary(
+                after: position,
+                attributeNames: _names,
+                constraints: _constraints,
+                endOfCurrent: true
+            )
             let attributes = runs._guts.runs[runIndex].attributes
             return (attributes[T.self], attributes[U.self], attributes[V.self], start ..< end)
         }
@@ -424,10 +517,32 @@ extension AttributedString.Runs {
                 if _index == _slice.endIndex {
                     return nil
                 }
-                let run = _slice.runs[_index]
-                let next = _slice.index(after: _index)
-                let range = _index ..< next
-                _index = next
+                
+                var run: AttributedString.Runs.Run
+                var range: Range<AttributedString.Index>
+                if _slice.runs._isDiscontiguous {
+                    // Need to find the end of the current run (which may not be the same as the start of the next since it's discontiguous)
+                    run = _slice.runs[_index]
+                    let end = _slice.runs._slicedRunBoundary(
+                        after: _index,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: true)
+                    let next = _slice.runs._slicedRunBoundary(
+                        after: end,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: false)
+                    range = _index ..< end
+                    _index = next
+                } else {
+                    // Contiguous runs ensures that the next index is the end of our run, which we can cache as the start of the next
+                    run = _slice.runs[_index]
+                    let next = _slice.index(after: _index)
+                    range = _index ..< next
+                    _index = next
+                }
+                
                 return (
                     run._attributes[T.self],
                     run._attributes[U.self],
@@ -440,27 +555,31 @@ extension AttributedString.Runs {
         public func makeIterator() -> Iterator {
             Iterator(self)
         }
-
+        
         public var startIndex: Index {
-            Index(runs._strBounds.lowerBound)
+            Index(runs.startIndex._stringIndex!)
         }
-
+        
         public var endIndex: Index {
-            Index(runs._strBounds.upperBound)
+            Index(runs.endIndex._stringIndex!)
         }
 
         public func index(before i: Index) -> Index {
             runs._slicedRunBoundary(
                 before: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfPrevious: false
+            )
         }
 
         public func index(after i: Index) -> Index {
             runs._slicedRunBoundary(
                 after: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfCurrent: false
+            )
         }
 
         public subscript(position: AttributedString.Index) -> Element {
@@ -468,7 +587,12 @@ extension AttributedString.Runs {
                 roundingDown: position,
                 attributeNames: _names,
                 constraints: _constraints)
-            let end = self.index(after: position)
+            let end = runs._slicedRunBoundary(
+                after: position,
+                attributeNames: _names,
+                constraints: _constraints,
+                endOfCurrent: true
+            )
             let attributes = runs._guts.runs[runIndex].attributes
             return (
                 attributes[T.self],
@@ -580,10 +704,32 @@ extension AttributedString.Runs {
                 if _index == _slice.endIndex {
                     return nil
                 }
-                let run = _slice.runs[_index]
-                let next = _slice.index(after: _index)
-                let range = _index ..< next
-                _index = next
+                
+                var run: AttributedString.Runs.Run
+                var range: Range<AttributedString.Index>
+                if _slice.runs._isDiscontiguous {
+                    // Need to find the end of the current run (which may not be the same as the start of the next since it's discontiguous)
+                    run = _slice.runs[_index]
+                    let end = _slice.runs._slicedRunBoundary(
+                        after: _index,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: true)
+                    let next = _slice.runs._slicedRunBoundary(
+                        after: end,
+                        attributeNames: _slice._names,
+                        constraints: _slice._constraints,
+                        endOfCurrent: false)
+                    range = _index ..< end
+                    _index = next
+                } else {
+                    // Contiguous runs ensures that the next index is the end of our run, which we can cache as the start of the next
+                    run = _slice.runs[_index]
+                    let next = _slice.index(after: _index)
+                    range = _index ..< next
+                    _index = next
+                }
+                
                 return (
                     run._attributes[T.self],
                     run._attributes[U.self],
@@ -597,27 +743,31 @@ extension AttributedString.Runs {
         public func makeIterator() -> Iterator {
             Iterator(self)
         }
-
+        
         public var startIndex: Index {
-            Index(runs._strBounds.lowerBound)
+            Index(runs.startIndex._stringIndex!)
         }
-
+        
         public var endIndex: Index {
-            Index(runs._strBounds.upperBound)
+            Index(runs.endIndex._stringIndex!)
         }
 
         public func index(before i: Index) -> Index {
             runs._slicedRunBoundary(
                 before: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfPrevious: false
+            )
         }
 
         public func index(after i: Index) -> Index {
             runs._slicedRunBoundary(
                 after: i,
                 attributeNames: _names,
-                constraints: _constraints)
+                constraints: _constraints,
+                endOfCurrent: false
+            )
         }
 
         public subscript(position: AttributedString.Index) -> Element {
@@ -625,7 +775,12 @@ extension AttributedString.Runs {
                 roundingDown: position,
                 attributeNames: _names,
                 constraints: _constraints)
-            let end = self.index(after: position)
+            let end = runs._slicedRunBoundary(
+                after: position,
+                attributeNames: _names,
+                constraints: _constraints,
+                endOfCurrent: true
+            )
             let attributes = runs._guts.runs[runIndex].attributes
             return (
                 attributes[T.self],

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -372,9 +372,25 @@ extension Range where Bound == AttributedString.Index {
     }
 }
 
+extension RangeSet where Bound == AttributedString.Index {
+    internal var _bstringIndices: RangeSet<BigString.Index> {
+        RangeSet<BigString.Index>(self.ranges.map(\._bstringRange))
+    }
+}
+
+extension RangeSet where Bound == BigString.Index {
+    internal var _attributedStringIndices: RangeSet<AttributedString.Index> {
+        RangeSet<AttributedString.Index>(self.ranges.map(\._attributedStringRange))
+    }
+}
+
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Range where Bound == BigString.Index {
     internal var _utf8OffsetRange: Range<Int> {
         Range<Int>(uncheckedBounds: (lowerBound.utf8Offset, upperBound.utf8Offset))
+    }
+    
+    internal var _attributedStringRange: Range<AttributedString.Index> {
+        Range<AttributedString.Index>(uncheckedBounds: (AttributedString.Index(lowerBound), AttributedString.Index(upperBound)))
     }
 }

--- a/Sources/FoundationEssentials/AttributedString/CMakeLists.txt
+++ b/Sources/FoundationEssentials/AttributedString/CMakeLists.txt
@@ -35,5 +35,6 @@ target_sources(FoundationEssentials PRIVATE
     AttributedSubstring.swift
     Collection\ Stdlib\ Defaults.swift
     Conversion.swift
+    DiscontiguousAttributedSubstring.swift
     FoundationAttributes.swift
     String.Index+ABI.swift)

--- a/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
@@ -1,0 +1,320 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+@_spi(Unstable) internal import CollectionsInternal
+#elseif canImport(_RopeModule)
+internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
+#endif
+
+@dynamicMemberLookup
+@available(FoundationPreview 6.2, *)
+public struct DiscontiguousAttributedSubstring: Sendable {
+    /// The guts of the base attributed string.
+    internal var _guts: AttributedString.Guts
+    
+    internal var _indices: RangeSet<BigString.Index>
+    
+    internal var _identity: Int = 0
+    
+    internal init(_ guts: AttributedString.Guts, in indices: RangeSet<BigString.Index>) {
+        self._guts = guts
+        // Forcibly resolve bounds and round them down to nearest scalar boundary.
+        var ranges = Array(indices.ranges)
+        for i in ranges.indices {
+            let slice = _guts.string.unicodeScalars[ranges[i]]
+            ranges[i] = Range(uncheckedBounds: (slice.startIndex, slice.endIndex))
+        }
+        self._indices = RangeSet(ranges)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DiscontiguousAttributedSubstring {
+    public var base: AttributedString {
+        return AttributedString(_guts)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DiscontiguousAttributedSubstring : CustomStringConvertible {
+    public var description: String {
+        _guts.description(in: _indices)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DiscontiguousAttributedSubstring : Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        AttributedString.Guts._characterwiseIsEqual(lhs.runs, to: rhs.runs)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DiscontiguousAttributedSubstring : Hashable {
+    public func hash(into hasher: inout Hasher) {
+        for range in _indices.ranges {
+            _guts.characterwiseHash(in: range, into: &hasher)
+        }
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DiscontiguousAttributedSubstring : AttributedStringAttributeMutation {
+    internal mutating func ensureUniqueReference() {
+        // Note: slices should never discard the data outside their bounds, so we must make a
+        // copy of the entire base string here.
+        //
+        // (Discarding out-of-range data would change index values, interfere with "in-place"
+        // mutations of slices via the subscript accessors, and it would confuse the semantics of
+        // the `base` property.)
+        if !isKnownUniquelyReferenced(&_guts) {
+            _guts = _guts.copy()
+        }
+    }
+    
+    public mutating func setAttributes(_ attributes: AttributeContainer) {
+        ensureUniqueReference()
+        for range in _indices.ranges {
+            _guts.setAttributes(attributes.storage, in: range)
+        }
+    }
+    
+    public mutating func mergeAttributes(_ attributes: AttributeContainer, mergePolicy:  AttributedString.AttributeMergePolicy = .keepNew) {
+        ensureUniqueReference()
+        for range in _indices.ranges {
+            _guts.mergeAttributes(attributes, in: range, mergePolicy: mergePolicy)
+        }
+    }
+    
+    public mutating func replaceAttributes(_ attributes: AttributeContainer, with others: AttributeContainer) {
+        guard attributes != others else {
+            return
+        }
+        ensureUniqueReference()
+        let hasConstrainedAttributes = attributes.storage.hasConstrainedAttributes || others.storage.hasConstrainedAttributes
+        var fixupRanges = [Range<Int>]()
+        for range in _indices.ranges {
+            _guts.runs(in: range._utf8OffsetRange).updateEach(
+                when: { $0.matches(attributes.storage) },
+                with: { runAttributes, utf8Range in
+                    for key in attributes.storage.keys {
+                        runAttributes[key] = nil
+                    }
+                    runAttributes.mergeIn(others)
+                    if hasConstrainedAttributes {
+                        fixupRanges.append(utf8Range)
+                    }
+                })
+        }
+        for range in fixupRanges {
+            // FIXME: Collect boundary constraints.
+            _guts.enforceAttributeConstraintsAfterMutation(in: range, type: .attributes)
+        }
+    }
+    
+    public subscript(bounds: some RangeExpression<AttributedString.Index>) -> DiscontiguousAttributedSubstring {
+        let characterView = AttributedString.CharacterView(_guts)
+        let bounds = bounds.relative(to: characterView)._bstringRange
+        if let first = _indices.ranges.first, let last = _indices.ranges.last, first.lowerBound <= bounds.lowerBound, last.upperBound >= bounds.upperBound {
+            return DiscontiguousAttributedSubstring(_guts, in: _indices.intersection(RangeSet(bounds)))
+        }
+        preconditionFailure("Attributed string index range \(bounds) is out of bounds")
+    }
+    
+    public subscript(bounds: RangeSet<AttributedString.Index>) -> DiscontiguousAttributedSubstring {
+        let bounds = bounds._bstringIndices
+        if bounds.ranges.isEmpty {
+            return DiscontiguousAttributedSubstring(_guts, in: bounds)
+        } else if let first = _indices.ranges.first,
+                  let last = _indices.ranges.last,
+                  let firstBounds = bounds.ranges.first,
+                  let lastBounds = bounds.ranges.last,
+                  first.lowerBound <= firstBounds.lowerBound,
+                  last.upperBound >= lastBounds.upperBound {
+            return DiscontiguousAttributedSubstring(_guts, in: _indices.intersection(bounds))
+        }
+        preconditionFailure("Attributed string index range \(bounds) is out of bounds")
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DiscontiguousAttributedSubstring {
+    public var characters: DiscontiguousSlice<AttributedString.CharacterView> {
+        AttributedString.CharacterView(_guts)[_indices._attributedStringIndices]
+    }
+    
+    public var unicodeScalars: DiscontiguousSlice<AttributedString.UnicodeScalarView> {
+        AttributedString.UnicodeScalarView(_guts)[_indices._attributedStringIndices]
+    }
+    
+    public var runs: AttributedString.Runs {
+        AttributedString.Runs(_guts, in: _indices)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension DiscontiguousAttributedSubstring {
+    public subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? where K.Value : Sendable {
+        get {
+            var result: AttributedString._AttributeValue?
+            for range in _indices.ranges {
+                guard let value = _guts.getUniformValue(in: range, key: K.self) else {
+                    return nil
+                }
+                if let previous = result, previous != value {
+                    return nil
+                }
+                result = value
+            }
+            return result?.rawValue(as: K.self)
+        }
+        set {
+            ensureUniqueReference()
+            if let v = newValue {
+                for range in _indices.ranges {
+                    _guts.setAttributeValue(v, forKey: K.self, in: range)
+                }
+            } else {
+                for range in _indices.ranges {
+                    _guts.removeAttributeValue(forKey: K.self, in: range)
+                }
+            }
+        }
+    }
+    
+    public subscript<K: AttributedStringKey>(
+        dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>
+    ) -> K.Value? where K.Value : Sendable {
+        get { self[K.self] }
+        set { self[K.self] = newValue }
+    }
+    
+    public subscript<S: AttributeScope>(
+        dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>
+    ) -> ScopedAttributeContainer<S> {
+        get {
+            var attributes = AttributedString._AttributeStorage()
+            var first = true
+            for range in _indices.ranges {
+                let value = _guts.getUniformValues(in: range)
+                guard !first else {
+                    attributes = value
+                    first = false
+                    continue
+                }
+                attributes = attributes.filterWithoutInvalidatingDependents {
+                    guard let value = value[$0.key] else { return false }
+                    return value == $0.value
+                }
+                if attributes.isEmpty {
+                    break
+                }
+            }
+            return ScopedAttributeContainer(attributes)
+            
+        }
+        _modify {
+            ensureUniqueReference()
+            var container = ScopedAttributeContainer<S>()
+            defer {
+                if let removedKey = container.removedKey {
+                    for range in _indices.ranges {
+                        _guts.removeAttributeValue(forKey: removedKey, in: range)
+                    }
+                } else {
+                    for range in _indices.ranges {
+                        _guts.mergeAttributes(AttributeContainer(container.storage), in: range)
+                    }
+                }
+            }
+            yield &container
+        }
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension AttributedString {
+    public init(_ substring: DiscontiguousAttributedSubstring) {
+        let created = AttributedString.Guts()
+        for range in substring._indices.ranges {
+            created.replaceSubrange(
+                created.string.endIndex ..< created.string.endIndex,
+                with: AttributedSubstring(substring._guts, in: range)
+            )
+        }
+        self.init(created)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension AttributedStringProtocol {
+    public subscript(_ indices: RangeSet<AttributedString.Index>) -> DiscontiguousAttributedSubstring {
+        let range = Range(uncheckedBounds: (startIndex, endIndex))._bstringRange
+        let newIndices = indices._bstringIndices.intersection(RangeSet(range))
+        return DiscontiguousAttributedSubstring(__guts, in: newIndices)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension AttributedString {
+    public subscript(_ indices: RangeSet<AttributedString.Index>) -> DiscontiguousAttributedSubstring {
+        get {
+            let range = Range(uncheckedBounds: (startIndex, endIndex))._bstringRange
+            let newIndices = indices._bstringIndices.intersection(RangeSet(range))
+            return DiscontiguousAttributedSubstring(_guts, in: newIndices)
+        }
+        _modify {
+            ensureUniqueReference()
+            let range = Range(uncheckedBounds: (startIndex, endIndex))._bstringRange
+            let newIndices = indices._bstringIndices.intersection(RangeSet(range))
+            var view = DiscontiguousAttributedSubstring(_guts, in: newIndices)
+            let ident = Self._nextModifyIdentity
+            view._identity = ident
+            _guts = Guts() // Preserve uniqueness of view
+            defer {
+                if view._identity != ident {
+                    fatalError("Mutating a DiscontiguousAttributedSubstring by replacing it with another from a different source is unsupported")
+                }
+                _guts = view._guts
+            }
+            yield &view
+        }
+        set {
+            // The behavior of this function can be semantically confusing - we are required to have a setter in order to allow mutations such as attrStr[rangeSet].foregroundColor = .green, but wholesale replacements like attrStr[rangeSet] = otherAttrStr[otherRangeSet] then become possible
+            // The general principle taken here is that the behavior of this function should be defined such that the _modify behavior is equivalent to a get followed by a mutation and then a set
+            // Therefore, this function must interpolate the sliced contents of the newValue into the discontiguous chunks referenced by indices. This makes the behavior unclear when newValue has more values than what fit into indices, and therefore this causes a precondition failure.
+            ensureUniqueReference()
+            let other = AttributedString(newValue)
+            var idxInOther = other.unicodeScalars.endIndex
+            for range in indices.ranges.lazy.reversed() {
+                let unicodeScalarLength = _guts.string.unicodeScalars.distance(from: range.lowerBound._value, to: range.upperBound._value)
+                guard let startIdx = other.unicodeScalars.index(idxInOther, offsetBy: -unicodeScalarLength, limitedBy: other.unicodeScalars.startIndex) else {
+                    preconditionFailure("Cannot set a DiscontiguousAttributedSubstring on a discontiguous slice of a different size")
+                }
+                let content = other[startIdx ..< idxInOther]
+                _guts.replaceSubrange(range._bstringRange, with: content)
+                idxInOther = startIdx
+            }
+            precondition(idxInOther == other.unicodeScalars.startIndex, "Cannot set a DiscontiguousAttributedSubstring on a discontiguous slice of a different size")
+        }
+    }
+    
+    public mutating func removeSubranges(_ subranges: RangeSet<Index>) {
+        ensureUniqueReference()
+        for range in subranges.ranges.lazy.reversed() {
+            _guts.replaceSubrange(range._bstringRange, with: AttributedString())
+        }
+    }
+}

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringCOWTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringCOWTests.swift
@@ -62,6 +62,12 @@ final class TestAttributedStringCOW: XCTestCase {
         return str.characters.index(str.startIndex, offsetBy: 2)..<str.characters.index(str.endIndex, offsetBy: -2)
     }
     
+    func makeSubranges(_ str: AttributedString) -> RangeSet<AttributedString.Index> {
+        let rangeA = str.characters.index(str.startIndex, offsetBy: 2)..<str.characters.index(str.startIndex, offsetBy: 4)
+        let rangeB = str.characters.index(str.startIndex, offsetBy: -4)..<str.characters.index(str.endIndex, offsetBy: -2)
+        return RangeSet([rangeA, rangeB])
+    }
+    
     lazy var container: AttributeContainer = {
         var container = AttributeContainer()
         container.testInt = 2
@@ -96,6 +102,9 @@ final class TestAttributedStringCOW: XCTestCase {
             str.removeSubrange(..<str.characters.index(str.startIndex, offsetBy: 3))
         }
         assertCOWBehavior { (str) in
+            str.removeSubranges(makeSubranges(str))
+        }
+        assertCOWBehavior { (str) in
             str.replaceSubrange(..<str.characters.index(str.startIndex, offsetBy: 3), with: AttributedString("b", attributes: containerB))
         }
         assertCOWBehavior { (str) in
@@ -127,6 +136,31 @@ final class TestAttributedStringCOW: XCTestCase {
         }
         assertCOWBehavior { (str) in
             str[makeSubrange(str)].test.testInt = 3
+        }
+    }
+    
+    func testDiscontiguousSubstring() {
+        assertCOWBehavior { (str) in
+            str[makeSubranges(str)].setAttributes(container)
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubranges(str)].mergeAttributes(container)
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubranges(str)].replaceAttributes(container, with: containerB)
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubranges(str)][AttributeScopes.TestAttributes.TestIntAttribute.self] = 3
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubranges(str)].testInt = 3
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubranges(str)].test.testInt = 3
+        }
+        assertCOWBehavior { (str) in
+            let other = AttributedString("___________")
+            str[makeSubranges(str)] = other[makeSubranges(other)]
         }
     }
     

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringDiscontiguousTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringDiscontiguousTests.swift
@@ -1,0 +1,319 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+final class AttributedStringDiscontiguousTests: XCTestCase {
+    func testEmptySlice() {
+        let str = AttributedString()
+        let slice = str[RangeSet()]
+        XCTAssertTrue(slice.runs.isEmpty)
+        XCTAssertTrue(slice.characters.isEmpty)
+        XCTAssertTrue(slice.unicodeScalars.isEmpty)
+        XCTAssertEqual(slice, slice)
+        XCTAssertEqual(slice.runs.startIndex, slice.runs.endIndex)
+        XCTAssertEqual(slice.characters.startIndex, slice.characters.endIndex)
+        XCTAssertEqual(slice.unicodeScalars.startIndex, slice.unicodeScalars.endIndex)
+        XCTAssertEqual(AttributedString("abc")[RangeSet()], AttributedString("def")[RangeSet()])
+        
+        for r in slice.runs {
+            XCTFail("Enumerating empty runs should not have produced \(r)")
+        }
+        for c in slice.characters {
+            XCTFail("Enumerating empty characters should not have produced \(c)")
+        }
+        for s in slice.unicodeScalars {
+            XCTFail("Enumerating empty unicode scalars should not have produced \(s)")
+        }
+    }
+    
+    func testCharacters() {
+        let str = AttributedString("abcdefgabc")
+        let fullSlice = str[str.startIndex ..< str.endIndex].characters
+        let fullDiscontiguousSlice = str[RangeSet(str.startIndex ..< str.endIndex)].characters
+        XCTAssertTrue(fullSlice.elementsEqual(fullDiscontiguousSlice))
+        
+        let rangeA = str.startIndex ..< str.index(str.startIndex, offsetByCharacters: 3)
+        let rangeB = str.index(str.endIndex, offsetByCharacters: -3) ..< str.endIndex
+        let rangeSet = RangeSet([rangeA, rangeB])
+        let slice = str[rangeSet].characters
+        XCTAssertEqual(Array(slice), ["a", "b", "c", "a", "b", "c"])
+    }
+    
+    func testUnicodeScalars() {
+        let str = AttributedString("abcdefgabc")
+        let fullSlice = str[str.startIndex ..< str.endIndex].unicodeScalars
+        let fullDiscontiguousSlice = str[RangeSet(str.startIndex ..< str.endIndex)].unicodeScalars
+        XCTAssertTrue(fullSlice.elementsEqual(fullDiscontiguousSlice))
+        
+        let rangeA = str.startIndex ..< str.index(str.startIndex, offsetByUnicodeScalars: 3)
+        let rangeB = str.index(str.endIndex, offsetByUnicodeScalars: -3) ..< str.endIndex
+        let rangeSet = RangeSet([rangeA, rangeB])
+        let slice = str[rangeSet].unicodeScalars
+        XCTAssertEqual(Array(slice), ["a", "b", "c", "a", "b", "c"])
+    }
+    
+    func testAttributes() {
+        let str = AttributedString("abcdefg")
+        let rangeA = str.startIndex ..< str.index(str.startIndex, offsetByCharacters: 1)
+        let rangeB = str.index(str.startIndex, offsetByCharacters: 2) ..< str.index(str.startIndex, offsetByCharacters: 3)
+        let rangeC = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 5)
+        let ranges = RangeSet([rangeA, rangeB, rangeC])
+        
+        do {
+            var a = str
+            a[ranges].testInt = 2
+            var b = str
+            for range in ranges.ranges {
+                b[range].testInt = 2
+            }
+            XCTAssertEqual(a, b)
+        }
+        
+        do {
+            var a = str
+            a[ranges].test.testInt = 2
+            var b = str
+            for range in ranges.ranges {
+                b[range].test.testInt = 2
+            }
+            XCTAssertEqual(a, b)
+        }
+        
+        do {
+            var a = str
+            a[ranges][AttributeScopes.TestAttributes.TestIntAttribute.self] = 2
+            var b = str
+            for range in ranges.ranges {
+                b[range][AttributeScopes.TestAttributes.TestIntAttribute.self] = 2
+            }
+            XCTAssertEqual(a, b)
+        }
+        
+        do {
+            var a = str
+            a.testInt = 3
+            a[ranges].testInt = nil
+            var b = str
+            b.testInt = 3
+            for range in ranges.ranges {
+                b[range].testInt = nil
+            }
+            XCTAssertEqual(a, b)
+        }
+        
+        do {
+            var a = str
+            a.testInt = 2
+            XCTAssertEqual(a[ranges].testInt, 2)
+            a[rangeA].testInt = 3
+            XCTAssertEqual(a[ranges].testInt, nil)
+        }
+        
+        do {
+            var a = str
+            a.testString = "foo"
+            a[ranges].mergeAttributes(AttributeContainer.testInt(2))
+            var b = str
+            b.testString = "foo"
+            for range in ranges.ranges {
+                b[range].mergeAttributes(AttributeContainer.testInt(2))
+            }
+            XCTAssertEqual(a, b)
+        }
+        
+        do {
+            var a = str
+            a.testString = "foo"
+            a[ranges].setAttributes(AttributeContainer.testInt(2))
+            var b = str
+            b.testString = "foo"
+            for range in ranges.ranges {
+                b[range].setAttributes(AttributeContainer.testInt(2))
+            }
+            XCTAssertEqual(a, b)
+        }
+        
+        do {
+            var a = str
+            a.testString = "foo"
+            a[ranges].replaceAttributes(AttributeContainer(), with: AttributeContainer.testInt(2))
+            var b = str
+            b.testString = "foo"
+            for range in ranges.ranges {
+                b[range].replaceAttributes(AttributeContainer(), with: AttributeContainer.testInt(2))
+            }
+            XCTAssertEqual(a, b)
+        }
+        
+        do {
+            var a = str
+            a.testString = "foo"
+            a[ranges].replaceAttributes(AttributeContainer.testString("foo"), with: AttributeContainer.testInt(2))
+            var b = str
+            b.testString = "foo"
+            for range in ranges.ranges {
+                b[range].replaceAttributes(AttributeContainer.testString("foo"), with: AttributeContainer.testInt(2))
+            }
+            XCTAssertEqual(a, b)
+        }
+    }
+    
+    func testReinitialization() {
+        var str = AttributedString("abcdefg")
+        let rangeA = str.startIndex ..< str.index(str.startIndex, offsetByCharacters: 1)
+        let rangeB = str.index(str.startIndex, offsetByCharacters: 2) ..< str.index(str.startIndex, offsetByCharacters: 3)
+        let rangeC = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 5)
+        let ranges = RangeSet([rangeA, rangeB, rangeC])
+        str[ranges].testInt = 2
+        
+        let reinitialized = AttributedString(str[ranges])
+        XCTAssertEqual(reinitialized, AttributedString("ace", attributes: AttributeContainer.testInt(2)))
+    }
+    
+    func testReslicing() {
+        var str = AttributedString("abcdefg")
+        let rangeA = str.startIndex ..< str.index(str.startIndex, offsetByCharacters: 1)
+        let rangeB = str.index(str.startIndex, offsetByCharacters: 2) ..< str.index(str.startIndex, offsetByCharacters: 3)
+        let rangeC = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 5)
+        let ranges = RangeSet([rangeA, rangeB, rangeC])
+        str[ranges].testInt = 2
+        
+        XCTAssertEqual(str[ranges], str[ranges][ranges])
+        XCTAssertEqual(AttributedString(str[ranges][RangeSet([rangeA, rangeB])]), AttributedString("ac", attributes: AttributeContainer.testInt(2)))
+        XCTAssertEqual(AttributedString(str[ranges][rangeA.lowerBound ..< rangeB.upperBound]), AttributedString("ac", attributes: AttributeContainer.testInt(2)))
+        
+        XCTAssertEqual(str[RangeSet()][RangeSet()], str[RangeSet()])
+    }
+    
+    func testRuns() {
+        var str = AttributedString("AAA", attributes: AttributeContainer.testInt(2))
+        str += AttributedString("BBB", attributes: AttributeContainer.testInt(3).testString("foo"))
+        str += AttributedString("CC", attributes: AttributeContainer.testInt(3).testString("bar"))
+        str += AttributedString("D", attributes: AttributeContainer.testInt(3).testString("baz"))
+        str += AttributedString("EEEEEEEE")
+        
+        let rangeA = str.index(str.startIndex, offsetByCharacters: 1) ..< str.index(str.startIndex, offsetByCharacters: 2) // A
+        let rangeB = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 7) // BBC (2 runs)
+        let rangeC = str.index(str.startIndex, offsetByCharacters: 8) ..< str.index(str.startIndex, offsetByCharacters: 9) // D
+        let rangeD = str.index(str.startIndex, offsetByCharacters: 10) ..< str.index(str.startIndex, offsetByCharacters: 11) // E
+        let rangeE = str.index(str.startIndex, offsetByCharacters: 12) ..< str.index(str.startIndex, offsetByCharacters: 13) // E
+        let rangeSet = RangeSet([rangeA, rangeB, rangeC, rangeD, rangeE])
+        
+        let rangeB_first = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 6)
+        let rangeB_second = str.index(str.startIndex, offsetByCharacters: 6) ..< str.index(str.startIndex, offsetByCharacters: 7)
+        
+        let runs = str[rangeSet].runs
+        let expectedRanges = [rangeA, rangeB_first, rangeB_second, rangeC, rangeD, rangeE]
+        XCTAssertEqual(runs.count, expectedRanges.count)
+        XCTAssertEqual(runs.reversed().count, expectedRanges.reversed().count)
+        XCTAssertEqual(runs.map(\.range), expectedRanges)
+        XCTAssertEqual(runs.reversed().map(\.range), expectedRanges.reversed())
+    }
+    
+    func testCoalescedRuns() {
+        struct EquatableBox<T: Equatable, U: Equatable>: Equatable, CustomStringConvertible {
+            let t: T
+            let u: U
+            
+            var description: String {
+                "(\(String(describing: t)), \(String(describing: u)))"
+            }
+            
+            init(_ values: (T, U)) {
+                self.t = values.0
+                self.u = values.1
+            }
+            
+            init(_ t: T, _ u: U) {
+                self.t = t
+                self.u = u
+            }
+        }
+        var str = AttributedString("AAA", attributes: AttributeContainer.testInt(2))
+        str += AttributedString("BBB", attributes: AttributeContainer.testInt(3).testString("foo"))
+        str += AttributedString("CC", attributes: AttributeContainer.testInt(3).testString("bar"))
+        str += AttributedString("D", attributes: AttributeContainer.testInt(3).testString("baz"))
+        str += AttributedString("EEEEEEEE")
+        
+        let rangeA = str.index(str.startIndex, offsetByCharacters: 1) ..< str.index(str.startIndex, offsetByCharacters: 2) // A
+        let rangeB = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 7) // BBC (2 runs)
+        let rangeC = str.index(str.startIndex, offsetByCharacters: 8) ..< str.index(str.startIndex, offsetByCharacters: 9) // D
+        let rangeD = str.index(str.startIndex, offsetByCharacters: 10) ..< str.index(str.startIndex, offsetByCharacters: 11) // E
+        let rangeE = str.index(str.startIndex, offsetByCharacters: 12) ..< str.index(str.startIndex, offsetByCharacters: 13) // E
+        let rangeSet = RangeSet([rangeA, rangeB, rangeC, rangeD, rangeE])
+        
+        let rangeB_first = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 6)
+        let rangeB_second = str.index(str.startIndex, offsetByCharacters: 6) ..< str.index(str.startIndex, offsetByCharacters: 7)
+        
+        let runs = str[rangeSet].runs
+        
+        let testIntExpectation = [EquatableBox(2, rangeA), EquatableBox(3, rangeB), EquatableBox(3, rangeC), EquatableBox(nil, rangeD), EquatableBox(nil, rangeE)]
+        XCTAssertEqual(runs[\.testInt].map(EquatableBox.init), testIntExpectation)
+        XCTAssertEqual(runs[\.testInt].reversed().map(EquatableBox.init), testIntExpectation.reversed())
+        
+        let testStringExpectation = [EquatableBox(nil, rangeA), EquatableBox("foo", rangeB_first), EquatableBox("bar", rangeB_second), EquatableBox("baz", rangeC), EquatableBox(nil, rangeD), EquatableBox(nil, rangeE)]
+        XCTAssertEqual(runs[\.testString].map(EquatableBox.init), testStringExpectation)
+        XCTAssertEqual(runs[\.testString].reversed().map(EquatableBox.init), testStringExpectation.reversed())
+    }
+    
+    func testRemoveSubranges() {
+        var str = AttributedString("abcdefg")
+        let rangeA = str.startIndex ..< str.index(str.startIndex, offsetByCharacters: 1)
+        let rangeB = str.index(str.startIndex, offsetByCharacters: 2) ..< str.index(str.startIndex, offsetByCharacters: 3)
+        let rangeC = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 5)
+        let ranges = RangeSet([rangeA, rangeB, rangeC])
+        str[ranges].testInt = 2
+        str.testBool = true
+        str[rangeA].testString = "foo"
+        
+        str.removeSubranges(ranges)
+        let result = AttributedString("bdfg", attributes: AttributeContainer.testBool(true))
+        XCTAssertEqual(str, result)
+    }
+    
+    func testSliceSetter() {
+        var str = AttributedString("abcdefg")
+        let rangeA = str.startIndex ..< str.index(str.startIndex, offsetByCharacters: 1)
+        let rangeB = str.index(str.startIndex, offsetByCharacters: 2) ..< str.index(str.startIndex, offsetByCharacters: 3)
+        let rangeC = str.index(str.startIndex, offsetByCharacters: 4) ..< str.index(str.startIndex, offsetByCharacters: 5)
+        let ranges = RangeSet([rangeA, rangeB, rangeC])
+        str[ranges].testInt = 2
+        str.testBool = true
+        str[rangeA].testString = "foo"
+        
+        do {
+            var copy = str
+            copy[ranges] = copy[ranges]
+            XCTAssertEqual(copy, str)
+        }
+        
+        do {
+            var copy = str
+            copy[ranges] = str[ranges]
+            XCTAssertEqual(copy, str)
+        }
+        
+        do {
+            let str2 = AttributedString("Z_Y_X__")
+            let rangeA2 = str2.startIndex ..< str2.index(str2.startIndex, offsetByCharacters: 1)
+            let rangeB2 = str2.index(str.startIndex, offsetByCharacters: 2) ..< str2.index(str2.startIndex, offsetByCharacters: 3)
+            let rangeC2 = str2.index(str.startIndex, offsetByCharacters: 4) ..< str2.index(str2.startIndex, offsetByCharacters: 5)
+            let ranges2 = RangeSet([rangeA2, rangeB2, rangeC2])
+            var copy = str
+            copy[ranges] = str2[ranges2]
+            XCTAssertEqual(String(copy.characters), "ZbYdXfg")
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the API changes proposed in [SF-0014](https://github.com/swiftlang/swift-foundation/blob/main/Proposals/0014-attributed-string-discontiguous-operations.md) by adding a new `DiscontiguousAttributedSubstring` type (the result of slicing an `AttributedString` with a `RangeSet`) which vends out slices of each underlying view, an upgraded `Runs` view which now handles discontiguous segments, and performs operations over the discontiguous subranges.