### PR TITLE
Improve performance for comparing AttributedStrings with differing character counts

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -414,12 +414,21 @@ let benchmarks = {
 #endif
     
     let manyAttributesString2 = createManyAttributesString()
+    let manyAttributesString3 =  {
+        var str = createManyAttributesString()
+        str.characters.append("a")
+        return str
+    }()
     let manyAttributesStringRange = manyAttributesString.characters.index(manyAttributesString.startIndex, offsetBy: manyAttributesString.characters.count / 2)...
     let manyAttributesSubstring = manyAttributesString[manyAttributesStringRange]
     let manyAttributes2Substring = manyAttributesString2[manyAttributesStringRange]
 
     Benchmark("equality") { benchmark in
         blackHole(manyAttributesString == manyAttributesString2)
+    }
+    
+    Benchmark("equalityDifferingCharacters") { benchmark in
+        blackHole(manyAttributesString == manyAttributesString3)
     }
     
     Benchmark("substringEquality") { benchmark in

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -92,7 +92,7 @@ extension AttributedString.Guts {
 
     internal static func _characterwiseIsEqual(
         _ left: AttributedString.Runs,
-        to right: AttributedString.Runs,
+        to right: AttributedString.Runs
     ) -> Bool {
         // To decide if two attributed strings are equal, we need to logically split them up on
         // run boundaries, then check that each pair of pieces contains the same attribute values

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -78,11 +78,7 @@ extension AttributedString.Guts {
         _ left: AttributedString.Guts,
         to right: AttributedString.Guts
     ) -> Bool {
-        _characterwiseIsEqual(
-            AttributedString.Runs(left, in: Range(uncheckedBounds: (left.string.startIndex, left.string.endIndex))),
-            to: AttributedString.Runs(right, in: Range(uncheckedBounds: (right.string.startIndex, right.string.endIndex))),
-            fullString: true
-        )
+        characterwiseIsEqual(left, in: left.stringBounds, to: right, in: right.stringBounds)
     }
 
     internal static func characterwiseIsEqual(
@@ -91,13 +87,12 @@ extension AttributedString.Guts {
     ) -> Bool {
         let leftRuns = AttributedString.Runs(left, in: leftRange)
         let rightRuns = AttributedString.Runs(right, in: rightRange)
-        return _characterwiseIsEqual(leftRuns, to: rightRuns, fullString: false)
+        return _characterwiseIsEqual(leftRuns, to: rightRuns)
     }
 
     internal static func _characterwiseIsEqual(
         _ left: AttributedString.Runs,
         to right: AttributedString.Runs,
-        fullString: Bool
     ) -> Bool {
         // To decide if two attributed strings are equal, we need to logically split them up on
         // run boundaries, then check that each pair of pieces contains the same attribute values
@@ -116,7 +111,7 @@ extension AttributedString.Guts {
         guard left.count == right.count else { return false }
         guard !left.isEmpty else { return true }
         
-        if fullString {
+        if !left._isPartial && !right._isPartial {
             // For a full BigString, we can get the grapheme cluster count in constant time since
             // the grapheme cluster count is cached at the node level in the tree. It is not
             // possible for two AttributedStrings with differing character counts to be equal,

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -31,6 +31,16 @@ extension AttributedString {
         internal let _strBounds: RangeSet<BigString.Index>
         internal let _isDiscontiguous: Bool
         
+        internal var _isPartial: Bool {
+            guard !_isDiscontiguous else {
+                return true
+            }
+            guard let lower = _bounds.lowerBound._stringIndex, let upper = _bounds.upperBound._stringIndex else {
+                preconditionFailure("AttributedString.Runs created with bounds that have un-set string indices")
+            }
+            return _guts.string.startIndex != lower || _guts.string.endIndex != upper
+        }
+        
         internal init(_ guts: Guts, in bounds: Range<BigString.Index>) {
             self.init(guts, in: RangeSet(bounds))
         }

--- a/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
@@ -57,7 +57,7 @@ extension DiscontiguousAttributedSubstring : CustomStringConvertible {
 @available(FoundationPreview 6.2, *)
 extension DiscontiguousAttributedSubstring : Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        AttributedString.Guts._characterwiseIsEqual(lhs.runs, to: rhs.runs, fullString: false)
+        AttributedString.Guts._characterwiseIsEqual(lhs.runs, to: rhs.runs)
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/DiscontiguousAttributedSubstring.swift
@@ -57,7 +57,7 @@ extension DiscontiguousAttributedSubstring : CustomStringConvertible {
 @available(FoundationPreview 6.2, *)
 extension DiscontiguousAttributedSubstring : Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        AttributedString.Guts._characterwiseIsEqual(lhs.runs, to: rhs.runs)
+        AttributedString.Guts._characterwiseIsEqual(lhs.runs, to: rhs.runs, fullString: false)
     }
 }
 


### PR DESCRIPTION
Two `AttributedString`s with differing character counts will never compare equal. When we can cheaply determine that the character counts are inequal, we should return early from `AttributedString.==` rather than comparing each runs contents. This situation can be quite common (for example, just appending a single character to the end of the last run like when a user types into a text box) and it turns a full run-by-run comparison of the entire string into a single constant time evaluation. The benchmark results highlight that for this worst-case, but common, scenario the wins are significant:

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (M)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      92 │      91 │      90 │      88 │      83 │      71 │      71 │      89 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  branch                  │  480077 │  461567 │  453119 │  452863 │  444671 │  353023 │   11964 │   10000 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │  479985 │  461476 │  453029 │  452775 │  444588 │  352952 │   11893 │    9911 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │  521723 │  507116 │  503366 │  514517 │  535648 │  497115 │   16751 │    9911 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

Note: there's an explanation left in the comments of the code but this optimization is currently only performed for `AttributedString.==` and not for `AttributedSubstring.==` or `DiscontiguousAttributedSubstring.==`.