### PR TITLE
Fix ambiguity on macOS in PropertyListEncoderTests

### DIFF
--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -1547,12 +1547,12 @@ data1 = <7465
     }
     
     func test_garbageCharactersAfterXMLTagName() throws {
-        let garbage = "<plist><dict><key>bar</key><stringGARBAGE>foo</string></dict></plist>".data(using: .utf8)!
+        let garbage = "<plist><dict><key>bar</key><stringGARBAGE>foo</string></dict></plist>".data(using: String._Encoding.utf8)!
         
         XCTAssertThrowsError(try PropertyListDecoder().decode([String:String].self, from: garbage))
         
         // Historical behavior allows for whitespace to immediately follow tag names
-        let acceptable = "<plist><dict><key>bar</key><string      >foo</string></dict></plist>".data(using: .utf8)!
+        let acceptable = "<plist><dict><key>bar</key><string      >foo</string></dict></plist>".data(using: String._Encoding.utf8)!
         
         XCTAssertEqual(try PropertyListDecoder().decode([String:String].self, from: acceptable), ["bar":"foo"])
     }


### PR DESCRIPTION
https://github.com/swiftlang/swift-foundation/pull/1180 accidentally introduces a build issue on macOS due to new ambiguity between `Foundation.String.Encoding` and `FoundationEssentials.String.Encoding` but we weren't able to detect that since macOS CI is currently nonfunctional. This fixes the ambiguity using the same trick we use elsewhere in our unit tests. I've validated locally that this fixes the build issues on macOS.