### PR TITLE
AttributedString character insertion doesn't invalidate text dependent attributes

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
@@ -183,11 +183,18 @@ extension AttributedString.Guts {
     /// - Returns: The UTF-8 range that was modified during this invalidation.
     ///     (If no modification took place, then the result is `range`.)
     func enforceAttributeConstraintsBeforeMutation(to utf8Range: Range<Int>) -> Range<Int> {
-        guard !utf8Range.isEmpty else { return utf8Range }
+        var utf8Start = utf8Range.lowerBound
+        var utf8End = utf8Range.upperBound
+
+        // Eagerly record the attributes at the end of the mutation as invalidating attributes at the start may change attributes at the end (if the mutation is within a run)
+        let originalEndingAttributes = if utf8End > 0 {
+            _characterInvalidatedAttributes(at: utf8End - 1)
+        } else {
+            _AttributeStorage()
+        }
 
         // Invalidate attributes preceding the range.
-        var utf8Start = utf8Range.lowerBound
-        do {
+        if utf8Start < string.utf8.count {
             let attributes = _characterInvalidatedAttributes(at: utf8Start)
             var remainingKeys = Set(attributes.keys)
             let runs = runs(in: 0 ..< utf8Start)
@@ -210,9 +217,8 @@ extension AttributedString.Guts {
         }
 
         // Invalidate attributes following the range.
-        var utf8End = utf8Range.upperBound
-        do {
-            let attributes = _characterInvalidatedAttributes(at: utf8End - 1)
+        if utf8End > 0 {
+            let attributes = originalEndingAttributes
             var remainingKeys = Set(attributes.keys)
             let runs = runs(in: utf8End ..< string.utf8.count)
             var i = runs.startIndex

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringConstrainingBehaviorTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringConstrainingBehaviorTests.swift
@@ -509,6 +509,14 @@ class TestAttributedStringConstrainingBehavior: XCTestCase {
         verify(string: result, matches: [("Hello, world", 1, 2), ("ABC", 1, nil)], for: \.testInt, \.testCharacterDependent)
         
         result = str
+        result.characters.insert("A", at: result.startIndex)
+        verify(string: result, matches: [("A", 1, nil), ("Hello, world", 1, 2)], for: \.testInt, \.testCharacterDependent)
+        
+        result = str
+        result.characters.insert("A", at: result.index(afterCharacter: result.startIndex))
+        verify(string: result, matches: [("HAello, world", 1, nil)], for: \.testInt, \.testCharacterDependent)
+        
+        result = str
         result.characters.removeSubrange(result.index(afterCharacter: result.startIndex) ..< result.index(beforeCharacter: result.endIndex))
         verify(string: result, matches: [("Hd", 1, nil)], for: \.testInt, \.testCharacterDependent)
 
@@ -566,5 +574,13 @@ class TestAttributedStringConstrainingBehavior: XCTestCase {
         result[result.startIndex ..< result.index(afterCharacter: result.startIndex)] = replacement[replacement.startIndex ..< replacement.index(afterCharacter: str.startIndex)]
         verify(string: result, matches: [("H", nil, nil, "Hello"), ("ello, world", 1, nil, nil)], for: \.testInt, \.testCharacterDependent, \.testString)
     }
-
+    
+    func testInvalidationCharacterInsertionBetweenRuns() {
+        var str = AttributedString("Hello", attributes: .init().testInt(1).testCharacterDependent(2))
+        str += AttributedString("World", attributes: .init().testInt(1).testCharacterDependent(3))
+        
+        // Inserting text between two runs should not invalidate text dependent attributes in either of the surrounding runs
+        str.characters.insert("|", at: str.index(str.startIndex, offsetByCharacters: 5))
+        verify(string: str, matches: [("Hello", 1, 2), ("|", 1, nil), ("World", 1, 3)], for: \.testInt, \.testCharacterDependent)
+    }
 }


### PR DESCRIPTION
When inserting a character into an attribute run, if that run contains any text-dependent attributes we should invalidate those attributes. However if the text is inserted between two runs of that attribute value, neither surrounding run should be invalidated. This updates `enforceAttributeConstraintsBeforeMutation(to:)` to ensure that we handle an empty range mutation (i.e. an insertion) correctly rather than skipping constraint enforcement for empty ranges.

rdar://149623441