### PR TITLE
Re-add existing SPI for enumerating NSAttributedString.Key Runs

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -782,6 +782,11 @@ extension AttributedString.Runs {
     }
     
     @_spi(AttributedString)
+    public subscript(nsAttributedStringKeys keys: NSAttributedString.Key...) -> NSAttributesSlice {
+        self[nsAttributedStringKeys: keys]
+    }
+    
+    @_spi(AttributedString)
     public subscript(nsAttributedStringKeys keys: [NSAttributedString.Key]) -> NSAttributesSlice {
         return NSAttributesSlice(runs: self, names: keys.map { $0.rawValue })
     }


### PR DESCRIPTION
With further testing, it's not safe to remove the existing SPI here in favor of the new one so this change adds the existing SPI back alongside the new SPI