### PR TITLE
Remove URL workaround for Linux crash once SCL-F is rebuilt

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -690,18 +690,6 @@ public struct URL: Equatable, Sendable, Hashable {
     ///
     /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
     public init?(string: __shared String, relativeTo url: __shared URL?) {
-        #if os(Linux)
-        // Workaround for a Linux-only crash where swift-corelibs-foundation's
-        // NSURL.baseURL.getter returns a value of 0x1 when bridging to URL.
-        // Crash doesn't occur when swift-corelibs-foundation is rebuilt with
-        // the new swift-foundation URL code, so this is temporary to get
-        // swift-foundation CI to pass.
-        if unsafeBitCast(url, to: (UnsafeRawPointer, UnsafeRawPointer).self) == (UnsafeRawPointer(bitPattern: 0x1), UnsafeRawPointer(bitPattern: 0x0)) {
-            guard let inner = URL._type.init(string: string, relativeTo: nil) else { return nil }
-            _url = inner.convertingFileReference()
-            return
-        }
-        #endif
         guard let inner = URL._type.init(string: string, relativeTo: url) else { return nil }
         _url = inner.convertingFileReference()
     }


### PR DESCRIPTION
Tested with a recent nightly-main container, and removing the Linux-only workaround `unsafeBitCast == 0x1` check works now that swift-corelibs-foundation was built with the new swift-foundation `URL` changes in #1238.

Removing the other `private var _padding` workaround still causes a crash in libXCTest on Linux, so that will require further investigation.