### PR TITLE
Revert strict IPv6 validation in URL

### DIFF
--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -884,6 +884,11 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.host, "fe80::a%100%CustomZone")
         XCTAssertEqual(url.host(percentEncoded: true), "fe80::a%25100%25CustomZone")
         XCTAssertEqual(url.host(percentEncoded: false), "fe80::a%100%CustomZone")
+
+        // Make sure an IP-literal with invalid characters `{` and `}`
+        // returns `nil` even if we can percent-encode the zone-ID.
+        let invalid = URL(string: "http://[{Invalid}%100%EncodableZone]")
+        XCTAssertNil(invalid)
     }
 
     #if !os(Windows)


### PR DESCRIPTION
Previously, `URL` and the `URLParser` mistakenly allowed invalid characters in an IP-literal (within the square brackets) if the zone-ID was percent-encoded. This was revealed by testing the `NSURL` and `CFURL` re-core in Swift. My original goal was to make the new implementation match the slightly more strict validation of the old NS/CFURL implementations for compatibility.

However, I misunderstood which characters `CFURL` was actually allowing when validating an IP-literal. Instead of validating hex digits, colons, and periods before a potential zone ID, it was allowing any valid ASCII character anywhere in the host, so malformed URLs like `http://[www.apple.com]` were allowed.

While I think better IPv6 validation would ultimately be good, it could impact bincompat for `URL`, `URLComponents`, and `NSURL` (using the Swift parser) in rare cases when a client passes an invalid IPv6 string. This PR keeps the proper compatibility fix while reverting the stricter IPv6 validation code, which we could revisit at a later time.