### PR TITLE
Reenable exit tests on Ubuntu 20.04

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,19 +75,10 @@ let wasiLibcCSettings: [CSetting] = [
     .define("_WASI_EMULATED_MMAN", .when(platforms: [.wasi])),
 ]
 
-var testOnlySwiftSettings: [SwiftSetting] = [
+let testOnlySwiftSettings: [SwiftSetting] = [
     // The latest Windows toolchain does not yet have exit tests in swift-testing
     .define("FOUNDATION_EXIT_TESTS", .when(platforms: [.macOS, .linux, .openbsd]))
 ]
-
-#if os(Linux)
-import FoundationEssentials
-
-if ProcessInfo.processInfo.operatingSystemVersionString.hasPrefix("Ubuntu 20.") {
-    // Exit tests currently hang indefinitely on Ubuntu 20.
-    testOnlySwiftSettings.removeFirst()
-}
-#endif
 
 let package = Package(
     name: "swift-foundation",


### PR DESCRIPTION
Now that the underlying issue in swift-testing has been resolved via https://github.com/swiftlang/swift-testing/pull/1145, let's try re-enabling this again