### PR TITLE
fix recurrence nanosecond handling for nanosecond values > 0.5

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -235,7 +235,7 @@ extension Calendar {
                 }
                 var componentsForEnumerating = recurrence.calendar._dateComponents(components, from: start) 
                 
-                startDateNanoseconds = start.timeIntervalSince1970.remainder(dividingBy: 1)
+                startDateNanoseconds = start.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 1)
                 
                 let expansionChangesDay = dayOfYearAction == .expand || dayOfMonthAction == .expand || weekAction == .expand || weekdayAction == .expand
                 let expansionChangesMonth = dayOfYearAction == .expand || monthAction == .expand || weekAction == .expand

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -805,14 +805,19 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
     }
     
     func testDailyRecurrenceRuleWithNonzeroNanosecondComponent() {
-        let start = Date(timeIntervalSince1970: 1746627600.5) // 2025-05-07T07:20:00.500-07:00
-        let rule = Calendar.RecurrenceRule.daily(calendar: gregorian, end: .afterOccurrences(2))
-        let results = Array(rule.recurrences(of: start))
+        let referenceStart = Date(timeIntervalSinceReferenceDate: 1746627600) // 2025-05-07T07:20:00.000-07:00
+        let referenceEnd = Date(timeIntervalSinceReferenceDate: 1746714000) // 2025-05-08T07:20:00.000-07:00
         
-        let expectedResults: [Date] = [
-            start,
-            Date(timeIntervalSince1970: 1746714000.5), // 2025-05-08T07:20:00.500-07:00
-        ]
-        XCTAssertEqual(results, expectedResults)
+        for nsec in stride(from: 0, through: 1, by: 0.05) {
+            let start = referenceStart.addingTimeInterval(nsec)
+            let rule = Calendar.RecurrenceRule.daily(calendar: gregorian, end: .afterOccurrences(2))
+            let results = Array(rule.recurrences(of: start))
+            
+            let expectedResults: [Date] = [
+                start,
+                referenceEnd.addingTimeInterval(nsec)
+            ]
+            XCTAssertEqual(results, expectedResults, "Failed for nanoseconds \(nsec)")
+        }
     }
 }


### PR DESCRIPTION
This PR is a follow up to #1284: we missed the fact that `remainder(dividingBy:)` can produce negative values if the input's fractional part is greater than 0.5. (eg: `1.9.remainder(dividingBy: 1)` is -0.1).

Since the dates produced by `Calendar.DatesByRecurring.Iterator` all have their nanosecond component set to 0 (rather than being rounded to the nearest whole number), we need to use `truncatingRemainder(dividingBy:)` instead.

I also changed it to operate on `timeIntervalSinceReferenceDate` instead of `timeIntervalSince1970`, since that saves us on having to perform the `timeIntervalSince1970` computation every time.