### PR TITLE
Add `.spi` file to generate documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [FoundationEssentials, FoundationInternationalization]


### PR DESCRIPTION
## Motivation

The Swift Package Index is capable of hosting documentation. `swift-foundation` is currently not publishing documentation there but it would be really helpful to understand what types are available in the `FoundationEssentials` and `FoundationInternationalization` modules.

## Modification

This PR adds an `.spi` file to trigger the generation of documentation by the Swift Package Index.

## Result

Publicly hosted documentation for the products provided by `swift-foundation`