### PR TITLE
[6.1] URL compatibility and bug fixes

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1837,7 +1837,7 @@ public struct URL: Equatable, Sendable, Hashable {
         var components = URLComponents(parseInfo: _parseInfo)
         let newPath = components.percentEncodedPath.removingDotSegments
         components.percentEncodedPath = newPath
-        return components.url(relativeTo: baseURL)!
+        return components.url(relativeTo: baseURL) ?? self
     }
 
     /// Standardizes the path of a file URL by removing dot segments.

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -777,19 +777,12 @@ public struct URL: Equatable, Sendable, Hashable {
     ///
     /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
     public init?(string: __shared String) {
+        guard !string.isEmpty else { return nil }
         #if FOUNDATION_FRAMEWORK
         guard foundation_swift_url_enabled() else {
-            guard !string.isEmpty, let inner = NSURL(string: string) else { return nil }
+            guard let inner = NSURL(string: string) else { return nil }
             _url = URL._converted(from: inner)
             return
-        }
-        // Linked-on-or-after check for apps which pass an empty string.
-        // The new URL(string:) implementations allow the empty string
-        // as input since an empty path is valid and can be resolved
-        // against a base URL. This is shown in the RFC 3986 examples:
-        // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1
-        if Self.compatibility1 && string.isEmpty {
-            return nil
         }
         #endif // FOUNDATION_FRAMEWORK
         guard let parseInfo = Parser.parse(urlString: string, encodingInvalidCharacters: true) else {

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1113,7 +1113,9 @@ public struct URL: Equatable, Sendable, Hashable {
         }
 
         if let baseScheme = _baseParseInfo.scheme {
-            result.scheme = String(baseScheme)
+            // Scheme might be empty, which URL allows for compatibility,
+            // but URLComponents does not, so we force it internally.
+            result.forceScheme(String(baseScheme))
         }
 
         if hasAuthority {

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1488,7 +1488,7 @@ public struct URL: Equatable, Sendable, Hashable {
         }
         #endif
         if _baseParseInfo != nil {
-            return absoluteURL.path(percentEncoded: percentEncoded)
+            return absoluteURL.relativePath(percentEncoded: percentEncoded)
         }
         if percentEncoded {
             return String(_parseInfo.path)

--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -676,7 +676,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             return CFURLCreateWithString(kCFAllocatorDefault, string as CFString, nil) as URL?
         }
         #endif
-        return URL(string: string)
+        return URL(string: string, relativeTo: nil)
     }
 
     /// Returns a URL created from the URLComponents relative to a base URL.

--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -676,7 +676,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             return CFURLCreateWithString(kCFAllocatorDefault, string as CFString, nil) as URL?
         }
         #endif
-        return URL(string: string, relativeTo: nil)
+        return URL(stringOrEmpty: string, relativeTo: nil)
     }
 
     /// Returns a URL created from the URLComponents relative to a base URL.
@@ -690,7 +690,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             return CFURLCreateWithString(kCFAllocatorDefault, string as CFString, base as CFURL) as URL?
         }
         #endif
-        return URL(string: string, relativeTo: base)
+        return URL(stringOrEmpty: string, relativeTo: base)
     }
 
     /// Returns a URL string created from the URLComponents.

--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -142,10 +142,12 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             return nil
         }
 
-        mutating func setScheme(_ newValue: String?) throws {
+        mutating func setScheme(_ newValue: String?, force: Bool = false) throws {
             reset(.scheme)
-            guard Parser.validate(newValue, component: .scheme) else {
-                throw InvalidComponentError.scheme
+            if !force {
+                guard Parser.validate(newValue, component: .scheme) else {
+                    throw InvalidComponentError.scheme
+                }
             }
             _scheme = newValue
             if encodedHost != nil {
@@ -731,6 +733,11 @@ public struct URLComponents: Hashable, Equatable, Sendable {
                 fatalError("Attempting to set scheme with invalid characters")
             }
         }
+    }
+
+    /// Used by `URL` to allow empty scheme for compatibility.
+    internal mutating func forceScheme(_ scheme: String) {
+        try? components.setScheme(scheme, force: true)
     }
 
 #if FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -179,7 +179,7 @@ final class URLTests : XCTestCase {
             }
             #endif
 
-            let url = URL(string: test.key, relativeTo: base)
+            let url = URL(stringOrEmpty: test.key, relativeTo: base)
             XCTAssertNotNil(url, "Got nil url for string: \(test.key)")
             XCTAssertEqual(url?.absoluteString, test.value, "Failed test for string: \(test.key)")
         }
