### PR TITLE
Update the link for Proposals 0022-writing-direction-attribute.md

### DIFF
--- a/Proposals/0022-writing-direction-attribute.md
+++ b/Proposals/0022-writing-direction-attribute.md
@@ -1,6 +1,6 @@
 # Writing Direction Attribute
 
-* Proposal: [SF-0022](NNNN-writing-direction-attribute.md)
+* Proposal: [SF-0022](0022-writing-direction-attribute.md)
 * Authors: [Max Obermeier](https://github.com/themomax)
 * Review Manager: [Tina L](https://github.com/itingliu)
 * Status: **Approved and Implemented**


### PR DESCRIPTION
Update the link for Proposals `0022-writing-direction-attribute.md` . Currently, it displays `404 not found` error.