### PR TITLE
New XML PropertyListDecoder parser accepts malformed tags

### DIFF
--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -1545,6 +1545,17 @@ data1 = <7465
         }
 
     }
+    
+    func test_garbageCharactersAfterXMLTagName() throws {
+        let garbage = "<plist><dict><key>bar</key><stringGARBAGE>foo</string></dict></plist>".data(using: .utf8)!
+        
+        XCTAssertThrowsError(try PropertyListDecoder().decode([String:String].self, from: garbage))
+        
+        // Historical behavior allows for whitespace to immediately follow tag names
+        let acceptable = "<plist><dict><key>bar</key><string      >foo</string></dict></plist>".data(using: .utf8)!
+        
+        XCTAssertEqual(try PropertyListDecoder().decode([String:String].self, from: acceptable), ["bar":"foo"])
+    }
 }
             
 


### PR DESCRIPTION
A mistake was made during translation of PropertyListSerialization XML parsing to native PropertyListDecoder with regard to open tags.

`PropertyListSerialization` accepts open tags that look like any of the following:

```
`<` <VALIDTAG> `>`
`<` <VALIDTAG> `/` `>`
`<` <VALIDTAG> <WHITESPACE> <ANYTHING> `>`
```

The latter case is to handle tags with attributes, which are typically only used on the `plist` tag, e.g. `<plist version="1.0">`.

The adapted code was too permissive and accepted:

```
`<` <VALIDTAG> <ANYTHING> `>`
`<` <VALIDTAG> <ANYTHING> `/` `>`
```

Which means we accepted input like:

```
<stringGARBAGE>foo</string>
```

This PR fixes that by checking the next character after a valid tag name before accepting it.