### PR TITLE
Reduce size of `cachedFixedComponentsLocales`

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale+Components.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Components.swift
@@ -87,6 +87,7 @@ extension Locale {
         }
 
         // Returns an ICU-style identifier like "de_DE@calendar=gregorian"
+        // Must include every component stored by a `Locale.Components`, and be kept in sync with `init(identifier:)`.
         package var icuIdentifier: String {
 
             var keywords = [(ICULegacyKey, String)]()

--- a/Sources/FoundationEssentials/Locale/Locale+Components.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Components.swift
@@ -85,6 +85,41 @@ extension Locale {
         public init(languageCode: Locale.LanguageCode? = nil, script: Locale.Script? = nil, languageRegion: Locale.Region? = nil) {
             self.languageComponents = Language.Components(languageCode: languageCode, script: script, region: languageRegion)
         }
+
+        // Returns an ICU-style identifier like "de_DE@calendar=gregorian"
+        package var icuIdentifier: String {
+
+            var keywords = [(ICULegacyKey, String)]()
+            if let id = calendar?.cldrIdentifier { keywords.append((Calendar.Identifier.legacyKeywordKey, id)) }
+            if let id = collation?._normalizedIdentifier { keywords.append((Locale.Collation.legacyKeywordKey, id)) }
+            if let id = currency?._normalizedIdentifier { keywords.append((Locale.Currency.legacyKeywordKey, id)) }
+            if let id = numberingSystem?._normalizedIdentifier { keywords.append((Locale.NumberingSystem.legacyKeywordKey, id)) }
+            if let id = firstDayOfWeek?.rawValue { keywords.append((Locale.Weekday.legacyKeywordKey, id)) }
+            if let id = hourCycle?.rawValue { keywords.append((Locale.HourCycle.legacyKeywordKey, id)) }
+            if let id = measurementSystem?._normalizedIdentifier { keywords.append((Locale.MeasurementSystem.legacyKeywordKey, id)) }
+            // No need for redundant region keyword
+            if let region = region, region != languageComponents.region {
+                // rg keyword value is actually a subdivision code
+                keywords.append((Locale.Region.legacyKeywordKey, Locale.Subdivision.subdivision(for: region)._normalizedIdentifier))
+            }
+            if let id = subdivision?._normalizedIdentifier { keywords.append((Locale.Subdivision.legacyKeywordKey, id)) }
+            if let id = timeZone?.identifier { keywords.append((TimeZone.legacyKeywordKey, id)) }
+            if let id = variant?._normalizedIdentifier { keywords.append((Locale.Variant.legacyKeywordKey, id)) }
+
+            var locID = languageComponents.identifier
+            let keywordCounts = keywords.count
+            if keywordCounts > 0 {
+                locID.append("@")
+            }
+
+            for (i, (key, val)) in keywords.enumerated() {
+                locID.append("\(key.key)=\(val)")
+                if i != keywordCounts - 1 {
+                    locID.append(";")
+                }
+            }
+            return locID
+        }
     }
 }
 

--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -45,7 +45,7 @@ struct LocaleCache : Sendable, ~Copyable {
         }
 
         private var cachedFixedLocales: [String : any _LocaleProtocol] = [:]
-        private var cachedFixedComponentsLocales: [Locale.Components : any _LocaleProtocol] = [:]
+        private var cachedFixedComponentsLocales: [String : any _LocaleProtocol] = [:]
 
 #if FOUNDATION_FRAMEWORK
         private var cachedFixedIdentifierToNSLocales: [String : _NSSwiftLocale] = [:]
