### PR TITLE
[SE-0456, -0467] Data+Span+MutableSpan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,8 @@ list(APPEND _SwiftFoundation_availability_names
 list(APPEND _SwiftFoundation_availability_releases
     ${_SwiftFoundation_BaseAvailability}
     ${_SwiftFoundation_BaseAvailability}
-    ${_SwiftFoundation_BaseAvailability})
+    ${_SwiftFoundation_BaseAvailability}
+    ${_SwiftFoundation_FutureAvailability})
 
 foreach(version ${_SwiftFoundation_versions})
     foreach(name release IN ZIP_LISTS _SwiftFoundation_availability_names _SwiftFoundation_availability_releases)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,8 @@ list(APPEND _SwiftFoundation_versions
 list(APPEND _SwiftFoundation_availability_names
     "FoundationPreview"
     "FoundationPredicate"
-    "FoundationPredicateRegex")
+    "FoundationPredicateRegex"
+    "FoundationSpan")
 
 # The aligned availability for each name (in the same order)
 list(APPEND _SwiftFoundation_availability_releases

--- a/Package.swift
+++ b/Package.swift
@@ -136,6 +136,14 @@ let package = Package(
           swiftSettings: [
             .enableExperimentalFeature("VariadicGenerics"),
             .enableExperimentalFeature("LifetimeDependence"),
+            .enableExperimentalFeature(
+              "InoutLifetimeDependence",
+              .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
+            ),
+            .enableExperimentalFeature(
+              "LifetimeDependenceMutableAccessors",
+              .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
+            ),
             .enableExperimentalFeature("AddressableTypes"),
             .enableExperimentalFeature("BuiltinModule"),
             .enableExperimentalFeature("AccessLevelOnImport")
@@ -153,7 +161,16 @@ let package = Package(
             resources: [
                 .copy("Resources")
             ],
-            swiftSettings: availabilityMacros + featureSettings
+            swiftSettings: [
+              .enableExperimentalFeature(
+                "InoutLifetimeDependence",
+                .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
+              ),
+              .enableExperimentalFeature(
+                "LifetimeDependenceMutableAccessors",
+                .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
+              ),
+            ] + availabilityMacros + featureSettings
         ),
 
         // FoundationInternationalization

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let availabilityTags: [_Availability] = [
     _Availability("FoundationPreview"), // Default FoundationPreview availability,
     _Availability("FoundationPredicate"), // Predicate relies on pack parameter runtime support
     _Availability("FoundationPredicateRegex"), // Predicate regexes rely on new stdlib APIs
-    _Availability("FoundationSpan"), // Availability of Span types
+    _Availability("FoundationSpan", availability: .future), // Availability of Span types
 ]
 let versionNumbers = ["0.1", "0.2", "0.3", "0.4", "6.0.2", "6.1", "6.2"]
 

--- a/Package.swift
+++ b/Package.swift
@@ -145,6 +145,7 @@ let package = Package(
               .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
             ),
             .enableExperimentalFeature("AddressableTypes"),
+            .enableExperimentalFeature("AllowUnsafeAttribute"),
             .enableExperimentalFeature("BuiltinModule"),
             .enableExperimentalFeature("AccessLevelOnImport")
           ] + availabilityMacros + featureSettings,

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ import CompilerPluginSupport
 let availabilityTags: [_Availability] = [
     _Availability("FoundationPreview"), // Default FoundationPreview availability,
     _Availability("FoundationPredicate"), // Predicate relies on pack parameter runtime support
-    _Availability("FoundationPredicateRegex") // Predicate regexes rely on new stdlib APIs
+    _Availability("FoundationPredicateRegex"), // Predicate regexes rely on new stdlib APIs
+    _Availability("FoundationSpan"), // Availability of Span types
 ]
 let versionNumbers = ["0.1", "0.2", "0.3", "0.4", "6.0.2", "6.1", "6.2"]
 
@@ -134,6 +135,9 @@ let package = Package(
           ] + wasiLibcCSettings,
           swiftSettings: [
             .enableExperimentalFeature("VariadicGenerics"),
+            .enableExperimentalFeature("LifetimeDependence"),
+            .enableExperimentalFeature("AddressableTypes"),
+            .enableExperimentalFeature("BuiltinModule"),
             .enableExperimentalFeature("AccessLevelOnImport")
           ] + availabilityMacros + featureSettings,
           linkerSettings: [

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ On all other Swift platforms, `swift-foundation` is available as part of the too
 ## Building and Testing
 
 > [!NOTE]
-> Building swift-foundation requires the in-development Swift 6.0 toolchain. You can download the Swift 6.0 nightly toolchain from [the Swift website](https://swift.org/install).
+> Building swift-foundation requires the in-development Swift 6.2 toolchain. You can download the Swift 6.2 nightly toolchain from [the Swift website](https://swift.org/install).
 
 Before building Foundation, first ensure that you have a Swift toolchain installed. Next, check out the _Getting Started_ section of the [Foundation Build Process](Foundation_Build_Process.md#getting-started) guide for detailed steps on building and testing.
 

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -74,7 +74,9 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
     target_compile_options(FoundationEssentials PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -Xcc -Xfrontend -D_GNU_SOURCE>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -Xcc -Xfrontend -D_GNU_SOURCE>"
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend InoutLifetimeDependence>"
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend LifetimeDependenceMutableAccessors>")
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 endif()
 

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -80,6 +80,9 @@ endif()
 
 target_compile_options(FoundationEssentials PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend VariadicGenerics>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend LifetimeDependence>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AddressableTypes>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend BuiltinModule>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>"

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2269,7 +2269,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     public var mutableSpan: MutableSpan<UInt8> {
         @lifetime(&self)
         mutating get {
-#if false
+#if false // see https://github.com/swiftlang/swift/issues/81218
             var bytes = mutableBytes
             let span = unsafe bytes._unsafeMutableView(as: UInt8.self)
             return _overrideLifetime(span, mutating: &self)

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2239,6 +2239,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
     }
 
+#if compiler(>=5.9) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
     @available(FoundationSpan 6.2, *)
     public var mutableBytes: MutableRawSpan {
         @lifetime(&self)
@@ -2298,6 +2299,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 #endif
         }
     }
+#endif // $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
 
     @_alwaysEmitIntoClient
     public func withContiguousStorageIfAvailable<ResultType>(_ body: (_ buffer: UnsafeBufferPointer<UInt8>) throws -> ResultType) rethrows -> ResultType? {
@@ -2986,8 +2988,6 @@ internal func _overrideLifetime<
 >(
   _ dependent: consuming T, borrowing source: borrowing U
 ) -> T {
-  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
-  // should be expressed by a builtin that is hidden within the function body.
   dependent
 }
 
@@ -3004,11 +3004,10 @@ internal func _overrideLifetime<
 >(
   _ dependent: consuming T, copying source: borrowing U
 ) -> T {
-  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
-  // should be expressed by a builtin that is hidden within the function body.
   dependent
 }
 
+#if compiler(>=5.9) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
 /// Unsafely discard any lifetime dependency on the `dependent` argument.
 /// Return a value identical to `dependent` with a lifetime dependency
 /// on the caller's exclusive borrow scope of the `source` argument.
@@ -3023,7 +3022,6 @@ internal func _overrideLifetime<
   _ dependent: consuming T,
   mutating source: inout U
 ) -> T {
-  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
-  // should be expressed by a builtin that is hidden within the function body.
   dependent
 }
+#endif // $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2209,7 +2209,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             let buffer: UnsafeRawBufferPointer
             switch _representation {
             case .empty:
-                buffer = UnsafeRawBufferPointer(_empty: ())
+                buffer = UnsafeRawBufferPointer(start: nil, count: 0)
             case .inline:
                 buffer = unsafe UnsafeRawBufferPointer(
                   start: UnsafeRawPointer(Builtin.addressOfBorrow(self)),
@@ -2245,7 +2245,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             let buffer: UnsafeMutableRawBufferPointer
             switch _representation {
             case .empty:
-                buffer = UnsafeMutableRawBufferPointer(_empty: ())
+                buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
             case .inline:
                 buffer = unsafe UnsafeMutableRawBufferPointer(
                   start: UnsafeMutableRawPointer(Builtin.addressOfBorrow(self)),
@@ -2277,7 +2277,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             let buffer: UnsafeMutableRawBufferPointer
             switch _representation {
             case .empty:
-                buffer = UnsafeMutableRawBufferPointer(_empty: ())
+                buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
             case .inline:
                 buffer = unsafe UnsafeMutableRawBufferPointer(
                   start: UnsafeMutableRawPointer(Builtin.addressOfBorrow(self)),

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2203,6 +2203,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         return try _representation.withUnsafeBytes(body)
     }
 
+#if compiler(>=6.2) && $LifetimeDependence
     @available(FoundationSpan 6.2, *)
     public var bytes: RawSpan {
         @lifetime(borrow self)
@@ -2238,6 +2239,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             return _overrideLifetime(span, borrowing: self)
         }
     }
+#endif
 
 #if compiler(>=5.9) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
     @available(FoundationSpan 6.2, *)
@@ -2974,7 +2976,7 @@ extension Data : Codable {
 }
 
 // TODO: remove once _overrideLifetime is public in the standard library
-
+#if compiler(>=6.2) && $LifetimeDependence
 /// Unsafely discard any lifetime dependency on the `dependent` argument. Return
 /// a value identical to `dependent` with a lifetime dependency on the caller's
 /// borrow scope of the `source` argument.
@@ -3006,6 +3008,7 @@ internal func _overrideLifetime<
 ) -> T {
   dependent
 }
+#endif
 
 #if compiler(>=5.9) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
 /// Unsafely discard any lifetime dependency on the `dependent` argument.

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -605,7 +605,9 @@ internal final class __DataStorage : @unchecked Sendable {
 
 @frozen
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
+#if compiler(>=6.2)
 @_addressableForDependencies
+#endif
 public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollection, RangeReplaceableCollection, MutableDataProtocol, ContiguousBytes, Sendable {
 
     public typealias Index = Int
@@ -2201,7 +2203,6 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         return try _representation.withUnsafeBytes(body)
     }
 
-#if compiler(>=6.2)
     @available(FoundationSpan 6.2, *)
     public var bytes: RawSpan {
         @lifetime(borrow self)
@@ -2297,7 +2298,6 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 #endif
         }
     }
-#endif
 
     @_alwaysEmitIntoClient
     public func withContiguousStorageIfAvailable<ResultType>(_ body: (_ buffer: UnsafeBufferPointer<UInt8>) throws -> ResultType) rethrows -> ResultType? {
@@ -2971,7 +2971,6 @@ extension Data : Codable {
     }
 }
 
-#if compiler(>=6.2)
 // TODO: remove once _overrideLifetime is public in the standard library
 
 /// Unsafely discard any lifetime dependency on the `dependent` argument. Return
@@ -3028,4 +3027,3 @@ internal func _overrideLifetime<
   // should be expressed by a builtin that is hidden within the function body.
   dependent
 }
-#endif

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -1634,6 +1634,140 @@ class DataTests : XCTestCase {
         // source.advanced(by: 5)
     }
 
+    @available(FoundationSpan 6.2, *)
+    func test_InlineDataSpan() throws {
+        var source = Data()
+        var span = source.span
+        XCTAssertTrue(span.isEmpty)
+
+        source.append(contentsOf: [1, 2, 3])
+        span = source.span
+        XCTAssertFalse(span.isEmpty)
+        XCTAssertEqual(span.count, source.count)
+        XCTAssertEqual(span[0], 1)
+    }
+
+    @available(FoundationSpan 6.2, *)
+    func test_InlineSliceDataSpan() throws {
+        let source = Data(0 ... .max)
+        let span = source.span
+        XCTAssertEqual(span.count, source.count)
+        XCTAssertEqual(span[span.indices.last!], .max)
+    }
+
+    @available(FoundationSpan 6.2, *)
+    func test_LargeSliceDataSpan() throws {
+#if _pointerBitWidth(_64)
+        let count = Int(Int32.max)
+#elseif _pointerBitWidth(_32)
+        let count = Int(Int16.max)
+#else
+        #error("This test needs updating")
+#endif
+
+        let source = Data(repeating: 0, count: count).dropFirst()
+        XCTAssertNotEqual(source.startIndex, 0)
+        let span = source.span
+        XCTAssertFalse(span.isEmpty)
+    }
+
+    @available(FoundationSpan 6.2, *)
+    func test_InlineDataMutableSpan() throws {
+        var source = Data()
+        var span = source.mutableSpan
+        XCTAssertTrue(span.isEmpty)
+
+        source.append(contentsOf: [1, 2, 3])
+        let count = source.count
+        span = source.mutableSpan
+        let i = try XCTUnwrap(span.indices.randomElement())
+        XCTAssertFalse(span.isEmpty)
+        XCTAssertEqual(span.count, count)
+        let v = UInt8.random(in: 10..<100)
+        span[i] = v
+        XCTAssertEqual(source[i], v)
+    }
+
+    @available(FoundationSpan 6.2, *)
+    func test_InlineSliceDataMutableSpan() throws {
+        var source = Data(0..<100)
+        let count = source.count
+        var span = source.mutableSpan
+        XCTAssertEqual(span.count, count)
+        let i = try XCTUnwrap(span.indices.randomElement())
+        span[i] = .max
+        XCTAssertEqual(source[i], .max)
+    }
+
+    @available(FoundationSpan 6.2, *)
+    func test_LargeSliceDataMutableSpan() throws {
+  #if _pointerBitWidth(_64)
+        var count = Int(Int32.max)
+  #elseif _pointerBitWidth(_32)
+        var count = Int(Int16.max)
+  #else
+        #error("This test needs updating")
+  #endif
+
+        var source = Data(repeating: 0, count: count).dropFirst()
+        XCTAssertNotEqual(source.startIndex, 0)
+        count = source.count
+        var span = source.mutableSpan
+        XCTAssertEqual(span.count, count)
+        let i = try XCTUnwrap(span.indices.dropFirst().randomElement())
+        span[i] = .max
+        XCTAssertEqual(source[i], 0)
+        XCTAssertEqual(source[i+1], .max)
+    }
+
+    @available(FoundationSpan 6.2, *)
+    func test_InlineDataMutableRawSpan() throws {
+        var source = Data()
+        var span = source.mutableBytes
+        XCTAssertTrue(span.isEmpty)
+
+        source.append(contentsOf: [1, 2, 3])
+        let count = source.count
+        span = source.mutableBytes
+        let i = try XCTUnwrap(span.byteOffsets.randomElement())
+        XCTAssertFalse(span.isEmpty)
+        XCTAssertEqual(span.byteCount, count)
+        let v = UInt8.random(in: 10..<100)
+        span.storeBytes(of: v, toByteOffset: i, as: UInt8.self)
+        XCTAssertEqual(source[i], v)
+    }
+
+    @available(FoundationSpan 6.2, *)
+    func test_InlineSliceDataMutableRawSpan() throws {
+        var source = Data(0..<100)
+        let count = source.count
+        var span = source.mutableBytes
+        XCTAssertEqual(span.byteCount, count)
+        let i = try XCTUnwrap(span.byteOffsets.randomElement())
+        span.storeBytes(of: -1, toByteOffset: i, as: Int8.self)
+        XCTAssertEqual(source[i], .max)
+    }
+
+    @available(FoundationSpan 6.2, *)
+    func test_LargeSliceDataMutableRawSpan() throws {
+#if _pointerBitWidth(_64)
+        var count = Int(Int32.max)
+#elseif _pointerBitWidth(_32)
+        var count = Int(Int16.max)
+#else
+        #error("This test needs updating")
+#endif
+
+        var source = Data(repeating: 0, count: count).dropFirst()
+        XCTAssertNotEqual(source.startIndex, 0)
+        count = source.count
+        var span = source.mutableBytes
+        XCTAssertEqual(span.byteCount, count)
+        let i = try XCTUnwrap(span.byteOffsets.dropFirst().randomElement())
+        span.storeBytes(of: -1, toByteOffset: i, as: Int8.self)
+        XCTAssertEqual(source[i], 0)
+        XCTAssertEqual(source[i+1], .max)
+    }
 
     #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
     func test_bounding_failure_subdata() {

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -1637,7 +1637,7 @@ class DataTests : XCTestCase {
     func test_InlineDataSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.span
         XCTAssertTrue(span.isEmpty)
@@ -1653,7 +1653,7 @@ class DataTests : XCTestCase {
     func test_InlineSliceDataSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         let source = Data(0 ... .max)
         let span = source.span
         XCTAssertEqual(span.count, source.count)
@@ -1672,7 +1672,7 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         let source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         let span = source.span
@@ -1683,7 +1683,7 @@ class DataTests : XCTestCase {
     func test_InlineDataMutableSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.mutableSpan
         XCTAssertTrue(span.isEmpty)
@@ -1703,7 +1703,7 @@ class DataTests : XCTestCase {
     func test_InlineSliceDataMutableSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableSpan
@@ -1725,7 +1725,7 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         count = source.count
@@ -1741,7 +1741,7 @@ class DataTests : XCTestCase {
     func test_InlineDataMutableRawSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.mutableBytes
         XCTAssertTrue(span.isEmpty)
@@ -1761,7 +1761,7 @@ class DataTests : XCTestCase {
     func test_InlineSliceDataMutableRawSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableBytes
@@ -1783,7 +1783,7 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
-#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         count = source.count

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -1637,6 +1637,7 @@ class DataTests : XCTestCase {
     func test_InlineDataSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.span
         XCTAssertTrue(span.isEmpty)
@@ -1646,15 +1647,18 @@ class DataTests : XCTestCase {
         XCTAssertFalse(span.isEmpty)
         XCTAssertEqual(span.count, source.count)
         XCTAssertEqual(span[0], 1)
+#endif
     }
 
     func test_InlineSliceDataSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         let source = Data(0 ... .max)
         let span = source.span
         XCTAssertEqual(span.count, source.count)
         XCTAssertEqual(span[span.indices.last!], .max)
+#endif
     }
 
     func test_LargeSliceDataSpan() throws {
@@ -1668,15 +1672,18 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         let source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         let span = source.span
         XCTAssertFalse(span.isEmpty)
+#endif
     }
 
     func test_InlineDataMutableSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.mutableSpan
         XCTAssertTrue(span.isEmpty)
@@ -1690,11 +1697,13 @@ class DataTests : XCTestCase {
         let v = UInt8.random(in: 10..<100)
         span[i] = v
         XCTAssertEqual(source[i], v)
+#endif
     }
 
     func test_InlineSliceDataMutableSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableSpan
@@ -1702,6 +1711,7 @@ class DataTests : XCTestCase {
         let i = try XCTUnwrap(span.indices.randomElement())
         span[i] = .max
         XCTAssertEqual(source[i], .max)
+#endif
     }
 
     func test_LargeSliceDataMutableSpan() throws {
@@ -1715,6 +1725,7 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         count = source.count
@@ -1724,11 +1735,13 @@ class DataTests : XCTestCase {
         span[i] = .max
         XCTAssertEqual(source[i], 0)
         XCTAssertEqual(source[i+1], .max)
+#endif
     }
 
     func test_InlineDataMutableRawSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.mutableBytes
         XCTAssertTrue(span.isEmpty)
@@ -1742,11 +1755,13 @@ class DataTests : XCTestCase {
         let v = UInt8.random(in: 10..<100)
         span.storeBytes(of: v, toByteOffset: i, as: UInt8.self)
         XCTAssertEqual(source[i], v)
+#endif
     }
 
     func test_InlineSliceDataMutableRawSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableBytes
@@ -1754,6 +1769,7 @@ class DataTests : XCTestCase {
         let i = try XCTUnwrap(span.byteOffsets.randomElement())
         span.storeBytes(of: -1, toByteOffset: i, as: Int8.self)
         XCTAssertEqual(source[i], .max)
+#endif
     }
 
     func test_LargeSliceDataMutableRawSpan() throws {
@@ -1767,6 +1783,7 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
+#if $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         count = source.count
@@ -1776,6 +1793,7 @@ class DataTests : XCTestCase {
         span.storeBytes(of: -1, toByteOffset: i, as: Int8.self)
         XCTAssertEqual(source[i], 0)
         XCTAssertEqual(source[i+1], .max)
+#endif
     }
 
     #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -1683,6 +1683,7 @@ class DataTests : XCTestCase {
     func test_InlineDataMutableSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
+#if !canImport(Darwin) || FOUNDATION_FRAMEWORK
 #if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.mutableSpan
@@ -1696,21 +1697,27 @@ class DataTests : XCTestCase {
         XCTAssertEqual(span.count, count)
         let v = UInt8.random(in: 10..<100)
         span[i] = v
+        var sub = span.extracting(i ..< i+1)
+        sub.update(repeating: v)
         XCTAssertEqual(source[i], v)
+#endif
 #endif
     }
 
     func test_InlineSliceDataMutableSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
+#if !canImport(Darwin) || FOUNDATION_FRAMEWORK
 #if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableSpan
         XCTAssertEqual(span.count, count)
         let i = try XCTUnwrap(span.indices.randomElement())
-        span[i] = .max
+        var sub = span.extracting(i..<i+1)
+        sub.update(repeating: .max)
         XCTAssertEqual(source[i], .max)
+#endif
 #endif
     }
 
@@ -1725,6 +1732,7 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
+#if !canImport(Darwin) || FOUNDATION_FRAMEWORK
 #if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
@@ -1735,6 +1743,7 @@ class DataTests : XCTestCase {
         span[i] = .max
         XCTAssertEqual(source[i], 0)
         XCTAssertEqual(source[i+1], .max)
+#endif
 #endif
     }
 
@@ -1753,7 +1762,8 @@ class DataTests : XCTestCase {
         XCTAssertFalse(span.isEmpty)
         XCTAssertEqual(span.byteCount, count)
         let v = UInt8.random(in: 10..<100)
-        span.storeBytes(of: v, toByteOffset: i, as: UInt8.self)
+        var sub = span.extracting(i..<i+1)
+        sub.storeBytes(of: v, as: UInt8.self)
         XCTAssertEqual(source[i], v)
 #endif
     }

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -1634,8 +1634,9 @@ class DataTests : XCTestCase {
         // source.advanced(by: 5)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_InlineDataSpan() throws {
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
         var source = Data()
         var span = source.span
         XCTAssertTrue(span.isEmpty)
@@ -1647,16 +1648,18 @@ class DataTests : XCTestCase {
         XCTAssertEqual(span[0], 1)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_InlineSliceDataSpan() throws {
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
         let source = Data(0 ... .max)
         let span = source.span
         XCTAssertEqual(span.count, source.count)
         XCTAssertEqual(span[span.indices.last!], .max)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_LargeSliceDataSpan() throws {
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
 #if _pointerBitWidth(_64)
         let count = Int(Int32.max)
 #elseif _pointerBitWidth(_32)
@@ -1671,8 +1674,9 @@ class DataTests : XCTestCase {
         XCTAssertFalse(span.isEmpty)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_InlineDataMutableSpan() throws {
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
         var source = Data()
         var span = source.mutableSpan
         XCTAssertTrue(span.isEmpty)
@@ -1688,8 +1692,9 @@ class DataTests : XCTestCase {
         XCTAssertEqual(source[i], v)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_InlineSliceDataMutableSpan() throws {
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableSpan
@@ -1699,15 +1704,16 @@ class DataTests : XCTestCase {
         XCTAssertEqual(source[i], .max)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_LargeSliceDataMutableSpan() throws {
-  #if _pointerBitWidth(_64)
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
+#if _pointerBitWidth(_64)
         var count = Int(Int32.max)
-  #elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32)
         var count = Int(Int16.max)
-  #else
+#else
         #error("This test needs updating")
-  #endif
+#endif
 
         var source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
@@ -1720,8 +1726,9 @@ class DataTests : XCTestCase {
         XCTAssertEqual(source[i+1], .max)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_InlineDataMutableRawSpan() throws {
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
         var source = Data()
         var span = source.mutableBytes
         XCTAssertTrue(span.isEmpty)
@@ -1737,8 +1744,9 @@ class DataTests : XCTestCase {
         XCTAssertEqual(source[i], v)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_InlineSliceDataMutableRawSpan() throws {
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableBytes
@@ -1748,8 +1756,9 @@ class DataTests : XCTestCase {
         XCTAssertEqual(source[i], .max)
     }
 
-    @available(FoundationSpan 6.2, *)
     func test_LargeSliceDataMutableRawSpan() throws {
+        guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
+
 #if _pointerBitWidth(_64)
         var count = Int(Int32.max)
 #elseif _pointerBitWidth(_32)


### PR DESCRIPTION
Add the properties `span`, `mutableSpan`, `bytes` and `mutableBytes` to `Data`, as proposed in [SE-0456](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0456-stdlib-span-properties.md) and [SE-0467](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0467-MutableSpan.md).

Addresses rdar://137711067