### PR TITLE
Make URL template regex dependency framework-only for now

### DIFF
--- a/Sources/FoundationEssentials/URL/URLTemplate.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate.swift
@@ -130,7 +130,7 @@ extension URL {
 }
 
 // MARK: - Parse
-
+#if FOUNDATION_FRAMEWORK
 extension URL.Template {
     /// Creates a new template from its text form.
     ///
@@ -164,6 +164,7 @@ extension URL.Template {
         }
     }
 }
+#endif
 
 // MARK: -
 

--- a/Sources/FoundationEssentials/URL/URLTemplate_Expression.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate_Expression.swift
@@ -10,7 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 internal import RegexBuilder
+#endif
+
 #if canImport(CollectionsInternal)
 internal import CollectionsInternal
 #elseif canImport(OrderedCollections)
@@ -79,6 +82,7 @@ extension URL.Template.Expression.Element: CustomStringConvertible {
     }
 }
 
+#if FOUNDATION_FRAMEWORK
 extension URL.Template.Expression {
     init(_ input: String) throws {
         var remainder = input[...]
@@ -202,6 +206,7 @@ extension URL.Template {
         }
     }
 }
+#endif
 
 // .------------------------------------------------------------------.
 // |          NUL     +      .       /       ;      ?      &      #   |

--- a/Sources/FoundationEssentials/URL/URLTemplate_PercentEncoding.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate_PercentEncoding.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 internal import RegexBuilder
+#endif
 
 extension String {
     /// Convert to NFC and percent-escape.

--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ExpressionTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ExpressionTests.swift
@@ -20,6 +20,7 @@ import struct Foundation.URL
 #endif
 import Testing
 
+#if FOUNDATION_FRAMEWORK
 @Suite("URL.Template Expression")
 private enum ExpressionTests {
     private typealias Expression = URL.Template.Expression
@@ -276,3 +277,4 @@ private enum ExpressionTests {
         #expect((try? Expression(input)) == nil, "Should fail to parse, but not crash.")
     }
 }
+#endif

--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_TemplateTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_TemplateTests.swift
@@ -54,6 +54,7 @@ private var variables: [URL.Template.VariableName: URL.Template.Value] {
     ]
 }
 
+#if FOUNDATION_FRAMEWORK
 private func assertReplacing(template: String, result: String, sourceLocation: SourceLocation = #_sourceLocation) {
     do {
         let t = try #require(URL.Template(template))
@@ -263,3 +264,4 @@ private enum TemplateTests {
         assertReplacing(template: "{&keys*}", result: "&semi=%3B&dot=.&comma=%2C")
     }
 }
+#endif


### PR DESCRIPTION
Makes these APIs `FOUNDATION_FRAMEWORK` only for now until we can determine how to have an `internal import` of `RegexBuilder` without breaking a variety of downstream projects that start seeing the members it introduces in extensions on stdlib types since clients aren't building with the `MemberImportVisibility` feature flag yet