### PR TITLE
Use lstat() semantics for URL directory detection

### DIFF
--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -399,6 +399,44 @@ final class URLTests : XCTestCase {
         }
     }
 
+    func testURLFilePathDoesNotFollowLastSymlink() throws {
+        try FileManagerPlayground {
+            Directory("dir") {
+                "Foo"
+                SymbolicLink("symlink", destination: "../dir")
+            }
+        }.test {
+            let currentDirectoryPath = $0.currentDirectoryPath
+            let baseURL = URL(filePath: currentDirectoryPath, directoryHint: .isDirectory)
+
+            let dirURL = baseURL.appending(path: "dir", directoryHint: .checkFileSystem)
+            XCTAssertTrue(dirURL.hasDirectoryPath)
+
+            var symlinkURL = dirURL.appending(path: "symlink", directoryHint: .notDirectory)
+
+            // FileManager uses stat(), which will follow the symlink to the directory.
+
+            #if FOUNDATION_FRAMEWORK
+            var isDirectory: ObjCBool = false
+            XCTAssertTrue(FileManager.default.fileExists(atPath: symlinkURL.path, isDirectory: &isDirectory))
+            XCTAssertTrue(isDirectory.boolValue)
+            #else
+            var isDirectory = false
+            XCTAssertTrue(FileManager.default.fileExists(atPath: symlinkURL.path, isDirectory: &isDirectory))
+            XCTAssertTrue(isDirectory)
+            #endif
+
+            // URL uses lstat(), which will not follow the symlink at the end of the path.
+            // Check that URL(filePath:) and .appending(path:) preserve this behavior.
+
+            symlinkURL = URL(filePath: symlinkURL.path, directoryHint: .checkFileSystem)
+            XCTAssertFalse(symlinkURL.hasDirectoryPath)
+
+            symlinkURL = baseURL.appending(path: "symlink", directoryHint: .checkFileSystem)
+            XCTAssertFalse(symlinkURL.hasDirectoryPath)
+        }
+    }
+
     func testURLRelativeDotDotResolution() throws {
         let baseURL = URL(filePath: "/docs/src/")
         var result = URL(filePath: "../images/foo.png", relativeTo: baseURL)


### PR DESCRIPTION
Historically, `NS/URL` checks if a path is a directory using `getattrlist` with `FSOPT_NOFOLLOW`. This is equivalent to `lstat()` in the sense that it won't follow a symlink at the end of the path, and it will report information about the symlink itself.

In the Swift `URL` implementation, I called into `FileManager` to check if a path is a directory, but `FileManager` uses `stat()` for this purpose (and historically always has).

Since `URL` historically doesn't follow a symlink at the end of the path, this PR switches to using `lstat()` on UNIX-like platforms instead of calling into `FileManager`.

On Windows, we can create the file handle with `FILE_FLAG_OPEN_REPARSE_POINT` to achieve the same semantics.