### PR TITLE
Make trivial AttributedString dynamicMemberLookup subscripts inlinable

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
@@ -33,6 +33,7 @@ extension AttributeContainer {
     }
 
     @preconcurrency
+    @inlinable // Trivial implementation, allows callers to optimize away the keypath allocation
     public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? where K.Value : Sendable {
         get { self[K.self] }
         set { self[K.self] = newValue }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
@@ -81,6 +81,7 @@ extension AttributedString.Runs.Run {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs.Run {
     @preconcurrency
+    @inlinable // Trivial implementation, allows callers to optimize away the keypath allocation
     public subscript<K: AttributedStringKey>(
         dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>
     ) -> K.Value?

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -243,6 +243,7 @@ extension AttributedString: AttributedStringProtocol {
     }
     
     @preconcurrency
+    @inlinable // Trivial implementation, allows callers to optimize away the keypath allocation
     public subscript<K: AttributedStringKey>(
         dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>
     ) -> K.Value? where K.Value: Sendable {

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -177,6 +177,7 @@ extension AttributedSubstring {
     }
 
     @preconcurrency
+    @inlinable // Trivial implementation, allows callers to optimize away the keypath allocation
     public subscript<K: AttributedStringKey>(
         dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>
     ) -> K.Value? where K.Value : Sendable {

--- a/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
@@ -194,6 +194,7 @@ extension DiscontiguousAttributedSubstring {
         }
     }
     
+    @inlinable // Trivial implementation, allows callers to optimize away the keypath allocation
     public subscript<K: AttributedStringKey>(
         dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>
     ) -> K.Value? where K.Value : Sendable {


### PR DESCRIPTION
When profiling some uses of `AttributedString`, we noticed that simple attribute mutations like `attrStr.languageIdentifier = "en"` spend a decent amount of time in `swift_getKeyPath` allocating and initializing a `KeyPath` to provide to the `dynamicMemberLookup` subscript. In reality, this `KeyPath` instance is never used, we only use it to infer the type of the `K: AttributedStringKey` generic argument and then the implementation of this subscript forwards that type on to the subscript that accepts a concrete type. By marking the dynamic member subscripts (at least those that are trivially implemented) `@inlinable`, the compiler can see the immediate indirection to the alternative subscript and inline it which then allows the optimizer to optimize away the allocation/initialization and release of the `KeyPath` entirely resulting in no time spent allocating `KeyPath`s at runtime.

Unfortunately I was unable to measure the speedup here via our benchmarks (likely due to a lack of library evolution or the caller in the benchmark making the keypath in a more optimal way). However, I was able to determine that with a simple caller of these subscripts with this change I now see the `swift_getKeyPath` calls disappear from the caller.