### PR TITLE
Use the `package` access level instead of `@testable` imports

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -11,15 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_spi(Unstable) internal import CollectionsInternal
+@_spi(Unstable) package import CollectionsInternal
 #elseif canImport(_RopeModule)
-internal import _RopeModule
+package import _RopeModule
 #elseif canImport(_FoundationCollections)
-internal import _FoundationCollections
+package import _FoundationCollections
 #endif
 
 extension AttributedString {
-    internal final class Guts : @unchecked Sendable {
+    package final class Guts : @unchecked Sendable {
         typealias Index = AttributedString.Index
         typealias Runs = AttributedString.Runs
         typealias AttributeMergePolicy = AttributedString.AttributeMergePolicy
@@ -30,7 +30,7 @@ extension AttributedString {
         typealias _AttributeStorage = AttributedString._AttributeStorage
 
         var version: Version
-        var string: BigString
+        package var string: BigString
         var runs: _InternalRuns
         var trackedRanges: [Range<BigString.Index>]
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -21,7 +21,7 @@ internal import _FoundationCollections
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct AttributedString : Sendable {
-    internal var _guts: Guts
+    package var _guts: Guts
 
     internal init(_ guts: Guts) {
         _guts = guts

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -403,7 +403,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
     /// For use by `NSCoding` implementation in `NSCalendar` and `Codable` for `Calendar` only.
-    internal init(identifier: Calendar.Identifier, locale: Locale, timeZone: TimeZone?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
+    package init(identifier: Calendar.Identifier, locale: Locale, timeZone: TimeZone?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
         _calendar = CalendarCache.cache.fixed(identifier: identifier, locale: locale, timeZone: timeZone, firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDaysInFirstWeek, gregorianStartDate: gregorianStartDate)
     }
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -38,7 +38,7 @@ extension Date {
         timeIntervalSinceReferenceDate / 86400 + Self.julianDayAtDateReference
     }
 
-    func julianDay() throws (GregorianCalendarError) -> Int {
+    package func julianDay() throws (GregorianCalendarError) -> Int {
         let jd = (julianDate + 0.5).rounded(.down)
         guard jd <= Double(Self.maxJulianDay), jd >= Double(Self.minJulianDay) else {
             throw .overflow(nil, self, nil)
@@ -51,7 +51,7 @@ extension Date {
         self.init(julianDate: Double(julianDay))
     }
 
-    init(julianDate: Double) {
+    package init(julianDate: Double) {
         let secondsSinceJulianReference = (julianDate - Self.julianDayAtDateReference) * 86400
         self.init(timeIntervalSinceReferenceDate: secondsSinceJulianReference)
     }
@@ -165,13 +165,13 @@ enum ResolvedDateComponents {
 
 
 /// Internal-use error for indicating unexpected situations when finding dates.
-enum GregorianCalendarError : Error {
+package enum GregorianCalendarError : Error {
     case overflow(Calendar.Component?, Date? /* failing start date */, Date? /* failing end date */)
     case notAdvancing(Date /* next */, Date /* previous */)
 }
 
 /// This class is a placeholder and work-in-progress to provide an implementation of the Gregorian calendar.
-internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
+package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
 #if canImport(os)
     internal static let logger: Logger = {
@@ -191,7 +191,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
     let inf_ti : TimeInterval = 4398046511104.0
 
-    init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
+    package init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
 
         // ISO8601 has different default values for time zone, locale, firstWeekday, and minimumDaysInFirstWeek
         let defaultTimeZone: TimeZone
@@ -250,14 +250,14 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         self.identifier = identifier
     }
 
-    let identifier: Calendar.Identifier
+    package let identifier: Calendar.Identifier
 
-    var locale: Locale?
+    package var locale: Locale?
 
-    var timeZone: TimeZone
+    package var timeZone: TimeZone
 
     var _firstWeekday: Int?
-    var firstWeekday: Int {
+    package var firstWeekday: Int {
         set {
             precondition(newValue >= 1 && newValue <= 7, "Weekday should be in the range of 1...7")
             _firstWeekday = newValue
@@ -275,7 +275,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     }
 
     var _minimumDaysInFirstWeek: Int?
-    var minimumDaysInFirstWeek: Int {
+    package var minimumDaysInFirstWeek: Int {
         set {
             if newValue < 1 {
                 _minimumDaysInFirstWeek = 1
@@ -298,7 +298,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         }
     }
 
-    func copy(changingLocale: Locale?, changingTimeZone: TimeZone?, changingFirstWeekday: Int?, changingMinimumDaysInFirstWeek: Int?) -> _CalendarProtocol {
+    package func copy(changingLocale: Locale?, changingTimeZone: TimeZone?, changingFirstWeekday: Int?, changingMinimumDaysInFirstWeek: Int?) -> _CalendarProtocol {
         let newTimeZone = changingTimeZone ?? self.timeZone
         let newLocale = changingLocale ?? self.locale
 
@@ -323,7 +323,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return _CalendarGregorian.init(identifier: identifier, timeZone: newTimeZone, locale: newLocale, firstWeekday: newFirstWeekday, minimumDaysInFirstWeek: newMinDays, gregorianStartDate: nil)
     }
 
-    func hash(into hasher: inout Hasher) {
+    package func hash(into hasher: inout Hasher) {
         hasher.combine(identifier)
         hasher.combine(timeZone)
         hasher.combine(firstWeekday)
@@ -337,7 +337,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
     // Returns the range of a component in Gregorian Calendar.
     // When there are multiple possible upper bounds, the smallest one is returned.
-    func minimumRange(of component: Calendar.Component) -> Range<Int>? {
+    package func minimumRange(of component: Calendar.Component) -> Range<Int>? {
         switch component {
         case .era: 0..<2
         case .year: 1..<140743
@@ -362,7 +362,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
     // Returns the range of a component in Gregorian Calendar.
     // When there are multiple possible upper bounds, the largest one is returned.
-    func maximumRange(of component: Calendar.Component) -> Range<Int>? {
+    package func maximumRange(of component: Calendar.Component) -> Range<Int>? {
         switch component {
         case .era: return 0..<2
         case .year: return 1..<144684
@@ -497,7 +497,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return ord1..<(ord2 + 1)
     }
 
-    func range(of smaller: Calendar.Component, in larger: Calendar.Component, for date: Date) -> Range<Int>? {
+    package func range(of smaller: Calendar.Component, in larger: Calendar.Component, for date: Date) -> Range<Int>? {
         func isValidComponent(_ c: Calendar.Component) -> Bool {
             return !(c == .calendar || c == .timeZone || c == .weekdayOrdinal || c == .nanosecond)
         }
@@ -865,7 +865,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
     // FIXME: This is almost the same with Calendar_ICU's _locked_start(of:).
     // There is a chance of refactoring Calendar_ICU to use this one
-    func start(of unit: Calendar.Component, at: Date) -> Date? {
+    package func start(of unit: Calendar.Component, at: Date) -> Date? {
         let time = at.timeIntervalSinceReferenceDate
 
         var effectiveUnit = unit
@@ -922,7 +922,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return (work, daysAdded)
     }
 
-    func ordinality(of smaller: Calendar.Component, in larger: Calendar.Component, for date: Date) -> Int? {
+    package func ordinality(of smaller: Calendar.Component, in larger: Calendar.Component, for date: Date) -> Int? {
         let result: Int?
         do {
             result = try _ordinality(of: smaller, in: larger, for: date)
@@ -1445,7 +1445,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         // No return here to ensure we've covered all cases in switch statements above, even via `default`.
     }
 
-    func dateInterval(of component: Calendar.Component, for date: Date) -> DateInterval? {
+    package func dateInterval(of component: Calendar.Component, for date: Date) -> DateInterval? {
         let time = date.timeIntervalSinceReferenceDate
         var effectiveUnit = component
         switch effectiveUnit {
@@ -1582,7 +1582,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return TimeInterval(totalSecond)
     }
 
-    func isDateInWeekend(_ date: Date) -> Bool {
+    package func isDateInWeekend(_ date: Date) -> Bool {
         let weekendRange: WeekendRange
         if let localeWeekendRange = locale?.weekendRange {
             weekendRange = localeWeekendRange
@@ -1595,7 +1595,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     }
 
     // For testing purpose
-    internal func isDateInWeekend(_ date: Date, weekendRange: WeekendRange) -> Bool {
+    package func isDateInWeekend(_ date: Date, weekendRange: WeekendRange) -> Bool {
 
         // First, compare the day of the week
         let dayOfWeek = dateComponent(.weekday, from: date)
@@ -1660,7 +1660,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return true
     }
 
-    func date(from components: DateComponents) -> Date? {
+    package func date(from components: DateComponents) -> Date? {
         guard _CalendarGregorian.isComponentsInSupportedRange(components) else {
 
             // One or more values exceeds supported date range
@@ -1682,7 +1682,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return relativeWeekday
     }
 
-    func numberOfDaysInMonth(_ month: Int, year: Int) -> Int {
+    package func numberOfDaysInMonth(_ month: Int, year: Int) -> Int {
         var month = month
         var year = year
         if month > 12 {
@@ -1978,7 +1978,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return weekNo
     }
 
-    func dateComponents(_ components: Calendar.ComponentSet, from d: Date, in timeZone: TimeZone) -> DateComponents {
+    package func dateComponents(_ components: Calendar.ComponentSet, from d: Date, in timeZone: TimeZone) -> DateComponents {
         let timezoneOffset = timeZone.secondsFromGMT(for: d)
         let localDate = d + Double(timezoneOffset)
 
@@ -2132,11 +2132,11 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return dc
     }
 
-    func dateComponents(_ components: Calendar.ComponentSet, from date: Date) -> DateComponents {
+    package func dateComponents(_ components: Calendar.ComponentSet, from date: Date) -> DateComponents {
         dateComponents(components, from: date, in: timeZone)
     }
 
-    func dateComponent(_ component: Calendar.Component, from date: Date) -> Int {
+    package func dateComponent(_ component: Calendar.Component, from date: Date) -> Int {
         guard let value = dateComponents(.init(single: component), from: date, in: timeZone).value(for: component) else {
             preconditionFailure("dateComponents(:from:in:) unexpectedly returns nil for requested component")
         }
@@ -2227,7 +2227,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return nil
     }
 
-    func add(_ field: Calendar.Component, to date: Date, amount: Int, inTimeZone timeZone: TimeZone) throws (GregorianCalendarError) -> Date {
+    package func add(_ field: Calendar.Component, to date: Date, amount: Int, inTimeZone timeZone: TimeZone) throws (GregorianCalendarError) -> Date {
 
         guard amount != 0 else {
             return date
@@ -2406,7 +2406,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return newValue
     }
 
-    func addAndWrap(_ field: Calendar.Component, to date: Date, amount: Int, inTimeZone timeZone: TimeZone) throws (GregorianCalendarError) -> Date {
+    package func addAndWrap(_ field: Calendar.Component, to date: Date, amount: Int, inTimeZone timeZone: TimeZone) throws (GregorianCalendarError) -> Date {
 
         guard amount != 0 else {
             return date
@@ -2851,7 +2851,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         return result
     }
 
-    func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date? {
+    package func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date? {
         do {
             if wrappingComponents {
                 return try self.date(byAddingAndWrapping: components, to: date)
@@ -2866,7 +2866,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     // MARK: Differences
 
     // Calendar::fieldDifference
-    func difference(inComponent component: Calendar.Component, from start: Date, to end: Date) throws (GregorianCalendarError) -> (difference: Int, newStart: Date) {
+    package func difference(inComponent component: Calendar.Component, from start: Date, to end: Date) throws (GregorianCalendarError) -> (difference: Int, newStart: Date) {
         guard end != start else {
             return (0, start)
         }
@@ -2944,7 +2944,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     }
 
 
-    func dateComponents(_ components: Calendar.ComponentSet, from start: Date, to end: Date) -> DateComponents {
+    package func dateComponents(_ components: Calendar.ComponentSet, from start: Date, to end: Date) -> DateComponents {
 
         var diffsInNano: Int
         var curr: Date

--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -142,7 +142,7 @@ extension UInt8 {
     internal static var _newline: UInt8 { UInt8(ascii: "\n") }
     internal static var _tab: UInt8 { UInt8(ascii: "\t") }
 
-    internal static var _colon: UInt8 { UInt8(ascii: ":") }
+    package static var _colon: UInt8 { UInt8(ascii: ":") }
     internal static let _semicolon = UInt8(ascii: ";")
     internal static var _comma: UInt8 { UInt8(ascii: ",") }
 
@@ -175,7 +175,7 @@ extension UInt8 {
         return Int(self &- UInt8(ascii: "0"))
     }
 
-    internal var isLetter: Bool? {
+    package var isLetter: Bool? {
         return (0x41 ... 0x5a) ~= self || (0x61 ... 0x7a) ~= self
     }
 }

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -444,7 +444,7 @@ extension Decimal : ExpressibleByIntegerLiteral {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal: Hashable {
-    internal subscript(index: UInt32) -> UInt16 {
+    package subscript(index: UInt32) -> UInt16 {
         get {
             switch index {
             case 0: return _mantissa.0

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -68,15 +68,15 @@ private let powerOfTen: [Decimal.VariableLengthInteger] = [
 
 // MARK: - Mathmatics
 extension Decimal {
-    internal static let maxSize: UInt32 = 8
+    package static let maxSize: UInt32 = 8
 
-    internal enum _CalculationError: Error {
+    package enum _CalculationError: Error {
         case overflow
         case underflow
         case divideByZero
     }
 
-    internal func _add(
+    package func _add(
         rhs: Decimal,
         roundingMode: RoundingMode
     ) throws -> (result: Decimal, lossOfPrecision: Bool) {
@@ -154,7 +154,7 @@ extension Decimal {
         return (result: result, lossOfPrecision: lossOfPrecision)
     }
 
-    internal func _add(_ amount: UInt16) throws -> Decimal {
+    package func _add(_ amount: UInt16) throws -> Decimal {
         var result = self
         var carry: UInt32 = UInt32(amount)
         var index: UInt32 = 0
@@ -175,7 +175,7 @@ extension Decimal {
         return result
     }
 
-    internal func _subtract(
+    package func _subtract(
         rhs: Decimal,
         roundingMode: RoundingMode
     ) throws -> Decimal {
@@ -215,7 +215,7 @@ extension Decimal {
         return result
     }
 
-    internal func _multiply(
+    package func _multiply(
         by multiplicand: Decimal,
         roundingMode: RoundingMode
     ) throws -> Decimal {
@@ -250,7 +250,7 @@ extension Decimal {
         return result
     }
 
-    internal func _multiplyByPowerOfTen(
+    package func _multiplyByPowerOfTen(
         power: Int, roundingMode: RoundingMode
     ) throws -> Decimal {
         if self.isNaN {
@@ -294,7 +294,7 @@ extension Decimal {
         return (result: result, remainder: UInt16(remainder))
     }
 
-    internal func _divide(
+    package func _divide(
         by divisor: Decimal,
         roundingMode: RoundingMode
     ) throws -> Decimal {
@@ -366,7 +366,7 @@ extension Decimal {
         return result
     }
 
-    internal func _power(
+    package func _power(
         exponent: Int, roundingMode: RoundingMode
     ) throws -> Decimal {
         if self.isNaN {
@@ -410,7 +410,7 @@ extension Decimal {
         return result
     }
 
-    internal static func _compare(lhs: Decimal, rhs: Decimal) -> ComparisonResult {
+    package static func _compare(lhs: Decimal, rhs: Decimal) -> ComparisonResult {
         if lhs.isNaN {
             if rhs.isNaN {
                 return .orderedSame
@@ -457,7 +457,7 @@ extension Decimal {
         return result
     }
 
-    internal static func _normalize(a: inout Decimal, b: inout Decimal, roundingMode: RoundingMode) throws -> Bool {
+    package static func _normalize(a: inout Decimal, b: inout Decimal, roundingMode: RoundingMode) throws -> Bool {
         var diffExp = Int(a._exponent - b._exponent)
         // If the two numbers share the same exponents,
         // the normalization is already done
@@ -529,7 +529,7 @@ extension Decimal {
         }
     }
 
-    internal mutating func compact() {
+    package mutating func compact() {
         var secureExponent = self._exponent
         if self._isCompact != 0 || self.isNaN || self._length == 0 {
             // No need to compact
@@ -564,7 +564,7 @@ extension Decimal {
         self._isCompact = 1
     }
 
-    internal func _round(
+    package func _round(
         scale: Int, roundingMode: RoundingMode
     ) throws -> Decimal {
         var s = scale + Int(self._exponent)
@@ -654,7 +654,7 @@ extension Decimal {
 
 // MARK: - Numeric Values
 extension Decimal {
-    internal var doubleValue: Double {
+    package var doubleValue: Double {
         if _length == 0 {
             return _isNegative == 1 ? Double.nan : 0
         }
@@ -701,7 +701,7 @@ extension Decimal {
         return UInt64(value._mantissa.3) << 48 | UInt64(value._mantissa.2) << 32 | UInt64(value._mantissa.1) << 16 | UInt64(value._mantissa.0)
     }
 
-    internal var int64Value: Int64 {
+    package var int64Value: Int64 {
         let uint64Value = self._unsignedInt64Value
         if self._isNegative > 0 {
             if uint64Value == Int64.max.magnitude + 1 {
@@ -716,7 +716,7 @@ extension Decimal {
         return Int64(bitPattern: uint64Value)
     }
 
-    internal var uint64Value: UInt64 {
+    package var uint64Value: UInt64 {
         let value = self._unsignedInt64Value
         if self._isNegative == 0 {
             return value

--- a/Sources/FoundationEssentials/Decimal/Decimal.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal.swift
@@ -41,7 +41,7 @@ public struct Decimal: Sendable {
     internal var storage: Storage
 
     // Int8
-    internal var _exponent: Int32 {
+    package var _exponent: Int32 {
         get {
             return Int32(self.storage.exponent)
         }
@@ -51,7 +51,7 @@ public struct Decimal: Sendable {
     }
 
     // 4 bits
-    internal var _length: UInt32 {
+    package var _length: UInt32 {
         get {
             return UInt32(self.storage.lengthFlagsAndReserved >> 4)
         }
@@ -63,7 +63,7 @@ public struct Decimal: Sendable {
     }
     
     // Bool
-    internal var _isNegative: UInt32 {
+    package var _isNegative: UInt32 {
         get {
             return UInt32((self.storage.lengthFlagsAndReserved >> 3) & 0x01)
         }
@@ -77,7 +77,7 @@ public struct Decimal: Sendable {
     }
     
     // Bool
-    internal var _isCompact: UInt32 {
+    package var _isCompact: UInt32 {
         get {
             return UInt32((self.storage.lengthFlagsAndReserved >> 2) & 0x01)
         }
@@ -91,7 +91,7 @@ public struct Decimal: Sendable {
     }
     
     // Only 18 bits
-    internal var _reserved: UInt32 {
+    package var _reserved: UInt32 {
         get {
             return (UInt32(self.storage.lengthFlagsAndReserved & 0x03) << 16) | UInt32(self.storage.reserved)
         }
@@ -103,7 +103,7 @@ public struct Decimal: Sendable {
         }
     }
 
-    internal var _mantissa: Mantissa {
+    package var _mantissa: Mantissa {
         get {
             return self.storage.mantissa
         }
@@ -206,7 +206,7 @@ extension Decimal {
         _decimal(from: stringView, decimalSeparator: decimalSeparator, matchEntireString: matchEntireString).asOptional
     }
 #endif
-    internal func _toString(withDecimalSeparator separator: String) -> String {
+    package func _toString(withDecimalSeparator separator: String) -> String {
         if self.isNaN {
             return "NaN"
         }

--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -90,7 +90,7 @@ extension CocoaError {
         }
     }
     
-    static func errorWithFilePath(_ path: String, errno: Int32, reading: Bool, variant: String? = nil, source: String? = nil, destination: String? = nil) -> CocoaError {
+    package static func errorWithFilePath(_ path: String, errno: Int32, reading: Bool, variant: String? = nil, source: String? = nil, destination: String? = nil) -> CocoaError {
         CocoaError(Code(fileErrno: errno, reading: reading), path: path, underlying: POSIXError(errno: errno), variant: variant, source: source, destination: destination)
     }
     

--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+SearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+SearchPaths.swift
@@ -84,7 +84,7 @@ func _SearchPathURLs(for directory: FileManager.SearchPathDirectory, in domain: 
 #if FOUNDATION_FRAMEWORK
 @_cdecl("_NSSearchPathsForDirectoryInDomain")
 #endif
-func _DarwinSearchPaths(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, expandTilde: Bool) -> [String] {
+package func _DarwinSearchPaths(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, expandTilde: Bool) -> [String] {
     let basic = _DarwinSearchPathsSequence(directory: directory, domainMask: domain.intersection(.valid)).lazy.map {
         if expandTilde {
             $0.expandingTildeInPath

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManagerDelegate.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManagerDelegate.swift
@@ -35,7 +35,7 @@ public protocol FileManagerDelegate : AnyObject, Sendable {
 }
 
 // Default implementations for String-based requirements
-extension FileManagerDelegate {
+package extension FileManagerDelegate {
     func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
     func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
     func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
@@ -47,7 +47,7 @@ extension FileManagerDelegate {
 }
 
 // Default implementations for URL-based requirements
-extension FileManagerDelegate {
+package extension FileManagerDelegate {
     func fileManager(_ fileManager: FileManager, shouldCopyItemAt srcURL: URL, to dstURL: URL) -> Bool {
         self.fileManager(fileManager, shouldCopyItemAtPath: srcURL.relativePath, toPath: dstURL.relativePath)
     }

--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -48,7 +48,7 @@ extension BinaryInteger {
 ///   - words: The binary integer's words (least-significant word first).
 ///   - isSigned: The binary integer's signedness.  If true, `words` must be in two's complement form.
 ///
-internal func numericStringRepresentationForBinaryInteger(words: some Collection<UInt>, isSigned: Bool) -> String {
+package func numericStringRepresentationForBinaryInteger(words: some Collection<UInt>, isSigned: Bool) -> String {
     // Copies the words and then passes them to a non-generic, mutating, word-based algorithm.
     withUnsafeTemporaryAllocation(of: UInt.self, capacity: words.count) {
         let initializedEndIndex = $0.initialize(fromContentsOf: words)

--- a/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
@@ -296,7 +296,7 @@ extension Date.ISO8601FormatStyle : FormatStyle {
         return format(components, appendingTimeZoneOffset: secondsFromGMT)
     }
 
-    func format(_ components: DateComponents, appendingTimeZoneOffset timeZoneOffset: Int?) -> String {
+    package func format(_ components: DateComponents, appendingTimeZoneOffset timeZoneOffset: Int?) -> String {
         var needSeparator = false
         let capacity = 128 // It is believed no ISO8601 date can exceed this size
         let result = withUnsafeTemporaryAllocation(of: CChar.self, capacity: capacity + 1) { _buffer in

--- a/Sources/FoundationEssentials/Formatting/FormatterCache.swift
+++ b/Sources/FoundationEssentials/Formatting/FormatterCache.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 package struct FormatterCache<Format : Hashable & Sendable, FormattingType: Sendable>: Sendable {
-    let countLimit = 100
+    package let countLimit = 100
 
     private let _lock: LockedState<[Format: FormattingType]>
     package func formatter(for config: Format, creator: () throws -> FormattingType) rethrows -> FormattingType {

--- a/Sources/FoundationEssentials/JSON/BufferView.swift
+++ b/Sources/FoundationEssentials/JSON/BufferView.swift
@@ -13,9 +13,9 @@
 // A BufferView<Element> represents a span of memory which
 // contains initialized `Element` instances.
 
-internal struct BufferView<Element> {
+package struct BufferView<Element> {
     let start: BufferViewIndex<Element>
-    let count: Int
+    package let count: Int
 
     private var baseAddress: UnsafeRawPointer { start._rawValue }
 
@@ -34,11 +34,11 @@ internal struct BufferView<Element> {
         self.init(_unchecked: (index, count))
     }
 
-    init(unsafeBaseAddress: UnsafeRawPointer, count: Int) {
+    package init(unsafeBaseAddress: UnsafeRawPointer, count: Int) {
         self.init(start: .init(rawValue: unsafeBaseAddress), count: count)
     }
 
-    init?(unsafeBufferPointer buffer: UnsafeBufferPointer<Element>) {
+    package init?(unsafeBufferPointer buffer: UnsafeBufferPointer<Element>) {
         guard let baseAddress = UnsafeRawPointer(buffer.baseAddress) else { return nil }
         self.init(unsafeBaseAddress: baseAddress, count: buffer.count)
     }
@@ -46,7 +46,7 @@ internal struct BufferView<Element> {
 
 extension BufferView /*where Element: BitwiseCopyable*/ {
 
-    init?(unsafeRawBufferPointer buffer: UnsafeRawBufferPointer) {
+    package init?(unsafeRawBufferPointer buffer: UnsafeRawBufferPointer) {
         guard _isPOD(Element.self) else { fatalError() }
         guard let p = buffer.baseAddress else { return nil }
         let (q, r) = buffer.count.quotientAndRemainder(dividingBy: MemoryLayout<Element>.stride)
@@ -59,12 +59,12 @@ extension BufferView /*where Element: BitwiseCopyable*/ {
 
 extension BufferView: Sequence {
 
-    func makeIterator() -> BufferViewIterator<Element> {
+    package func makeIterator() -> BufferViewIterator<Element> {
         .init(from: startIndex, to: endIndex)
     }
 
     //FIXME: mark closure parameter as non-escaping
-    func withContiguousStorageIfAvailable<R>(
+    package func withContiguousStorageIfAvailable<R>(
         _ body: (UnsafeBufferPointer<Element>) throws -> R
     ) rethrows -> R? {
         try baseAddress.withMemoryRebound(to: Element.self, capacity: count) {
@@ -102,18 +102,18 @@ extension BufferView:
     BidirectionalCollection,
     RandomAccessCollection {
 
-    typealias Element = Element
-    typealias Index = BufferViewIndex<Element>
-    typealias SubSequence = Self
+    package typealias Element = Element
+    package typealias Index = BufferViewIndex<Element>
+    package typealias SubSequence = Self
 
     @inline(__always)
-    var startIndex: Index { start }
+    package var startIndex: Index { start }
 
     @inline(__always)
-    var endIndex: Index { start.advanced(by: count) }
+    package var endIndex: Index { start.advanced(by: count) }
 
     @inline(__always)
-    var indices: Range<Index> {
+    package var indices: Range<Index> {
         .init(uncheckedBounds: (startIndex, endIndex))
     }
 
@@ -165,27 +165,27 @@ extension BufferView:
     }
 
     @inline(__always)
-    func index(after i: Index) -> Index {
+    package func index(after i: Index) -> Index {
         i.advanced(by: +1)
     }
 
     @inline(__always)
-    func index(before i: Index) -> Index {
+    package func index(before i: Index) -> Index {
         i.advanced(by: -1)
     }
 
     @inline(__always)
-    func formIndex(after i: inout Index) {
+    package func formIndex(after i: inout Index) {
         i = index(after: i)
     }
 
     @inline(__always)
-    func formIndex(before i: inout Index) {
+    package func formIndex(before i: inout Index) {
         i = index(before: i)
     }
 
     @inline(__always)
-    func index(_ i: Index, offsetBy distance: Int) -> Index {
+    package func index(_ i: Index, offsetBy distance: Int) -> Index {
         i.advanced(by: distance)
     }
 
@@ -195,12 +195,12 @@ extension BufferView:
     }
 
     @inline(__always)
-    func distance(from start: Index, to end: Index) -> Int {
+    package func distance(from start: Index, to end: Index) -> Int {
         start.distance(to: end)
     }
 
     @inline(__always)
-    subscript(position: Index) -> Element {
+    package subscript(position: Index) -> Element {
         get {
             _checkBounds(position)
             return self[unchecked: position]
@@ -208,7 +208,7 @@ extension BufferView:
     }
 
     @inline(__always)
-    subscript(unchecked position: Index) -> Element {
+    package subscript(unchecked position: Index) -> Element {
         get {
             if _isPOD(Element.self) {
                 return position._rawValue.loadUnaligned(as: Element.self)
@@ -219,7 +219,7 @@ extension BufferView:
     }
 
     @inline(__always)
-    subscript(bounds: Range<Index>) -> Self {
+    package subscript(bounds: Range<Index>) -> Self {
         get {
             _checkBounds(bounds)
             return self[unchecked: bounds]
@@ -227,7 +227,7 @@ extension BufferView:
     }
 
     @inline(__always)
-    subscript(unchecked bounds: Range<Index>) -> Self {
+    package subscript(unchecked bounds: Range<Index>) -> Self {
         get { BufferView(_unchecked: (bounds.lowerBound, bounds.count)) }
     }
 
@@ -237,7 +237,7 @@ extension BufferView:
         }
     }
 
-    subscript(unchecked bounds: some RangeExpression<Index>) -> Self {
+    package subscript(unchecked bounds: some RangeExpression<Index>) -> Self {
         get {
             self[unchecked: bounds.relative(to: self)]
         }
@@ -254,14 +254,14 @@ extension BufferView:
 extension BufferView /* where Element: BitwiseCopyable */ {
 
     //FIXME: mark closure parameter as non-escaping
-    func withUnsafeRawPointer<R>(
+    package func withUnsafeRawPointer<R>(
         _ body: (_ pointer: UnsafeRawPointer, _ count: Int) throws -> R
     ) rethrows -> R {
         try body(baseAddress, count * MemoryLayout<Element>.stride)
     }
 
     //FIXME: mark closure parameter as non-escaping
-    func withUnsafeBytes<R>(
+    package func withUnsafeBytes<R>(
         _ body: (_ buffer: UnsafeRawBufferPointer) throws -> R
     ) rethrows -> R {
         try body(.init(start: baseAddress, count: count))
@@ -272,7 +272,7 @@ extension BufferView /* where Element: BitwiseCopyable */ {
 extension BufferView {
 
     //FIXME: mark closure parameter as non-escaping
-    func withUnsafePointer<R>(
+    package func withUnsafePointer<R>(
         _ body: (
             _ pointer: UnsafePointer<Element>,
             _ capacity: Int
@@ -284,7 +284,7 @@ extension BufferView {
     }
 
     //FIXME: mark closure parameter as non-escaping
-    func withUnsafeBufferPointer<R>(
+    package func withUnsafeBufferPointer<R>(
         _ body: (UnsafeBufferPointer<Element>) throws -> R
     ) rethrows -> R {
         try baseAddress.withMemoryRebound(to: Element.self, capacity: count) {
@@ -296,7 +296,7 @@ extension BufferView {
 //MARK: load and store
 extension BufferView /* where Element: BitwiseCopyable */ {
 
-    func load<T>(
+    package func load<T>(
         fromByteOffset offset: Int = 0, as: T.Type
     ) -> T {
         guard _isPOD(Element.self) else { fatalError() }
@@ -310,12 +310,12 @@ extension BufferView /* where Element: BitwiseCopyable */ {
         return baseAddress.load(fromByteOffset: offset, as: T.self)
     }
 
-    func load<T>(from index: Index, as: T.Type) -> T {
+    package func load<T>(from index: Index, as: T.Type) -> T {
         let o = distance(from: startIndex, to: index) * MemoryLayout<Element>.stride
         return load(fromByteOffset: o, as: T.self)
     }
 
-    func loadUnaligned<T /*: BitwiseCopyable */>(
+    package func loadUnaligned<T /*: BitwiseCopyable */>(
         fromByteOffset offset: Int = 0, as: T.Type
     ) -> T {
         guard _isPOD(Element.self) && _isPOD(T.self) else { fatalError() }
@@ -329,7 +329,7 @@ extension BufferView /* where Element: BitwiseCopyable */ {
         return baseAddress.loadUnaligned(fromByteOffset: offset, as: T.self)
     }
 
-    func loadUnaligned<T /*: BitwiseCopyable */>(
+    package func loadUnaligned<T /*: BitwiseCopyable */>(
         from index: Index, as: T.Type
     ) -> T {
         let o = distance(from: startIndex, to: index) * MemoryLayout<Element>.stride
@@ -342,7 +342,7 @@ extension BufferView /* where Element: BitwiseCopyable */ {
 extension BufferView {
 
     @inline(__always)
-    subscript(offset offset: Int) -> Element {
+    package subscript(offset offset: Int) -> Element {
         get {
             precondition(0 <= offset && offset < count)
             return self[uncheckedOffset: offset]

--- a/Sources/FoundationEssentials/JSON/BufferViewIndex.swift
+++ b/Sources/FoundationEssentials/JSON/BufferViewIndex.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal struct BufferViewIndex<Element> {
+package struct BufferViewIndex<Element> {
     let _rawValue: UnsafeRawPointer
 
     @inline(__always)
@@ -29,22 +29,22 @@ extension BufferViewIndex: Equatable {}
 extension BufferViewIndex: Hashable {}
 
 extension BufferViewIndex: Strideable {
-    typealias Stride = Int
+    package typealias Stride = Int
 
     @inline(__always)
-    func distance(to other: BufferViewIndex) -> Int {
+    package func distance(to other: BufferViewIndex) -> Int {
         _rawValue.distance(to: other._rawValue) / MemoryLayout<Element>.stride
     }
 
     @inline(__always)
-    func advanced(by n: Int) -> BufferViewIndex {
+    package func advanced(by n: Int) -> BufferViewIndex {
         .init(rawValue: _rawValue.advanced(by: n &* MemoryLayout<Element>.stride))
     }
 }
 
 extension BufferViewIndex: Comparable {
     @inline(__always)
-    static func < (lhs: BufferViewIndex, rhs: BufferViewIndex) -> Bool {
+    package static func < (lhs: BufferViewIndex, rhs: BufferViewIndex) -> Bool {
         lhs._rawValue < rhs._rawValue
     }
 }

--- a/Sources/FoundationEssentials/JSON/BufferViewIterator.swift
+++ b/Sources/FoundationEssentials/JSON/BufferViewIterator.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal struct BufferViewIterator<Element> {
+package struct BufferViewIterator<Element> {
     var curPointer: UnsafeRawPointer
     let endPointer: UnsafeRawPointer
 
@@ -26,7 +26,7 @@ internal struct BufferViewIterator<Element> {
 
 extension BufferViewIterator: IteratorProtocol {
 
-    mutating func next() -> Element? {
+    mutating package func next() -> Element? {
         guard curPointer < endPointer else { return nil }
         defer {
             curPointer = curPointer.advanced(by: MemoryLayout<Element>.stride)

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -1180,16 +1180,16 @@ extension FixedWidthInteger {
     }
 }
 
-internal extension UInt8 {
-    static var _verticalTab: UInt8 { UInt8(0x0b) }
-    static var _formFeed: UInt8 { UInt8(0x0c) }
-    static var _nbsp: UInt8 { UInt8(0xa0) }
-    static var _asterisk: UInt8 { UInt8(ascii: "*") }
-    static var _slash: UInt8 { UInt8(ascii: "/") }
-    static var _singleQuote: UInt8 { UInt8(ascii: "'") }
-    static var _dollar: UInt8 { UInt8(ascii: "$") }
-    static var _underscore: UInt8 { UInt8(ascii: "_") }
-    static var _dot: UInt8 { UInt8(ascii: ".") }
+extension UInt8 {
+    internal static var _verticalTab: UInt8 { UInt8(0x0b) }
+    internal static var _formFeed: UInt8 { UInt8(0x0c) }
+    internal static var _nbsp: UInt8 { UInt8(0xa0) }
+    internal static var _asterisk: UInt8 { UInt8(ascii: "*") }
+    package static var _slash: UInt8 { UInt8(ascii: "/") }
+    internal static var _singleQuote: UInt8 { UInt8(ascii: "'") }
+    internal static var _dollar: UInt8 { UInt8(ascii: "$") }
+    internal static var _underscore: UInt8 { UInt8(ascii: "_") }
+    internal static var _dot: UInt8 { UInt8(ascii: ".") }
 }
 
 var _json5Infinity: StaticString { "Infinity" }

--- a/Sources/FoundationEssentials/Locale/Locale.swift
+++ b/Sources/FoundationEssentials/Locale/Locale.swift
@@ -57,7 +57,7 @@ public struct Locale : Hashable, Equatable, Sendable {
         case cldr
     }
 
-    internal var _locale: any _LocaleProtocol
+    package var _locale: any _LocaleProtocol
 
     /// Returns a locale which tracks the user's current preferences.
     ///
@@ -79,7 +79,7 @@ public struct Locale : Hashable, Equatable, Sendable {
     }
     
     /// Unlocalized locale (`en_001`).
-    internal static var unlocalized : Locale {
+    package static var unlocalized : Locale {
         Locale(inner: LocaleCache.unlocalized)
     }
 
@@ -90,7 +90,7 @@ public struct Locale : Hashable, Equatable, Sendable {
     }
 #endif
     /// This returns an instance of `Locale` that's set up exactly like it would be if the user changed the current locale to that identifier, set the preferences keys in the overrides dictionary, then called `current`.
-    internal static func localeAsIfCurrent(name: String?, overrides: LocalePreferences? = nil, disableBundleMatching: Bool = false) -> Locale {
+    package static func localeAsIfCurrent(name: String?, overrides: LocalePreferences? = nil, disableBundleMatching: Bool = false) -> Locale {
         // On Darwin, this overrides are applied on top of CFPreferences.
         return LocaleCache.cache.localeAsIfCurrent(name: name, overrides: overrides, disableBundleMatching: disableBundleMatching)
     }

--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -32,7 +32,7 @@ dynamic package func _localeICUClass() -> _LocaleProtocol.Type {
 #endif
 
 /// Singleton which listens for notifications about preference changes for Locale and holds cached singletons.
-struct LocaleCache : Sendable, ~Copyable {
+package struct LocaleCache : Sendable, ~Copyable {
     // MARK: - State
 
     struct State {
@@ -117,7 +117,7 @@ struct LocaleCache : Sendable, ~Copyable {
 
     let lock: LockedState<State>
 
-    static let cache = LocaleCache()
+    package static let cache = LocaleCache()
     private let _currentCache = LockedState<(any _LocaleProtocol)?>(initialState: nil)
 
 #if FOUNDATION_FRAMEWORK
@@ -131,7 +131,7 @@ struct LocaleCache : Sendable, ~Copyable {
 
     /// For testing of `autoupdatingCurrent` only. If you want to test `current`, create a custom `Locale` with the appropriate settings using `localeAsIfCurrent(name:overrides:disableBundleMatching:)` and use that instead.
     /// This mutates global state of the current locale, so it is not safe to use in concurrent testing.
-    func resetCurrent(to preferences: LocalePreferences) {
+    package func resetCurrent(to preferences: LocalePreferences) {
         // Disable bundle matching so we can emulate a non-English main bundle during test
         let newLocale = _localeICUClass().init(name: nil, prefs: preferences, disableBundleMatching: true)
         _currentCache.withLock {
@@ -142,7 +142,7 @@ struct LocaleCache : Sendable, ~Copyable {
 #endif
     }
 
-    func reset() {
+    package func reset() {
         _currentCache.withLock { $0 = nil }
 #if FOUNDATION_FRAMEWORK
         _currentNSCache.withLock { $0 = nil }

--- a/Sources/FoundationEssentials/PropertyList/XMLPlistEncodingFormat.swift
+++ b/Sources/FoundationEssentials/PropertyList/XMLPlistEncodingFormat.swift
@@ -593,7 +593,7 @@ private class __PlistReferencingEncoderXML : __PlistEncoderXML {
 
 // MARK: - Format
 
-struct _XMLPlistEncodingFormat : PlistEncodingFormat {
+package struct _XMLPlistEncodingFormat : PlistEncodingFormat {
     enum Reference: PlistEncodingReference {
         
         class Box<T> {
@@ -703,9 +703,9 @@ struct _XMLPlistEncodingFormat : PlistEncodingFormat {
         }
     }
     
-    struct Writer : PlistWriting {
-        
-        static let header: StaticString =
+    package struct Writer : PlistWriting {
+
+        package static let header: StaticString =
 """
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/Sources/FoundationEssentials/String/BidirectionalCollection.swift
+++ b/Sources/FoundationEssentials/String/BidirectionalCollection.swift
@@ -35,7 +35,7 @@ extension BidirectionalCollection where Index == String.Index {
 }
 
 extension BidirectionalCollection {
-    func _trimmingCharacters(while predicate: (Element) -> Bool) -> SubSequence {
+    package func _trimmingCharacters(while predicate: (Element) -> Bool) -> SubSequence {
         var idx = startIndex
         while idx < endIndex && predicate(self[idx]) {
             formIndex(after: &idx)

--- a/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
@@ -15,7 +15,7 @@ internal import _FoundationCShims
 // Represents sets of unicode scalars of those whose bitmap data we own.
 // whitespace, whitespaceAndNewline, and newline are not included since they're not stored with bitmaps
 // This only contains a subset of predefined CFCharacterSet that are in use for now.
-internal struct BuiltInUnicodeScalarSet {
+package struct BuiltInUnicodeScalarSet {
     enum SetType {
         case lowercaseLetter
         case uppercaseLetter
@@ -51,7 +51,7 @@ internal struct BuiltInUnicodeScalarSet {
     }
 
     // CFUniCharIsMemberOf
-    func contains(_ scalar: Unicode.Scalar) -> Bool {
+    package func contains(_ scalar: Unicode.Scalar) -> Bool {
         let planeNo = Int((scalar.value >> 16) & 0xFF)
         let bitmp = _bitmapPtrForPlane(planeNo)
         return _isMemberOfBitmap(scalar, bitmp)
@@ -86,11 +86,11 @@ internal struct BuiltInUnicodeScalarSet {
         return new
     }
 
-    static let uppercaseLetters = Self.init(type: .uppercaseLetter)
-    static let lowercaseLetters = Self.init(type: .lowercaseLetter)
-    static let caseIgnorables = Self.init(type: .caseIgnorable)
-    static let hfsPlusDecomposables = Self.init(type: .hfsPlusDecomposable)
-    static let graphemeExtends = Self.init(type: .graphemeExtend)
-    static let canonicalDecomposables = Self.init(type: .canonicalDecomposable)
+    package static let uppercaseLetters = Self.init(type: .uppercaseLetter)
+    package static let lowercaseLetters = Self.init(type: .lowercaseLetter)
+    package static let caseIgnorables = Self.init(type: .caseIgnorable)
+    package static let hfsPlusDecomposables = Self.init(type: .hfsPlusDecomposable)
+    package static let graphemeExtends = Self.init(type: .graphemeExtend)
+    package static let canonicalDecomposables = Self.init(type: .canonicalDecomposable)
 }
 

--- a/Sources/FoundationEssentials/String/String+Comparison.swift
+++ b/Sources/FoundationEssentials/String/String+Comparison.swift
@@ -231,7 +231,7 @@ extension _StringCompareOptionsIterable {
         return result == .orderedSame ? compareResult : result
     }
 
-    func _range<S: BidirectionalCollection>(of strToFind: S, toHalfWidth: Bool, diacriticsInsensitive: Bool, caseFold: Bool, anchored: Bool, backwards: Bool) -> Range<Index>? where S.Index == Index, S.Element == Element {
+    package func _range<S: BidirectionalCollection>(of strToFind: S, toHalfWidth: Bool, diacriticsInsensitive: Bool, caseFold: Bool, anchored: Bool, backwards: Bool) -> Range<Index>? where S.Index == Index, S.Element == Element {
 
         if !toHalfWidth && !diacriticsInsensitive && !caseFold {
             return _range(of: strToFind, anchored: anchored, backwards: backwards)
@@ -599,7 +599,7 @@ extension Substring {
         return unicodeScalars._rangeOfCharacter(anchored: options.contains(.anchored), backwards: options.contains(.backwards), matchingPredicate: set.contains)
     }
 
-    func _range(of strToFind: Substring, options: String.CompareOptions) throws -> Range<Index>? {
+    package func _range(of strToFind: Substring, options: String.CompareOptions) throws -> Range<Index>? {
         #if !NO_REGEX
         if options.contains(.regularExpression) {
             guard let regex = try RegexPatternCache.cache.regex(for: String(strToFind), caseInsensitive: options.contains(.caseInsensitive)) else {

--- a/Sources/FoundationEssentials/String/String+Encoding.swift
+++ b/Sources/FoundationEssentials/String/String+Encoding.swift
@@ -55,7 +55,7 @@ extension String {
     // - Swift doesn't allow typealias to builtin types like String
     // We therefore rename String.Encoding to String._Encoding for package
     // internal use so we can use `String._Encoding` to disambiguate.
-    internal typealias _Encoding = Encoding
+    package typealias _Encoding = Encoding
 
 #if FOUNDATION_FRAMEWORK
     public typealias EncodingConversionOptions = NSString.EncodingConversionOptions

--- a/Sources/FoundationEssentials/String/String+Essentials.swift
+++ b/Sources/FoundationEssentials/String/String+Essentials.swift
@@ -52,7 +52,7 @@ extension String {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension String {
-    func _capitalized() -> String {
+    package func _capitalized() -> String {
         var new = ""
         new.reserveCapacity(utf8.count)
 

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -46,7 +46,7 @@ extension String {
 
     // MARK: - Non-filesystem String Extensions
 
-    internal var pathComponents: [String] {
+    package var pathComponents: [String] {
         _convertingSlashesIfNeeded()._pathComponents
     }
 
@@ -76,7 +76,7 @@ extension String {
         return result
     }
 
-    internal func deletingLastPathComponent() -> String {
+    package func deletingLastPathComponent() -> String {
         _convertingSlashesIfNeeded()._deletingLastPathComponent()
     }
     
@@ -113,7 +113,7 @@ extension String {
         return String(self[...previousNonSlash])
     }
         
-    internal func appendingPathComponent(_ component: String) -> String {
+    package func appendingPathComponent(_ component: String) -> String {
         _convertingSlashesIfNeeded()._appendingPathComponent(component)
     }
     
@@ -129,7 +129,7 @@ extension String {
         return (self + "/" + component)._standardizingSlashes
     }
 
-    internal var lastPathComponent: String {
+    package var lastPathComponent: String {
         _convertingSlashesIfNeeded()._lastPathComponent
     }
     
@@ -162,7 +162,7 @@ extension String {
     }
 
     // Internal for testing purposes
-    internal static let invalidExtensionScalars = Set<Unicode.Scalar>([
+    package static let invalidExtensionScalars = Set<Unicode.Scalar>([
         " ",
         "/",
         "\u{061c}", // ARABIC LETTER MARK
@@ -179,7 +179,7 @@ extension String {
         "\u{2069}", // POP DIRECTIONAL ISOLATE
     ])
 
-    internal func deletingPathExtension() -> String {
+    package func deletingPathExtension() -> String {
         guard !pathExtension.isEmpty else {
             return self
         }
@@ -206,7 +206,7 @@ extension String {
         }
     }
 
-    internal func appendingPathExtension(_ pathExtension: String) -> String {
+    package func appendingPathExtension(_ pathExtension: String) -> String {
         guard !pathExtension.isEmpty, validatePathExtension(pathExtension) else {
             return self
         }
@@ -222,7 +222,7 @@ extension String {
         return result
     }
 
-    internal var pathExtension: String {
+    package var pathExtension: String {
         let lastComponent = lastPathComponent.utf8
         guard lastComponent.last != ._dot,
               !lastComponent.starts(with: [._dot, ._dot]),
@@ -251,7 +251,7 @@ extension String {
         return self[...basePathEnd] + relativePath
     }
 
-    internal var removingDotSegments: String {
+    package var removingDotSegments: String {
         _convertingSlashesIfNeeded()._removingDotSegments
     }
     
@@ -371,7 +371,7 @@ extension String {
     /// characters with a single `/`
     /// NOTE: Internal so it's testable
     /// - Returns: The replaced String
-    internal func _compressingSlashes() -> String {
+    package func _compressingSlashes() -> String {
         guard utf8.count > 1 else {
             return self
         }
@@ -546,7 +546,7 @@ extension String {
     }
     
     // From swift-corelibs-foundation's NSTemporaryDirectory. Internal for now, pending a better public API.
-    internal static var temporaryDirectoryPath: String {
+    package static var temporaryDirectoryPath: String {
         func normalizedPath(with path: String) -> String {
             let result = path._convertingSlashesIfNeeded()
             guard result.utf8.last != ._slash else {
@@ -655,7 +655,7 @@ extension String {
         return result
     }
 
-    var standardizingPath: String {
+    package var standardizingPath: String {
         expandingTildeInPath._standardizingPath
     }
 
@@ -713,7 +713,7 @@ extension String {
         #endif // canImport(Darwin)
     }
     
-    func _resolvingSymlinksInPath() -> String? {
+    package func _resolvingSymlinksInPath() -> String? {
         guard !isEmpty else { return nil }
         #if os(Windows)
         return try? self.withNTPathRepresentation {
@@ -868,7 +868,7 @@ extension StringProtocol {
     }
 
     // Internal for testing purposes
-    internal func _hasDotDotComponent() -> Bool {
+    package func _hasDotDotComponent() -> Bool {
         guard utf8.count >= 2 else {
             return false
         }

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -393,7 +393,7 @@ extension StringProtocol {
 
 extension StringProtocol {
     @inline(never)
-    internal func _lineBounds(
+    package func _lineBounds(
         around range: some RangeExpression<Index>
     ) -> (start: Index, end: Index, contentsEnd: Index) {
         // Avoid generic paths in the common case by manually specializing on `String` and
@@ -432,7 +432,7 @@ extension StringProtocol {
     }
 
     @inline(never)
-    internal func _paragraphBounds(
+    package func _paragraphBounds(
         around range: some RangeExpression<Index>
     ) -> (start: Index, end: Index, contentsEnd: Index) {
         // Avoid generic paths in the common case by manually specializing on `String` and

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -67,7 +67,7 @@ public struct TimeZone : Hashable, Equatable, Sendable {
         _tz = cached
     }
 
-    internal init?(name: String) {
+    package init?(name: String) {
         // Try the cache first
         if let cached = TimeZoneCache.cache.fixed(name) {
             _tz = cached

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -619,11 +619,11 @@ extension URLResourceValues : Sendable {}
 #endif // FOUNDATION_FRAMEWORK
 
 #if FOUNDATION_FRAMEWORK
-internal func foundation_swift_url_enabled() -> Bool {
+package func foundation_swift_url_enabled() -> Bool {
     return _foundation_swift_url_feature_enabled()
 }
 #else
-internal func foundation_swift_url_enabled() -> Bool { return true }
+package func foundation_swift_url_enabled() -> Bool { return true }
 #endif
 
 #if canImport(os)
@@ -805,7 +805,7 @@ public struct URL: Equatable, Sendable, Hashable {
     /// an empty string, such as when `.deletingLastPathComponent()` of a single path
     /// component. This previously worked since `URL` just wrapped an `NSURL`, which
     /// allows the empty string.
-    internal init?(stringOrEmpty: String, relativeTo url: URL? = nil) {
+    package init?(stringOrEmpty: String, relativeTo url: URL? = nil) {
         #if FOUNDATION_FRAMEWORK
         guard foundation_swift_url_enabled() else {
             guard let inner = NSURL(string: stringOrEmpty, relativeTo: url) else { return nil }
@@ -1470,7 +1470,7 @@ public struct URL: Equatable, Sendable, Hashable {
         #endif
     }
 
-    var fileSystemPath: String {
+    package var fileSystemPath: String {
         return URL.fileSystemPath(for: path())
     }
 

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -2276,7 +2276,7 @@ extension Calendar.Component {
 }
 
 extension Calendar {
-    static func localeIdentifierWithCalendar(localeIdentifier: String, calendarIdentifier: Calendar.Identifier) -> String? {
+    package static func localeIdentifierWithCalendar(localeIdentifier: String, calendarIdentifier: Calendar.Identifier) -> String? {
         var comps = Locale.Components(identifier: localeIdentifier)
         comps.calendar = calendarIdentifier
         return comps.icuIdentifier

--- a/Sources/FoundationInternationalization/Duration+Utils.swift
+++ b/Sources/FoundationInternationalization/Duration+Utils.swift
@@ -13,7 +13,7 @@
 // MARK: Rounding
 
 extension Duration {
-    func rounded(increment: Duration, rule: FloatingPointRoundingRule = .toNearestOrEven) -> Duration {
+    package func rounded(increment: Duration, rule: FloatingPointRoundingRule = .toNearestOrEven) -> Duration {
         rounded(rule, toMultipleOf: increment).value
     }
 
@@ -148,6 +148,6 @@ extension Duration {
 
 // MARK: Utility
 
-func abs(_ duration: Duration) -> Duration {
+package func abs(_ duration: Duration) -> Duration {
     duration < .zero ? Duration.zero - duration : duration
 }

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
@@ -170,7 +170,7 @@ extension Date {
              })
          }
 
-         internal func _format(_ destDate: Date, refDate: Date) -> String {
+        package func _format(_ destDate: Date, refDate: Date) -> String {
              guard let (component, value) = _largestNonZeroComponent(destDate, reference: refDate, adjustComponent: componentAdjustmentStrategy) else {
                  return ""
              }

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
@@ -43,7 +43,7 @@ extension Date.FormatStyle {
         public struct VerbatimHour : Hashable, Sendable { let option: SymbolType.VerbatimHourOption }
 
         static let maxPadding = 10
-        enum SymbolType : Hashable {
+        package enum SymbolType : Hashable {
             case era(EraOption)
             case year(YearOption)
             case yearForWeekOfYear(YearForWeekOfYearOption)
@@ -64,20 +64,20 @@ extension Date.FormatStyle {
             case secondFraction(SecondFractionOption)
             case timeZone(TimeZoneSymbolOption)
 
-            enum EraOption : String, Codable, Hashable {
+            package enum EraOption : String, Codable, Hashable {
                 case abbreviated = "G"
                 case wide = "GGGG"
                 case narrow = "GGGGG"
             }
 
-            enum YearOption : RawRepresentable, Codable, Hashable {
+            package enum YearOption : RawRepresentable, Codable, Hashable {
                 case defaultDigits
                 case twoDigits
                 case padded(Int)
                 case relatedGregorian(Int)
                 case extended(Int)
 
-                var rawValue: String {
+                package var rawValue: String {
                     let raw: String
                     switch self {
                     case .defaultDigits:
@@ -94,7 +94,7 @@ extension Date.FormatStyle {
                     return raw
                 }
 
-                init?(rawValue: String) {
+                package init?(rawValue: String) {
                     guard let begin = rawValue.first else {
                         return nil
                     }
@@ -119,12 +119,12 @@ extension Date.FormatStyle {
                 }
             }
 
-            enum YearForWeekOfYearOption : RawRepresentable, Codable, Hashable {
+            package enum YearForWeekOfYearOption : RawRepresentable, Codable, Hashable {
                 case defaultDigits
                 case twoDigits
                 case padded(Int)
 
-                var rawValue: String {
+                package var rawValue: String {
                     let raw: String
                     switch self {
                     case .defaultDigits:
@@ -137,7 +137,7 @@ extension Date.FormatStyle {
                     return raw
                 }
 
-                init?(rawValue: String) {
+                package init?(rawValue: String) {
                     if rawValue.allSatisfy({ $0 == "Y" }) {
                         if rawValue.count == 1 {
                             self = .defaultDigits
@@ -152,13 +152,13 @@ extension Date.FormatStyle {
                 }
             }
 
-            enum CyclicYearOption : String, Codable, Hashable {
+            package enum CyclicYearOption : String, Codable, Hashable {
                 case abbreviated = "U"
                 case wide = "UUUU"
                 case narrow = "UUUUU"
             }
 
-            enum QuarterOption : String, Codable, Hashable {
+            package enum QuarterOption : String, Codable, Hashable {
                 case oneDigit = "Q"
                 case twoDigits = "QQ"
                 case abbreviated = "QQQ"
@@ -166,7 +166,7 @@ extension Date.FormatStyle {
                 case narrow = "QQQQQ"
             }
 
-            enum StandaloneQuarterOption : String, Codable, Hashable {
+            package enum StandaloneQuarterOption : String, Codable, Hashable {
                 case oneDigit = "q"
                 case twoDigits = "qq"
                 case abbreviated = "qqq"
@@ -174,7 +174,7 @@ extension Date.FormatStyle {
                 case narrow = "qqqqq"
             }
 
-            enum MonthOption : String, Codable, Hashable {
+            package enum MonthOption : String, Codable, Hashable {
                 case defaultDigits = "M"
                 case twoDigits = "MM"
                 case abbreviated = "MMM"
@@ -182,7 +182,7 @@ extension Date.FormatStyle {
                 case narrow = "MMMMM"
             }
 
-            enum StandaloneMonthOption : String, Codable, Hashable {
+            package enum StandaloneMonthOption : String, Codable, Hashable {
                 case defaultDigits = "L"
                 case twoDigits = "LL"
                 case abbreviated = "LLL"
@@ -190,25 +190,25 @@ extension Date.FormatStyle {
                 case narrow = "LLLLL"
             }
 
-            enum WeekOption : String, Codable, Hashable {
+            package enum WeekOption : String, Codable, Hashable {
                 case defaultDigits = "w"
                 case twoDigits = "ww"
                 case weekOfMonth = "W"
             }
 
-            enum DayOfYearOption : String, Codable, Hashable {
+            package enum DayOfYearOption : String, Codable, Hashable {
                 case defaultDigits = "D"
                 case twoDigits = "DD"
                 case threeDigits = "DDD"
             }
 
-            enum DayOption : RawRepresentable, Codable, Hashable {
+            package enum DayOption : RawRepresentable, Codable, Hashable {
                 case defaultDigits
                 case twoDigits
                 case ordinalOfDayInMonth
                 case julianModified(Int)
 
-                var rawValue: String {
+                package var rawValue: String {
                     let raw: String
                     switch self {
                     case .defaultDigits:
@@ -223,7 +223,7 @@ extension Date.FormatStyle {
                     return raw
                 }
 
-                init?(rawValue: String) {
+                package init?(rawValue: String) {
                     switch rawValue {
                     case "d":
                         self = .defaultDigits
@@ -241,7 +241,7 @@ extension Date.FormatStyle {
                 }
             }
 
-            enum WeekdayOption : String, Codable, Hashable {
+            package enum WeekdayOption : String, Codable, Hashable {
                 case abbreviated = "EEE"
                 case wide = "EEEE"
                 case narrow = "EEEEE"
@@ -250,7 +250,7 @@ extension Date.FormatStyle {
                 case twoDigits = "ee"
             }
 
-            enum StandaloneWeekdayOption : String, Codable, Hashable {
+            package enum StandaloneWeekdayOption : String, Codable, Hashable {
                 case oneDigit = "c"
                 case abbreviated = "ccc"
                 case wide = "cccc"
@@ -258,7 +258,7 @@ extension Date.FormatStyle {
                 case short = "cccccc"
             }
 
-            enum DayPeriodOption : String, Codable, Hashable {
+            package enum DayPeriodOption : String, Codable, Hashable {
                 case abbreviated = "a"
                 case wide = "aaaa"
                 case narrow = "aaaaa"
@@ -270,7 +270,7 @@ extension Date.FormatStyle {
                 case conversationalWide = "BBBBB"
             }
 
-            enum HourOption : String, Codable, Hashable {
+            package enum HourOption : String, Codable, Hashable {
                 case defaultDigitsWithAbbreviatedAMPM = "j"
                 case twoDigitsWithAbbreviatedAMPM = "jj"
                 case defaultDigitsWithWideAMPM = "jjj"
@@ -289,7 +289,7 @@ extension Date.FormatStyle {
                 case conversationalTwoDigitsWithNarrowAMPM = "CCCCCC"
             }
 
-            enum VerbatimHourOption : String, Codable, Hashable {
+            package enum VerbatimHourOption : String, Codable, Hashable {
                 case twelveHourDefaultDigitsOneBased = "h"
                 case twelveHourTwoDigitsOneBased = "hh"
                 case twentyFourHourDefaultDigitsZeroBased = "H"
@@ -301,19 +301,19 @@ extension Date.FormatStyle {
                 case twentyFourHourTwoDigitsOneBased = "kk"
             }
 
-            enum MinuteOption : String, Codable, Hashable {
+            package enum MinuteOption : String, Codable, Hashable {
                 case defaultDigits = "m"
                 case twoDigits = "mm"
             }
 
-            enum SecondOption : String, Codable, Hashable {
+            package enum SecondOption : String, Codable, Hashable {
                 case defaultDigits = "s"
                 case twoDigits = "ss"
             }
 
-            enum SecondFractionOption : RawRepresentable, Codable, Hashable {
+            package enum SecondFractionOption : RawRepresentable, Codable, Hashable {
 
-                init?(rawValue: String) {
+                package init?(rawValue: String) {
                     guard let first = rawValue.first else { return nil }
                     guard rawValue.allSatisfy({ $0 == first }) else { return nil }
                     switch first {
@@ -364,7 +364,7 @@ extension Date.FormatStyle {
 
             }
 
-            enum TimeZoneSymbolOption : String, Codable, Hashable {
+            package enum TimeZoneSymbolOption : String, Codable, Hashable {
                 case shortSpecificName = "z"
                 case longSpecificName = "zzzz"
                 case iso8601Basic = "Z"

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatString.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatString.swift
@@ -17,7 +17,7 @@ import FoundationEssentials
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
     public struct FormatString : Hashable, Sendable {
-        internal var rawFormat: String = ""
+        package var rawFormat: String = ""
     }
 }
 

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -39,7 +39,7 @@ extension Date {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.FormatStyle {
-    internal struct DateFieldCollection : Codable, Hashable {
+    package struct DateFieldCollection : Codable, Hashable {
         var era: Symbol.SymbolType.EraOption?
         var year: Symbol.SymbolType.YearOption?
         var quarter: Symbol.SymbolType.QuarterOption?
@@ -54,6 +54,38 @@ extension Date.FormatStyle {
         var second: Symbol.SymbolType.SecondOption?
         var secondFraction: Symbol.SymbolType.SecondFractionOption?
         var timeZoneSymbol: Symbol.SymbolType.TimeZoneSymbolOption?
+
+        package init(
+            era: Date.FormatStyle.Symbol.SymbolType.EraOption? = nil,
+            year: Date.FormatStyle.Symbol.SymbolType.YearOption? = nil,
+            quarter: Date.FormatStyle.Symbol.SymbolType.QuarterOption? = nil,
+            month: Date.FormatStyle.Symbol.SymbolType.MonthOption? = nil,
+            week: Date.FormatStyle.Symbol.SymbolType.WeekOption? = nil,
+            day: Date.FormatStyle.Symbol.SymbolType.DayOption? = nil,
+            dayOfYear: Date.FormatStyle.Symbol.SymbolType.DayOfYearOption? = nil,
+            weekday: Date.FormatStyle.Symbol.SymbolType.WeekdayOption? = nil,
+            dayPeriod: Date.FormatStyle.Symbol.SymbolType.DayPeriodOption? = nil,
+            hour: Date.FormatStyle.Symbol.SymbolType.HourOption? = nil,
+            minute: Date.FormatStyle.Symbol.SymbolType.MinuteOption? = nil,
+            second: Date.FormatStyle.Symbol.SymbolType.SecondOption? = nil,
+            secondFraction: Date.FormatStyle.Symbol.SymbolType.SecondFractionOption? = nil,
+            timeZoneSymbol: Date.FormatStyle.Symbol.SymbolType.TimeZoneSymbolOption? = nil
+        ) {
+            self.era = era
+            self.year = year
+            self.quarter = quarter
+            self.month = month
+            self.week = week
+            self.day = day
+            self.dayOfYear = dayOfYear
+            self.weekday = weekday
+            self.dayPeriod = dayPeriod
+            self.hour = hour
+            self.minute = minute
+            self.second = second
+            self.secondFraction = secondFraction
+            self.timeZoneSymbol = timeZoneSymbol
+        }
 
         // Swap regular hour for conversational-style hour option if needed
         func preferredHour(withLocale locale: Locale?) -> Symbol.SymbolType.HourOption? {

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -28,7 +28,7 @@ import Darwin
 
 typealias UChar = UInt16
 
-final class ICUDateFormatter : @unchecked Sendable {
+package final class ICUDateFormatter : @unchecked Sendable {
 
     /// `Sendable` notes: `UDateFormat` is safe to use from multiple threads after initialization. The `UCal` using API clones the calendar before using it.
     var udateFormat: UnsafeMutablePointer<UDateFormat?>
@@ -104,7 +104,7 @@ final class ICUDateFormatter : @unchecked Sendable {
 
     // MARK: -
 
-    func format(_ date: Date) -> String? {
+    package func format(_ date: Date) -> String? {
         return _withResizingUCharBuffer { buffer, size, status in
             udat_formatForFields(udateFormat, date.udate, buffer, Int32(size), nil, &status)
         }
@@ -277,7 +277,7 @@ final class ICUDateFormatter : @unchecked Sendable {
         var datePatternOverride: String?
     }
 
-    static func cachedFormatter(for format: Date.FormatStyle) -> ICUDateFormatter? {
+    package static func cachedFormatter(for format: Date.FormatStyle) -> ICUDateFormatter? {
         cachedFormatter(for: .init(format))
     }
 

--- a/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
@@ -106,7 +106,7 @@ extension Duration {
     }
 
     // Returns an array of values corresponding to each unit in `units`
-    func valuesForUnits(
+    package func valuesForUnits(
         _ units: [UnitsFormatStyle.Unit],
         trailingFractionalLength: Int,
         smallestUnitRounding: FloatingPointRoundingRule,

--- a/Sources/FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift
@@ -149,7 +149,7 @@ extension Duration {
     }
 
     // For testing purpose. See notes about String._Encoding
-    internal typealias _TimeFormatStyle = TimeFormatStyle
+    package typealias _TimeFormatStyle = TimeFormatStyle
 }
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)

--- a/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
@@ -431,7 +431,7 @@ extension Duration {
         }
 
         // Returns the units that are going to show up in the final string, sorted from largest to smallest
-        static func unitsToUse(duration: Duration, allowedUnits: Set<Unit>, maximumUnitCount: Int?, roundSmallerParts: FloatingPointRoundingRule, trailingFractionalPartLength: Int, roundingIncrement: Double?, dropZeroUnits: Bool) -> (units: [Unit], values: [Double]) {
+        package static func unitsToUse(duration: Duration, allowedUnits: Set<Unit>, maximumUnitCount: Int?, roundSmallerParts: FloatingPointRoundingRule, trailingFractionalPartLength: Int, roundingIncrement: Double?, dropZeroUnits: Bool) -> (units: [Unit], values: [Double]) {
 
             var units = allowedUnits.sorted { $0.unit.rawValue < $1.unit.rawValue }
             var values = duration.valuesForUnits(units, trailingFractionalLength: trailingFractionalPartLength, smallestUnitRounding: roundSmallerParts, roundingIncrement: roundingIncrement)
@@ -497,7 +497,7 @@ extension Duration {
     }
 
     // For testing purpose. See notes about String._Encoding
-    internal typealias _UnitsFormatStyle = UnitsFormatStyle
+    package typealias _UnitsFormatStyle = UnitsFormatStyle
 }
 
 // `FormatStyle` static membership lookup

--- a/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
@@ -29,7 +29,7 @@ extension Decimal {
     public struct ParseStrategy<Format> : FoundationEssentials.ParseStrategy, Codable, Hashable where Format : FoundationEssentials.FormatStyle, Format.FormatInput == Decimal {
         public var formatStyle: Format
         public var lenient: Bool
-        internal init(formatStyle: Format, lenient: Bool) {
+        package init(formatStyle: Format, lenient: Bool) {
             self.formatStyle = formatStyle
             self.lenient = lenient
         }

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
@@ -28,7 +28,7 @@ public struct FloatingPointFormatStyle<Value: BinaryFloatingPoint>: Codable, Has
     }
 
     public typealias Configuration = NumberFormatStyleConfiguration
-    internal var collection: Configuration.Collection = Configuration.Collection()
+    package var collection: Configuration.Collection = Configuration.Collection()
 
     public func grouping(_ group: Configuration.Grouping) -> Self {
         var new = self

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -19,7 +19,7 @@ internal import _FoundationICU
 typealias ICUNumberFormatterSkeleton = String
 
 /// For testing purposes, remove all caches from below formatters.
-internal func resetAllNumberFormatterCaches() {
+package func resetAllNumberFormatterCaches() {
     ICUNumberFormatter.cache.removeAllObjects()
     ICUCurrencyNumberFormatter.cache.removeAllObjects()
     ICUPercentNumberFormatter.cache.removeAllObjects()
@@ -27,11 +27,11 @@ internal func resetAllNumberFormatterCaches() {
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-internal class ICUNumberFormatterBase : @unchecked Sendable {
+package class ICUNumberFormatterBase : @unchecked Sendable {
     /// `Sendable` notes: ICU's `UNumberFormatter` itself is thread safe. The result type is not, but we create that each time we format.
-    internal let uformatter: OpaquePointer
+    package let uformatter: OpaquePointer
     /// Stored for testing purposes only
-    internal let skeleton: String
+    package let skeleton: String
 
     init?(skeleton: String, localeIdentifier: String) {
         self.skeleton = skeleton
@@ -140,11 +140,11 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
         }
     }
 
-    func format(_ v: Int64) -> String? {
+    package func format(_ v: Int64) -> String? {
         try? FormatResult(formatter: uformatter, value: v).string
     }
 
-    func format(_ v: Double) -> String? {
+    package func format(_ v: Double) -> String? {
         try? FormatResult(formatter: uformatter, value: v).string
     }
 
@@ -220,7 +220,7 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
 
 // MARK: - Integer
 
-final class ICUNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
+package final class ICUNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
         let skeleton: String
         let localeIdentifier: String
@@ -234,15 +234,15 @@ final class ICUNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
         }
     }
 
-    static func create<T: BinaryInteger>(for style: IntegerFormatStyle<T>) -> ICUNumberFormatter? {
+    package static func create<T: BinaryInteger>(for style: IntegerFormatStyle<T>) -> ICUNumberFormatter? {
         _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
-    static func create(for style: Decimal.FormatStyle) -> ICUNumberFormatter? {
+    package static func create(for style: Decimal.FormatStyle) -> ICUNumberFormatter? {
         _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
-    static func create<T: BinaryFloatingPoint>(for style: FloatingPointFormatStyle<T>) -> ICUNumberFormatter? {
+    package static func create<T: BinaryFloatingPoint>(for style: FloatingPointFormatStyle<T>) -> ICUNumberFormatter? {
         _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
@@ -256,7 +256,7 @@ final class ICUNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
 
 // MARK: - Currency
 
-final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
+package final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
         let skeleton: String
         let currencyCode: String
@@ -282,15 +282,15 @@ final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase, @unchecked Send
         }
     }
 
-    static func create<T: BinaryInteger>(for style: IntegerFormatStyle<T>.Currency) -> ICUCurrencyNumberFormatter? {
+    package static func create<T: BinaryInteger>(for style: IntegerFormatStyle<T>.Currency) -> ICUCurrencyNumberFormatter? {
         _create(with: .init(skeleton: style.collection.skeleton, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
-    static func create(for style: Decimal.FormatStyle.Currency) -> ICUCurrencyNumberFormatter? {
+    package static func create(for style: Decimal.FormatStyle.Currency) -> ICUCurrencyNumberFormatter? {
         _create(with: .init(skeleton: style.collection.skeleton, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
-    static func create<T: BinaryFloatingPoint>(for style: FloatingPointFormatStyle<T>.Currency) -> ICUCurrencyNumberFormatter? {
+    package static func create<T: BinaryFloatingPoint>(for style: FloatingPointFormatStyle<T>.Currency) -> ICUCurrencyNumberFormatter? {
         _create(with: .init(skeleton: style.collection.skeleton, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
@@ -19,7 +19,7 @@ public struct IntegerFormatStyle<Value: BinaryInteger>: Codable, Hashable, Senda
     public typealias Configuration = NumberFormatStyleConfiguration
 
     public var locale: Locale
-    internal var collection: Configuration.Collection = Configuration.Collection()
+    package var collection: Configuration.Collection = Configuration.Collection()
 
     public init(locale: Locale = .autoupdatingCurrent) {
         self.locale = locale

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -90,15 +90,35 @@ public struct FormatStyleCapitalizationContext : Codable, Hashable, Sendable {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum NumberFormatStyleConfiguration {
-    internal struct Collection : Codable, Hashable, Sendable {
-        var scale: Double?
-        var precision: Precision?
-        var group: Grouping?
-        var signDisplayStrategy: SignDisplayStrategy?
-        var decimalSeparatorStrategy: DecimalSeparatorDisplayStrategy?
-        var rounding: RoundingRule?
-        var roundingIncrement: RoundingIncrement?
-        var notation: Notation?
+    package struct Collection : Codable, Hashable, Sendable {
+        package var scale: Double?
+        package var precision: Precision?
+        package var group: Grouping?
+        package var signDisplayStrategy: SignDisplayStrategy?
+        package var decimalSeparatorStrategy: DecimalSeparatorDisplayStrategy?
+        package var rounding: RoundingRule?
+        package var roundingIncrement: RoundingIncrement?
+        package var notation: Notation?
+
+        package init(
+            scale: Double? = nil,
+            precision: NumberFormatStyleConfiguration.Precision? = nil,
+            group: NumberFormatStyleConfiguration.Grouping? = nil,
+            signDisplayStrategy: NumberFormatStyleConfiguration.SignDisplayStrategy? = nil,
+            decimalSeparatorStrategy: NumberFormatStyleConfiguration.DecimalSeparatorDisplayStrategy? = nil,
+            rounding: NumberFormatStyleConfiguration.RoundingRule? = nil,
+            roundingIncrement: NumberFormatStyleConfiguration.RoundingIncrement? = nil,
+            notation: NumberFormatStyleConfiguration.Notation? = nil
+        ) {
+            self.scale = scale
+            self.precision = precision
+            self.group = group
+            self.signDisplayStrategy = signDisplayStrategy
+            self.decimalSeparatorStrategy = decimalSeparatorStrategy
+            self.rounding = rounding
+            self.roundingIncrement = roundingIncrement
+            self.notation = notation
+        }
     }
 
     public typealias RoundingRule = FloatingPointRoundingRule
@@ -132,11 +152,11 @@ public enum NumberFormatStyleConfiguration {
 
     public struct Precision : Codable, Hashable, Sendable {
 
-        enum Option: Hashable {
+        package enum Option: Hashable {
             case significantDigits(min: Int, max: Int?)
             case integerAndFractionalLength(minInt: Int?, maxInt: Int?, minFraction: Int?, maxFraction: Int?)
         }
-        var option: Option
+        package var option: Option
 
         // The maximum total length that ICU allows is 999.
         // We take one off to reserve one character for the non-zero digit skeleton (the "0" skeleton in the number format)
@@ -289,11 +309,11 @@ public enum NumberFormatStyleConfiguration {
         }
     }
 
-    internal enum RoundingIncrement: Hashable, CustomStringConvertible {
+    package enum RoundingIncrement: Hashable, CustomStringConvertible {
         case integer(value: Int)
         case floatingPoint(value: Double)
 
-        var description: String {
+        package var description: String {
             switch self {
             case .integer(let value):
                 return String(value)
@@ -511,7 +531,7 @@ extension NumberFormatStyleConfiguration.RoundingIncrement: Codable {
         case floatingPoint
     }
 
-    init(from decoder: Decoder) throws {
+    package init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         if let value = try container.decodeIfPresent(Int.self, forKey: .integer) {
             self = .integer(value: value)
@@ -522,7 +542,7 @@ extension NumberFormatStyleConfiguration.RoundingIncrement: Codable {
         }
     }
 
-    func encode(to encoder: Encoder) throws {
+    package func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
         case .integer(let value):
@@ -544,7 +564,7 @@ extension NumberFormatStyleConfiguration.Precision.Option : Codable {
         case maxFractionalLength
     }
 
-    init(from decoder: Decoder) throws {
+    package init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         if let minSignificantDigits = try container.decodeIfPresent(Int.self, forKey: .minSignificantDigits), let maxSignificantDigits = try container.decodeIfPresent(Int.self, forKey: .maxSignificantDigits) {
             self = .significantDigits(min: minSignificantDigits, max: maxSignificantDigits)
@@ -556,7 +576,7 @@ extension NumberFormatStyleConfiguration.Precision.Option : Codable {
         }
     }
 
-    func encode(to encoder: Encoder) throws {
+    package func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
         case .significantDigits(let min, let max):
@@ -576,7 +596,7 @@ extension NumberFormatStyleConfiguration.Precision.Option : Codable {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension NumberFormatStyleConfiguration.Collection {
-    var skeleton: String {
+    package var skeleton: String {
         var s = ""
         if let scale = scale {
             s += scale.skeleton + " "
@@ -693,7 +713,7 @@ extension NumberFormatStyleConfiguration.Precision {
         return incrementStem
     }
 
-    var skeleton : String {
+    package var skeleton : String {
         switch self.option {
         case .significantDigits(let min, let max):
             return significantDigitsSkeleton(min: min, max: max)
@@ -751,7 +771,7 @@ extension NumberFormatStyleConfiguration.Grouping {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension NumberFormatStyleConfiguration.SignDisplayStrategy {
-    var skeleton : String {
+    package var skeleton : String {
         let stem: String
         switch positive {
         case .always:
@@ -891,7 +911,7 @@ extension CurrencyFormatStyleConfiguration.Collection {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension CurrencyFormatStyleConfiguration.SignDisplayStrategy {
-    var skeleton: String {
+    package var skeleton: String {
         var stem: String
         if accounting {
             switch positive {

--- a/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
+++ b/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
@@ -16,7 +16,7 @@ import FoundationEssentials
 
 internal import _FoundationICU
 
-final class ICUPatternGenerator : @unchecked Sendable {
+final package class ICUPatternGenerator : @unchecked Sendable {
 
     /// `Sendable` notes: We create this in init, and the non-thread safe API of `udatpg_getBestPatternWithOptions` is performed on a clone of it. `udatpg_getDefaultHourCycle` is thread safe as the underlying data is initialized at init time of the pattern generator itself.
     let upatternGenerator: UnsafeMutablePointer<UDateTimePatternGenerator?>
@@ -85,7 +85,7 @@ final class ICUPatternGenerator : @unchecked Sendable {
 
     static let _patternGeneratorCache = FormatterCache<PatternGeneratorInfo, ICUPatternGenerator?>()
 
-    static func localizedPattern(symbols: Date.FormatStyle.DateFieldCollection, locale: Locale, calendar: Calendar) -> String {
+    static package func localizedPattern(symbols: Date.FormatStyle.DateFieldCollection, locale: Locale, calendar: Calendar) -> String {
         let skeleton = symbols.formatterTemplate(overridingDayPeriodWithLocale: locale)
         guard let upatternGenerator = cachedPatternGenerator(localeIdentifier: locale.identifierCapturingPreferences, calendarIdentifier: calendar.identifier), let pattern = upatternGenerator._patternForSkeleton(skeleton) else {
             return skeleton

--- a/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
@@ -23,7 +23,7 @@ internal import _FoundationICU
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Components {
     // Returns an ICU-style identifier like "de_DE@calendar=gregorian"
-    internal var icuIdentifier: String {
+    package var icuIdentifier: String {
         var keywords: [ICULegacyKey: String] = [:]
         if let id = calendar?.cldrIdentifier { keywords[Calendar.Identifier.legacyKeywordKey] = id }
         if let id = collation?._normalizedIdentifier { keywords[Locale.Collation.legacyKeywordKey] = id }
@@ -180,7 +180,7 @@ extension Locale.LanguageCode {
     }
     
     // This is sorted
-    internal static let _isoLanguageCodeStrings: [String] = {
+    package static let _isoLanguageCodeStrings: [String] = {
         var result: [String] = []
         let langs = uloc_getISOLanguages()
         guard var langs else { return [] }
@@ -276,7 +276,7 @@ extension Locale.Region {
     }
 
     /// Used for deprecated ISO Country Code
-    internal static let isoCountries: [String] = {
+    package static let isoCountries: [String] = {
         var result: [String] = []
         let langs = uloc_getISOCountries()
         guard var langs else { return [] }

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1592,7 +1592,7 @@ extension Locale {
         return ICULegacyKey(legacyKey)
     }
 
-    internal static func keywordValue(identifier: String, key: String) -> String? {
+    package static func keywordValue(identifier: String, key: String) -> String? {
         // Unlike other many ICU variables, `ULOC_KEYWORD_AND_VALUES_CAPACITY` does not include null-termination.
         // Manually add one here.
         return _withFixedCharBuffer(size: ULOC_KEYWORD_AND_VALUES_CAPACITY + 1) { buffer, size, status in

--- a/Sources/FoundationInternationalization/String/String+Locale.swift
+++ b/Sources/FoundationInternationalization/String/String+Locale.swift
@@ -14,14 +14,14 @@ import FoundationEssentials
 #endif
 
 extension String {
-    func _lowercased(with locale: Locale?) -> String {
+    package func _lowercased(with locale: Locale?) -> String {
         guard let casemap = ICU.CaseMap.caseMappingForLocale(locale?.identifier), let lowered = casemap.lowercase(self) else {
             return lowercased()
         }
         return lowered
     }
 
-    func _capitalized(with locale: Locale?) -> String {
+    package func _capitalized(with locale: Locale?) -> String {
         guard let casemap = ICU.CaseMap.caseMappingForLocale(locale?.identifier) else {
             return capitalized
         }
@@ -38,7 +38,7 @@ extension String {
         return result
     }
 
-    func _uppercased(with locale: Locale?) -> String {
+    package func _uppercased(with locale: Locale?) -> String {
         guard let casemap = ICU.CaseMap.caseMappingForLocale(locale?.identifier), let uppered = casemap.uppercase(self) else {
             return uppercased()
         }

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -39,8 +39,8 @@ private func _timeZoneIdentifier_ICU(forWindowsIdentifier windowsIdentifier: Str
 }
 #endif
 
-internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
-    init?(secondsFromGMT: Int) {
+package final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
+    package init?(secondsFromGMT: Int) {
         fatalError("Unexpected init")
     }
     
@@ -84,7 +84,7 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
     }
 
-    required init?(identifier: String) {
+    required package init?(identifier: String) {
         guard !identifier.isEmpty else {
             return nil
         }
@@ -104,15 +104,15 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
     }
     
     // MARK: -
-    var identifier: String {
+    package var identifier: String {
         self.name
     }
     
-    var data: Data? {
+    package var data: Data? {
         nil
     }
 
-    func secondsFromGMT(for date: Date) -> Int {
+    package func secondsFromGMT(for date: Date) -> Int {
         return lock.withLock {
             let udate = date.udate
             guard let c = $0.calendar(identifier) else {
@@ -136,7 +136,7 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
     }
 
-    func abbreviation(for date: Date) -> String? {
+    package func abbreviation(for date: Date) -> String? {
         let dst = daylightSavingTimeOffset(for: date) != 0.0
         return lock.withLock {
             guard let c = $0.calendar(identifier) else { return nil }
@@ -144,11 +144,11 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
     }
 
-    func isDaylightSavingTime(for date: Date) -> Bool {
+    package func isDaylightSavingTime(for date: Date) -> Bool {
         return daylightSavingTimeOffset(for: date) != 0.0
     }
 
-    func daylightSavingTimeOffset(for date: Date) -> TimeInterval {
+    package func daylightSavingTimeOffset(for date: Date) -> TimeInterval {
         lock.withLock {
             let udate = date.udate
 
@@ -164,14 +164,14 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
     }
 
-    func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
+    package func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
         lock.withLock {
             guard let c = $0.calendar(identifier) else { return nil }
             return Self.nextDaylightSavingTimeTransition(forLocked: c, startingAt: date, limit: Date.validCalendarRange.upperBound)
         }
     }
 
-    func rawAndDaylightSavingTimeOffset(for date: Date, repeatedTimePolicy: TimeZone.DaylightSavingTimePolicy = .former, skippedTimePolicy: TimeZone.DaylightSavingTimePolicy = .former) -> (rawOffset: Int, daylightSavingOffset: TimeInterval) {
+    package func rawAndDaylightSavingTimeOffset(for date: Date, repeatedTimePolicy: TimeZone.DaylightSavingTimePolicy = .former, skippedTimePolicy: TimeZone.DaylightSavingTimePolicy = .former) -> (rawOffset: Int, daylightSavingOffset: TimeInterval) {
         return lock.withLock {
             guard let calendar = $0.calendar(identifier) else { return (0, 0) }
             var rawOffset: Int32 = 0
@@ -205,7 +205,7 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
     }
 
-    func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
+    package func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
         let locID = locale?.identifier ?? ""
         return lock.withLock {
             guard let c = $0.calendar(identifier) else { return nil }

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -15,7 +15,7 @@
 // See this issue for more info on this file: https://github.com/apple/swift-foundation/issues/40
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 
 public typealias Calendar = Foundation.Calendar
 public typealias TimeZone = Foundation.TimeZone
@@ -115,8 +115,8 @@ public typealias Expression = Foundation.Expression
 #else
 
 #if DEBUG
-@_exported @testable import FoundationEssentials
-@_exported @testable import FoundationInternationalization
+@_exported import FoundationEssentials
+@_exported import FoundationInternationalization
 // XCTest implicitly imports Foundation
 #else
 @_exported import FoundationEssentials

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringCOWTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringCOWTests.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 extension AttributedStringProtocol {

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringCOWTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringCOWTests.swift
@@ -14,12 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif
-
 extension AttributedStringProtocol {
     fileprivate mutating func genericSetAttribute() {
         self.testInt = 3

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -15,11 +15,11 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 #if FOUNDATION_FRAMEWORK
-@testable @_spi(AttributedString) import Foundation
+@_spi(AttributedString) import Foundation
 // For testing default attribute scope conversion
 #if canImport(Accessibility)
 import Accessibility

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -14,10 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
 #if FOUNDATION_FRAMEWORK
 @_spi(AttributedString) import Foundation
 // For testing default attribute scope conversion

--- a/Tests/FoundationEssentialsTests/BufferViewTests.swift
+++ b/Tests/FoundationEssentialsTests/BufferViewTests.swift
@@ -15,11 +15,11 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class BufferViewTests: XCTestCase {

--- a/Tests/FoundationEssentialsTests/BufferViewTests.swift
+++ b/Tests/FoundationEssentialsTests/BufferViewTests.swift
@@ -14,14 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class BufferViewTests: XCTestCase {
 
     func testOptionalStorage() {

--- a/Tests/FoundationEssentialsTests/BuiltInUnicodeScalarSetTest.swift
+++ b/Tests/FoundationEssentialsTests/BuiltInUnicodeScalarSetTest.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 final class BuiltInUnicodeScalarSetTest: XCTestCase {

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -19,9 +19,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 class DataIOTests : XCTestCase {

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -18,12 +18,6 @@ import TestSupport
 @preconcurrency import Glibc
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
 class DataIOTests : XCTestCase {
     
     // MARK: - Helpers

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -19,9 +19,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 extension Data {

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -18,12 +18,6 @@ import TestSupport
 @preconcurrency import Glibc
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
 extension Data {
     func withUnsafeUInt8Bytes<R>(_ c: (UnsafePointer<UInt8>) throws -> R) rethrows -> R {
         return try self.withUnsafeBytes { (ptr) in

--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -14,10 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
 final class DateTests : XCTestCase {
 
     func testDateComparison() {

--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -15,7 +15,7 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 final class DateTests : XCTestCase {

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -15,10 +15,10 @@ import TestSupport
 #endif  // canImport(TestSupport)
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
 @_spi(SwiftCorelibsFoundation)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 final class DecimalTests : XCTestCase {

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -14,9 +14,7 @@
 import TestSupport
 #endif  // canImport(TestSupport)
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
+#if canImport(FoundationEssentials)
 @_spi(SwiftCorelibsFoundation)
 import FoundationEssentials
 #endif

--- a/Tests/FoundationEssentialsTests/ErrorTests.swift
+++ b/Tests/FoundationEssentialsTests/ErrorTests.swift
@@ -14,10 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
 final class ErrorTests : XCTestCase {
     func thisThrows() throws {
         throw CocoaError(CocoaError.Code(rawValue: 42), userInfo: ["hi" : "there"])

--- a/Tests/FoundationEssentialsTests/ErrorTests.swift
+++ b/Tests/FoundationEssentialsTests/ErrorTests.swift
@@ -15,7 +15,7 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 final class ErrorTests : XCTestCase {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerPlayground.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerPlayground.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 private protocol Buildable {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerPlayground.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerPlayground.swift
@@ -14,12 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif
-
 private protocol Buildable {
     func build(in path: String, using fileManager: FileManager) throws
 }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -16,11 +16,11 @@ import TestSupport
 #endif // canImport(TestSupport)
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 #if canImport(Android)

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -15,14 +15,6 @@
 import TestSupport
 #endif // canImport(TestSupport)
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 #if canImport(Android)
 @preconcurrency import Android
 #endif

--- a/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
@@ -12,11 +12,11 @@
 import XCTest
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 #if canImport(Numberick) // Not included by default as it's a 3rd party library; requires https://github.com/oscbyspro/Numberick.git be added the package dependencies.

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
@@ -15,11 +15,11 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class ISO8601FormatStyleFormattingTests: XCTestCase {

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
@@ -14,14 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class ISO8601FormatStyleFormattingTests: XCTestCase {
 
     func test_ISO8601Format() throws {

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
@@ -11,11 +11,11 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class ISO8601FormatStyleParsingTests: XCTestCase {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 final class GregorianCalendarRecurrenceRuleTests: XCTestCase {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -14,12 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
 final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
     /// A Gregorian calendar in GMT with no time zone changes
     var gregorian: Calendar = {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -15,11 +15,11 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 // Tests for _GregorianCalendar

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -14,14 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 // Tests for _GregorianCalendar
 final class GregorianCalendarTests : XCTestCase {
 

--- a/Tests/FoundationEssentialsTests/IndexPathTests.swift
+++ b/Tests/FoundationEssentialsTests/IndexPathTests.swift
@@ -12,7 +12,7 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 class TestIndexPath: XCTestCase {

--- a/Tests/FoundationEssentialsTests/IndexPathTests.swift
+++ b/Tests/FoundationEssentialsTests/IndexPathTests.swift
@@ -11,10 +11,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
 class TestIndexPath: XCTestCase {
     func testEmpty() {
         let ip = IndexPath()

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -22,11 +22,11 @@ import TestSupport
 
 #if canImport(FoundationEssentials)
 @_spi(SwiftCorelibsFoundation)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 // MARK: - Test Suite

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -25,10 +25,6 @@ import TestSupport
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 // MARK: - Test Suite
 
 final class JSONEncoderTests : XCTestCase {

--- a/Tests/FoundationEssentialsTests/LockedStateTests.swift
+++ b/Tests/FoundationEssentialsTests/LockedStateTests.swift
@@ -14,12 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif
-
 final class LockedStateTests : XCTestCase {
     final class TestObject {
         var deinitBlock: () -> Void = {}

--- a/Tests/FoundationEssentialsTests/LockedStateTests.swift
+++ b/Tests/FoundationEssentialsTests/LockedStateTests.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 final class LockedStateTests : XCTestCase {

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #else
-@testable import Foundation
+import Foundation
 #endif
 
 #if canImport(Darwin)

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -14,12 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)

--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -12,9 +12,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #elseif canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 // MARK: - Test Suite

--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -11,12 +11,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#elseif canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
 // MARK: - Test Suite
 
 class TestPropertyListEncoder : XCTestCase {

--- a/Tests/FoundationEssentialsTests/ResourceUtilities.swift
+++ b/Tests/FoundationEssentialsTests/ResourceUtilities.swift
@@ -20,9 +20,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 #if FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/ResourceUtilities.swift
+++ b/Tests/FoundationEssentialsTests/ResourceUtilities.swift
@@ -20,12 +20,6 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
-#if FOUNDATION_FRAMEWORK
 // Always compiled into the Tests project
 final internal class Canary { }
 #endif

--- a/Tests/FoundationEssentialsTests/SortComparatorTests.swift
+++ b/Tests/FoundationEssentialsTests/SortComparatorTests.swift
@@ -14,12 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
 class SortComparatorTests: XCTestCase {
     func test_comparable_descriptors() {
         let intDesc: ComparableComparator<Int> = ComparableComparator<Int>()

--- a/Tests/FoundationEssentialsTests/SortComparatorTests.swift
+++ b/Tests/FoundationEssentialsTests/SortComparatorTests.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 class SortComparatorTests: XCTestCase {

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 #if canImport(TestSupport)

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -10,12 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
 #if canImport(TestSupport)
 import TestSupport
 #endif

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -16,11 +16,11 @@ import TestSupport
 #endif // canImport(TestSupport)
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 private func checkBehavior<T: Equatable>(_ result: T, new: T, old: T, file: StaticString = #filePath, line: UInt = #line) {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -15,14 +15,6 @@
 import TestSupport
 #endif // canImport(TestSupport)
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 private func checkBehavior<T: Equatable>(_ result: T, new: T, old: T, file: StaticString = #filePath, line: UInt = #line) {
     #if FOUNDATION_FRAMEWORK
     if foundation_swift_url_enabled() {

--- a/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
@@ -14,13 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationInternationalization
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
 final class CalendarRecurrenceRuleTests: XCTestCase {
     /// A Gregorian calendar with a time zone set to California
     var gregorian: Calendar = {

--- a/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
@@ -15,10 +15,10 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationInternationalization
-@testable import FoundationEssentials
+import FoundationInternationalization
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 final class CalendarRecurrenceRuleTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -14,13 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationInternationalization
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
 extension DateComponents {
     fileprivate static func differenceBetween(_ d1: DateComponents?, _ d2: DateComponents?, compareQuarter: Bool, within nanosecondAccuracy: Int = 5000) -> String? {
         let components: [Calendar.Component] = [.era, .year, .month, .day, .dayOfYear, .hour, .minute, .second, .weekday, .weekdayOrdinal, .weekOfYear, .yearForWeekOfYear, .weekOfMonth, .timeZone, .isLeapMonth, .calendar, .quarter, .nanosecond]

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -15,10 +15,10 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationInternationalization
-@testable import FoundationEssentials
+import FoundationInternationalization
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 extension DateComponents {

--- a/Tests/FoundationInternationalizationTests/DurationExtensionTests.swift
+++ b/Tests/FoundationInternationalizationTests/DurationExtensionTests.swift
@@ -14,15 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class DurationExtensionTests : XCTestCase {
 
     func testRoundingMode() {

--- a/Tests/FoundationInternationalizationTests/DurationExtensionTests.swift
+++ b/Tests/FoundationInternationalizationTests/DurationExtensionTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class DurationExtensionTests : XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class DateFormatStyleTests : XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -14,14 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
 
 final class DateFormatStyleTests : XCTestCase {
     let referenceDate = Date(timeIntervalSinceReferenceDate: 0)

--- a/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class DateIntervalFormatStyleTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
@@ -14,15 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class DateIntervalFormatStyleTests: XCTestCase {
 
     let minute: TimeInterval = 60

--- a/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
@@ -14,15 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class DateRelativeFormatStyleTests: XCTestCase {
 
     let oneHour: TimeInterval = 60 * 60

--- a/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class DateRelativeFormatStyleTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/DiscreteFormatStyleTestUtilities.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DiscreteFormatStyleTestUtilities.swift
@@ -14,14 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#endif
-
-#if canImport(FoundationInternationalization)
-import FoundationInternationalization
-#endif
-
 extension DiscreteFormatStyle where FormatInput : Comparable {
     /// Produces a sequence that generates all outputs of a discrete format style from a given start to a given end.
     func evaluate(from initialInput: FormatInput, to end: FormatInput, _ advance: @escaping (FormatInput, FormatInput) -> FormatInput? = { prev, next in next }) -> LazySequence<DiscreteFormatStyleSequence<Self>> {

--- a/Tests/FoundationInternationalizationTests/Formatting/DiscreteFormatStyleTestUtilities.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DiscreteFormatStyleTestUtilities.swift
@@ -15,11 +15,11 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationInternationalization
+import FoundationInternationalization
 #endif
 
 extension DiscreteFormatStyle where FormatInput : Comparable {

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
@@ -14,17 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
-
-
 extension Duration {
     init(weeks: Int64 = 0, days: Int64 = 0, hours: Int64 = 0, minutes: Int64 = 0, seconds: Int64 = 0, milliseconds: Int64 = 0, microseconds: Int64 = 0) {
         self = .init(secondsComponent: Int64(weeks * 604800 + days * 86400 + hours * 3600 + minutes * 60 + seconds),

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
@@ -15,11 +15,11 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationInternationalization
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 let week = 604800

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
@@ -14,14 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 let week = 604800
 let day = 86400
 let hour = 3600

--- a/Tests/FoundationInternationalizationTests/Formatting/FormatterCacheTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/FormatterCacheTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class FormatterCacheTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/FormatterCacheTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/FormatterCacheTests.swift
@@ -14,15 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class FormatterCacheTests: XCTestCase {
 
     final class TestCacheItem: Equatable, Sendable {

--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -11,12 +11,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class ICUPatternGeneratorTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -10,15 +10,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class ICUPatternGeneratorTests: XCTestCase {
 
     typealias DateFieldCollection = Date.FormatStyle.DateFieldCollection

--- a/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 class ListFormatStyleTests : XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
@@ -14,15 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 class ListFormatStyleTests : XCTestCase {
     func test_orList() {
         var style: ListFormatStyle<StringStyle, [String]> = .list(type: .or, width: .standard)

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleICUSkeletonTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleICUSkeletonTests.swift
@@ -14,15 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class NumberFormatStyleICUSkeletonTests: XCTestCase {
 
     func testNumberConfigurationSkeleton() throws {

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleICUSkeletonTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleICUSkeletonTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class NumberFormatStyleICUSkeletonTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class NumberFormatStyleTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -14,15 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class NumberFormatStyleTests: XCTestCase {
 
     let enUSLocale = Locale(identifier: "en_US")

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -15,12 +15,12 @@ import TestSupport
 #endif
 
 #if canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
 final class NumberParseStrategyTests : XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -14,15 +14,6 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#endif
-
 final class NumberParseStrategyTests : XCTestCase {
     func testIntStrategy() {
         let format: IntegerFormatStyle<Int> = .init()

--- a/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
@@ -14,13 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-import FoundationInternationalization
-#endif // FOUNDATION_FRAMEWORK
-
 final class LocaleComponentsTests: XCTestCase {
 
     func testRegions() {

--- a/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
@@ -15,10 +15,10 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
 final class LocaleComponentsTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/LocaleLanguageTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleLanguageTests.swift
@@ -15,10 +15,10 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #elseif canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
 final class LocaleLanguageComponentsTests : XCTestCase {

--- a/Tests/FoundationInternationalizationTests/LocaleLanguageTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleLanguageTests.swift
@@ -14,13 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#elseif canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif // FOUNDATION_FRAMEWORK
-
 final class LocaleLanguageComponentsTests : XCTestCase {
 
     func verifyComponents(_ identifier: String,

--- a/Tests/FoundationInternationalizationTests/LocaleTestUtilities.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTestUtilities.swift
@@ -15,10 +15,10 @@
 // REQUIRES: objc_interop
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
 // MARK: - Stubs

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -21,10 +21,10 @@
 // REQUIRES: objc_interop
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #elseif canImport(FoundationInternationalization)
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
 #if canImport(TestSupport)

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -20,13 +20,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#elseif canImport(FoundationInternationalization)
-import FoundationEssentials
-import FoundationInternationalization
-#endif // FOUNDATION_FRAMEWORK
-
 #if canImport(TestSupport)
 import TestSupport
 #endif

--- a/Tests/FoundationInternationalizationTests/SortDescriptorConversionTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorConversionTests.swift
@@ -15,12 +15,6 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
-#if FOUNDATION_FRAMEWORK
 
 /// Tests interop with Objective-C `NSSortDescriptor`.
 class SortDescriptorConversionTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/SortDescriptorConversionTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorConversionTests.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
 #if FOUNDATION_FRAMEWORK

--- a/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
@@ -14,13 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-import FoundationInternationalization
-#endif // FOUNDATION_FRAMEWORK
-
 class Hello {
     var str: NSMutableString = "hi"
 }

--- a/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
@@ -15,10 +15,10 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
 class Hello {

--- a/Tests/FoundationInternationalizationTests/StringSortComparatorTests.swift
+++ b/Tests/FoundationInternationalizationTests/StringSortComparatorTests.swift
@@ -15,10 +15,10 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
 class StringSortComparatorTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/StringSortComparatorTests.swift
+++ b/Tests/FoundationInternationalizationTests/StringSortComparatorTests.swift
@@ -14,13 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-import FoundationInternationalization
-#endif // FOUNDATION_FRAMEWORK
-
 class StringSortComparatorTests: XCTestCase {
 #if FOUNDATION_FRAMEWORK
     // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, only support unlocalized comparisons

--- a/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
+++ b/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
 #if canImport(TestSupport)

--- a/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
+++ b/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
@@ -10,13 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-import FoundationInternationalization
-#endif // FOUNDATION_FRAMEWORK
-
 #if canImport(TestSupport)
 import TestSupport
 #endif

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -14,12 +14,6 @@
 import TestSupport
 #endif
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#elseif canImport(FoundationInternationalization)
-import FoundationInternationalization
-#endif
-
 final class TimeZoneTests : XCTestCase {
 
     func test_timeZoneBasics() {

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -15,9 +15,9 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #elseif canImport(FoundationInternationalization)
-@testable import FoundationInternationalization
+import FoundationInternationalization
 #endif
 
 final class TimeZoneTests : XCTestCase {

--- a/Tests/FoundationInternationalizationTests/URLTests+UIDNA.swift
+++ b/Tests/FoundationInternationalizationTests/URLTests+UIDNA.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #else
-@testable import FoundationEssentials
-@testable import FoundationInternationalization
+import FoundationEssentials
+import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
 #if canImport(TestSupport)

--- a/Tests/FoundationInternationalizationTests/URLTests+UIDNA.swift
+++ b/Tests/FoundationInternationalizationTests/URLTests+UIDNA.swift
@@ -10,13 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-import Foundation
-#else
-import FoundationEssentials
-import FoundationInternationalization
-#endif // FOUNDATION_FRAMEWORK
-
 #if canImport(TestSupport)
 import TestSupport
 #endif


### PR DESCRIPTION
`@testable` imports have a number of build-time drawbacks, including:
- Building the package in `release` configuration and then running tests requires the entire package to be rebuilt because SwiftPM needs to pass `--enable-testing` to the compiler invocations.
- The usage of `@testable` means that swift-foundation cannot be included in the unified (aka. multiroot) build of all the other packages in Swift CI, which means that it needs to re-build swift-syntax, unnecessarily increasing CI time.

To fix this, make all `@testable` imports normal imports and mark the declarations that were previously accessed through `@testable` as `package`.