### PR TITLE
[Data] Fix build issue with Static SDK for Linux.

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -336,7 +336,7 @@ internal func readBytesFromFile(path inPath: PathOrURL, reportProgress: Bool, ma
     }
     
     let fileSize = min(Int(clamping: filestat.st_size), maxLength ?? Int.max)
-    let fileType = mode_t(filestat.st_mode) & mode_t(S_IFMT)
+    let fileType = mode_t(filestat.st_mode) & S_IFMT
 #if !NO_FILESYSTEM
     let shouldMap = shouldMapFileDescriptor(fd, path: inPath, options: options)
 #else


### PR DESCRIPTION
Musl's definition of `S_IFMT` gets imported by the Swift importer, which means Swift can see `S_IFMT` as a `CInt` and also `S_IFMT` from the Swift overlay as a `mode_t`.  The upshot is that attempting to convert it to `mode_t` produces an ambiguity error, as Swift doesn't know which definition to use.