### PR TITLE
[Windows] Clean up workarounds and enable `Span`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -141,14 +141,6 @@ let package = Package(
           swiftSettings: [
             .enableExperimentalFeature("VariadicGenerics"),
             .enableExperimentalFeature("LifetimeDependence"),
-            .enableExperimentalFeature(
-              "InoutLifetimeDependence",
-              .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
-            ),
-            .enableExperimentalFeature(
-              "LifetimeDependenceMutableAccessors",
-              .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
-            ),
             .enableExperimentalFeature("AddressableTypes"),
             .enableExperimentalFeature("AllowUnsafeAttribute"),
             .enableExperimentalFeature("BuiltinModule"),
@@ -167,16 +159,7 @@ let package = Package(
             resources: [
                 .copy("Resources")
             ],
-            swiftSettings: [
-              .enableExperimentalFeature(
-                "InoutLifetimeDependence",
-                .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
-              ),
-              .enableExperimentalFeature(
-                "LifetimeDependenceMutableAccessors",
-                .when(platforms: [.macOS, .iOS, .watchOS, .tvOS, .linux])
-              ),
-            ] + availabilityMacros + featureSettings + testOnlySwiftSettings
+            swiftSettings: availabilityMacros + featureSettings + testOnlySwiftSettings
         ),
 
         // FoundationInternationalization

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -74,9 +74,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
     target_compile_options(FoundationEssentials PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -Xcc -Xfrontend -D_GNU_SOURCE>"
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend InoutLifetimeDependence>"
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend LifetimeDependenceMutableAccessors>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -Xcc -Xfrontend -D_GNU_SOURCE>")
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 endif()
 

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2203,7 +2203,6 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         return try _representation.withUnsafeBytes(body)
     }
 
-#if compiler(>=6.2) && $LifetimeDependence
     @available(FoundationSpan 6.2, *)
     public var bytes: RawSpan {
         @lifetime(borrow self)
@@ -2299,7 +2298,6 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 #endif
         }
     }
-#endif // compiler(>=6.2) && $LifetimeDependence
 
     @_alwaysEmitIntoClient
     public func withContiguousStorageIfAvailable<ResultType>(_ body: (_ buffer: UnsafeBufferPointer<UInt8>) throws -> ResultType) rethrows -> ResultType? {
@@ -2974,7 +2972,6 @@ extension Data : Codable {
 }
 
 // TODO: remove once _overrideLifetime is public in the standard library
-#if compiler(>=6.2) && $LifetimeDependence
 /// Unsafely discard any lifetime dependency on the `dependent` argument. Return
 /// a value identical to `dependent` with a lifetime dependency on the caller's
 /// borrow scope of the `source` argument.
@@ -3023,4 +3020,3 @@ internal func _overrideLifetime<
 ) -> T {
   dependent
 }
-#endif // compiler(>=6.2) && $LifetimeDependence

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2239,9 +2239,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             return _overrideLifetime(span, borrowing: self)
         }
     }
-#endif
 
-#if compiler(>=5.9) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
     @available(FoundationSpan 6.2, *)
     public var mutableBytes: MutableRawSpan {
         @lifetime(&self)
@@ -2301,7 +2299,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 #endif
         }
     }
-#endif // $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#endif // compiler(>=6.2) && $LifetimeDependence
 
     @_alwaysEmitIntoClient
     public func withContiguousStorageIfAvailable<ResultType>(_ body: (_ buffer: UnsafeBufferPointer<UInt8>) throws -> ResultType) rethrows -> ResultType? {
@@ -3008,9 +3006,7 @@ internal func _overrideLifetime<
 ) -> T {
   dependent
 }
-#endif
 
-#if compiler(>=5.9) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
 /// Unsafely discard any lifetime dependency on the `dependent` argument.
 /// Return a value identical to `dependent` with a lifetime dependency
 /// on the caller's exclusive borrow scope of the `source` argument.
@@ -3027,4 +3023,4 @@ internal func _overrideLifetime<
 ) -> T {
   dependent
 }
