### PR TITLE
Enable MemberImportVisibility upcoming feature in Foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,9 +35,10 @@ let availabilityMacros: [SwiftSetting] = versionNumbers.flatMap { version in
     }
 }
 
-let concurrencyChecking: [SwiftSetting] = [
+let featureSettings: [SwiftSetting] = [
     .enableExperimentalFeature("StrictConcurrency"),
-    .enableUpcomingFeature("InferSendableFromCaptures")
+    .enableUpcomingFeature("InferSendableFromCaptures"),
+    .enableUpcomingFeature("MemberImportVisibility")
 ]
 
 var dependencies: [Package.Dependency] {
@@ -98,7 +99,7 @@ let package = Package(
                 "FoundationInternationalization",
             ],
             cSettings: wasiLibcCSettings,
-            swiftSettings: availabilityMacros + concurrencyChecking
+            swiftSettings: availabilityMacros + featureSettings
         ),
 
         // FoundationEssentials
@@ -134,7 +135,7 @@ let package = Package(
           swiftSettings: [
             .enableExperimentalFeature("VariadicGenerics"),
             .enableExperimentalFeature("AccessLevelOnImport")
-          ] + availabilityMacros + concurrencyChecking,
+          ] + availabilityMacros + featureSettings,
           linkerSettings: [
             .linkedLibrary("wasi-emulated-getpid", .when(platforms: [.wasi])),
           ]
@@ -148,7 +149,7 @@ let package = Package(
             resources: [
                 .copy("Resources")
             ],
-            swiftSettings: availabilityMacros + concurrencyChecking
+            swiftSettings: availabilityMacros + featureSettings
         ),
 
         // FoundationInternationalization
@@ -172,7 +173,7 @@ let package = Package(
             cSettings: wasiLibcCSettings,
             swiftSettings: [
                 .enableExperimentalFeature("AccessLevelOnImport")
-            ] + availabilityMacros + concurrencyChecking
+            ] + availabilityMacros + featureSettings
         ),
         
         .testTarget(
@@ -181,7 +182,7 @@ let package = Package(
                 "TestSupport",
                 "FoundationInternationalization",
             ],
-            swiftSettings: availabilityMacros + concurrencyChecking
+            swiftSettings: availabilityMacros + featureSettings
         ),
         
         // FoundationMacros
@@ -198,7 +199,7 @@ let package = Package(
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
                 .enableExperimentalFeature("AccessLevelOnImport")
-            ] + availabilityMacros + concurrencyChecking
+            ] + availabilityMacros + featureSettings
         ),
     ]
 )
