### PR TITLE
Prevent crashing when calling quotactl with UIDs greater than Int32.max

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -718,7 +718,7 @@ extension _FileManagerImpl {
             func _quotactl<T>(_ path: UnsafePointer<CChar>, _ cmd: Int32, _ type: Int32, _ uid: uid_t, init: T) -> T? {
                 var res = `init`
                 let success = withUnsafeMutableBytes(of: &res) { buffer in
-                    quotactl(path, QCMD(cmd, type), Int32(uid), buffer.baseAddress!) == 0
+                    quotactl(path, QCMD(cmd, type), Int32(bitPattern: uid), buffer.baseAddress!) == 0
                 }
                 return success ? res : nil
             }

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -718,6 +718,8 @@ extension _FileManagerImpl {
             func _quotactl<T>(_ path: UnsafePointer<CChar>, _ cmd: Int32, _ type: Int32, _ uid: uid_t, init: T) -> T? {
                 var res = `init`
                 let success = withUnsafeMutableBytes(of: &res) { buffer in
+                    // quotactl's parameter is annotated as `int` (signed 32bit) instead of `uid_t` (unsigned 32bit)
+                    // UIDs greater than Int32.max are valid so we perform a bit-pattern cast here to prevent crashing on such values
                     quotactl(path, QCMD(cmd, type), Int32(bitPattern: uid), buffer.baseAddress!) == 0
                 }
                 return success ? res : nil


### PR DESCRIPTION
When calling `quotactl` on Darwin as part of `FileManager.attributesOfFileSystem(atPath:)`, we take the effective user ID (a `uid_t`) and attempt to pass it to `quotactl` (whose parameter is a C `int` imported as `Int32`). The cast we perform currently causes a crash when the current EUID is greater than `Int32.max`. This is an annotation issue with `quotactl` which should be taking an unsigned integer instead of a signed integer. For now, to prevent the crash and restore the pre-swift-rewrite behavior, we can change this to a bit-pattern cast so that when `quotactl`'s implementation reinterprets the number as an unsigned integer it works.

Unfortunately there's no way to add a unit test for this as it requires the current EUID to be an abnormally large value which is not possible in our test environment since the tests are not guaranteed to be launched as root and only a super user can change the EUID to a value like that.

rdar://143724213