-#endif // $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
+#endif // compiler(>=6.2) && $LifetimeDependence

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -1637,7 +1637,6 @@ class DataTests : XCTestCase {
     func test_InlineDataSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.span
         XCTAssertTrue(span.isEmpty)
@@ -1647,18 +1646,15 @@ class DataTests : XCTestCase {
         XCTAssertFalse(span.isEmpty)
         XCTAssertEqual(span.count, source.count)
         XCTAssertEqual(span[0], 1)
-#endif
     }
 
     func test_InlineSliceDataSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         let source = Data(0 ... .max)
         let span = source.span
         XCTAssertEqual(span.count, source.count)
         XCTAssertEqual(span[span.indices.last!], .max)
-#endif
     }
 
     func test_LargeSliceDataSpan() throws {
@@ -1672,19 +1668,16 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         let source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         let span = source.span
         XCTAssertFalse(span.isEmpty)
-#endif
     }
 
     func test_InlineDataMutableSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
 #if !canImport(Darwin) || FOUNDATION_FRAMEWORK
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.mutableSpan
         XCTAssertTrue(span.isEmpty)
@@ -1701,14 +1694,12 @@ class DataTests : XCTestCase {
         sub.update(repeating: v)
         XCTAssertEqual(source[i], v)
 #endif
-#endif
     }
 
     func test_InlineSliceDataMutableSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
 #if !canImport(Darwin) || FOUNDATION_FRAMEWORK
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableSpan
@@ -1717,7 +1708,6 @@ class DataTests : XCTestCase {
         var sub = span.extracting(i..<i+1)
         sub.update(repeating: .max)
         XCTAssertEqual(source[i], .max)
-#endif
 #endif
     }
 
@@ -1733,7 +1723,6 @@ class DataTests : XCTestCase {
 #endif
 
 #if !canImport(Darwin) || FOUNDATION_FRAMEWORK
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         count = source.count
@@ -1744,13 +1733,11 @@ class DataTests : XCTestCase {
         XCTAssertEqual(source[i], 0)
         XCTAssertEqual(source[i+1], .max)
 #endif
-#endif
     }
 
     func test_InlineDataMutableRawSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data()
         var span = source.mutableBytes
         XCTAssertTrue(span.isEmpty)
@@ -1765,13 +1752,11 @@ class DataTests : XCTestCase {
         var sub = span.extracting(i..<i+1)
         sub.storeBytes(of: v, as: UInt8.self)
         XCTAssertEqual(source[i], v)
-#endif
     }
 
     func test_InlineSliceDataMutableRawSpan() throws {
         guard #available(FoundationSpan 6.2, *) else { throw XCTSkip("Span not available") }
 
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(0..<100)
         let count = source.count
         var span = source.mutableBytes
@@ -1779,7 +1764,6 @@ class DataTests : XCTestCase {
         let i = try XCTUnwrap(span.byteOffsets.randomElement())
         span.storeBytes(of: -1, toByteOffset: i, as: Int8.self)
         XCTAssertEqual(source[i], .max)
-#endif
     }
 
     func test_LargeSliceDataMutableRawSpan() throws {
@@ -1793,7 +1777,6 @@ class DataTests : XCTestCase {
         #error("This test needs updating")
 #endif
 
-#if compiler(>=6.2) && $InoutLifetimeDependence && $LifetimeDependenceMutableAccessors
         var source = Data(repeating: 0, count: count).dropFirst()
         XCTAssertNotEqual(source.startIndex, 0)
         count = source.count
@@ -1803,7 +1786,6 @@ class DataTests : XCTestCase {
         span.storeBytes(of: -1, toByteOffset: i, as: Int8.self)
         XCTAssertEqual(source[i], 0)
         XCTAssertEqual(source[i+1], .max)
-#endif
     }
 
     #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653


### PR DESCRIPTION
Remove conditional compilation statements put in place to work around a mismatch in the compiler version used by the Windows CI.