### PR TITLE
Adopt utimensat for setting file modification dates

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -965,15 +965,15 @@ extension _FileManagerImpl {
             
             if let date = attributes[.modificationDate] as? Date {
                 let (isecs, fsecs) = modf(date.timeIntervalSince1970)
-                if let tv_sec = time_t(exactly: isecs),
-                   let tv_usec = suseconds_t(exactly: round(fsecs * 1000000.0)) {
-                    var timevals = (timeval(), timeval())
-                    timevals.0.tv_sec = tv_sec
-                    timevals.0.tv_usec = tv_usec
-                    timevals.1 = timevals.0
-                    try withUnsafePointer(to: timevals) {
-                        try $0.withMemoryRebound(to: timeval.self, capacity: 2) {
-                            if utimes(fileSystemRepresentation, $0) != 0 {
+                if let tv_sec = Int(exactly: isecs),
+                   let tv_nsec = Int(exactly: round(fsecs * 1000000000.0)) {
+                    var timespecs = (timespec(), timespec())
+                    timespecs.0.tv_sec = tv_sec
+                    timespecs.0.tv_nsec = tv_nsec
+                    timespecs.1 = timespecs.0
+                    try withUnsafePointer(to: timespecs) {
+                        try $0.withMemoryRebound(to: timespec.self, capacity: 2) {
+                            if utimensat(AT_FDCWD, fileSystemRepresentation, $0, 0) != 0 {
                                 throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
                             }
                         }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -793,6 +793,23 @@ final class FileManagerTests : XCTestCase {
         }
     }
     
+    func testNanosecondModificationDate() throws {
+        try FileManagerPlayground {
+            "foo"
+        }.test {
+            #if os(Windows)
+            // Windows supports 100-nanosecond precision (10 seconds + 300 nano seconds)
+            let date = Date(timeIntervalSince1970: 10.0000003)
+            #else
+            // non-Windows supports nanosecond precision (10 seconds + 3 nano seconds)
+            let date = Date(timeIntervalSince1970: 10.000000003)
+            #endif
+            try $0.setAttributes([.modificationDate : date], ofItemAtPath: "foo")
+            let readDate = try $0.attributesOfItem(atPath: "foo")[.modificationDate] as? Date
+            XCTAssertEqual(readDate, date)
+        }
+    }
+    
     func testImplicitlyConvertibleFileAttributes() throws {
         try FileManagerPlayground {
             File("foo", attributes: [.posixPermissions : UInt16(0o644)])


### PR DESCRIPTION
Adopts `utimensat` for setting file modification dates on non-Windows to support nanosecond precision

Resolves https://github.com/swiftlang/swift-foundation/issues/1259