### PR TITLE
[wasm] Fix WASI build by using `time_t` for tv_sec

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -965,7 +965,7 @@ extension _FileManagerImpl {
             
             if let date = attributes[.modificationDate] as? Date {
                 let (isecs, fsecs) = modf(date.timeIntervalSince1970)
-                if let tv_sec = Int(exactly: isecs),
+                if let tv_sec = time_t(exactly: isecs),
                    let tv_nsec = Int(exactly: round(fsecs * 1000000000.0)) {
                     var timespecs = (timespec(), timespec())
                     timespecs.0.tv_sec = tv_sec


### PR DESCRIPTION
`time_t` is defined as `Int64` in wasi-libc, not `Int`.
Leave `tv_nsec` as is now because it's defined as `long` 
c.f. https://pubs.opengroup.org/onlinepubs/009695399/basedefs/time.h.html