### PR TITLE
AttributedString Index Validity APIs

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -106,11 +106,11 @@ extension AttributedString.CharacterView: BidirectionalCollection {
     public typealias Index = AttributedString.Index
 
     public var startIndex: AttributedString.Index {
-        .init(_range.lowerBound)
+        .init(_range.lowerBound, version: _guts.version)
     }
 
     public var endIndex: AttributedString.Index {
-        .init(_range.upperBound)
+        .init(_range.upperBound, version: _guts.version)
     }
 
     @_alwaysEmitIntoClient
@@ -131,14 +131,14 @@ extension AttributedString.CharacterView: BidirectionalCollection {
 
     public func index(before i: AttributedString.Index) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.index(before: i._value))
+        let j = Index(_guts.string.index(before: i._value), version: _guts.version)
         precondition(j >= startIndex, "Can't advance AttributedString index before start index")
         return j
     }
 
     public func index(after i: AttributedString.Index) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.index(after: i._value))
+        let j = Index(_guts.string.index(after: i._value), version: _guts.version)
         precondition(j <= endIndex, "Can't advance AttributedString index after end index")
         return j
     }
@@ -157,7 +157,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
     @usableFromInline
     internal func _index(_ i: AttributedString.Index, offsetBy distance: Int) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.index(i._value, offsetBy: distance))
+        let j = Index(_guts.string.index(i._value, offsetBy: distance), version: _guts.version)
         precondition(j >= startIndex && j <= endIndex, "AttributedString index out of bounds")
         return j
     }
@@ -192,7 +192,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         }
         precondition(j >= startIndex._value && j <= endIndex._value,
                      "AttributedString index out of bounds")
