### PR TITLE
Fix Windows .alwaysMapped deallocator

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -268,8 +268,8 @@ internal func readBytesFromFile(path inPath: PathOrURL, reportProgress: Bool, ma
         let szMapSize: UInt64 = min(UInt64(maxLength ?? Int.max), szFileSize)
         let pData: UnsafeMutableRawPointer =
             MapViewOfFile(hMapping, FILE_MAP_READ, 0, 0, SIZE_T(szMapSize))
-        return ReadBytesResult(bytes: pData, length: Int(szMapSize), deallocator: .custom({ hMapping, _ in
-            guard UnmapViewOfFile(hMapping) else {
+        return ReadBytesResult(bytes: pData, length: Int(szMapSize), deallocator: .custom({ pData, _ in
+            guard UnmapViewOfFile(pData) else {
                 fatalError("UnmapViewOfFile")
             }
             guard CloseHandle(hMapping) else {


### PR DESCRIPTION
The custom deallocator is passed a pointer to the allocated buffer, _not_ the underlying handle. The call to `CloseHandle` here was failing with `ERROR_INVALID_HANDLE`, but by changing the callback parameter to shadow `pData` instead of `hMapping` (and updating the call to `UnmapViewOfFile`), the call to `CloseHandle` now runs on the expected captured `hMapping` handle.

cc @compnerd 