### PR TITLE
Improve performance of enumerating constraint-bound attributes consistent across many runs

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -464,6 +464,43 @@ let benchmarks = {
         blackHole(hasher.finalize())
     }
 #endif
+    
+    let manyAttributesWithParagraph = {
+        var str = createManyAttributesString()
+        str.testParagraphConstrained = 2
+        return str
+    }()
+    
+    Benchmark("paragraphBoundSliceEnumeration-shortRuns") { benchmark in
+        for (value, range) in manyAttributesWithParagraph.runs[\.testParagraphConstrained] {
+            blackHole(value)
+        }
+    }
+    
+    Benchmark("paragraphBoundSliceEnumeration-shortRuns-reversed") { benchmark in
+        for (value, range) in manyAttributesWithParagraph.runs[\.testParagraphConstrained].reversed() {
+            blackHole(value)
+        }
+    }
+    
+    let longParagraphsString = {
+        var str = String(repeating: "a", count: 10000) + "\n"
+        str += String(repeating: "b", count: 10000) + "\n"
+        str += String(repeating: "c", count: 10000)
+        return AttributedString(str, attributes: AttributeContainer.testParagraphConstrained(1).testInt(2))
+    }()
+    
+    Benchmark("paragraphBoundSliceEnumeration-longRuns") { benchmark in
+        for (value, range) in longParagraphsString.runs[\.testParagraphConstrained] {
+            blackHole(value)
+        }
+    }
+    
+    Benchmark("paragraphBoundSliceEnumeration-longRuns-reversed") { benchmark in
+        for (value, range) in longParagraphsString.runs[\.testParagraphConstrained].reversed() {
+            blackHole(value)
+        }
+    }
 }
 
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -24,13 +24,13 @@ extension AttributedString.Runs {
 
         let runs: Runs
         let _names: [String]
-        let _constraints: [AttributeRunBoundaries]
+        let _constraints: Set<AttributeRunBoundaries?>
 
         init(runs: Runs) {
             self.runs = runs
             // FIXME: ☠️ Get these from a proper cache in runs._guts.
             _names = [T.name]
-            _constraints = T._constraintsInvolved
+            _constraints = [T.runBoundaries]
         }
 
         public struct Iterator: IteratorProtocol, Sendable {
@@ -162,13 +162,13 @@ extension AttributedString.Runs {
 
         let runs : Runs
         let _names: [String]
-        let _constraints: [AttributeRunBoundaries]
+        let _constraints: Set<AttributeRunBoundaries?>
 
         init(runs: Runs) {
             self.runs = runs
             // FIXME: ☠️ Get these from a proper cache in runs._guts.
             _names = [T.name, U.name]
-            _constraints = Array(_contents: T.runBoundaries, U.runBoundaries)
+            _constraints = [T.runBoundaries, U.runBoundaries]
         }
 
         public struct Iterator: IteratorProtocol, Sendable {
@@ -320,13 +320,13 @@ extension AttributedString.Runs {
 
         let runs : Runs
         let _names: [String]
-        let _constraints: [AttributeRunBoundaries]
+        let _constraints: Set<AttributeRunBoundaries?>
 
         init(runs: Runs) {
             self.runs = runs
             // FIXME: ☠️ Get these from a proper cache in runs._guts.
             _names = [T.name, U.name, V.name]
-            _constraints = Array(_contents: T.runBoundaries, U.runBoundaries, V.runBoundaries)
+            _constraints = [T.runBoundaries, U.runBoundaries, V.runBoundaries]
         }
 
         public struct Iterator: IteratorProtocol, Sendable {
@@ -490,14 +490,13 @@ extension AttributedString.Runs {
 
         let runs : Runs
         let _names: [String]
-        let _constraints: [AttributeRunBoundaries]
+        let _constraints: Set<AttributeRunBoundaries?>
 
         init(runs: Runs) {
             self.runs = runs
             // FIXME: ☠️ Get these from a proper cache in runs._guts.
             _names = [T.name, U.name, V.name, W.name]
-            _constraints = Array(
-                _contents: T.runBoundaries, U.runBoundaries, V.runBoundaries, W.runBoundaries)
+            _constraints = [T.runBoundaries, U.runBoundaries, V.runBoundaries, W.runBoundaries]
         }
 
         public struct Iterator: IteratorProtocol, Sendable {
@@ -675,18 +674,19 @@ extension AttributedString.Runs {
 
         let runs : Runs
         let _names: [String]
-        let _constraints: [AttributeRunBoundaries]
+        let _constraints: Set<AttributeRunBoundaries?>
 
         init(runs: Runs) {
             self.runs = runs
             // FIXME: ☠️ Get these from a proper cache in runs._guts.
             _names = [T.name, U.name, V.name, W.name]
-            _constraints = Array(
-                _contents: T.runBoundaries,
+            _constraints = [
+                T.runBoundaries,
                 U.runBoundaries,
                 V.runBoundaries,
                 W.runBoundaries,
-                X.runBoundaries)
+                X.runBoundaries
+            ]
         }
 
         public struct Iterator: IteratorProtocol, Sendable {
@@ -955,75 +955,3 @@ extension AttributedString.Runs {
 }
 
 #endif // FOUNDATION_FRAMEWORK
-
-extension RangeReplaceableCollection {
-    internal init(_contents item1: Element?) {
-        self.init()
-        if let item1 { self.append(item1) }
-    }
-
-    internal init(_contents item1: Element?, _ item2: Element?) {
-        self.init()
-        var c = 0
-        if item1 != nil { c &+= 1 }
-        if item2 != nil { c &+= 1 }
-        guard c > 0 else { return }
-        self.reserveCapacity(c)
-        if let item1 { self.append(item1) }
-        if let item2 { self.append(item2) }
-    }
-
-    internal init(_contents item1: Element?, _ item2: Element?, _ item3: Element?) {
-        self.init()
-        var c = 0
-        if item1 != nil { c &+= 1 }
-        if item2 != nil { c &+= 1 }
-        if item3 != nil { c &+= 1 }
-        guard c > 0 else { return }
-        self.reserveCapacity(c)
-        if let item1 { self.append(item1) }
-        if let item2 { self.append(item2) }
-        if let item3 { self.append(item3) }
-    }
-
-    internal init(
-        _contents item1: Element?, _ item2: Element?, _ item3: Element?, _ item4: Element?
-    ) {
-        self.init()
-        var c = 0
-        if item1 != nil { c &+= 1 }
-        if item2 != nil { c &+= 1 }
-        if item3 != nil { c &+= 1 }
-        if item4 != nil { c &+= 1 }
-        guard c > 0 else { return }
-        self.reserveCapacity(c)
-        if let item1 { self.append(item1) }
-        if let item2 { self.append(item2) }
-        if let item3 { self.append(item3) }
-        if let item4 { self.append(item4) }
-    }
-
-    internal init(
-        _contents item1: Element?,
-        _ item2: Element?,
-        _ item3: Element?,
-        _ item4: Element?,
-        _ item5: Element?
-    ) {
-        self.init()
-        var c = 0
-        if item1 != nil { c &+= 1 }
-        if item2 != nil { c &+= 1 }
-        if item3 != nil { c &+= 1 }
-        if item4 != nil { c &+= 1 }
-        if item5 != nil { c &+= 1 }
-        guard c > 0 else { return }
-        self.reserveCapacity(c)
-        if let item1 { self.append(item1) }
-        if let item2 { self.append(item2) }
-        if let item3 { self.append(item3) }
-        if let item4 { self.append(item4) }
-        if let item5 { self.append(item5) }
-    }
-}
-

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -123,14 +123,6 @@ extension AttributedStringKey {
     public static var invalidationConditions : Set<AttributedString.AttributeInvalidationCondition>? { nil }
 }
 
-extension AttributedStringKey {
-    // FIXME: ☠️ Allocating an Array here is not a good idea.
-    static var _constraintsInvolved: [AttributedString.AttributeRunBoundaries] {
-        guard let rb = runBoundaries else { return [] }
-        return [rb]
-    }
-}
-
 // MARK: Attribute Scopes
 
 @dynamicMemberLookup @frozen

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
@@ -83,6 +83,13 @@ extension Collection where Element == AttributedString.AttributeRunBoundaries {
     }
 }
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension Collection where Element == AttributedString.AttributeRunBoundaries? {
+    var _containsScalarConstraint: Bool {
+        self.contains { $0?._isScalarConstrained ?? false }
+    }
+}
+
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Guts {
     


### PR DESCRIPTION
Attributes bound to particular run boundaries (paragraphs, characters, etc.) are guaranteed to have consistent values between each boundary. This invariant is enforced at mutation time so that reading the attributed string can take advantage of this information. One place where we have yet to take advantage of this is when enumerating runs sliced to a particular attribute (for example `attrStr.runs[\.someParagraphConstrainedAttribute]`). Currently, we follow these steps to find the end of a coalesced run:

- Iterate run-by-run through the storage comparing attribute values until we find the run where the attribute value has changed
- If we have iterated past the end of the current chunk in a discontiguous slice, jump back to the end of the chunk
- Scan the original location through the current location looking for a constraint boundary and jump back to that index if found

However, since we know that attribute values must be consistent up to the next constraint boundary, there's no need to look at the attribute values at all! If we are only dealing with a single kind of run boundary (for any number of attributes) we can just find the next constraint break (within the current discontiguous slice chunk) and return that without spending time comparing attribute values (which can be quite expensive). I added some benchmarks that show quite a bit of improvement in this area with these updates:

```
----------------------------------------------------------------------------------------------------------------------------
paragraphBoundSliceEnumeration-shortRuns metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (K)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │     395 │     377 │     372 │     366 │     356 │     278 │     262 │     367 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  branch                  │    4859 │    4351 │    4347 │    4343 │    4283 │    4051 │    2841 │    4276 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    4464 │    3974 │    3975 │    3977 │    3927 │    3773 │    2579 │    3909 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │    1130 │    1054 │    1069 │    1087 │    1103 │    1357 │     984 │    3909 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
paragraphBoundSliceEnumeration-shortRuns-reversed metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (K)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │     199 │     190 │     187 │     184 │     181 │     170 │     168 │     187 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                  branch                  │    2700 │    2639 │    2639 │    2619 │    2601 │    2475 │    1920 │    2607 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    2501 │    2449 │    2452 │    2435 │    2420 │    2305 │    1752 │    2420 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │    1257 │    1289 │    1311 │    1323 │    1337 │    1356 │    1043 │    2420 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

The long run benchmarks are unchanged (because they don't spend a lot of time comparing attribute values) but these changes don't regress them in any way.

rdar://146903366