### PR TITLE
Lazily compute whether attribute changed in _attributeModified(_:old:new:)

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
@@ -186,12 +186,15 @@ extension AttributedString._AttributeStorage {
             invalidatableKeys.remove(key)
         }
 
-        guard old != new else { return }
+        // Lazy to ensure we only check if the value changed when we actually need to because we found a dependent attribute
+        // Unboxing the attribute value to call its == implementation can be expensive, so for text that doesn't contain dependent attributes avoid it when possible
+        lazy var valueChanged = { old != new }()
 
         for k in invalidatableKeys {
             guard k != key else { continue }
             guard let value = contents[k] else { continue }
             guard value.isInvalidatedOnChange(of: key) else { continue }
+            guard valueChanged else { return }
             // FIXME: ☠️ This subscript assignment is recursively calling this same method.
             // FIXME: Collect invalidated keys into a temporary set instead, and progressively
             // FIXME: extend that set until all its keys are gone.


### PR DESCRIPTION
`_attributeModified` is called when an attribute value in an attribute storage dictionary was replaced by a new value. It is responsible for enforcing the invalidation constraints on attributes by removing any dependent attributes from the storage (recursively). Currently (assuming both a new and old value exist) this function unconditionally compares the new and old values to return early if the value didn't change (meaning attributes shouldn't be invalidated). However, this requires unboxing the existential attribute values and calling through to their `==` implementation which can be expensive. Instead, we can make this calculation lazy, only performing it when we actually find another attribute dependent upon the changed one. In cases where there are no dependent attributes, we avoid the equality check altogether as it is unnecessary. This shows about a 6% to 11% improvement in the `setAttribute` benchmark:

```
╒══════════════════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│          Throughput (# / s) (K)          │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│                   main                   │       141 │       140 │       139 │       137 │       135 │       125 │       122 │       138 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                  branch                  │       150 │       148 │       147 │       146 │       145 │       142 │       136 │       147 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                    Δ                     │         9 │         8 │         8 │         9 │        10 │        17 │        14 │         9 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│              Improvement %               │         6 │         6 │         6 │         7 │         7 │        14 │        11 │         9 │
╘══════════════════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```