### PR TITLE
Resolve deprecation warning in Foundation Macros concerning FunctionCallExprSyntax initializer

### DIFF
--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -275,7 +275,7 @@ private class OptionalChainRewriter: SyntaxRewriter, PredicateSyntaxRewriter {
             let visited = self.visit(input)
             let closure = ClosureExprSyntax(statements: [CodeBlockItemSyntax(item: CodeBlockItemSyntax.Item(node))])
             let functionMember = MemberAccessExprSyntax(base: visited, name: "flatMap")
-            let functionCall = FunctionCallExprSyntax(calledExpression: functionMember, arguments: [], trailingClosure: closure)
+            let functionCall = FunctionCallExprSyntax(calledExpression: functionMember, leftParen: .leftParenToken(), arguments: [], rightParen: .rightParenToken(), trailingClosure: closure)
             return ExprSyntax(functionCall)
         }
         return node


### PR DESCRIPTION
This resolves a deprecation warning that was introduced by a swift-syntax change. We resolve the deprecation by switching to the recommended initializer.