### PR TITLE
Add swiftRegexBuilder dependency on Windows

### DIFF
--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -37,6 +37,7 @@ target_compile_options(FoundationInternationalization PRIVATE ${_SwiftFoundation
 target_compile_options(FoundationInternationalization PRIVATE -package-name "SwiftFoundation")
 
 target_link_libraries(FoundationInternationalization PUBLIC
+    $<$<PLATFORM_ID:Windows>:swiftRegexBuilder>
     FoundationEssentials
     _FoundationCShims
     _FoundationICU)


### PR DESCRIPTION
Following #1198 and #1262, this is needed to build on Windows.