### PR TITLE
Remove extra AttributedStringProtocol.range(of:) overload

### DIFF
--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTestSupport.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTestSupport.swift
@@ -153,17 +153,3 @@ enum TestError: Error {
     case conversionError
     case markdownError
 }
-
-#if !FOUNDATION_FRAMEWORK
-
-extension AttributedStringProtocol {
-    func range(of other: String) -> Range<AttributedString.Index>? {
-        let str = String(characters)
-        guard let strRange = str.firstRange(of: other) else { return nil }
-        let start = str.unicodeScalars.distance(from: str.startIndex, to: strRange.lowerBound)
-        let end = str.unicodeScalars.distance(from: str.startIndex, to: strRange.upperBound)
-        return unicodeScalars.index(startIndex, offsetBy: start) ..< unicodeScalars.index(startIndex, offsetBy: end)
-    }
-}
-
-#endif // !FOUNDATION_FRAMEWORK


### PR DESCRIPTION
I suspect this overload was added to our test files to support the tests before `AttributedStringProtocol.range(of:)` was ported to swift-foundation. But today, the `range(of:)` function exists in swift-foundation so we should remove this extra one from our tests to make sure we're testing the real function rather than the one overloaded by the tests.