### PR TITLE
Temporarily make Data.bytes a disfavored overload

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2205,6 +2205,9 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
 #if compiler(>=6.2) && $LifetimeDependence
     @available(FoundationSpan 6.2, *)
+#if FOUNDATION_FRAMEWORK
+    @_disfavoredOverload
+#endif // FOUNDATION_FRAMEWORK
     public var bytes: RawSpan {
         @lifetime(borrow self)
         borrowing get {


### PR DESCRIPTION
Make `Data.bytes` a disfavored overload, to resolve issues when a using project defines a property of that name, while also importing FoundationEssentials.