### PR TITLE
Add default keypath method handling for #Predicate.

### DIFF
--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -393,10 +393,8 @@ extension KeyPathExprSyntax {
                 }
             case .subscript(let sub):
                 result = ExprSyntax(SubscriptCallExprSyntax(calledExpression: result, arguments: sub.arguments))
-#if FOUNDATION_FRAMEWORK
-            default:
+            @unknown default:
                 return nil
-#endif
             }
         }
         return result


### PR DESCRIPTION
This accompanies the [swift-syntax](https://github.com/swiftlang/swift-syntax/pull/2950) and [compiler implementation](https://github.com/swiftlang/swift/pull/78823) for [Method and Initializer Keypaths](https://github.com/swiftlang/swift-evolution/pull/2675) which extends keypath usage to include references to methods and initializers.

Key path`.method` handling is currently unimplemented for `#Predicate` and will be added once this feature is accepted and slotted to be made available in a future version of Swift.