@@ -213,7 +214,7 @@ package.targets.append(contentsOf: [
             "FoundationMacros",
             "TestSupport"
         ],
-        swiftSettings: availabilityMacros + concurrencyChecking
+        swiftSettings: availabilityMacros + featureSettings
     )
 ])
 #endif

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -82,7 +82,8 @@ target_compile_options(FoundationEssentials PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend VariadicGenerics>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
-    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend MemberImportVisibility>")
 target_compile_options(FoundationEssentials PRIVATE ${_SwiftFoundation_availability_macros})
 target_compile_options(FoundationEssentials PRIVATE ${_SwiftFoundation_wasi_libc_flags})
 target_compile_options(FoundationEssentials PRIVATE -package-name "SwiftFoundation")

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -25,6 +25,10 @@ import WinSDK
 @preconcurrency import WASILibc
 #endif
 
+#if FOUNDATION_FRAMEWORK
+internal import Foundation_Private
+#endif
+
 #if os(Windows)
 extension _FILE_ID_128 /* : @retroactive Equatable */ {
     internal static func _equals(_ lhs: _FILE_ID_128, _ rhs: _FILE_ID_128) -> Bool {

--- a/Sources/FoundationEssentials/Locale/Locale+Language.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Language.swift
@@ -10,6 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
+internal import Foundation_Private
+#endif
+
 extension Locale {
 
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)

--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -12,6 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 internal import _ForSwiftFoundation
+internal import Foundation_Private
 #endif
 
 // Source of truth for a parsed URL

--- a/Sources/FoundationEssentials/URL/URL_Swift.swift
+++ b/Sources/FoundationEssentials/URL/URL_Swift.swift
@@ -24,6 +24,10 @@ import WinSDK
 @preconcurrency import WASILibc
 #endif
 
+#if canImport(os)
+internal import os
+#endif
+
 /// `_SwiftURL` provides the new Swift implementation for `URL`, using the same parser
 /// and `URLParseInfo` as `URLComponents`, but with a few compatibility behaviors.
 ///

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -31,7 +31,8 @@ add_subdirectory(TimeZone)
 target_compile_options(FoundationInternationalization PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
-    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend MemberImportVisibility>")
 target_compile_options(FoundationInternationalization PRIVATE ${_SwiftFoundation_availability_macros})
 target_compile_options(FoundationInternationalization PRIVATE ${_SwiftFoundation_wasi_libc_flags})
 target_compile_options(FoundationInternationalization PRIVATE -package-name "SwiftFoundation")

--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -16,6 +16,10 @@ internal import _FoundationICU
 internal import os
 #endif
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
 enum ICU { }
 
 internal struct ICUError: Error, CustomDebugStringConvertible {

--- a/Sources/FoundationInternationalization/URLParser+ICU.swift
+++ b/Sources/FoundationInternationalization/URLParser+ICU.swift
@@ -12,6 +12,9 @@
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #endif
+#if FOUNDATION_FRAMEWORK
+internal import Foundation_Private
+#endif
 
 internal import _FoundationICU
 

--- a/Sources/FoundationMacros/BundleMacro.swift
+++ b/Sources/FoundationMacros/BundleMacro.swift
@@ -12,6 +12,7 @@
 
 import SwiftSyntax
 import SwiftSyntaxMacros
+internal import SwiftSyntaxBuilder
 
 public struct BundleMacro: SwiftSyntaxMacros.ExpressionMacro, Sendable {
     public static func expansion(of node: some FreestandingMacroExpansionSyntax, in context: some MacroExpansionContext) throws -> ExprSyntax {

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -69,7 +69,8 @@ target_sources(FoundationMacros PRIVATE
 target_compile_options(FoundationMacros PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
-    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend MemberImportVisibility>")
 
 target_link_libraries(FoundationMacros PUBLIC
     SwiftSyntax::SwiftSyntax

--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_PercentEncodingTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_PercentEncodingTests.swift
@@ -17,13 +17,6 @@
 @testable import Foundation
 #endif
 import Testing
-#if FOUNDATION_FRAMEWORK
-@_spi(Unstable) internal import CollectionsInternal
-#elseif canImport(_RopeModule)
-internal import _RopeModule
-#elseif canImport(_FoundationCollections)
-internal import _FoundationCollections
-#endif
 
 extension String {
     fileprivate func encoded(

--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_TemplateTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_TemplateTests.swift
@@ -17,13 +17,6 @@
 @testable import Foundation
 #endif
 import Testing
-#if FOUNDATION_FRAMEWORK
-@_spi(Unstable) internal import CollectionsInternal
-#elseif canImport(_RopeModule)
-internal import _RopeModule
-#elseif canImport(_FoundationCollections)
-internal import _FoundationCollections
-#endif
 
 //
 // These test cases are (mostly) from RFC 6570.

--- a/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ValueTests.swift
+++ b/Tests/FoundationEssentialsTests/URITemplatingTests/URLTemplate_ValueTests.swift
@@ -19,12 +19,11 @@ import struct FoundationEssentials.URL
 import struct Foundation.URL
 #endif
 import Testing
-#if FOUNDATION_FRAMEWORK
-@_spi(Unstable) internal import CollectionsInternal
-#elseif canImport(_RopeModule)
-internal import _RopeModule
-#elseif canImport(_FoundationCollections)
-internal import _FoundationCollections
+
+#if canImport(CollectionsInternal)
+internal import CollectionsInternal
+#elseif canImport(OrderedCollections)
+internal import OrderedCollections
 #endif
 
 @Suite("URL.Template Value")


### PR DESCRIPTION
Enable the MemberImportVisibility compiler flag, which ensures that we don't accidentally depend on implicit imports in our sources. 