### PR TITLE
Include `<stdnoreturn.h>` last

### DIFF
--- a/Sources/_FoundationCShims/include/_CStdlib.h
+++ b/Sources/_FoundationCShims/include/_CStdlib.h
@@ -101,10 +101,6 @@
 #include <stdlib.h>
 #endif
 
-#if __has_include(<stdnoreturn.h>)
-#include <stdnoreturn.h>
-#endif
-
 #if __has_include(<string.h>)
 #include <string.h>
 #endif
@@ -162,6 +158,11 @@
 #error "possibly define TZDIR and TZDEFAULT for this platform"
 #endif /* TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD */
 
+#endif
+
+// Must be last to avoid conflicts with other headers on Windows.
+#if __has_include(<stdnoreturn.h>)
+#include <stdnoreturn.h>
 #endif
 
 #endif // FOUNDATION_CSTDLIB


### PR DESCRIPTION
Starting with the Windows SDK 10.0.26100.3916, inclusion of `<stdnoreturn.h>` clashes with some of the definitions in other ucrt headers. Move `<stdnoreturn.h>` to be last to work around this issue.