### PR TITLE
build: adjust the autolink library for Windows

### DIFF
--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -99,7 +99,7 @@ if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationEssentials PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend $<$<PLATFORM_ID:Windows>:${CMAKE_STATIC_LIBRARY_PREFIX_Swift}>_FoundationCollections>")
     target_compile_options(FoundationEssentials PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend $<$<PLATFORM_ID:Windows>:${CMAKE_STATIC_LIBRARY_PREFIX_Swift}>swiftSynchronization>")
 endif()
 
 set_target_properties(FoundationEssentials PROPERTIES

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationInternationalization PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
     target_compile_options(FoundationEssentials PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend $<$<PLATFORM_ID:Windows>:${CMAKE_STATIC_LIBRARY_PREFIX_Swift}>swiftSynchronization>")
 endif()
 
 set_target_properties(FoundationInternationalization PROPERTIES


### PR DESCRIPTION
When building statically, ensure that we prefix the Swift libraries with the correct prefix to permit static linking of the libraries.