### PR TITLE
fix `Calendar.RecurrenceRule`

### DIFF
--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -803,4 +803,16 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         ]
         XCTAssertEqual(results, expectedResults)
     }
+    
+    func testDailyRecurrenceRuleWithNonzeroNanosecondComponent() {
+        let start = Date(timeIntervalSince1970: 1746627600.5) // 2025-05-07T07:20:00.500-07:00
+        let rule = Calendar.RecurrenceRule.daily(calendar: gregorian, end: .afterOccurrences(2))
+        let results = Array(rule.recurrences(of: start))
+        
+        let expectedResults: [Date] = [
+            start,
+            Date(timeIntervalSince1970: 1746714000.5), // 2025-05-08T07:20:00.500-07:00
+        ]
+        XCTAssertEqual(results, expectedResults)
+    }
 }


### PR DESCRIPTION
This PR attempts to fix #1283, by adjisting `Calendar.DatesByRecurring.Iterator` to maintain nanosecond precision on the dates it produces, if the original start date had a non-zero nanosecond component.

This brings the behaviour of the `Calendar.RecurrenceRule` API in line with how it was defined and described in [the proposal](https://github.com/swiftlang/swift-foundation/blob/main/Proposals/0009-calendar-recurrence-rule.md).