### PR TITLE
Drop UTF-8 BOM when present while decoding UTF-8 bytes into String

### DIFF
--- a/Sources/FoundationEssentials/String/String+IO.swift
+++ b/Sources/FoundationEssentials/String/String+IO.swift
@@ -101,6 +101,10 @@ extension String {
             }
         case .utf8:
             func makeString(buffer: UnsafeBufferPointer<UInt8>) -> String? {
+                var buffer = buffer
+                if buffer.starts(with: [0xEF, 0xBB, 0xBF]) {
+                    buffer = UnsafeBufferPointer(rebasing: buffer.suffix(from: 3))
+                }
                 if let string = String._tryFromUTF8(buffer) {
                     return string
                 }

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -1004,6 +1004,13 @@ final class StringTests : XCTestCase {
         
         let utf32BEBOMStringMismatch = String(bytes: utf32BEWithBOM, encoding: String._Encoding.utf32LittleEndian)
         XCTAssertNil(utf32BEBOMStringMismatch)
+        
+        // UTF-8 With BOM
+        
+        let utf8BOM = Data([0xEF, 0xBB, 0xBF])
+        let helloWorld = Data("Hello, world".utf8)
+        XCTAssertEqual(String(bytes: utf8BOM + helloWorld, encoding: String._Encoding.utf8), "Hello, world")
+        XCTAssertEqual(String(bytes: helloWorld + utf8BOM, encoding: String._Encoding.utf8), "Hello, world\u{FEFF}")
     }
 
     func test_dataUsingEncoding_preservingBOM() {


### PR DESCRIPTION
Historically, `NSString` has dropped a UTF-8 BOM if present while parsing UTF-8 bytes, however the Swift implementation of `String(bytes:encoding:)` does not exhibit this behavior. While a UTF-8 BOM is not required since UTF-8 bytes can only have one ordering, there are still applications that may output this BOM at the start of a sequence of UTF-8 bytes. It seems reasonable that a higher level API like Foundation which handles BOMs in UTF-16/UTF-32 bytes would also be resilient in handling the presence of a UTF-8 BOM (unlike the stdlib-provided `String(decoding:as:)` APIs which are lower-level and do not handle BOMs or encodings of a particular endianness). This change drops the UTF-8 BOM from the decoded bytes if it is present at the start of the bytes (but only at the start of the bytes as elsewhere it is interpreted correctly as U+FEFF).

Resolves https://github.com/swiftlang/swift-foundation/issues/1164