### PR TITLE
[6.1] Update SwiftPM/CMake dependencies to match toolchain build

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -71,11 +71,11 @@ switch usePackage {
 
     case .useGitHubPackage:
         #if os(macOS)
-            packageDependency.append(.package(url: "https://github.com/apple/swift-foundation", branch: "main"))
+            packageDependency.append(.package(url: "https://github.com/apple/swift-foundation", branch: "release/6.1"))
             targetDependency.append(.product(name: "FoundationEssentials", package: "swift-foundation"))
             targetDependency.append(.product(name: "FoundationInternationalization", package: "swift-foundation"))
         #else
-            packageDependency.append(.package(url: "https://github.com/apple/swift-corelibs-foundation", branch: "main"))
+            packageDependency.append(.package(url: "https://github.com/apple/swift-corelibs-foundation", branch: "release/6.1"))
             targetDependency.append(.product(name: "Foundation", package: "swift-corelibs-foundation"))
         #endif
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
     message(STATUS "_SwiftFoundationICU_SourceDIR not provided, checking out local copy of swift-foundation-icu")
     FetchContent_Declare(SwiftFoundationICU
         GIT_REPOSITORY https://github.com/apple/swift-foundation-icu.git
-        GIT_TAG 0.0.9)
+        GIT_TAG release/6.1)
 endif()
 
 if (_SwiftCollections_SourceDIR)

--- a/Package.swift
+++ b/Package.swift
@@ -62,10 +62,10 @@ var dependencies: [Package.Dependency] {
                 from: "1.1.0"),
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
-                branch: "main"),
+                branch: "release/6.1"),
             .package(
                 url: "https://github.com/swiftlang/swift-syntax",
-                branch: "main")
+                branch: "release/6.1")
         ]
     }
 }

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT SwiftSyntax_FOUND)
     # If building at desk, check out and link against the SwiftSyntax repo's targets
     FetchContent_Declare(SwiftSyntax
         GIT_REPOSITORY https://github.com/swiftlang/swift-syntax.git
-        GIT_TAG 600.0.0)
+        GIT_TAG release/6.1)
     FetchContent_MakeAvailable(SwiftSyntax)
 else()
   message(STATUS "SwiftSyntax_DIR provided, using swift-syntax from ${SwiftSyntax_DIR}")


### PR DESCRIPTION
  - **Explanation**: Updates the dependencies declared in the SwiftPM package manifest and `CMakeLists.txt` files to match the versions of the dependencies actually used when building the toolchain. Having these be correct will be important when making lockstep changes (for example, between swift-foundation and swift-syntax) so that if a dependency like swift-syntax makes a breaking change on `main` it will not break the build of our package's `release/6.1` branch due to incorrectly depending on the wrong branch.
  - **Scope**: Only affects the version of used dependencies and does not change the project's code itself. Also only impacts "local" builds and not any toolchain builds
  - **Issues**: N/A
  - **Original PRs**: N/A
  - **Risk**: Low - does not impact toolchain build and change is intended to have no effect currently
  - **Testing**: SwiftPM build is tested in CI, and I've tested both the SwiftPM and standalone CMake build locally
  - **Reviewers**: N/A
