### PR TITLE
Forward ObjC messages to _BridgedURL in rare compatibility cases

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -635,12 +635,14 @@ public struct URL: Equatable, Sendable, Hashable {
 
 #if FOUNDATION_FRAMEWORK
     private static var _type: any _URLProtocol.Type {
+        if URL.compatibility2 {
+            return _BridgedURL.self
+        }
         return foundation_swift_url_enabled() ? _SwiftURL.self : _BridgedURL.self
     }
 #else
     private static let _type = _SwiftURL.self
 #endif
-
 
 #if FOUNDATION_FRAMEWORK
     internal let _url: any _URLProtocol & AnyObject


### PR DESCRIPTION
Some C APIs take in a `const void *` that is expected to be a `CFURLRef *` in certain cases. When a Swift API is generated for these functions, they instead take an `UnsafeRawPointer`.

Code passing an implicit raw pointer to a `struct URL` using `&var` notation can cause issues if the C function assumes the address of a `URL` points to a `NSURL *` or `CFURLRef`. This used to work because an `NSURL` was the first member of `struct URL`, but now that memory location contains the `_SwiftURL` class.

This PR allows us to restore the old behavior in very rare cases on Darwin where it's needed for compatibility by making `_BridgedURL` an `NSObject` and forwarding the ObjC messages it receives to the wrapped `NSURL`.