### PR TITLE
Add an upcall point to swift-corelibs-foundation for String encoding conversion

### DIFF
--- a/Sources/FoundationEssentials/String/String+IO.swift
+++ b/Sources/FoundationEssentials/String/String+IO.swift
@@ -45,6 +45,13 @@ private struct ExtendingToUTF16Sequence<Base: Sequence<UInt8>> : Sequence {
     }
 }
 
+#if !FOUNDATION_FRAMEWORK
+@_spi(SwiftCorelibsFoundation)
+dynamic public func _cfMakeStringFromBytes(_ bytes: UnsafeBufferPointer<UInt8>, encoding: UInt) -> String? {
+    // Provide swift-corelibs-foundation with an entry point to convert some bytes into a String
+    return nil
+}
+#endif
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension String {
@@ -225,7 +232,12 @@ extension String {
                 return nil
             }
 #else
-            return nil
+            if let string = (bytes.withContiguousStorageIfAvailable({ _cfMakeStringFromBytes($0, encoding: encoding.rawValue) }) ??
+                             Array(bytes).withUnsafeBufferPointer({ _cfMakeStringFromBytes($0, encoding: encoding.rawValue) })) {
+                self = string
+            } else {
+                return nil
+            }
 #endif
         }
     }


### PR DESCRIPTION
Add an upcall to swift-corelibs-foundation for converting String encodings that swift-foundation does not implement.

Partially resolves https://github.com/swiftlang/swift-foundation/issues/1216.