### PR TITLE
Use nonblocking IO for open

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -301,7 +301,8 @@ internal func readBytesFromFile(path inPath: PathOrURL, reportProgress: Bool, ma
         guard let inPathFileSystemRep else {
             throw CocoaError(.fileReadInvalidFileName)
         }
-        return open(inPathFileSystemRep, O_RDONLY, 0o666)
+        // Do not block on opening the file here. If the file is not a regular one, we will produce an error below after `fstat`.
+        return open(inPathFileSystemRep, O_RDONLY | O_NONBLOCK, 0o666)
     }
         
     guard fd >= 0 else {


### PR DESCRIPTION
Use nonblocking for `open`, so if the file is non-regular then we can proceed past this call without blocking. A later check will verify the kind of file with `fstat`.