### PR TITLE
Use the default time zone instead of gmt

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -193,25 +193,22 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
     init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
 
-        // ISO8601 has different default values for time zone, locale, firstWeekday, and minimumDaysInFirstWeek
-        let defaultTimeZone: TimeZone
+        // ISO8601 has different default values locale, firstWeekday, and minimumDaysInFirstWeek
         let defaultLocale: Locale?
         let defaultFirstWeekday: Int?
         let defaultMinimumDaysInFirstWeek: Int?
         
         if identifier == .iso8601 {
-            defaultTimeZone = .gmt
             defaultLocale = Locale.unlocalized
             defaultFirstWeekday = 2
             defaultMinimumDaysInFirstWeek = 4
         } else {
-            defaultTimeZone = .default
             defaultLocale = nil
             defaultFirstWeekday = nil
             defaultMinimumDaysInFirstWeek = nil
         }
                 
-        self.timeZone = timeZone ?? defaultTimeZone
+        self.timeZone = timeZone ?? .default
         if let gregorianStartDate {
             self.gregorianStartDate = gregorianStartDate
             do {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -3886,7 +3886,6 @@ final class GregorianCalendarTests : XCTestCase {
         
         XCTAssertEqual(calendar1.firstWeekday, 2)
         XCTAssertEqual(calendar1.minimumDaysInFirstWeek, 4)
-        XCTAssertEqual(calendar1.timeZone, .gmt)
         XCTAssertEqual(calendar1.locale, .unlocalized)
         
         // Verify that the properties are still mutable


### PR DESCRIPTION
Match the previous behavior of an `iso8601` calendar by setting the time zone to the `default` (which falls back to `current`) instead of using only `gmt`.