### PR TITLE
[wasm] Add O_NONBLOCK shim

### DIFF
--- a/Sources/FoundationEssentials/WASILibc+Extensions.swift
+++ b/Sources/FoundationEssentials/WASILibc+Extensions.swift
@@ -49,6 +49,9 @@ internal var O_TRUNC: Int32 {
 internal var O_WRONLY: Int32 {
     return _platform_shims_O_WRONLY()
 }
+internal var O_NONBLOCK: Int32 {
+    return _platform_shims_O_NONBLOCK()
+}
 internal var O_RDONLY: Int32 {
     return _platform_shims_O_RDONLY()
 }

--- a/Sources/_FoundationCShims/include/platform_shims.h
+++ b/Sources/_FoundationCShims/include/platform_shims.h
@@ -102,6 +102,7 @@ static inline int32_t _platform_shims_O_CREAT(void) { return O_CREAT; }
 static inline int32_t _platform_shims_O_EXCL(void) { return O_EXCL; }
 static inline int32_t _platform_shims_O_TRUNC(void) { return O_TRUNC; }
 static inline int32_t _platform_shims_O_WRONLY(void) { return O_WRONLY; }
+static inline int32_t _platform_shims_O_NONBLOCK(void) { return O_NONBLOCK; }
 static inline int32_t _platform_shims_O_RDONLY(void) { return O_RDONLY; }
 static inline int32_t _platform_shims_O_DIRECTORY(void) { return O_DIRECTORY; }
 static inline int32_t _platform_shims_O_NOFOLLOW(void) { return O_NOFOLLOW; }


### PR DESCRIPTION
05975959e67f57063445baabb652262dd764cc72 added a use of `O_NONBLOCK` but the constant cannot be imported from wasi-libc through ClangImporter directly, so we need to add a shim for it as well as other constants.