### PR TITLE
Revert "JSON/PropertyList coders userInfo should require Sendable values"

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -257,8 +257,7 @@ open class JSONDecoder {
     }
 
     /// Contextual user-provided information for use during decoding.
-    @preconcurrency
-    open var userInfo: [CodingUserInfoKey : any Sendable] {
+    open var userInfo: [CodingUserInfoKey : Any] {
         get {
             optionsLock.lock()
             defer { optionsLock.unlock() }
@@ -310,7 +309,7 @@ open class JSONDecoder {
         var dataDecodingStrategy: DataDecodingStrategy = .base64
         var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
         var keyDecodingStrategy: KeyDecodingStrategy = .useDefaultKeys
-        var userInfo: [CodingUserInfoKey : any Sendable] = [:]
+        var userInfo: [CodingUserInfoKey : Any] = [:]
         var json5: Bool = false
     }
 

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -295,8 +295,7 @@ open class JSONEncoder {
     }
 
     /// Contextual user-provided information for use during encoding.
-    @preconcurrency
-    open var userInfo: [CodingUserInfoKey : any Sendable] {
+    open var userInfo: [CodingUserInfoKey : Any] {
         get {
             optionsLock.lock()
             defer { optionsLock.unlock() }
@@ -325,7 +324,7 @@ open class JSONEncoder {
         var dataEncodingStrategy: DataEncodingStrategy = .base64
         var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy = .throw
         var keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys
-        var userInfo: [CodingUserInfoKey : any Sendable] = [:]
+        var userInfo: [CodingUserInfoKey : Any] = [:]
     }
 
     /// The options set on the top-level encoder.

--- a/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
@@ -38,8 +38,7 @@ open class PropertyListDecoder {
     // MARK: Options
 
     /// Contextual user-provided information for use during decoding.
-    @preconcurrency
-    open var userInfo: [CodingUserInfoKey : any Sendable] {
+    open var userInfo: [CodingUserInfoKey : Any] {
         get {
             optionsLock.lock()
             defer { optionsLock.unlock() }
@@ -63,7 +62,7 @@ open class PropertyListDecoder {
 
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
     internal struct _Options {
-        var userInfo: [CodingUserInfoKey : any Sendable] = [:]
+        var userInfo: [CodingUserInfoKey : Any] = [:]
     }
 
     /// The options set on the top-level decoder.

--- a/Sources/FoundationEssentials/PropertyList/PlistEncoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistEncoder.swift
@@ -51,8 +51,7 @@ open class PropertyListEncoder {
     }
 
     /// Contextual user-provided information for use during encoding.
-    @preconcurrency
-    open var userInfo: [CodingUserInfoKey : any Sendable] {
+    open var userInfo: [CodingUserInfoKey : Any] {
         get {
             optionsLock.lock()
             defer { optionsLock.unlock() }
@@ -77,7 +76,7 @@ open class PropertyListEncoder {
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
     internal struct _Options {
         var outputFormat: PropertyListDecoder.PropertyListFormat = .binary
-        var userInfo: [CodingUserInfoKey : any Sendable] = [:]
+        var userInfo: [CodingUserInfoKey : Any] = [:]
     }
 
     /// The options set on the top-level encoder.


### PR DESCRIPTION
Reverts swiftlang/swift-foundation#764. Linux + Windows toolchains are now both failing.