### PR TITLE
Resolve AttributedString attribute storage Sendable warnings

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
@@ -228,7 +228,8 @@ extension AttributedString : CodableWithConfiguration {
             {
                 let attributeEncoder = attributesContainer.superEncoder(forKey: AttributeKey(stringValue: name)!)
                 func project<K: EncodableAttributedStringKey>(_: K.Type) throws {
-                    try K.encode(attributes[K.self]!, to: attributeEncoder)
+                    // We must assume that the value is Sendable here because we are dynamically iterating a scope and the attribute keys do not statically declare the values are Sendable
+                    try K.encode(attributes[assumingSendable: K.self]!, to: attributeEncoder)
                 }
                 try project(encodableAttributeType)
             } // else: the attribute was not in the provided scope or was not encodable, so drop it
@@ -336,7 +337,8 @@ extension AttributedString : CodableWithConfiguration {
                 let decodableAttributeType = attributeKeyType as? any DecodableAttributedStringKey.Type
             {
                 func project<K: DecodableAttributedStringKey>(_: K.Type) throws {
-                    attributes[K.self] = try K.decode(from: try attributesContainer.superDecoder(forKey: key))
+                    // We must assume that the value is Sendable here because we are dynamically iterating a scope and the attribute keys do not statically declare the values are Sendable
+                    attributes[assumingSendable: K.self] = try K.decode(from: try attributesContainer.superDecoder(forKey: key))
                 }
                 try project(decodableAttributeType)
             }

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -111,7 +111,8 @@ extension AttributeContainer {
         for (key, value) in dictionary {
             if let type = attributeTable[key.rawValue] {
                 func project<K: AttributedStringKey>(_: K.Type) throws {
-                    storage[K.self] = try K._convertFromObjectiveCValue(value as AnyObject)
+                    // We must assume that the value is Sendable here because we are dynamically iterating a scope and the attribute keys do not statically declare the values are Sendable
+                    storage[assumingSendable: K.self] = try K._convertFromObjectiveCValue(value as AnyObject)
                 }
                 do {
                     try project(type)
@@ -145,7 +146,8 @@ extension Dictionary where Key == NSAttributedString.Key, Value == Any {
         for key in container.storage.keys {
             if let type = attributeTable[key] {
                 func project<K: AttributedStringKey>(_: K.Type) throws {
-                    self[NSAttributedString.Key(rawValue: key)] = try K._convertToObjectiveCValue(container.storage[K.self]!)
+                    // We must assume that the value is Sendable here because we are dynamically iterating a scope and the attribute keys do not statically declare the values are Sendable
+                    self[NSAttributedString.Key(rawValue: key)] = try K._convertToObjectiveCValue(container.storage[assumingSendable: K.self]!)
                 }
                 do {
                     try project(type)


### PR DESCRIPTION
`AttributedString` is `Sendable`, and it requires that all of its attribute values are `Sendable`. However, prior to this decision, we shipped attributes in the Apple SDKs that have non-`Sendable` values. We could not add an `AttributedStringKey.Value : Sendable` constraint because that constraint would cause downstream projects to fail to build when built with concurrency errors enabled, so instead every public `AttributedString` entry point has a `where Key.Value : Sendable` constraint to prevent reading/writing attributes values that are non-`Sendable`.

Unfortunately, there are a few situations where we cannot put this constraint because clients provide an attribute scope rather than an individual attribute key: attribute encoding/decoding and `NSAttributedString` conversion. In these cases, Foundation currently has warnings that indicate the values we're reading/writing may not be `Sendable`. This change effectively silences those warnings as there isn't anything we can do in Foundation about them.

This does leave a `Sendable` "escape hatch" in `AttributedString`: you can have an `NSAttributedString` that contains non-`Sendable` attributes and convert it to an `AttributedString` which stores it in a `Sendable` object. The constraints prevent reading the attribute value from `AttributedString` itself, but you can pass it across an isolation boundary and then convert it back to an `NSAttributedString` at which point you can read the non-`Sendable` value. Unfortunately, there's not much that we can do to prevent this currently, so the best we can do is at least allow Foundation to build without the warnings.

I've put this internal escape hatch in `FOUNDATION_FRAMEWORK` to help prevent accidental uses where it isn't needed.