### PR TITLE
Upgrade AttributedStringWritingDirection SPI to API

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -36,9 +36,6 @@ extension AttributeScopes {
         public let durationField: DurationFieldAttribute
 
         /// The base writing direction of a paragraph.
-        #if FOUNDATION_FRAMEWORK
-        @_spi(AttributedStringWritingDirection)
-        #endif
         @available(FoundationPreview 6.2, *)
         public let writingDirection: WritingDirectionAttribute
 
@@ -516,9 +513,6 @@ extension AttributeScopes.FoundationAttributes {
     }
 
     /// The attribute key for the base writing direction of a paragraph.
-    #if FOUNDATION_FRAMEWORK
-    @_spi(AttributedStringWritingDirection)
-    #endif
     @available(FoundationPreview 6.2, *)
     @frozen
     public enum WritingDirectionAttribute: CodableAttributedStringKey {
@@ -893,9 +887,6 @@ extension AttributedString {
     /// direction. In vertical scripts, a writing direction of ``leftToRight``
     /// is interpreted as top-to-bottom and a writing direction of
     /// ``rightToLeft`` is interpreted as bottom-to-top.
-    #if FOUNDATION_FRAMEWORK
-    @_spi(AttributedStringWritingDirection)
-    #endif
     @available(FoundationPreview 6.2, *)
     @frozen
     public enum WritingDirection: Codable, Hashable, CaseIterable, Sendable {

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -19,7 +19,7 @@ import TestSupport
 #endif // FOUNDATION_FRAMEWORK
 
 #if FOUNDATION_FRAMEWORK
-@testable @_spi(AttributedString) @_spi(AttributedStringWritingDirection) import Foundation
+@testable @_spi(AttributedString) import Foundation
 // For testing default attribute scope conversion
 #if canImport(Accessibility)
 import Accessibility


### PR DESCRIPTION
Now that blocking changes have been resolved, we can remove these `@_spi` markers