### PR TITLE
Use _CalendarGregorian for ISO8601

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Cache.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Cache.swift
@@ -25,8 +25,8 @@ dynamic package func _calendarICUClass() -> _CalendarProtocol.Type? {
 }
 #endif
 
-func _calendarClass(identifier: Calendar.Identifier, useGregorian: Bool) -> _CalendarProtocol.Type? {
-    if useGregorian && identifier == .gregorian {
+func _calendarClass(identifier: Calendar.Identifier) -> _CalendarProtocol.Type? {
+    if identifier == .gregorian || identifier == .iso8601 {
         return _CalendarGregorian.self
     } else {
         return _calendarICUClass()
@@ -54,7 +54,7 @@ struct CalendarCache : Sendable, ~Copyable {
                         
         let id = Locale.current._calendarIdentifier
         // If we cannot create the right kind of class, we fail immediately here
-        let calendarClass = _calendarClass(identifier: id, useGregorian: true)!
+        let calendarClass = _calendarClass(identifier: id)!
         let calendar = calendarClass.init(identifier: id, timeZone: nil, locale: Locale.current, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
         
         return _current.withLock {
@@ -90,7 +90,7 @@ struct CalendarCache : Sendable, ~Copyable {
         }
         
         // If we cannot create the right kind of class, we fail immediately here
-        let calendarClass = _calendarClass(identifier: id, useGregorian: true)!
+        let calendarClass = _calendarClass(identifier: id)!
         let new = calendarClass.init(identifier: id, timeZone: nil, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
         
         return _fixed.withLock {
@@ -106,7 +106,7 @@ struct CalendarCache : Sendable, ~Copyable {
     func fixed(identifier: Calendar.Identifier, locale: Locale?, timeZone: TimeZone?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) -> any _CalendarProtocol {
         // Note: Only the ObjC NSCalendar initWithCoder supports gregorian start date values. For Swift it is always nil.
         // If we cannot create the right kind of class, we fail immediately here
-        let calendarClass = _calendarClass(identifier: identifier, useGregorian: true)!
+        let calendarClass = _calendarClass(identifier: identifier)!
         return calendarClass.init(identifier: identifier, timeZone: timeZone, locale: locale, firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDaysInFirstWeek, gregorianStartDate: gregorianStartDate)
     }
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -191,11 +191,27 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
     let inf_ti : TimeInterval = 4398046511104.0
 
-    // FIXME: Support other Gregorian-calendar family such as ISO8601
-    // Only respects Gregorian identifier
     init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
 
-        self.timeZone = timeZone ?? TimeZone.default
+        // ISO8601 has different default values for time zone, locale, firstWeekday, and minimumDaysInFirstWeek
+        let defaultTimeZone: TimeZone
+        let defaultLocale: Locale?
+        let defaultFirstWeekday: Int?
+        let defaultMinimumDaysInFirstWeek: Int?
+        
+        if identifier == .iso8601 {
+            defaultTimeZone = .gmt
+            defaultLocale = Locale.unlocalized
+            defaultFirstWeekday = 2
+            defaultMinimumDaysInFirstWeek = 4
+        } else {
+            defaultTimeZone = .default
+            defaultLocale = nil
+            defaultFirstWeekday = nil
+            defaultMinimumDaysInFirstWeek = nil
+        }
+                
+        self.timeZone = timeZone ?? defaultTimeZone
         if let gregorianStartDate {
             self.gregorianStartDate = gregorianStartDate
             do {
@@ -212,10 +228,12 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
             self.gregorianStartDate = Date(timeIntervalSince1970: -12219292800) // 1582-10-15T00:00:00Z
         }
 
-        self.locale = locale
+        self.locale = locale ?? defaultLocale
 
         if let firstWeekday, (firstWeekday >= 1 && firstWeekday <= 7) {
             _firstWeekday = firstWeekday
+        } else if let defaultFirstWeekday {
+            _firstWeekday = defaultFirstWeekday
         }
 
         if var minimumDaysInFirstWeek {
@@ -225,12 +243,14 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
                 minimumDaysInFirstWeek = 7
             }
             _minimumDaysInFirstWeek = minimumDaysInFirstWeek
+        } else if let defaultMinimumDaysInFirstWeek {
+            _minimumDaysInFirstWeek = defaultMinimumDaysInFirstWeek
         }
+        
+        self.identifier = identifier
     }
 
-    var identifier: Calendar.Identifier {
-        .gregorian
-    }
+    let identifier: Calendar.Identifier
 
     var locale: Locale?
 

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -3876,5 +3876,25 @@ final class GregorianCalendarTests : XCTestCase {
         test(.minute, expected: -120)
         test(.second, expected: -7200)
     }
+    
+    // MARK: ISO8601
+    
+    func test_iso8601Gregorian() {
+        var calendar1 = Calendar(identifier: .iso8601)
+        let calendar2 = Calendar(identifier: .iso8601)
+        XCTAssertEqual(calendar1, calendar2)
+        
+        XCTAssertEqual(calendar1.firstWeekday, 2)
+        XCTAssertEqual(calendar1.minimumDaysInFirstWeek, 4)
+        XCTAssertEqual(calendar1.timeZone, .gmt)
+        XCTAssertEqual(calendar1.locale, .unlocalized)
+        
+        // Verify that the properties are still mutable
+        let tz = TimeZone(secondsFromGMT: -3600)!
+        calendar1.timeZone = tz
+        XCTAssertNotEqual(calendar1, calendar2)
+        
+        XCTAssertEqual(calendar1.timeZone, tz)
+    }
 }
 


### PR DESCRIPTION
Use the `_CalendarGregorian` implementation for the ISO8601 calendar, instead of ICU. This lowers it into FoundationEssentials. Previously, the same behavior could be achieved by customizing the init of a Gregorian calendar, but this makes it easier to do the right thing.