### PR TITLE
[wasm] Stop requiring `TZDIR` and `TZDEFAULT` on WASI

### DIFF
--- a/Sources/_FoundationCShims/include/_CStdlib.h
+++ b/Sources/_FoundationCShims/include/_CStdlib.h
@@ -156,7 +156,7 @@
 #ifndef TZDEFAULT
 #define TZDEFAULT    "/etc/localtime"
 #endif /* !defined TZDEFAULT */
-#elif TARGET_OS_WINDOWS
+#elif TARGET_OS_WINDOWS || TARGET_OS_WASI
 /* not required */
 #else
 #error "possibly define TZDIR and TZDEFAULT for this platform"


### PR DESCRIPTION
Those constants are not used on WASI in Swift side, so there's no need to require them in the C headers. The `#error` was introduced by 03fe46f43b3a2d8d9159d46a1f56517acc525e69.