### PR TITLE
Optimize removing nonexistent attributes in AttributedString

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -432,6 +432,12 @@ let benchmarks = {
         blackHole(hasher.finalize())
     }
     
+    Benchmark("removeNonExistentAttribute") { benchmark in
+        var str = manyAttributesString
+        str.testBool = nil
+        blackHole(str)
+    }
+    
     struct TestAttribute : AttributedStringKey {
         static var name = "0"
         typealias Value = Int

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -88,7 +88,7 @@ switch usePackage {
 
 let package = Package(
     name: "benchmarks",
-    platforms: [.macOS("13.3"), .iOS("16.4"), .tvOS("16.4"), .watchOS("9.4")], // Should match parent project
+    platforms: [.macOS("15"), .iOS("18"), .tvOS("18"), .watchOS("11")], // Should match parent project
     dependencies: packageDependency,
     targets: [
         .executableTarget(

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -391,7 +391,7 @@ extension AttributedString.Guts {
     ) where K.Value: Sendable {
         let utf8Range = unicodeScalarRange(roundingDown: range)._utf8OffsetRange
         self.runs(in: utf8Range).updateEach { attributes, range, mutated in
-            attributes[K.self] = nil
+            mutated = attributes.removeValue(forKey: K.self)
         }
         if K.runBoundaries != nil {
             self.enforceAttributeConstraintsAfterMutation(

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
@@ -216,6 +216,12 @@ extension AttributedString._AttributeStorage {
             _attributeModified(attributeName, old: oldValue, new: newValue)
         }
     }
+    
+    mutating func removeValue<T: AttributedStringKey>(forKey: T.Type) -> Bool {
+        let oldValue = self.contents.removeValue(forKey: T.name)
+        _attributeModified(T.name, old: oldValue, new: nil)
+        return oldValue != nil
+    }
 
     internal mutating func mergeIn(_ other: Self, mergePolicy: AttributeMergePolicy = .keepNew) {
         for (key, value) in other.contents {


### PR DESCRIPTION
When removing an attribute from an `AttributedString`, we iterate through each run and remove the value from the attribute storage for each run. After mutating a run, we need to check to see if that run needs to be coalesced with the surrounding runs. Previously when removing an attribute that didn't exist, we still checked whether each run needed to be coalesced with its surrounding runs. However, we only need to check this if we actually removed an item from the storage (otherwise the storage remains unchanged and the check is unnecessary, and potentially costly). Since the underlying `Dictionary` API already tells us when removing an item whether it existed to begin with, we can feed that information to the run enumeration to decide whether the coalescing check should be run. In a benchmark removing a non-existent attribute from an attributed string with many runs, this optimization improves throughput of the removal API by ~130% greatly speeding up this operation which is effectively a no-op in outcome

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (K)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │     162 │     161 │     160 │     159 │     157 │     152 │     150 │     160 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    pr                    │     380 │     375 │     373 │     368 │     355 │     345 │     342 │     370 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     218 │     214 │     213 │     209 │     198 │     193 │     192 │     210 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │     135 │     133 │     133 │     131 │     126 │     127 │     128 │     210 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

While I was here I also bumped the deployment target of the benchmarks to match that of the main project so that it can compile.