### PR TITLE
FoundationEssentials,FoundationInternationalization: adjust for aliasing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,7 @@ let availabilityMacros: [SwiftSetting] = versionNumbers.flatMap { version in
 
 let featureSettings: [SwiftSetting] = [
     .enableExperimentalFeature("StrictConcurrency"),
+    .enableExperimentalFeature("ImportMacroAliases"),
     .enableUpcomingFeature("InferSendableFromCaptures"),
     .enableUpcomingFeature("MemberImportVisibility")
 ]

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -117,6 +117,7 @@ import Darwin
 #elseif canImport(Android)
 @preconcurrency import Android
 import posix_filesystem.dirent
+internal import _FoundationCShims
 #elseif canImport(Glibc)
 @preconcurrency import Glibc
 internal import _FoundationCShims

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(TimeZone)
 
 target_compile_options(FoundationInternationalization PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend ImportMacroAliases>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend MemberImportVisibility>")

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -159,7 +159,7 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
     // MARK: -
 
     class FormatResult {
-        var result: OpaquePointer
+        var result: OpaquePointer?
 
         init(formatter: OpaquePointer, value: Int64) throws {
             var status = U_ZERO_ERROR
@@ -188,7 +188,9 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
             var str = value.description
 #endif // FOUNDATION_FRAMEWORK
             str.withUTF8 {
-                unumf_formatDecimal(formatter, $0.baseAddress, Int32($0.count), result, &status)
+                $0.withMemoryRebound(to: CChar.self) {
+                    unumf_formatDecimal(formatter, $0.baseAddress, Int32($0.count), result, &status)
+                }
             }
             try status.checkSuccess()
         }
@@ -200,7 +202,9 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
             
             var value = value
             value.withUTF8 {
-                unumf_formatDecimal(formatter, $0.baseAddress, Int32($0.count), result, &status)
+                $0.withMemoryRebound(to: CChar.self) {
+                    unumf_formatDecimal(formatter, $0.baseAddress, Int32($0.count), result, &status)
+                }
             }
             
             try status.checkSuccess()

--- a/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
@@ -18,7 +18,7 @@ import FoundationEssentials
 
 extension ICU {
     final class CaseMap : @unchecked Sendable {
-        let casemap: OpaquePointer
+        let casemap: OpaquePointer?
         
         let lock: LockedState<Void>
         

--- a/Sources/FoundationInternationalization/ICU/ICU+FieldPositer.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+FieldPositer.swift
@@ -14,7 +14,7 @@ internal import _FoundationICU
 
 extension ICU {
     final class FieldPositer {
-        let positer: OpaquePointer
+        let positer: OpaquePointer?
 
         internal init() throws {
             var status = U_ZERO_ERROR

--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -29,7 +29,10 @@ internal struct ICUError: Error, CustomDebugStringConvertible {
     }
 
     var debugDescription: String {
-        String(validatingUTF8: u_errorName(code)) ?? "Unknown ICU error \(code.rawValue)"
+        guard let error = u_errorName(code) else {
+            return "Unknown ICU error \(code.rawValue)"
+        }
+        return String(cString: error)
     }
 
 #if canImport(os)

--- a/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
@@ -216,7 +216,11 @@ extension Locale.Region {
             return nil
         }
 
-        guard let code = String(validatingUTF8: uregion_getRegionCode(containingRegion)) else {
+        guard let region = uregion_getRegionCode(containingRegion) else {
+            return nil
+        }
+
+        guard let code = String(validatingUTF8: region) else {
             return nil
         }
 
@@ -236,7 +240,11 @@ extension Locale.Region {
             return nil
         }
 
-        guard let code = String(validatingUTF8: uregion_getRegionCode(containingContinent)) else {
+        guard let region = uregion_getRegionCode(containingContinent) else {
+            return nil
+        }
+
+        guard let code = String(validatingUTF8: region) else {
             return nil
         }
 
@@ -445,7 +453,11 @@ extension Locale.Region {
             return nil
         }
 
-        guard let code = String(validatingCString: uregion_getRegionCode(containing)) else {
+        guard let region = uregion_getRegionCode(containing) else {
+            return nil
+        }
+
+        guard let code = String(validatingCString: region) else {
             return nil
         }
 
@@ -599,8 +611,8 @@ extension Locale.NumberingSystem {
         var status = U_ZERO_ERROR
         let numberingSystem = unumsys_open(localeIdentifier, &status)
         defer { unumsys_close(numberingSystem) }
-        if let numberingSystem, status.isSuccess {
-            self.init(String(cString: unumsys_getName(numberingSystem)))
+        if let numberingSystem, status.isSuccess, let name = unumsys_getName(numberingSystem) {
+            self.init(String(cString: name))
         } else {
             self = .latn
         }

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1543,7 +1543,8 @@ extension Locale {
         var working = Set<String>()
         let localeCount = uloc_countAvailable()
         for locale in 0..<localeCount {
-            let localeID = String(cString: uloc_getAvailable(locale))
+            guard let name = uloc_getAvailable(locale) else { continue }
+            let localeID = String(cString: name)
             working.insert(localeID)
         }
         return Array(working)


### PR DESCRIPTION
When enabling symbol renaming in ICU, we import the functions as an alias. This causes the implicit nullability translation with C to disappear. Make these conversions explicit so that we can enable symbol renaming on non-Darwin platforms.