### PR TITLE
Fix URL.Template availability annotations

### DIFF
--- a/Sources/FoundationEssentials/URL/URLTemplate.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate.swift
@@ -131,6 +131,7 @@ extension URL {
 
 // MARK: - Parse
 #if FOUNDATION_FRAMEWORK
+@available(FoundationPreview 6.2, *)
 extension URL.Template {
     /// Creates a new template from its text form.
     ///
@@ -168,6 +169,7 @@ extension URL.Template {
 
 // MARK: -
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template: CustomStringConvertible {
     public var description: String {
         elements.reduce(into: "") {

--- a/Sources/FoundationEssentials/URL/URLTemplate_Value.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate_Value.swift
@@ -18,6 +18,7 @@ internal import OrderedCollections
 internal import _FoundationCollections
 #endif
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template {
     /// The value of a variable used for expanding a template.
     ///
@@ -49,6 +50,7 @@ extension URL.Template {
     }
 }
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template.Value {
     /// A text value to be used with a ``URL.Template``.
     public static func text(_ text: String) -> URL.Template.Value {
@@ -68,18 +70,21 @@ extension URL.Template.Value {
 
 // MARK: -
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template.Value: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         self = .text(value)
     }
 }
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template.Value: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: String...) {
         self.init(underlying: .list(elements))
     }
 }
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template.Value: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (String, String)...) {
         self.init(underlying: .associativeList(OrderedDictionary(uniqueKeysWithValues: elements)))
@@ -88,6 +93,7 @@ extension URL.Template.Value: ExpressibleByDictionaryLiteral {
 
 // MARK: -
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template.Value: CustomStringConvertible {
     public var description: String {
         switch underlying {

--- a/Sources/FoundationEssentials/URL/URLTemplate_VariableName.swift
+++ b/Sources/FoundationEssentials/URL/URLTemplate_VariableName.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template {
     /// The name of a variable used for expanding a template.
     public struct VariableName: Sendable, Hashable {
@@ -34,6 +35,7 @@ extension String {
     }
 }
 
+@available(FoundationPreview 6.2, *)
 extension URL.Template.VariableName: CustomStringConvertible {
     public var description: String {
         String(self)


### PR DESCRIPTION
All public `URL.Template` extensions need to be marked with the `FoundationPreview 6.2` availability since extensions are separate declarations and availability is per declaration. Extensions don't automatically inherit the availability from the type they're extending.