### PR TITLE
[6.2][cherrypick] OpenBSD support. 

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -40,6 +40,8 @@ func _fgetxattr(_ fd: Int32, _ name: UnsafePointer<CChar>!, _ value: UnsafeMutab
     return fgetxattr(fd, name, value, size, position, options)
 #elseif os(FreeBSD)
     return extattr_get_fd(fd, EXTATTR_NAMESPACE_USER, name, value, size)
+#elseif os(OpenBSD)
+    return -1
 #elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
     return fgetxattr(fd, name, value, size)
 #else

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -639,6 +639,8 @@ private func writeExtendedAttributes(fd: Int32, attributes: [String : Data]) {
             _ = fsetxattr(fd, key, valueBuf.baseAddress!, valueBuf.count, 0, 0)
 #elseif os(FreeBSD)
             _ = extattr_set_fd(fd, EXTATTR_NAMESPACE_USER, key, valueBuf.baseAddress!, valueBuf.count)
+#elseif os(OpenBSD)
+            return
 #elseif canImport(Glibc) || canImport(Musl)
             _ = fsetxattr(fd, key, valueBuf.baseAddress!, valueBuf.count, 0)
 #endif

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -201,7 +201,7 @@ extension _FileManagerImpl {
             }
         }
         return results
-#elseif os(WASI)
+#elseif os(WASI) || os(OpenBSD)
         // wasi-libc does not support FTS for now
         throw CocoaError.errorWithFilePath(.featureUnsupported, path)
 #else

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -485,7 +485,7 @@ extension _FileManagerImpl {
 #endif
     }
 
-#if !os(Windows) && !os(WASI)
+#if !os(Windows) && !os(WASI) && !os(OpenBSD)
     private func _extendedAttribute(_ key: UnsafePointer<CChar>, at path: UnsafePointer<CChar>, followSymlinks: Bool) throws -> Data? {
         #if canImport(Darwin)
         var size = getxattr(path, key, nil, 0, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
@@ -647,7 +647,7 @@ extension _FileManagerImpl {
             
             var attributes = statAtPath.fileAttributes
             try? Self._catInfo(for: URL(filePath: path, directoryHint: .isDirectory), statInfo: statAtPath, into: &attributes)
-            #if !os(WASI) // WASI does not support extended attributes
+            #if !os(WASI) && !os(OpenBSD)
             if let extendedAttrs = try? _extendedAttributes(at: fsRep, followSymlinks: false) {
                 attributes[._extendedAttributes] = extendedAttrs
             }
@@ -735,6 +735,9 @@ extension _FileManagerImpl {
             
             #if canImport(Darwin)
             let fsNumber = result.f_fsid.val.0
+            let blockSize = UInt64(result.f_bsize)
+            #elseif os(OpenBSD)
+            let fsNumber = result.f_fsid
             let blockSize = UInt64(result.f_bsize)
             #else
             let fsNumber = result.f_fsid
@@ -950,7 +953,7 @@ extension _FileManagerImpl {
             try Self._setCatInfoAttributes(attributes, path: path)
             
             if let extendedAttrs = attributes[.init("NSFileExtendedAttributes")] as? [String : Data] {
-                #if os(WASI)
+                #if os(WASI) || os(OpenBSD)
                 // WASI does not support extended attributes
                 throw CocoaError.errorWithFilePath(.featureUnsupported, path)
                 #elseif canImport(Android)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -178,7 +178,7 @@ extension _FileManagerImpl {
         #endif
     }
 
-#if !os(Windows) && !os(WASI)
+#if !os(Windows) && !os(WASI) && !os(OpenBSD)
     static func _setAttribute(_ key: UnsafePointer<CChar>, value: Data, at path: UnsafePointer<CChar>, followSymLinks: Bool) throws {
         try value.withUnsafeBytes { buffer in
             #if canImport(Darwin)

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -354,7 +354,8 @@ struct _POSIXDirectoryContentsSequence: Sequence {
                     continue
                 }
                 #endif
-                #if os(FreeBSD)
+
+                #if os(FreeBSD) || os(OpenBSD)
                 guard dent.pointee.d_fileno != 0 else {
                     continue
                 }
@@ -363,6 +364,7 @@ struct _POSIXDirectoryContentsSequence: Sequence {
                     continue
                 }
                 #endif
+
                 // Use name
                 let fileName: String
                 #if os(WASI)

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -921,7 +921,7 @@ enum _FileOperations {
         }
         var current: off_t = 0
         
-        #if os(WASI)
+        #if os(WASI) || os(OpenBSD)
         // WASI doesn't have sendfile, so we need to do it in user space with read/write
         try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: chunkSize) { buffer in
             while current < total {
@@ -958,7 +958,7 @@ enum _FileOperations {
     
     #if !canImport(Darwin)
     private static func _copyDirectoryMetadata(srcFD: CInt, srcPath: @autoclosure () -> String, dstFD: CInt, dstPath: @autoclosure () -> String, delegate: some LinkOrCopyDelegate) throws {
-        #if !os(WASI) && !os(Android)
+        #if !os(WASI) && !os(Android) && !os(OpenBSD)
         // Copy extended attributes
         #if os(FreeBSD)
         // FreeBSD uses the `extattr_*` calls for setting extended attributes. Unlike like, the namespace for the extattrs are not determined by prefix of the attribute

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -31,7 +31,7 @@ package struct LockedState<State> {
     private struct _Lock {
 #if canImport(os)
         typealias Primitive = os_unfair_lock
-#elseif os(FreeBSD)
+#elseif os(FreeBSD) || os(OpenBSD)
         typealias Primitive = pthread_mutex_t?
 #elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
         typealias Primitive = pthread_mutex_t

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -224,7 +224,7 @@ extension Platform {
 // MARK: - Environment Variables
 extension Platform {
     static func getEnvSecure(_ name: String) -> String? {
-        #if canImport(Glibc)
+        #if canImport(Glibc) && !os(OpenBSD)
         if let value = secure_getenv(name) {
             return String(cString: value)
         } else {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -469,7 +469,7 @@ extension _ProcessInfo {
             return 0
         }
         return Int(count)
-#elseif os(Linux) || os(FreeBSD) || canImport(Android)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || canImport(Android)
         #if os(Linux)
         if let fsCount = Self.fsCoreCount() {
             return fsCount
@@ -481,7 +481,7 @@ extension _ProcessInfo {
         GetSystemInfo(&sysInfo)
         return sysInfo.dwActiveProcessorMask.nonzeroBitCount
 #else
-        return 0
+        return 1
 #endif
     }
     

--- a/Sources/_FoundationCShims/include/_CStdlib.h
+++ b/Sources/_FoundationCShims/include/_CStdlib.h
@@ -156,6 +156,10 @@
 #ifndef TZDEFAULT
 #define TZDEFAULT    "/etc/localtime"
 #endif /* !defined TZDEFAULT */
+#elif TARGET_OS_WINDOWS
+/* not required */
+#else
+#error "possibly define TZDIR and TZDEFAULT for this platform"
 #endif /* TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD */
 
 #endif


### PR DESCRIPTION
  - **Explanation**:
Cherrypick OpenBSD support changes onto 6.2. This will help reduce the delta between the branch and an eventual OpenBSD platform port.

  - **Scope**:
Most of the changes are limited to OpenBSD or changing defaults that do not apply to other operating systems.

  - **Issues**:
See OpenBSD port issue in https://github.com/swiftlang/swift/issues/78437

  - **Original PRs**:
 
    #1126 

  - **Risk**:
Minimal, since changes are mostly limited to OpenBSD.

  - **Testing**:
Original change has passed CI.

  - **Reviewers**:

@finagolfin 
@parkera 