### PR TITLE
Fix FileManager directories warning

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -82,12 +82,16 @@ extension _FileManagerImpl {
         if domain == .systemDomainMask {
             domain = ._partitionedSystemDomainMask
         }
-        let lastElement = domain == ._partitionedSystemDomainMask
-        #else
-        let lastElement = false
         #endif
+        
         let urls = Array(_SearchPathURLs(for: directory, in: domain, expandTilde: true))
-        guard let url = lastElement ? urls.last : urls.first else {
+        #if FOUNDATION_FRAMEWORK
+        let url = domain == ._partitionedSystemDomainMask ? urls.last : urls.first
+        #else
+        let url = urls.first
+        #endif
+        
+        guard let url else {
             throw CocoaError(.fileReadUnknown)
         }
         


### PR DESCRIPTION
Fixes a warning due to `lastElement` being unconditionally false in the non-`FOUNDATION_FRAMEWORK` branch

```
[2025-05-09T17:53:00.386Z] /build/swift-foundation/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift:90:44: warning: will never be executed
[2025-05-09T17:53:00.386Z]  88 |         #endif
[2025-05-09T17:53:00.386Z]  89 |         let urls = Array(_SearchPathURLs(for: directory, in: domain, expandTilde: true))
[2025-05-09T17:53:00.386Z]  90 |         guard let url = lastElement ? urls.last : urls.first else {
[2025-05-09T17:53:00.386Z]     |                         |                  `- warning: will never be executed
[2025-05-09T17:53:00.386Z]     |                         `- note: condition always evaluates to false
[2025-05-09T17:53:00.386Z]  91 |             throw CocoaError(.fileReadUnknown)
[2025-05-09T17:53:00.386Z]  92 |         }
```