### PR TITLE
Restore selective nil path behavior for bridged NSURLs

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Swift.swift
+++ b/Sources/FoundationEssentials/URL/URL_Swift.swift
@@ -1176,12 +1176,14 @@ extension _SwiftURL {
             ranges.append(CFRange(location: nsRange.location, length: nsRange.length))
         }
 
-        flags.insert(.hasPath)
-        if let pathRange = parseInfo.pathRange {
-            let nsRange = string._toRelativeNSRange(pathRange)
-            ranges.append(CFRange(location: nsRange.location, length: nsRange.length))
-        } else {
-            ranges.append(CFRange(location: kCFNotFound, length: 0))
+        if !parseInfo.path.isEmpty || parseInfo.netLocationRange?.isEmpty == false {
+            flags.insert(.hasPath)
+            if let pathRange = parseInfo.pathRange {
+                let nsRange = string._toRelativeNSRange(pathRange)
+                ranges.append(CFRange(location: nsRange.location, length: nsRange.length))
+            } else {
+                ranges.append(CFRange(location: kCFNotFound, length: 0))
+            }
         }
 
         if let queryRange = parseInfo.queryRange {


### PR DESCRIPTION
Fixes a compatibility issue that occurs when a `URL` such as `scheme://?query` is bridged to an `NSURL`. `NSURL` originally expected `.path` to return `nil` for this string, but `URL` and RFC 3986 say that the path *always* exists and is the empty string in this case. `URL` would then store an empty path range instead when bridging to `NSURL`, causing this discrepancy.

This PR fixes the issue during bridging by only storing the path range if `NSURL` would think there's a path, i.e. in the case where 1) the path is not empty, or 2) the path is empty, but we have a non-empty authority component.