### PR TITLE
Remove Thai Calendar

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -93,9 +93,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
         case dangi
         
         @available(FoundationPreview 6.2, *)
-        case thai
-        
-        @available(FoundationPreview 6.2, *)
         case vietnamese
 
         package static let cldrKeywordKey = "ca"
@@ -135,7 +132,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
             case "telugu": self = .telugu
             case "vikram": self = .vikram
             case "dangi": self = .dangi
-            case "thai": self = .thai
             case "vietnamese": self = .vietnamese
             default: return nil
             }
@@ -169,7 +165,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
             case .telugu: return "telugu"
             case .vikram: return "vikram"
             case .dangi: return "dangi"
-            case .thai: return "thai"
             case .vietnamese: return "vietnamese"
             }
         }
@@ -203,7 +198,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
             case .telugu: return "telugu"
             case .vikram: return "vikram"
             case .dangi: return "dangi"
-            case .thai: return "thai"
             case .vietnamese: return "vietnamese"
             }
         }
@@ -1404,8 +1398,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
             return .vikram
         case .dangi: 
             return .dangi
-        case .thai:
-            return .thai
         case .vietnamese:
             return .vietnamese
         }
@@ -1465,8 +1457,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
             return .vikram
         case .dangi:
             return .dangi
-        case .thai:
-            return .thai
         case .vietnamese:
             return .vietnamese
         default:

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1468,8 +1468,6 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
                 return Date(timeIntervalSinceReferenceDate: -60645542400.0)
             case .dangi:
                 fallthrough
-            case .thai:
-                fallthrough
             case .vietnamese:
                 // TODO: This is copied from `.chinese` and needs to be revisited for each new calendar.
                 if time < -146325744000.0 { return nil }
@@ -1589,8 +1587,6 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
                 if time < -60645542400.0 { return nil }
                 return DateInterval(start: Date(timeIntervalSinceReferenceDate: -60645542400.0), duration: inf_ti)
             case .dangi:
-                fallthrough
-            case .thai:
                 fallthrough
             case .vietnamese:
                 // TODO: This is copied from `.chinese` and needs to be revisited for each new calendar.


### PR DESCRIPTION
Due to lack of an authoritative source of calendrical calculations, we’re not able to add support for it in ICU and correspondingly in Swift Foundation. Removing the identifier that was previously exposed with #1171.

API Proposal Update in #1202.

145890794