### PR TITLE
Move off of RegexBuilder for URL.Template

### DIFF
--- a/Sources/FoundationEssentials/URL/URLTemplate.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate.swift
@@ -130,7 +130,7 @@ extension URL {
 }
 
 // MARK: - Parse
-#if FOUNDATION_FRAMEWORK
+
 extension URL.Template {
     /// Creates a new template from its text form.
     ///
@@ -164,7 +164,6 @@ extension URL.Template {
         }
     }
 }
-#endif
 
 // MARK: -
 

--- a/Sources/FoundationEssentials/URL/URLTemplate_Expression.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate_Expression.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal import RegexBuilder
 #if canImport(CollectionsInternal)
 internal import CollectionsInternal
 #elseif canImport(OrderedCollections)
@@ -104,7 +103,7 @@ extension URL.Template.Expression {
             let explode: Bool
             if let max = match.output.3 {
                 guard
-                    let m = max.map({ Int($0) })
+                    let m = Int(max)
                 else { throw URL.Template.InvalidExpression(text: "Invalid maximum length '\(input[match.range])'") }
                 maximumLength = m
                 explode = false
@@ -148,57 +147,23 @@ extension URL.Template {
 
         let operatorRegex: Regex<(Substring, Substring?)>
         let separatorRegex: Regex<(Substring)>
-        let elementRegex: Regex<(Substring, Substring, Substring?, Substring??)>
-        let uriTemplateRegex: Regex<Regex<(Substring, Regex<OneOrMore<Substring>.RegexOutput>.RegexOutput)>.RegexOutput>
+        let elementRegex: Regex<(Substring, Substring, Substring?, Substring?)>
+        let uriTemplateRegex: Regex<(Substring, Substring)>
 
         private init() {
-            self.operatorRegex = Regex {
-                Optionally {
-                    Capture {
-                        One(.anyOf("+#./;?&"))
-                    }
-                }
-            }
+            self.operatorRegex = try! Regex(#"([\+#.\/;\?&])?"#)
             .asciiOnlyWordCharacters()
             .asciiOnlyDigits()
             .asciiOnlyCharacterClasses()
-            self.separatorRegex = Regex {
-                ","
-            }
+            self.separatorRegex = try! Regex(#","#)
             .asciiOnlyWordCharacters()
             .asciiOnlyDigits()
             .asciiOnlyCharacterClasses()
-            self.elementRegex = Regex {
-                Capture {
-                    One(("a"..."z").union("A"..."Z"))
-                    ZeroOrMore(("a"..."z").union("A"..."Z").union("0"..."9").union(.anyOf("_")))
-                }
-                Optionally {
-                    Capture {
-                        ChoiceOf {
-                            Regex {
-                                ":"
-                                Capture {
-                                    ZeroOrMore(.digit)
-                                }
-                            }
-                            "*"
-                        }
-                    }
-                }
-            }
+            self.elementRegex = try! Regex(#"([a-zA-Z][a-zA-Z0-9_]*)(:([0-9]*)|\*)?"#)
             .asciiOnlyWordCharacters()
             .asciiOnlyDigits()
             .asciiOnlyCharacterClasses()
-            self.uriTemplateRegex = Regex {
-                "{"
-                Capture {
-                    OneOrMore {
-                        CharacterClass.any.subtracting(.anyOf("}"))
-                    }
-                }
-                "}"
-            }
+            self.uriTemplateRegex = try! Regex(#"{([^}]+)}"#)
         }
     }
 }

--- a/Sources/FoundationEssentials/URL/URLTemplate_Expression.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate_Expression.swift
@@ -10,10 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
 internal import RegexBuilder
-#endif
-
 #if canImport(CollectionsInternal)
 internal import CollectionsInternal
 #elseif canImport(OrderedCollections)
@@ -82,7 +79,6 @@ extension URL.Template.Expression.Element: CustomStringConvertible {
     }
 }
 
-#if FOUNDATION_FRAMEWORK
 extension URL.Template.Expression {
     init(_ input: String) throws {
         var remainder = input[...]
@@ -206,7 +202,6 @@ extension URL.Template {
         }
     }
 }
-#endif
 
 // .------------------------------------------------------------------.
 // |          NUL     +      .       /       ;      ?      &      #   |

--- a/Sources/FoundationEssentials/URL/URLTemplate_PercentEncoding.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate_PercentEncoding.swift
@@ -10,9 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
 internal import RegexBuilder
-#endif
 
 extension String {
     /// Convert to NFC and percent-escape.

--- a/Sources/FoundationEssentials/URL/URLTemplate_PercentEncoding.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate_PercentEncoding.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal import RegexBuilder
-
 extension String {
     /// Convert to NFC and percent-escape.
     func normalizedAddingPercentEncoding(

--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ExpressionTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ExpressionTests.swift
@@ -22,8 +22,8 @@ import Testing
 
 @Suite("URL.Template Expression")
 private enum ExpressionTests {
-    private typealias Expression = URL.Template.Expression
-    private typealias Element = URL.Template.Expression.Element
+    typealias Expression = URL.Template.Expression
+    typealias Element = URL.Template.Expression.Element
 
     @Test
     static func parsingWithSingleName() throws {

--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ExpressionTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ExpressionTests.swift
@@ -20,7 +20,6 @@ import struct Foundation.URL
 #endif
 import Testing
 
-#if FOUNDATION_FRAMEWORK
 @Suite("URL.Template Expression")
 private enum ExpressionTests {
     private typealias Expression = URL.Template.Expression
@@ -277,4 +276,3 @@ private enum ExpressionTests {
         #expect((try? Expression(input)) == nil, "Should fail to parse, but not crash.")
     }
 }
-#endif

--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_TemplateTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_TemplateTests.swift
@@ -54,7 +54,6 @@ private var variables: [URL.Template.VariableName: URL.Template.Value] {
     ]
 }
 
-#if FOUNDATION_FRAMEWORK
 private func assertReplacing(template: String, result: String, sourceLocation: SourceLocation = #_sourceLocation) {
     do {
         let t = try #require(URL.Template(template))
@@ -264,4 +263,3 @@ private enum TemplateTests {
         assertReplacing(template: "{&keys*}", result: "&semi=%3B&dot=.&comma=%2C")
     }
 }
-#endif


### PR DESCRIPTION
This fixes #1269

This uses `try! Regex("…")` instead of `RegexBuilder` to create regular expressions used by the URL Template implementation.