### PR TITLE
Follow up for #1198: Fix test  for FOUNDATION_FRAMEWORK

### DIFF
--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ExpressionTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ExpressionTests.swift
@@ -20,11 +20,11 @@ import struct Foundation.URL
 #endif
 import Testing
 
-private typealias Expression = URL.Template.Expression
-private typealias Element = URL.Template.Expression.Element
-
 @Suite("URL.Template Expression")
 private enum ExpressionTests {
+    private typealias Expression = URL.Template.Expression
+    private typealias Element = URL.Template.Expression.Element
+
     @Test
     static func parsingWithSingleName() throws {
         #expect(


### PR DESCRIPTION
`TestSupport` already defines a typealias for `Expression` as `public typealias Expression = Foundation.Expression`. Therefore the top level typealias `private typealias Expression = URL.Template.Expression` caused an error when `TestSupport` is imported.

Move the typealias declaration to inside the test suite.
