### PR TITLE
[FoundationInternationalization] Avoid implicitly linking RegexBuilder symbol

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -580,7 +580,8 @@ extension String {
     ///
     /// E.g.: `"'hello, it''s 'hh':'mm"` is turned into `"hhmm"`.
     fileprivate func purgingStringLiterals() -> String {
-        self.split(separator: "'", omittingEmptySubsequences: false)
+        // Explicitly specify Character("'") to avoid accidentally using an implicit RegexBuilder overload
+        self.split(separator: Character("'"), omittingEmptySubsequences: false)
             .enumerated()
             .filter { offset, _ in offset.isMultiple(of: 2) }
             .map(\.element)


### PR DESCRIPTION
This is a similar fix to https://github.com/swiftlang/swift-corelibs-foundation/pull/5204 but for `FoundationInternationalization` instead of `plutil`. Specifying `Character` explicitly here avoids attempting to link a RegexBuilder symbol instead of the symbol from the standard library.