### PR TITLE
New Calendar Identifiers

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -62,6 +62,42 @@ public struct Calendar : Hashable, Equatable, Sendable {
         @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
         case islamicUmmAlQura
 
+        @available(FoundationPreview 6.2, *)
+        case bangla
+        
+        @available(FoundationPreview 6.2, *)
+        case gujarati
+        
+        @available(FoundationPreview 6.2, *)
+        case kannada
+        
+        @available(FoundationPreview 6.2, *)
+        case malayalam
+        
+        @available(FoundationPreview 6.2, *)
+        case marathi
+        
+        @available(FoundationPreview 6.2, *)
+        case odia
+        
+        @available(FoundationPreview 6.2, *)
+        case tamil
+        
+        @available(FoundationPreview 6.2, *)
+        case telugu
+        
+        @available(FoundationPreview 6.2, *)
+        case vikram
+        
+        @available(FoundationPreview 6.2, *)
+        case dangi
+        
+        @available(FoundationPreview 6.2, *)
+        case thai
+        
+        @available(FoundationPreview 6.2, *)
+        case vietnamese
+
         package static let cldrKeywordKey = "ca"
         package static let legacyKeywordKey = ICULegacyKey("calendar")
 
@@ -89,6 +125,18 @@ public struct Calendar : Hashable, Equatable, Sendable {
             case "roc": self = .republicOfChina
             case "islamic-tbla": self = .islamicTabular
             case "islamic-umalqura": self = .islamicUmmAlQura
+            case "bangla": self = .bangla
+            case "gujarati": self = .gujarati
+            case "kannada": self = .kannada
+            case "malayalam": self = .malayalam
+            case "marathi": self = .marathi
+            case "odia": self = .odia
+            case "tamil": self = .tamil
+            case "telugu": self = .telugu
+            case "vikram": self = .vikram
+            case "dangi": self = .dangi
+            case "thai": self = .thai
+            case "vietnamese": self = .vietnamese
             default: return nil
             }
         }
@@ -111,6 +159,18 @@ public struct Calendar : Hashable, Equatable, Sendable {
             case .republicOfChina: return "roc"
             case .islamicTabular: return "islamic-tbla"
             case .islamicUmmAlQura: return "islamic-umalqura"
+            case .bangla: return "bangla"
+            case .gujarati: return "gujarati"
+            case .kannada: return "kannada"
+            case .malayalam: return "malayalam"
+            case .marathi: return "marathi"
+            case .odia: return "odia"
+            case .tamil: return "tamil"
+            case .telugu: return "telugu"
+            case .vikram: return "vikram"
+            case .dangi: return "dangi"
+            case .thai: return "thai"
+            case .vietnamese: return "vietnamese"
             }
         }
 
@@ -133,6 +193,18 @@ public struct Calendar : Hashable, Equatable, Sendable {
             case .coptic: return "coptic"
             case .ethiopicAmeteMihret: return "ethiopic"
             case .ethiopicAmeteAlem: return "ethiopic-amete-alem"
+            case .bangla: return "bangla"
+            case .gujarati: return "gujarati"
+            case .kannada: return "kannada"
+            case .malayalam: return "malayalam"
+            case .marathi: return "marathi"
+            case .odia: return "odia"
+            case .tamil: return "tamil"
+            case .telugu: return "telugu"
+            case .vikram: return "vikram"
+            case .dangi: return "dangi"
+            case .thai: return "thai"
+            case .vietnamese: return "vietnamese"
             }
         }
         
@@ -1312,6 +1384,30 @@ public struct Calendar : Hashable, Equatable, Sendable {
             return .islamicTabular
         case .islamicUmmAlQura:
             return .islamicUmmAlQura
+        case .bangla:
+            return .bangla
+        case .gujarati:
+            return .gujarati
+        case .kannada:
+            return .kannada
+        case .malayalam:
+            return .malayalam
+        case .marathi:
+            return .marathi
+        case .odia:
+            return .odia
+        case .tamil:
+            return .tamil
+        case .telugu:
+            return .telugu
+        case .vikram:
+            return .vikram
+        case .dangi: 
+            return .dangi
+        case .thai:
+            return .thai
+        case .vietnamese:
+            return .vietnamese
         }
     }
 
@@ -1349,6 +1445,30 @@ public struct Calendar : Hashable, Equatable, Sendable {
             return .islamicTabular
         case .islamicUmmAlQura:
             return .islamicUmmAlQura
+        case .bangla:
+            return .bangla
+        case .gujarati:
+            return .gujarati
+        case .kannada:
+            return .kannada
+        case .malayalam:
+            return .malayalam
+        case .marathi:
+            return .marathi
+        case .odia:
+            return .odia
+        case .tamil:
+            return .tamil
+        case .telugu:
+            return .telugu
+        case .vikram:
+            return .vikram
+        case .dangi:
+            return .dangi
+        case .thai:
+            return .thai
+        case .vietnamese:
+            return .vietnamese
         default:
             return nil
         }

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1446,6 +1446,33 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
                 if time < -42790982400.0 { return nil }
             case .chinese:
                 if time < -146325744000.0 { return nil }
+            case .bangla:
+                fallthrough
+            case .gujarati:
+                fallthrough
+            case .kannada:
+                fallthrough
+            case .malayalam:
+                fallthrough
+            case .marathi:
+                fallthrough
+            case .odia:
+                fallthrough
+            case .tamil:
+                fallthrough
+            case .telugu:
+                fallthrough
+            case .vikram:
+                // TODO: This is copied from `.indian` and needs to be revisited for each new calendar.
+                if time < -60645542400.0 { return nil }
+                return Date(timeIntervalSinceReferenceDate: -60645542400.0)
+            case .dangi:
+                fallthrough
+            case .thai:
+                fallthrough
+            case .vietnamese:
+                // TODO: This is copied from `.chinese` and needs to be revisited for each new calendar.
+                if time < -146325744000.0 { return nil }
             }
         case .hour:
             let ti = Double(timeZone.secondsFromGMT(for: capped))
@@ -1540,6 +1567,33 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
             case .japanese:
                 if time < -42790982400.0 { return nil }
             case .chinese:
+                if time < -146325744000.0 { return nil }
+            case .bangla:
+                fallthrough
+            case .gujarati:
+                fallthrough
+            case .kannada:
+                fallthrough
+            case .malayalam:
+                fallthrough
+            case .marathi:
+                fallthrough
+            case .odia:
+                fallthrough
+            case .tamil:
+                fallthrough
+            case .telugu:
+                fallthrough
+            case .vikram:
+                // TODO: This is copied from `.indian` and needs to be revisited for each new calendar.
+                if time < -60645542400.0 { return nil }
+                return DateInterval(start: Date(timeIntervalSinceReferenceDate: -60645542400.0), duration: inf_ti)
+            case .dangi:
+                fallthrough
+            case .thai:
+                fallthrough
+            case .vietnamese:
+                // TODO: This is copied from `.chinese` and needs to be revisited for each new calendar.
                 if time < -146325744000.0 { return nil }
             }
         case .hour:


### PR DESCRIPTION
Exposed identifiers for 12 calendars. API Proposal: [SF-017](https://github.com/swiftlang/swift-foundation/blob/main/Proposals/0017-expanded-calendar-support.md)

This is take two, as we needed to revert the [first attempt](https://github.com/swiftlang/swift-foundation/pull/1168) due to CI failures.

141795986