-        return Index(j)
+        return Index(j, version: _guts.version)
     }
 
     @_alwaysEmitIntoClient

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -29,12 +29,14 @@ extension AttributedString {
         typealias _AttributeValue = AttributedString._AttributeValue
         typealias _AttributeStorage = AttributedString._AttributeStorage
 
+        var version: Version
         var string: BigString
         var runs: _InternalRuns
 
         // Note: the caller is responsible for performing attribute fix-ups if needed based on the source of the runs
         init(string: BigString, runs: _InternalRuns) {
             precondition(string.isEmpty == runs.isEmpty, "An empty attributed string should not contain any runs")
+            self.version = Self.createNewVersion()
             self.string = string
             self.runs = runs
         }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+IndexValidity.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+IndexValidity.swift
@@ -60,11 +60,10 @@ extension AttributedString.Index {
 @available(FoundationPreview 6.2, *)
 extension Range<AttributedString.Index> {
     public func isValid(within text: some AttributedStringProtocol) -> Bool {
+        // Note: By nature of Range's lowerBound <= upperBound requirement, this is also sufficient to determine that lowerBound <= endIndex && upperBound >= startIndex
         self.lowerBound._version == text.__guts.version &&
         self.lowerBound >= text.startIndex &&
-        self.lowerBound <= text.endIndex &&
         self.upperBound._version == text.__guts.version &&
-        self.upperBound >= text.startIndex &&
         self.upperBound <= text.endIndex
     }
     

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+IndexValidity.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+IndexValidity.swift
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Synchronization)
+internal import Synchronization
+#endif
+
+extension AttributedString.Guts {
+    typealias Version = UInt
+    
+    #if canImport(Synchronization)
+    private static let _nextVersion = Atomic<Version>(0)
+    
+    static func createNewVersion() -> Version {
+        _nextVersion.wrappingAdd(1, ordering: .relaxed).oldValue
+    }
+    #else
+    private static let _nextVersion = LockedState<Version>(initialState: 0)
+    
+    static func createNewVersion() -> Version {
+        _nextVersion.withLock { value in
+            defer {
+                value &+= 1
+            }
+            return value
+        }
+    }
+    #endif
+    
+    func incrementVersion() {
+        self.version = Self.createNewVersion()
+    }
+}
+
+// MARK: - Public API
+
+@available(FoundationPreview 6.2, *)
+extension AttributedString.Index {
+    public func isValid(within text: some AttributedStringProtocol) -> Bool {
+        self._version == text.__guts.version &&
+        self >= text.startIndex &&
+        self < text.endIndex
+    }
+    
+    public func isValid(within text: DiscontiguousAttributedSubstring) -> Bool {
+        self._version == text._guts.version &&
+        text._indices.contains(self._value)
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension Range<AttributedString.Index> {
+    public func isValid(within text: some AttributedStringProtocol) -> Bool {
+        self.lowerBound._version == text.__guts.version &&
+        self.lowerBound >= text.startIndex &&
+        self.lowerBound <= text.endIndex &&
+        self.upperBound._version == text.__guts.version &&
+        self.upperBound >= text.startIndex &&
+        self.upperBound <= text.endIndex
+    }
+    
+    public func isValid(within text: DiscontiguousAttributedSubstring) -> Bool {
+        let endIndex = text._indices.ranges.last?.upperBound
+        return self.lowerBound._version == text._guts.version &&
+            (self.lowerBound._value == endIndex || text._indices.contains(self.lowerBound._value)) &&
+            self.upperBound._version == text._guts.version &&
+            (self.upperBound._value == endIndex || text._indices.contains(self.upperBound._value))
+    }
+}
+
+@available(FoundationPreview 6.2, *)
+extension RangeSet<AttributedString.Index> {
+    public func isValid(within text: some AttributedStringProtocol) -> Bool {
+        self.ranges.allSatisfy {
+            $0.isValid(within: text)
+        }
+    }
+    
+    public func isValid(within text: DiscontiguousAttributedSubstring) -> Bool {
+        self.ranges.allSatisfy {
+            $0.isValid(within: text)
+        }
+    }
+}

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -85,11 +85,11 @@ extension AttributedString.Runs {
         }
 
         public var startIndex: Index {
-            Index(runs.startIndex._stringIndex!)
+            Index(runs.startIndex._stringIndex!, version: runs._guts.version)
         }
 
         public var endIndex: Index {
-            Index(runs.endIndex._stringIndex!)
+            Index(runs.endIndex._stringIndex!, version: runs._guts.version)
         }
 
         public func index(before i: Index) -> Index {
@@ -223,11 +223,11 @@ extension AttributedString.Runs {
         }
         
         public var startIndex: Index {
-            Index(runs.startIndex._stringIndex!)
+            Index(runs.startIndex._stringIndex!, version: runs._guts.version)
         }
         
         public var endIndex: Index {
-            Index(runs.endIndex._stringIndex!)
+            Index(runs.endIndex._stringIndex!, version: runs._guts.version)
         }
 
         public func index(before i: Index) -> Index {
@@ -385,11 +385,11 @@ extension AttributedString.Runs {
         }
         
         public var startIndex: Index {
-            Index(runs.startIndex._stringIndex!)
+            Index(runs.startIndex._stringIndex!, version: runs._guts.version)
         }
         
         public var endIndex: Index {
-            Index(runs.endIndex._stringIndex!)
+            Index(runs.endIndex._stringIndex!, version: runs._guts.version)
         }
 
         public func index(before i: Index) -> Index {
@@ -557,11 +557,11 @@ extension AttributedString.Runs {
         }
         
         public var startIndex: Index {
-            Index(runs.startIndex._stringIndex!)
+            Index(runs.startIndex._stringIndex!, version: runs._guts.version)
         }
         
         public var endIndex: Index {
-            Index(runs.endIndex._stringIndex!)
+            Index(runs.endIndex._stringIndex!, version: runs._guts.version)
         }
 
         public func index(before i: Index) -> Index {
@@ -745,11 +745,11 @@ extension AttributedString.Runs {
         }
         
         public var startIndex: Index {
-            Index(runs.startIndex._stringIndex!)
+            Index(runs.startIndex._stringIndex!, version: runs._guts.version)
         }
         
         public var endIndex: Index {
-            Index(runs.endIndex._stringIndex!)
+            Index(runs.endIndex._stringIndex!, version: runs._guts.version)
         }
 
         public func index(before i: Index) -> Index {
@@ -895,11 +895,11 @@ extension AttributedString.Runs {
         }
 
         public var startIndex: Index {
-            Index(_runs.startIndex._stringIndex!)
+            Index(_runs.startIndex._stringIndex!, version: _runs._guts.version)
         }
 
         public var endIndex: Index {
-            Index(_runs.endIndex._stringIndex!)
+            Index(_runs.endIndex._stringIndex!, version: _runs._guts.version)
         }
 
         public func index(before i: Index) -> Index {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
@@ -60,8 +60,8 @@ extension AttributedString.Runs.Run: CustomStringConvertible {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs.Run {
     public var range: Range<AttributedString.Index> {
-        let lower = AttributedString.Index(_range.lowerBound)
-        let upper = AttributedString.Index(_range.upperBound)
+        let lower = AttributedString.Index(_range.lowerBound, version: _guts.version)
+        let upper = AttributedString.Index(_range.upperBound, version: _guts.version)
         return Range(uncheckedBounds: (lower, upper))
     }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -486,22 +486,22 @@ extension AttributedString.Runs {
         let currentRange = _strBounds.ranges[currentRangeIdx]
         if strIndexEnd < currentRange.upperBound {
             // The coalesced run ends within the current range, so just look for the next break in the coalesced run
-            return .init(_guts.string._firstConstraintBreak(in: i._value ..< strIndexEnd, with: constraints))
+            return .init(_guts.string._firstConstraintBreak(in: i._value ..< strIndexEnd, with: constraints), version: _guts.version)
         } else {
             // The coalesced run extends beyond our range
             // First determine if there's a constraint break to handle
             let constraintBreak = _guts.string._firstConstraintBreak(in: i._value ..< currentRange.upperBound, with: constraints)
             if constraintBreak == currentRange.upperBound {
-                if endOfCurrent { return .init(currentRange.upperBound) }
+                if endOfCurrent { return .init(currentRange.upperBound, version: _guts.version) }
                 // No constraint break, return the next subrange start or the end index
                 if currentRangeIdx == _strBounds.ranges.count - 1 {
-                    return .init(currentRange.upperBound)
+                    return .init(currentRange.upperBound, version: _guts.version)
                 } else {
-                    return .init(_strBounds.ranges[currentRangeIdx + 1].lowerBound)
+                    return .init(_strBounds.ranges[currentRangeIdx + 1].lowerBound, version: _guts.version)
                 }
             } else {
                 // There is a constraint break before the end of the subrange, so return that break
-                return .init(constraintBreak)
+                return .init(constraintBreak, version: _guts.version)
             }
         }
         
@@ -533,7 +533,7 @@ extension AttributedString.Runs {
             currentRangeIdx -= 1
             currentRange = _strBounds.ranges[currentRangeIdx]
             currentStringIdx = currentRange.upperBound
-            if endOfPrevious { return .init(currentStringIdx) }
+            if endOfPrevious { return .init(currentStringIdx, version: _guts.version) }
         }
         let beforeStringIdx = _guts.string.utf8.index(before: currentStringIdx)
         let r = _guts.runs.index(atUTF8Offset: beforeStringIdx.utf8Offset)
@@ -541,10 +541,10 @@ extension AttributedString.Runs {
         if startRun.utf8Offset >= currentRange.lowerBound.utf8Offset {
             // The coalesced run begins within the current range, so just look for the next break in the coalesced run
             let runStartStringIdx = _guts.string.utf8.index(beforeStringIdx, offsetBy: startRun.utf8Offset - beforeStringIdx.utf8Offset)
-            return .init(_guts.string._lastConstraintBreak(in: runStartStringIdx ..< currentStringIdx, with: constraints))
+            return .init(_guts.string._lastConstraintBreak(in: runStartStringIdx ..< currentStringIdx, with: constraints), version: _guts.version)
         } else {
             // The coalesced run starts before the current range, and we've already looked back once so we shouldn't look back again
-            return .init(_guts.string._lastConstraintBreak(in: currentRange.lowerBound ..< currentStringIdx, with: constraints))
+            return .init(_guts.string._lastConstraintBreak(in: currentRange.lowerBound ..< currentStringIdx, with: constraints), version: _guts.version)
         }
     }
 
@@ -569,7 +569,7 @@ extension AttributedString.Runs {
 
         let j = _guts.string.unicodeScalars.index(after: i._value)
         let last = _guts.string._lastConstraintBreak(in: stringStart ..< j, with: constraints)
-        return (.init(last), r.runIndex)
+        return (.init(last, version: _guts.version), r.runIndex)
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UTF16View.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UTF16View.swift
@@ -61,11 +61,11 @@ extension AttributedString.UTF16View: BidirectionalCollection {
     public typealias Subsequence = Self
 
     public var startIndex: AttributedString.Index {
-        .init(_range.lowerBound)
+        .init(_range.lowerBound, version: _guts.version)
     }
 
     public var endIndex: AttributedString.Index {
-        .init(_range.upperBound)
+        .init(_range.upperBound, version: _guts.version)
     }
 
     public var count: Int {
@@ -74,21 +74,21 @@ extension AttributedString.UTF16View: BidirectionalCollection {
 
     public func index(before i: AttributedString.Index) -> AttributedString.Index {
         precondition(i > startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.utf16.index(before: i._value))
+        let j = Index(_guts.string.utf16.index(before: i._value), version: _guts.version)
         precondition(j >= startIndex, "Can't advance AttributedString index before start index")
         return j
     }
 
     public func index(after i: AttributedString.Index) -> AttributedString.Index {
         precondition(i >= startIndex && i < endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.utf16.index(after: i._value))
+        let j = Index(_guts.string.utf16.index(after: i._value), version: _guts.version)
         precondition(j <= endIndex, "Can't advance AttributedString index after end index")
         return j
     }
 
     public func index(_ i: AttributedString.Index, offsetBy distance: Int) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.utf16.index(i._value, offsetBy: distance))
+        let j = Index(_guts.string.utf16.index(i._value, offsetBy: distance), version: _guts.version)
         precondition(j >= startIndex && j <= endIndex, "AttributedString index out of bounds")
         return j
     }
@@ -107,7 +107,7 @@ extension AttributedString.UTF16View: BidirectionalCollection {
         }
         precondition(j >= startIndex._value && j <= endIndex._value,
                      "AttributedString index out of bounds")
-        return Index(j)
+        return Index(j, version: _guts.version)
     }
 
     public func distance(

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UTF8View.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UTF8View.swift
@@ -61,11 +61,11 @@ extension AttributedString.UTF8View: BidirectionalCollection {
     public typealias Subsequence = Self
 
     public var startIndex: AttributedString.Index {
-        .init(_range.lowerBound)
+        .init(_range.lowerBound, version: _guts.version)
     }
 
     public var endIndex: AttributedString.Index {
-        .init(_range.upperBound)
+        .init(_range.upperBound, version: _guts.version)
     }
 
     public var count: Int {
@@ -74,21 +74,21 @@ extension AttributedString.UTF8View: BidirectionalCollection {
 
     public func index(before i: AttributedString.Index) -> AttributedString.Index {
         precondition(i > startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.utf8.index(before: i._value))
+        let j = Index(_guts.string.utf8.index(before: i._value), version: _guts.version)
         precondition(j >= startIndex, "Can't advance AttributedString index before start index")
         return j
     }
 
     public func index(after i: AttributedString.Index) -> AttributedString.Index {
         precondition(i >= startIndex && i < endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.utf8.index(after: i._value))
+        let j = Index(_guts.string.utf8.index(after: i._value), version: _guts.version)
         precondition(j <= endIndex, "Can't advance AttributedString index after end index")
         return j
     }
 
     public func index(_ i: AttributedString.Index, offsetBy distance: Int) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.utf8.index(i._value, offsetBy: distance))
+        let j = Index(_guts.string.utf8.index(i._value, offsetBy: distance), version: _guts.version)
         precondition(j >= startIndex && j <= endIndex, "AttributedString index out of bounds")
         return j
     }
@@ -107,7 +107,7 @@ extension AttributedString.UTF8View: BidirectionalCollection {
         }
         precondition(j >= startIndex._value && j <= endIndex._value,
                      "AttributedString index out of bounds")
-        return Index(j)
+        return Index(j, version: _guts.version)
     }
 
     public func distance(

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -107,11 +107,11 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
     public typealias Index = AttributedString.Index
 
     public var startIndex: AttributedString.Index {
-        .init(_range.lowerBound)
+        .init(_range.lowerBound, version: _guts.version)
     }
 
     public var endIndex: AttributedString.Index {
-        .init(_range.upperBound)
+        .init(_range.upperBound, version: _guts.version)
     }
 
     @_alwaysEmitIntoClient
@@ -132,21 +132,21 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
 
     public func index(before i: AttributedString.Index) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.unicodeScalars.index(before: i._value))
+        let j = Index(_guts.string.unicodeScalars.index(before: i._value), version: _guts.version)
         precondition(j >= startIndex, "Can't advance AttributedString index before start index")
         return j
     }
 
     public func index(after i: AttributedString.Index) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.unicodeScalars.index(after: i._value))
+        let j = Index(_guts.string.unicodeScalars.index(after: i._value), version: _guts.version)
         precondition(j <= endIndex, "Can't advance AttributedString index after end index")
         return j
     }
 
     public func index(_ i: AttributedString.Index, offsetBy distance: Int) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
-        let j = Index(_guts.string.unicodeScalars.index(i._value, offsetBy: distance))
+        let j = Index(_guts.string.unicodeScalars.index(i._value, offsetBy: distance), version: _guts.version)
         precondition(j >= startIndex && j <= endIndex, "AttributedString index out of bounds")
         return j
     }
@@ -181,7 +181,7 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
         }
         precondition(j >= startIndex._value && j <= endIndex._value,
                      "AttributedString index out of bounds")
-        return Index(j)
+        return Index(j, version: _guts.version)
     }
 
     @_alwaysEmitIntoClient

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -203,9 +203,11 @@ extension AttributedString { // AttributedStringAttributeMutation
 extension AttributedString: AttributedStringProtocol {
     public struct Index : Comparable, Sendable {
         internal var _value: BigString.Index
+        internal var _version: AttributedString.Guts.Version
 
-        internal init(_ value: BigString.Index) {
+        internal init(_ value: BigString.Index, version: AttributedString.Guts.Version) {
             self._value = value
+            self._version = version
         }
 
         public static func == (left: Self, right: Self) -> Bool {
@@ -218,11 +220,11 @@ extension AttributedString: AttributedStringProtocol {
     }
     
     public var startIndex : Index {
-        Index(_guts.string.startIndex)
+        Index(_guts.string.startIndex, version: _guts.version)
     }
     
     public var endIndex : Index {
-        Index(_guts.string.endIndex)
+        Index(_guts.string.endIndex, version: _guts.version)
     }
     
     @preconcurrency
@@ -276,6 +278,7 @@ extension AttributedString {
         if !isKnownUniquelyReferenced(&_guts) {
             _guts = _guts.copy()
         }
+        _guts.incrementVersion()
     }
 
     public mutating func append(_ s: some AttributedStringProtocol) {
@@ -379,8 +382,10 @@ extension RangeSet where Bound == AttributedString.Index {
 }
 
 extension RangeSet where Bound == BigString.Index {
-    internal var _attributedStringIndices: RangeSet<AttributedString.Index> {
-        RangeSet<AttributedString.Index>(self.ranges.map(\._attributedStringRange))
+    internal func _attributedStringIndices(version: AttributedString.Guts.Version) -> RangeSet<AttributedString.Index> {
+        RangeSet<AttributedString.Index>(self.ranges.lazy.map {
+            $0._attributedStringRange(version: version)
+        })
     }
 }
 
@@ -390,7 +395,7 @@ extension Range where Bound == BigString.Index {
         Range<Int>(uncheckedBounds: (lowerBound.utf8Offset, upperBound.utf8Offset))
     }
     
-    internal var _attributedStringRange: Range<AttributedString.Index> {
-        Range<AttributedString.Index>(uncheckedBounds: (AttributedString.Index(lowerBound), AttributedString.Index(upperBound)))
+    internal func _attributedStringRange(version: AttributedString.Guts.Version) -> Range<AttributedString.Index> {
+        Range<AttributedString.Index>(uncheckedBounds: (AttributedString.Index(lowerBound, version: version), AttributedString.Index(upperBound, version: version)))
     }
 }

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -299,7 +299,7 @@ extension AttributedStringProtocol {
         let start = bstring.utf8.index(bounds.lowerBound, offsetBy: utf8Start)
         let end = bstring.utf8.index(bounds.lowerBound, offsetBy: utf8End)
 
-        return AttributedString.Index(start) ..< AttributedString.Index(end)
+        return AttributedString.Index(start, version: self.__guts.version) ..< AttributedString.Index(end, version: self.__guts.version)
 #else
         // TODO: Implement localized AttributedStringProtocol.range(of:) for FoundationPreview
         return _range(of: stringToFind, options: options)

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -152,8 +152,8 @@ extension AttributedSubstring {
     }
     
     internal var _bounds: Range<AttributedString.Index> {
-        let lower = AttributedString.Index(_range.lowerBound)
-        let upper = AttributedString.Index(_range.upperBound)
+        let lower = AttributedString.Index(_range.lowerBound, version: _guts.version)
+        let upper = AttributedString.Index(_range.upperBound, version: _guts.version)
         return Range(uncheckedBounds: (lower, upper))
     }
 
@@ -216,7 +216,7 @@ extension AttributedStringProtocol {
         precondition(i._value < bounds.upperBound, "Can't advance beyond end index")
         let next = guts.index(afterRun: i._value)
         assert(next > i._value)
-        return AttributedString.Index(Swift.min(next, bounds.upperBound))
+        return AttributedString.Index(Swift.min(next, bounds.upperBound), version: guts.version)
     }
 
     public func index(beforeRun i: AttributedString.Index) -> AttributedString.Index {
@@ -229,7 +229,7 @@ extension AttributedStringProtocol {
         precondition(i._value <= bounds.upperBound, "Invalid attributed string index")
         let prev = guts.index(beforeRun: i._value)
         assert(prev < i._value)
-        return AttributedString.Index(Swift.max(prev, bounds.lowerBound))
+        return AttributedString.Index(Swift.max(prev, bounds.lowerBound), version: guts.version)
     }
 
     public func index(_ i: AttributedString.Index, offsetByRuns distance: Int) -> AttributedString.Index {
@@ -253,12 +253,12 @@ extension AttributedStringProtocol {
 
         let result = guts.string.utf8.index(i._value, offsetBy: run.utf8Offset - i._value.utf8Offset)
         let clamped = Swift.min(Swift.max(result, bounds.lowerBound), bounds.upperBound)
-        return AttributedString.Index(clamped)
+        return AttributedString.Index(clamped, version: guts.version)
     }
 
     internal func _utf8Index(at utf8Offset: Int) -> AttributedString.Index {
         let startOffset = self.startIndex._value.utf8Offset
-        return AttributedString.Index(self.__guts.utf8Index(at: startOffset + utf8Offset))
+        return AttributedString.Index(self.__guts.utf8Index(at: startOffset + utf8Offset), version: self.__guts.version)
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -88,11 +88,11 @@ extension AttributedSubstring { // Equatable
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedSubstring : AttributedStringProtocol {
     public var startIndex: AttributedString.Index {
-        .init(_range.lowerBound)
+        .init(_range.lowerBound, version: _guts.version)
     }
 
     public var endIndex: AttributedString.Index {
-        .init(_range.upperBound)
+        .init(_range.upperBound, version: _guts.version)
     }
 
     internal mutating func ensureUniqueReference() {

--- a/Sources/FoundationEssentials/AttributedString/CMakeLists.txt
+++ b/Sources/FoundationEssentials/AttributedString/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(FoundationEssentials PRIVATE
     AttributedString+AttributeTransformation.swift
     AttributedString+CharacterView.swift
     AttributedString+Guts.swift
+    AttributedString+IndexValidity.swift
     AttributedString+Runs+AttributeSlices.swift
     AttributedString+Runs+Run.swift
     AttributedString+Runs.swift

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -446,7 +446,7 @@ extension Range where Bound == AttributedString.Index {
         let end = bstr.utf16.index(start, offsetBy: range.length)
 
         guard start >= string.startIndex._value, end <= string.endIndex._value else { return nil }
-        self.init(uncheckedBounds: (.init(start), .init(end)))
+        self.init(uncheckedBounds: (.init(start, version: string.__guts.version), .init(end, version: string.__guts.version)))
     }
 #endif // FOUNDATION_FRAMEWORK
 

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -314,7 +314,7 @@ extension AttributedString.Index {
         }
         let j = target.__guts.string.index(roundingDown: i)
         guard j == i else { return nil }
-        self.init(j)
+        self.init(j, version: target.__guts.version)
     }
 }
 
@@ -485,7 +485,7 @@ extension Range where Bound == AttributedString.Index {
         else {
             return nil
         }
-        self.init(uncheckedBounds: (.init(lower), .init(upper)))
+        self.init(uncheckedBounds: (.init(lower, version: attributedString.__guts.version), .init(upper, version: attributedString.__guts.version)))
     }
 }
 
@@ -498,14 +498,20 @@ extension AttributedString {
         typealias Element = Index
         
         let string: Substring
-        init(_ string: Substring) { self.string = string }
+        let version: Guts.Version
+        
+        init(_ string: Substring, version: Guts.Version) {
+            self.string = string
+            self.version = version
+        }
+        
         subscript(position: Index) -> Index { position }
-        var startIndex: Index { Index(BigString.Index(_utf8Offset: string.startIndex._utf8Offset)) }
-        var endIndex: Index { Index(BigString.Index(_utf8Offset: string.endIndex._utf8Offset)) }
+        var startIndex: Index { Index(BigString.Index(_utf8Offset: string.startIndex._utf8Offset), version: version) }
+        var endIndex: Index { Index(BigString.Index(_utf8Offset: string.endIndex._utf8Offset), version: version) }
         func index(after i: Index) -> Index {
             let j = String.Index(_utf8Offset: i._value.utf8Offset)
             let k = string.index(after: j)
-            return Index(BigString.Index(_utf8Offset: k._utf8Offset))
+            return Index(BigString.Index(_utf8Offset: k._utf8Offset), version: version)
         }
     }
 }
@@ -525,7 +531,8 @@ extension Range where Bound == String.Index {
             return
         }
         let str = Substring(string)
-        let dummy = AttributedString._IndexConverterFromAttributedString(str)
+        // Due to the FIXME notes above, we do not have a valid version to supply here since we have no AttributedString, so instead we use a newly created version to maintain existing behavior
+        let dummy = AttributedString._IndexConverterFromAttributedString(str, version: AttributedString.Guts.createNewVersion())
         let range = region.relative(to: dummy)
         self.init(_range: range, in: str)
     }

--- a/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
@@ -152,11 +152,11 @@ extension DiscontiguousAttributedSubstring : AttributedStringAttributeMutation {
 @available(FoundationPreview 6.2, *)
 extension DiscontiguousAttributedSubstring {
     public var characters: DiscontiguousSlice<AttributedString.CharacterView> {
-        AttributedString.CharacterView(_guts)[_indices._attributedStringIndices]
+        AttributedString.CharacterView(_guts)[_indices._attributedStringIndices(version: _guts.version)]
     }
     
     public var unicodeScalars: DiscontiguousSlice<AttributedString.UnicodeScalarView> {
-        AttributedString.UnicodeScalarView(_guts)[_indices._attributedStringIndices]
+        AttributedString.UnicodeScalarView(_guts)[_indices._attributedStringIndices(version: _guts.version)]
     }
     
     public var runs: AttributedString.Runs {

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringIndexValidityTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringIndexValidityTests.swift
@@ -1,0 +1,213 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+final class AttributedStringIndexValidityTests: XCTestCase {
+    public func testStartEndRange() {
+        let str = AttributedString("Hello, world")
+        
+        XCTAssertTrue(str.startIndex.isValid(within: str))
+        XCTAssertFalse(str.endIndex.isValid(within: str))
+        XCTAssertTrue((str.startIndex ..< str.endIndex).isValid(within: str))
+        XCTAssertTrue((str.startIndex ..< str.startIndex).isValid(within: str))
+        XCTAssertTrue((str.endIndex ..< str.endIndex).isValid(within: str))
+        
+        let subStart = str.index(afterCharacter: str.startIndex)
+        let subEnd = str.index(beforeCharacter: str.endIndex)
+        
+        do {
+            let substr = str[str.startIndex ..< str.endIndex]
+            XCTAssertTrue(substr.startIndex.isValid(within: substr))
+            XCTAssertFalse(substr.endIndex.isValid(within: substr))
+            XCTAssertTrue((substr.startIndex ..< substr.endIndex).isValid(within: substr))
+        }
+        
+        do {
+            let substr = str[subStart ..< str.endIndex]
+            XCTAssertTrue(substr.startIndex.isValid(within: substr))
+            XCTAssertFalse(substr.endIndex.isValid(within: substr))
+            XCTAssertTrue((substr.startIndex ..< substr.endIndex).isValid(within: substr))
+        }
+        
+        do {
+            let substr = str[str.startIndex ..< subEnd]
+            XCTAssertTrue(substr.startIndex.isValid(within: substr))
+            XCTAssertFalse(substr.endIndex.isValid(within: substr))
+            XCTAssertTrue((substr.startIndex ..< substr.endIndex).isValid(within: substr))
+        }
+        
+        do {
+            let substr = str[subStart ..< subEnd]
+            XCTAssertTrue(substr.startIndex.isValid(within: substr))
+            XCTAssertFalse(substr.endIndex.isValid(within: substr))
+            XCTAssertTrue((substr.startIndex ..< substr.endIndex).isValid(within: substr))
+            XCTAssertTrue((substr.startIndex ..< substr.startIndex).isValid(within: substr))
+            XCTAssertTrue((substr.endIndex ..< substr.endIndex).isValid(within: substr))
+        }
+        
+        do {
+            let substr = str[RangeSet(str.startIndex ..< str.endIndex)]
+            XCTAssertTrue(str.startIndex.isValid(within: substr))
+            XCTAssertFalse(str.endIndex.isValid(within: substr))
+            XCTAssertTrue((str.startIndex ..< str.endIndex).isValid(within: substr))
+        }
+        
+        do {
+            let substr = str[RangeSet(subStart ..< str.endIndex)]
+            XCTAssertTrue(subStart.isValid(within: substr))
+            XCTAssertFalse(str.endIndex.isValid(within: substr))
+            XCTAssertTrue((subStart ..< str.endIndex).isValid(within: substr))
+        }
+        
+        do {
+            let substr = str[RangeSet(str.startIndex ..< subEnd)]
+            XCTAssertTrue(str.startIndex.isValid(within: substr))
+            XCTAssertFalse(subEnd.isValid(within: substr))
+            XCTAssertTrue((str.startIndex ..< subEnd).isValid(within: substr))
+        }
+        
+        do {
+            let substr = str[RangeSet(subStart ..< subEnd)]
+            XCTAssertTrue(subStart.isValid(within: substr))
+            XCTAssertFalse(subEnd.isValid(within: substr))
+            XCTAssertTrue((subStart ..< subEnd).isValid(within: substr))
+            XCTAssertTrue((subStart ..< subStart).isValid(within: substr))
+            XCTAssertTrue((subEnd ..< subEnd).isValid(within: substr))
+        }
+    }
+    
+    public func testExhaustiveIndices() {
+        let str = AttributedString("Hello Cafe\u{301} 👍🏻🇺🇸 World")
+        for idx in str.characters.indices {
+            XCTAssertTrue(idx.isValid(within: str))
+        }
+        for idx in str.unicodeScalars.indices {
+            XCTAssertTrue(idx.isValid(within: str))
+        }
+        for idx in str.utf8.indices {
+            XCTAssertTrue(idx.isValid(within: str))
+        }
+        for idx in str.utf16.indices {
+            XCTAssertTrue(idx.isValid(within: str))
+        }
+    }
+    
+    public func testOutOfBoundsContiguous() {
+        let str = AttributedString("Hello, world")
+        let subStart = str.index(afterCharacter: str.startIndex)
+        let subEnd = str.index(beforeCharacter: str.endIndex)
+        let substr = str[subStart ..< subEnd]
+        
+        XCTAssertFalse(str.startIndex.isValid(within: substr))
+        XCTAssertFalse(str.endIndex.isValid(within: substr))
+        XCTAssertFalse((str.startIndex ..< str.endIndex).isValid(within: substr))
+        XCTAssertFalse((str.startIndex ..< substr.startIndex).isValid(within: substr))
+        XCTAssertFalse((substr.startIndex ..< str.endIndex).isValid(within: substr))
+        XCTAssertFalse((str.startIndex ..< str.startIndex).isValid(within: substr))
+        XCTAssertFalse((str.endIndex ..< str.endIndex).isValid(within: substr))
+    }
+    
+    public func testOutOfBoundsDiscontiguous() {
+        let str = AttributedString("Hello, world")
+        let idxA = str.index(afterCharacter: str.startIndex)
+        let idxB = str.index(afterCharacter: idxA)
+        let idxD = str.index(beforeCharacter: str.endIndex)
+        let idxC = str.index(beforeCharacter: idxD)
+        let middleIdx = str.index(afterCharacter: idxB)
+        let substr = str[RangeSet([idxA ..< idxB, idxC ..< idxD])]
+        
+        XCTAssertFalse(str.startIndex.isValid(within: substr))
+        XCTAssertFalse(str.endIndex.isValid(within: substr))
+        XCTAssertFalse(idxD.isValid(within: substr))
+        XCTAssertFalse(middleIdx.isValid(within: substr))
+        XCTAssertFalse((str.startIndex ..< idxA).isValid(within: substr))
+        XCTAssertFalse((idxA ..< middleIdx).isValid(within: substr))
+        XCTAssertFalse((middleIdx ..< idxD).isValid(within: substr))
+        XCTAssertFalse((str.startIndex ..< str.startIndex).isValid(within: substr))
+        XCTAssertFalse((str.endIndex ..< str.endIndex).isValid(within: substr))
+    }
+    
+    public func testMutationInvalidation() {
+        func checkInPlace(_ mutation: (inout AttributedString) -> (), file: StaticString = #file, line: UInt = #line) {
+            var str = AttributedString("Hello World")
+            let idxA = str.startIndex
+            let idxB = str.index(afterCharacter: idxA)
+            
+            XCTAssertTrue(idxA.isValid(within: str), "Initial index A was invalid in original", file: file, line: line)
+            XCTAssertTrue(idxB.isValid(within: str), "Initial index B was invalid in original", file: file, line: line)
+            XCTAssertTrue((idxA ..< idxB).isValid(within: str), "Initial range was invalid in original", file: file, line: line)
+            XCTAssertTrue(RangeSet(idxA ..< idxB).isValid(within: str), "Initial range set was invalid in original", file: file, line: line)
+            
+            mutation(&str)
+            
+            XCTAssertFalse(idxA.isValid(within: str), "Initial index A was valid in in-place mutated", file: file, line: line)
+            XCTAssertFalse(idxB.isValid(within: str), "Initial index B was valid in in-place mutated", file: file, line: line)
+            XCTAssertFalse((idxA ..< idxB).isValid(within: str), "Initial range was valid in in-place mutated", file: file, line: line)
+            XCTAssertFalse(RangeSet(idxA ..< idxB).isValid(within: str), "Initial range set was valid in in-place mutated", file: file, line: line)
+        }
+        
+        func checkCopy(_ mutation: (inout AttributedString) -> (), file: StaticString = #file, line: UInt = #line) {
+            let str = AttributedString("Hello World")
+            let idxA = str.startIndex
+            let idxB = str.index(afterCharacter: idxA)
+            
+            var copy = str
+            XCTAssertTrue(idxA.isValid(within: str), "Initial index A was invalid in original", file: file, line: line)
+            XCTAssertTrue(idxB.isValid(within: str), "Initial index B was invalid in original", file: file, line: line)
+            XCTAssertTrue((idxA ..< idxB).isValid(within: str), "Initial range was invalid in original", file: file, line: line)
+            XCTAssertTrue(RangeSet(idxA ..< idxB).isValid(within: str), "Initial range set was invalid in original", file: file, line: line)
+            XCTAssertTrue(idxA.isValid(within: copy), "Initial index A was invalid in copy", file: file, line: line)
+            XCTAssertTrue(idxB.isValid(within: copy), "Initial index B was invalid in copy", file: file, line: line)
+            XCTAssertTrue((idxA ..< idxB).isValid(within: copy), "Initial range was invalid in copy", file: file, line: line)
+            XCTAssertTrue(RangeSet(idxA ..< idxB).isValid(within: copy), "Initial range set was invalid in copy", file: file, line: line)
+            
+            mutation(&copy)
+            
+            XCTAssertTrue(idxA.isValid(within: str), "Initial index A was invalid in original after copy", file: file, line: line)
+            XCTAssertTrue(idxB.isValid(within: str), "Initial index B was invalid in original after copy", file: file, line: line)
+            XCTAssertTrue((idxA ..< idxB).isValid(within: str), "Initial range was invalid in original after copy", file: file, line: line)
+            XCTAssertTrue(RangeSet(idxA ..< idxB).isValid(within: str), "Initial range set was invalid in original after copy", file: file, line: line)
+            XCTAssertFalse(idxA.isValid(within: copy), "Initial index A was valid in copy", file: file, line: line)
+            XCTAssertFalse(idxB.isValid(within: copy), "Initial index B was valid in copy", file: file, line: line)
+            XCTAssertFalse((idxA ..< idxB).isValid(within: copy), "Initial range was valid in copy", file: file, line: line)
+            XCTAssertFalse(RangeSet(idxA ..< idxB).isValid(within: copy), "Initial range set was valid in copy", file: file, line: line)
+        }
+        
+        func check(_ mutation: (inout AttributedString) -> (), file: StaticString = #file, line: UInt = #line) {
+            checkInPlace(mutation, file: file, line: line)
+            checkCopy(mutation, file: file, line: line)
+        }
+        
+        check {
+            $0.replaceSubrange($0.startIndex ..< $0.endIndex, with: AttributedString("Hello"))
+        }
+        
+        check {
+            $0.testInt = 2
+        }
+        
+        check {
+            $0.characters.append(contentsOf: "Hello")
+        }
+        
+        check {
+            $0.unicodeScalars.remove(at: $0.startIndex)
+        }
+        
+        check {
+            $0[$0.startIndex ..< $0.index(afterCharacter: $0.startIndex)].testInt = 2
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the index validity checking APIs as proposed in [SF-0015](https://github.com/swiftlang/swift-foundation/blob/main/Proposals/0015-attributedstring-tracking-indices.md) by adding a new version number tracked within each `AttributedString` and `AttributedString.Index`. As neither type is frozen, we have the flexibility in the future to optimize this (for example, by taking advantage of the version number stored within the already-nested `BigString.Index` if the swift-collections package provided access to it) if we deem necessary.