### PR TITLE
[6.1] Fix Windows .alwaysMapped deallocator (#1147)

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -266,8 +266,8 @@ internal func readBytesFromFile(path inPath: PathOrURL, reportProgress: Bool, ma
         let szMapSize: UInt64 = min(UInt64(maxLength ?? Int.max), szFileSize)
         let pData: UnsafeMutableRawPointer =
             MapViewOfFile(hMapping, FILE_MAP_READ, 0, 0, SIZE_T(szMapSize))
-        return ReadBytesResult(bytes: pData, length: Int(szMapSize), deallocator: .custom({ hMapping, _ in
-            guard UnmapViewOfFile(hMapping) else {
+        return ReadBytesResult(bytes: pData, length: Int(szMapSize), deallocator: .custom({ pData, _ in
+            guard UnmapViewOfFile(pData) else {
                 fatalError("UnmapViewOfFile")
             }
             guard CloseHandle(hMapping) else {


### PR DESCRIPTION
(cherry picked from commit 281db8e767eeeb679510d81b06c8d1778f91b66e)