### PR TITLE
Convert Macro tests to swift-testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -247,8 +247,7 @@ package.targets.append(contentsOf: [
     .testTarget(
         name: "FoundationMacrosTests",
         dependencies: [
-            "FoundationMacros",
-            "TestSupport"
+            "FoundationMacros"
         ],
         swiftSettings: availabilityMacros + featureSettings + testOnlySwiftSettings
     )

--- a/Tests/FoundationMacrosTests/BundleMacroTests.swift
+++ b/Tests/FoundationMacrosTests/BundleMacroTests.swift
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import Testing
 import FoundationMacros
 
-final class BundleMacroTests: XCTestCase {
+@Suite("#bundle Macro")
+private struct BundleMacroTests {
 
-    func testSimple() {
+    @Test func testSimple() {
         AssertMacroExpansion(
             macros: ["bundle": BundleMacro.self],
             """
@@ -35,7 +36,7 @@ final class BundleMacroTests: XCTestCase {
         )
     }
 
-    func testUsingParenthesis() {
+    @Test func testUsingParenthesis() {
         AssertMacroExpansion(
             macros: ["bundle": BundleMacro.self],
             """

--- a/Tests/FoundationMacrosTests/PredicateMacroBasicTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroBasicTests.swift
@@ -10,10 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import Testing
 
-final class PredicateMacroBasicTests: XCTestCase {
-    func testSimple() {
+@Suite("#Predicate Macro Basics")
+private struct PredicateMacroBasicTests {
+    @Test func simple() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { input in
@@ -30,7 +31,7 @@ final class PredicateMacroBasicTests: XCTestCase {
         )
     }
     
-    func testImplicitReturn() {
+    @Test func implicitReturn() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { input in
@@ -47,7 +48,7 @@ final class PredicateMacroBasicTests: XCTestCase {
         )
     }
     
-    func testInferredGenerics() {
+    @Test func inferredGenerics() {
         AssertPredicateExpansion(
             """
             #Predicate { input in
@@ -64,7 +65,7 @@ final class PredicateMacroBasicTests: XCTestCase {
         )
     }
     
-    func testShorthandArgumentNames() {
+    @Test func shorthandArgumentNames() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> {
@@ -81,7 +82,7 @@ final class PredicateMacroBasicTests: XCTestCase {
         )
     }
     
-    func testExplicitClosureArgumentTypes() {
+    @Test func explicitClosureArgumentTypes() {
         AssertPredicateExpansion(
             """
             #Predicate<Int, String> { (a: Int, b: String) -> Bool in
@@ -98,7 +99,7 @@ final class PredicateMacroBasicTests: XCTestCase {
         )
     }
     
-    func testDiagnoseMissingTrailingClosure() {
+    @Test func diagnoseMissingTrailingClosure() {
         AssertPredicateExpansion(
             """
             #Predicate
@@ -141,7 +142,7 @@ final class PredicateMacroBasicTests: XCTestCase {
         )
     }
     
-    func testKeyPath() {
+    @Test func keyPath() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> {
@@ -192,7 +193,7 @@ final class PredicateMacroBasicTests: XCTestCase {
         )
     }
     
-    func testComments() {
+    @Test func comments() {
         AssertPredicateExpansion(
             """
             // comment

--- a/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
@@ -10,10 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import Testing
 
-final class PredicateMacroFunctionCallTests: XCTestCase {
-    func testSubscript() {
+@Suite("#Predicate Macro Function Calls")
+private struct PredicateMacroFunctionCallTests {
+    @Test func `subscript`() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { input in
@@ -96,7 +97,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testContains() {
+    @Test func contains() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -130,7 +131,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testContainsWhere() {
+    @Test func containsWhere() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { inputA in
@@ -175,7 +176,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testAllSatisfy() {
+    @Test func allSatisfy() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { inputA in
@@ -220,7 +221,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testFilter() {
+    @Test func filter() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { inputA in
@@ -347,7 +348,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testStartsWith() {
+    @Test func startsWith() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { inputA in
@@ -386,7 +387,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testMin() {
+    @Test func min() {
         AssertPredicateExpansion(
             """
             #Predicate<[Int]> { inputA in
@@ -406,7 +407,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testMax() {
+    @Test func max() {
         AssertPredicateExpansion(
             """
             #Predicate<[Int]> { inputA in
@@ -426,7 +427,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testLocalizedStandardContains() {
+    @Test func localizedStandardContains() {
         AssertPredicateExpansion(
             """
             #Predicate<String> { inputA in
@@ -462,7 +463,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testLocalizedStandardCompare() {
+    @Test func localizedStandardCompare() {
         AssertPredicateExpansion(
             """
             #Predicate<String> { inputA in
@@ -516,7 +517,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
-    func testCaseInsensitiveCompare() {
+    @Test func caseInsensitiveCompare() {
         AssertPredicateExpansion(
             """
             #Predicate<String> { inputA in
@@ -535,7 +536,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
     }
     
     #if FOUNDATION_FRAMEWORK
-    func testEvaluate() {
+    @Test func evaluate() {
         AssertPredicateExpansion(
             """
             #Predicate<String> { input in
@@ -584,7 +585,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
     }
     #endif
     
-    func testDiagnoseUnsupportedFunction() {
+    @Test func diagnoseUnsupportedFunction() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { inputA in

--- a/Tests/FoundationMacrosTests/PredicateMacroLanguageOperatorTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroLanguageOperatorTests.swift
@@ -10,10 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import Testing
 
-final class PredicateMacroLanguageOperatorTests: XCTestCase {
-    func testEqual() {
+@Suite("#Predicate Macro Language Operators")
+private struct PredicateMacroLanguageOperatorTests {
+    @Test func equal() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -31,7 +32,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testEqualExplicitReturn() {
+    @Test func equalExplicitReturn() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -49,7 +50,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testNotEqual() {
+    @Test func notEqual() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -67,7 +68,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testComparison() {
+    @Test func comparison() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -137,7 +138,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testConjunction() {
+    @Test func conjunction() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -155,7 +156,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testDisjunction() {
+    @Test func disjunction() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -173,7 +174,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testArithmetic() {
+    @Test func arithmetic() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -226,7 +227,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testDivision() {
+    @Test func division() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -244,7 +245,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testRemainder() {
+    @Test func remainder() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -262,7 +263,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testNegation() {
+    @Test func negation() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -279,7 +280,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testUnaryMinus() {
+    @Test func unaryMinus() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -296,7 +297,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testNilCoalesce() {
+    @Test func nilCoalesce() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -314,7 +315,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testRanges() {
+    @Test func ranges() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in
@@ -348,7 +349,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testOptionalChaining() {
+    @Test func optionalChaining() {
         AssertPredicateExpansion(
             """
             #Predicate<Object?> { inputA in
@@ -533,7 +534,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testForceUnwrap() {
+    @Test func forceUnwrap() {
         AssertPredicateExpansion(
             """
             #Predicate<Object?> { inputA in
@@ -668,7 +669,7 @@ final class PredicateMacroLanguageOperatorTests: XCTestCase {
         )
     }
     
-    func testDiagnoseUnknownOperator() {
+    @Test func diagnoseUnknownOperator() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object> { inputA, inputB in

--- a/Tests/FoundationMacrosTests/PredicateMacroLanguageTokenTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroLanguageTokenTests.swift
@@ -10,10 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import Testing
 
-final class PredicateMacroLanguageTokenTests: XCTestCase {
-    func testConditional() {
+@Suite("#Predicate Macro Language Tokens")
+private struct PredicateMacroLanguageTokenTests {
+    @Test func conditional() {
         AssertPredicateExpansion(
             """
             #Predicate<Object, Object, Object> { inputA, inputB, inputC in
@@ -32,7 +33,7 @@ final class PredicateMacroLanguageTokenTests: XCTestCase {
         )
     }
     
-    func testTypeCheck() {
+    @Test func typeCheck() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { input in
@@ -49,7 +50,7 @@ final class PredicateMacroLanguageTokenTests: XCTestCase {
         )
     }
     
-    func testConditionalCast() {
+    @Test func conditionalCast() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { input in
@@ -105,7 +106,7 @@ final class PredicateMacroLanguageTokenTests: XCTestCase {
         )
     }
     
-    func testIfExpressions() {
+    @Test func ifExpressions() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { input in
@@ -381,7 +382,7 @@ final class PredicateMacroLanguageTokenTests: XCTestCase {
         )
     }
     
-    func testNilLiterals() {
+    @Test func nilLiterals() {
         AssertPredicateExpansion(
             """
             #Predicate<Object?> { input in
@@ -399,7 +400,7 @@ final class PredicateMacroLanguageTokenTests: XCTestCase {
         )
     }
     
-    func testDiagnoseDeclarations() {
+    @Test func diagnoseDeclarations() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { input in
@@ -461,7 +462,7 @@ final class PredicateMacroLanguageTokenTests: XCTestCase {
         )
     }
     
-    func testDiagnoseMiscellaneousStatements() {
+    @Test func diagnoseMiscellaneousStatements() {
         AssertPredicateExpansion(
             """
             #Predicate<Object> { input in

--- a/Tests/FoundationMacrosTests/PredicateMacroUsageTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroUsageTests.swift
@@ -12,12 +12,12 @@
 
 #if FOUNDATION_FRAMEWORK
 
-import XCTest
+import Testing
+import Foundation
 
 // MARK: - Stubs
 
 @inline(never)
-@available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 fileprivate func _blackHole<T>(_ t: T) {}
 
 @inline(never)
@@ -26,9 +26,10 @@ fileprivate func _blackHoleExplicitInput(_ predicate: Predicate<Int>) {}
 
 // MARK: - Tests
 
-@available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
-final class PredicateMacroUsageTests: XCTestCase {
-    func testUsage() {
+@Suite("#Predicate Macro Usage")
+private struct PredicateMacroUsageTests {
+    @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+    @Test func usage() {
         _blackHole(#Predicate<Bool> {
             return $0
         })


### PR DESCRIPTION
This pulls the macro changes from https://github.com/swiftlang/swift-foundation/pull/908 and applies them (and updates the `#bundle` tests) to bring all of our macros to swift-testing