@@ -99,17 +99,18 @@ struct LocaleCache : Sendable, ~Copyable {
 
 #endif // FOUNDATION_FRAMEWORK
 
-        func fixedComponents(_ comps: Locale.Components) -> (any _LocaleProtocol)? {
+        func fixedComponents(_ comps: String) -> (any _LocaleProtocol)? {
             cachedFixedComponentsLocales[comps]
         }
 
         mutating func fixedComponentsWithCache(_ comps: Locale.Components) -> any _LocaleProtocol {
-            if let l = fixedComponents(comps) {
+            let identifier = comps.icuIdentifier
+            if let l = fixedComponents(identifier) {
                 return l
             } else {
                 let new = _localeICUClass().init(components: comps)
 
-                cachedFixedComponentsLocales[comps] = new
+                cachedFixedComponentsLocales[identifier] = new
                 return new
             }
         }

--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -45,7 +45,7 @@ struct LocaleCache : Sendable, ~Copyable {
         }
 
         private var cachedFixedLocales: [String : any _LocaleProtocol] = [:]
-        private var cachedFixedComponentsLocales: [String : any _LocaleProtocol] = [:]
+        private var cachedFixedComponentsLocales: [String /*ICU identifier*/: any _LocaleProtocol] = [:]
 
 #if FOUNDATION_FRAMEWORK
         private var cachedFixedIdentifierToNSLocales: [String : _NSSwiftLocale] = [:]
@@ -99,13 +99,9 @@ struct LocaleCache : Sendable, ~Copyable {
 
 #endif // FOUNDATION_FRAMEWORK
 
-        func fixedComponents(_ comps: String) -> (any _LocaleProtocol)? {
-            cachedFixedComponentsLocales[comps]
-        }
-
         mutating func fixedComponentsWithCache(_ comps: Locale.Components) -> any _LocaleProtocol {
             let identifier = comps.icuIdentifier
-            if let l = fixedComponents(identifier) {
+            if let l = cachedFixedComponentsLocales[identifier] {
                 return l
             } else {
                 let new = _localeICUClass().init(components: comps)

--- a/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
@@ -22,34 +22,7 @@ internal import _FoundationICU
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Components {
-    // Returns an ICU-style identifier like "de_DE@calendar=gregorian"
-    internal var icuIdentifier: String {
-        var keywords: [ICULegacyKey: String] = [:]
-        if let id = calendar?.cldrIdentifier { keywords[Calendar.Identifier.legacyKeywordKey] = id }
-        if let id = collation?._normalizedIdentifier { keywords[Locale.Collation.legacyKeywordKey] = id }
-        if let id = currency?._normalizedIdentifier { keywords[Locale.Currency.legacyKeywordKey] = id }
-        if let id = numberingSystem?._normalizedIdentifier { keywords[Locale.NumberingSystem.legacyKeywordKey] = id }
-        if let id = firstDayOfWeek?.rawValue { keywords[Locale.Weekday.legacyKeywordKey] = id }
-        if let id = hourCycle?.rawValue { keywords[Locale.HourCycle.legacyKeywordKey] = id }
-        if let id = measurementSystem?._normalizedIdentifier { keywords[Locale.MeasurementSystem.legacyKeywordKey] = id }
-        // No need for redundant region keyword
-        if let region = region, region != languageComponents.region {
-            // rg keyword value is actually a subdivision code
-            keywords[Locale.Region.legacyKeywordKey] = Locale.Subdivision.subdivision(for: region)._normalizedIdentifier
-        }
-        if let id = subdivision?._normalizedIdentifier { keywords[Locale.Subdivision.legacyKeywordKey] = id }
-        if let id = timeZone?.identifier { keywords[TimeZone.legacyKeywordKey] = id }
-        if let id = variant?._normalizedIdentifier { keywords[Locale.Variant.legacyKeywordKey] = id }
 
-        var locID = languageComponents.identifier
-        for (key, val) in keywords {
-            // This uses legacy key-value pairs, like "collation=phonebook" instead of "-cu-phonebk", so be sure that the above values are `legacyKeywordKey`
-            // See Locale.Components.legacyKey(forKey:) for more info on performance costs
-            locID = Locale.identifierWithKeywordValue(locID, key: key, value: val)
-        }
-        return locID
-    }
-    
     /// - Parameter identifier: Unicode language identifier such as "en-u-nu-thai-ca-buddhist-kk-true"
     public init(identifier: String) {
         let languageComponents = Locale.Language.Components(identifier: identifier)


### PR DESCRIPTION
Previously we maintain a cache `private var cachedFixedComponentsLocales: [Locale.Components : any _LocaleProtocol]`, and every call to `Locale(components: Locale.Components)` reads a
nd writes to the cache. This results in a cache with non trivial size of keys.

Optimize this by replacing the key with a String instead of the full `Locale.Components` instance.

Using this as the baseline:

```swift
for identifier in Locale.availableIdentifiers {
    let locale = Locale(identifier: identifier)
}
```

With the following as the testing code:

```swift
for identifier in Locale.availableIdentifiers {
    let components = Locale.Components(identifier: identifier)
    let locale = Locale(components: components)
    let components2 = Locale.Components(locale: locale)
    let locale2 = Locale(components: components2) // cache hit
}
```

Previously, this incurred +2.6 MB of footprint comparing to the above baseline. After the fix, it incurred only +0.9MB increase.

Also benchmarked that we have not regressed the time now that we are using the string-based identifier as the key.