@@ -242,7 +242,7 @@ final class URLTests : XCTestCase {
             "http:g"        :  "g", // For strict parsers
         ]
         for test in tests {
-            let url = URL(string: test.key, relativeTo: base)!
+            let url = URL(stringOrEmpty: test.key, relativeTo: base)!
             XCTAssertEqual(url.path(), test.value)
             if (url.hasDirectoryPath && url.path().count > 1) {
                 // The trailing slash is stripped in .path for file system compatibility
@@ -607,11 +607,13 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(appended.absoluteString, "file:///var/mobile/relative/no:slash")
         XCTAssertEqual(appended.relativePath, "relative/no:slash")
 
-        // `appending(component:)` should explicitly treat `component` as a single
-        // path component, meaning "/" should be encoded to "%2F" before appending
+        // .appending(component:) should explicitly treat slashComponent as a single
+        // path component, meaning "/" should be encoded to "%2F" before appending.
+        // However, the old behavior didn't do this for file URLs, so we maintain the
+        // old behavior to prevent breakage.
         appended = url.appending(component: slashComponent, directoryHint: .notDirectory)
-        checkBehavior(appended.absoluteString, new: "file:///var/mobile/relative/%2Fwith:slash", old: "file:///var/mobile/relative/with:slash")
-        checkBehavior(appended.relativePath, new: "relative/%2Fwith:slash", old: "relative/with:slash")
+        XCTAssertEqual(appended.absoluteString, "file:///var/mobile/relative/with:slash")
+        XCTAssertEqual(appended.relativePath, "relative/with:slash")
 
         appended = url.appendingPathComponent(component, isDirectory: false)
         XCTAssertEqual(appended.absoluteString, "file:///var/mobile/relative/no:slash")
@@ -687,7 +689,7 @@ final class URLTests : XCTestCase {
         checkBehavior(relative.path, new: "/", old: "/..")
 
         relative = URL(filePath: "", relativeTo: absolute)
-        checkBehavior(relative.relativePath, new: "", old: ".")
+        XCTAssertEqual(relative.relativePath, ".")
         XCTAssertTrue(relative.hasDirectoryPath)
         XCTAssertEqual(relative.path, "/absolute")
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1375,6 +1375,16 @@ final class URLTests : XCTestCase {
 
         XCTAssertNotNil(URL(string: comp.string!))
         XCTAssertNotNil(URLComponents(string: comp.string!))
+
+        // In rare cases, an app might rely on URL allowing an empty scheme,
+        // but then take that string and pass it to URLComponents to modify
+        // other components of the URL. We shouldn't percent-encode the colon
+        // in these cases.
+
+        let url = try XCTUnwrap(URL(string: "://host/path"))
+        comp = try XCTUnwrap(URLComponents(string: url.absoluteString))
+        comp.query = "key=value"
+        XCTAssertEqual(comp.string, "://host/path?key=value")
     }
 
     func testURLComponentsInvalidPaths() {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1425,6 +1425,12 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(comp.path, "/my\u{0}path")
     }
 
+    func testURLStandardizedEmptyString() {
+        let url = URL(string: "../../../")!
+        let standardized = url.standardized
+        XCTAssertTrue(standardized.path().isEmpty)
+    }
+
 #if FOUNDATION_FRAMEWORK
     func testURLComponentsBridging() {
         var nsURLComponents = NSURLComponents(

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1347,6 +1347,19 @@ final class URLTests : XCTestCase {
         comp = try XCTUnwrap(URLComponents(string: legalURLString))
         XCTAssertEqual(comp.string, legalURLString)
         XCTAssertEqual(comp.percentEncodedPath, colonFirstPath)
+
+        // Colons should be percent-encoded by URLComponents.string if
+        // they could be misinterpreted as a scheme separator.
+
+        comp = URLComponents()
+        comp.percentEncodedPath = "not%20a%20scheme:"
+        XCTAssertEqual(comp.string, "not%20a%20scheme%3A")
+
+        // These would fail if we did not percent-encode the colon.
+        // .string should always produce a valid URL string, or nil.
+
+        XCTAssertNotNil(URL(string: comp.string!))
+        XCTAssertNotNil(URLComponents(string: comp.string!))
     }
 
     func testURLComponentsInvalidPaths() {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -966,6 +966,21 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(schemeOnly.absoluteString, "scheme:foo")
     }
 
+    func testURLEmptySchemeCompatibility() throws {
+        var url = try XCTUnwrap(URL(string: ":memory:"))
+        XCTAssertEqual(url.scheme, "")
+
+        let base = try XCTUnwrap(URL(string: "://home"))
+        XCTAssertEqual(base.host(), "home")
+
+        url = try XCTUnwrap(URL(string: "/path", relativeTo: base))
+        XCTAssertEqual(url.scheme, "")
+        XCTAssertEqual(url.host(), "home")
+        XCTAssertEqual(url.path, "/path")
+        XCTAssertEqual(url.absoluteString, "://home/path")
+        XCTAssertEqual(url.absoluteURL.scheme, "")
+    }
+
     func testURLComponentsPercentEncodedUnencodedProperties() throws {
         var comp = URLComponents()
 


### PR DESCRIPTION
**Explanation:** Cherry-picking `URL` bug fixes that improve compatibility and stability, aligning the 6.1 behavior with what we expect moving forward.
**Scope:** Impacts some `URL` and `URLComponents` APIs that were found to cause bincompat issues in apps due to new behavior. Changes were made to be more compatible with usage that was previously allowed. See #1113 for more details. Other PRs are small follow-on fixes for crashes or unintended behavior as a result of #1103 and #1113.
**Original PRs:** #1103, #1110, #1113, #1117, #1119, #1139 
**Risk:** Low - restores previous behaviors or fixes crashes, well-tested on Darwin and swift-foundation `main` branch.
**Testing:** Added unit tests, swift-ci, testing on Darwin, stable in `main` for 1-2 months.
**Reviewers:** @jmschonfeld, @itingliu, @parkera

Resolves #958 and #962 for `release/6.1`