### PR TITLE
Fix appending empty query items changing the URL

### DIFF
--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -592,7 +592,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
                 return
             }
             guard !newValue.isEmpty else {
-                _query = ""
+                _query = nil
                 return
             }
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -450,6 +450,11 @@ final class URLTests : XCTestCase {
             testAppendQueryItems.absoluteString,
             "https://www.example.com?id=42&color=blue"
         )
+        let emptyQueryItems: [URLQueryItem] = []
+        XCTAssertEqual(
+            base.appending(queryItems: emptyQueryItems).absoluteString,
+            "https://www.example.com"
+        )
 
         // Appending components
         XCTAssertEqual(


### PR DESCRIPTION
We experienced some regressions in our URL handling code after upgrading to the latest Foundation. Some of them I think are real bug-fixes (for instance: appending a single component `path/subpath` now appends `path%2Fsubpath` which is what it always should have done), but this one I suspect is a new bug.

When appending an empty list of `URLQueryItem`, the current implementation will still append the `?` to the end of the URL. I think this is because the underlying `_query` is unintentionally set to `""` instead of `nil`, which causes [this check](https://github.com/swiftlang/swift-foundation/blob/74275a96e87170eab064bf720367ca8e63150cbb/Sources/FoundationEssentials/URL/URLComponents.swift#L483) on the Optional to pass, appending the string `"?\(percentEncodedQuery)"` which just expands to `"?"` (as `percentEncodedQuery` is the empty string).