### PR TITLE
Character-only mutations should not overwrite paragraph-bound attributes in paragraph following mutation

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -283,7 +283,7 @@ extension AttributedString.CharacterView: RangeReplaceableCollection {
         _guts.runs.replaceUTF8Subrange(utf8Range, with: CollectionOfOne(run))
 
         // Invalidate attributes surrounding the affected range. (Phase 2)
-        _guts._finalizeStringMutation(state)
+        _guts._finalizeStringMutation(state, type: .characters)
     }
 
     public mutating func replaceSubrange(

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -457,7 +457,8 @@ extension AttributedString.Guts {
     }
 
     func _finalizeStringMutation(
-        _ state: (mutationStartUTF8Offset: Int, isInsertion: Bool, oldUTF8Count: Int, invalidationRange: Range<Int>)
+        _ state: (mutationStartUTF8Offset: Int, isInsertion: Bool, oldUTF8Count: Int, invalidationRange: Range<Int>),
+        type: _MutationType
     ) {
         let utf8Delta = self.string.utf8.count - state.oldUTF8Count
         self._finalizeTrackedIndicesUpdate(mutationStartOffset: state.mutationStartUTF8Offset, isInsertion: state.isInsertion, utf8LengthDelta: utf8Delta)
@@ -465,7 +466,7 @@ extension AttributedString.Guts {
         let upper = state.invalidationRange.upperBound + utf8Delta
         self.enforceAttributeConstraintsAfterMutation(
             in: lower ..< upper,
-            type: .attributesAndCharacters)
+            type: type)
     }
 
     func replaceSubrange(
@@ -493,7 +494,7 @@ extension AttributedString.Guts {
             let state = _prepareStringMutation(in: range)
             self.string.unicodeScalars.replaceSubrange(range, with: replacementScalars)
             self.runs.replaceUTF8Subrange(utf8TargetRange, with: replacementRuns)
-            _finalizeStringMutation(state)
+            _finalizeStringMutation(state, type: .attributesAndCharacters)
         } else {
             self.runs.replaceUTF8Subrange(utf8TargetRange, with: replacementRuns)
             self.enforceAttributeConstraintsAfterMutation(in: range._utf8OffsetRange, type: .attributes)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -264,7 +264,7 @@ extension AttributedString.UnicodeScalarView: RangeReplaceableCollection {
         _guts.runs.replaceUTF8Subrange(utf8Range, with: CollectionOfOne(run))
 
         // Invalidate attributes surrounding the affected range. (Phase 2)
-        _guts._finalizeStringMutation(state)
+        _guts._finalizeStringMutation(state, type: .characters)
     }
     
     public mutating func replaceSubrange(

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringConstrainingBehaviorTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringConstrainingBehaviorTests.swift
@@ -224,6 +224,10 @@ class TestAttributedStringConstrainingBehavior: XCTestCase {
         verify(string: result, matches: [("HeTestllo, world\n", 1), ("Next Paragraph", 2)], for: \.testParagraphConstrained)
         
         result = str
+        result.characters.insert(contentsOf: "Test", at: result.index(result.startIndex, offsetByCharacters: 13))
+        verify(string: result, matches: [("Hello, world\n", 1), ("TestNext Paragraph", 2)], for: \.testParagraphConstrained)
+        
+        result = str
         result.characters.append(contentsOf: "Test")
         verify(string: result, matches: [("Hello, world\n", 1), ("Next ParagraphTest", 2)], for: \.testParagraphConstrained)
         
@@ -257,7 +261,7 @@ class TestAttributedStringConstrainingBehavior: XCTestCase {
         
         result = str
         result.characters.replaceSubrange(result.index(result.startIndex, offsetByCharacters: 8) ..< result.index(result.startIndex, offsetByCharacters: 15), with: "Test\nReplacement")
-        verify(string: result, matches: [("Hello, wTest\n", 1), ("Replacementxt Paragraph", 1)], for: \.testParagraphConstrained)
+        verify(string: result, matches: [("Hello, wTest\n", 1), ("Replacementxt Paragraph", 2)], for: \.testParagraphConstrained)
     }
     
     func testParagraphAttributedTextMutation() {


### PR DESCRIPTION
When mutating text in an AttributedString that contains paragraph-bound attributes we fix-up the attributes post-mutation by looking at the paragraphs surrounding the mutation. There are up to two applicable paragraphs: one that begins before the mutation and ends somewhere within the mutation (the "starting" paragraph), and one that begins within the mutation and ends after the mutation (the "ending" paragraph). These may be the same paragraph (when the mutation is in the middle of the paragraph), or one or the other may not exist (if the mutation is at the start or the end of a paragraph).

Today, when the mutation is a character-based mutation (i.e. not just setting an attribute value) we always take the attributes from the beginning of the starting paragraph and apply them to the portion that extends into the mutation, and apply the attributes from the beginning of the ending paragraph (within the mutation) and apply them to the rest of the ending paragraph outside the mutation. This is correct for `AttributedString` based replacements (inserting an `AttributedString` into another `AttributedString`) but this isn't quite right for character based replacements (via the character view) where no attributes are supplied. Instead of the inferred attributes of the newly inserted text overwriting the ending paragraph, we should use the attributes from the existing ending paragraph in the inserted/mutated text. This mainly impacts when characters are inserted or mutated at the start of a paragraph and ensures it has the same behavior as when text is inserted anywhere else in the paragraph.