### PR TITLE
Update `CMakeLists.txt` with missing `URLTemplate_Expression.swift`

### DIFF
--- a/Sources/FoundationEssentials/URL/CMakeLists.txt
+++ b/Sources/FoundationEssentials/URL/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(FoundationEssentials PRIVATE
     URLComponents.swift
     URLComponents_ObjC.swift
     URLParser.swift
+    URLTemplate_Expression.swift
     URLTemplate_PercentEncoding.swift
     URLTemplate_Substitution.swift
     URLTemplate_Value.swift


### PR DESCRIPTION
https://github.com/swiftlang/swift-foundation/pull/1198 added most of the new files, but missed `URLTemplate_Expression.swift`, add it.