### PR TITLE
Disable macOS GitHub Actions CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       linux_swift_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
-      enable_macos_checks: true
+      enable_macos_checks: false
       macos_xcode_versions: '["16.3"]'
       macos_versions: '["sequoia"]'
 


### PR DESCRIPTION
It turns out that swiftlang's GitHub actions macOS CI doesn't use a nightly snapshot like the linux/windows testing, but instead uses the compiler from the Xcode installed on the device which currently only contains a 6.1 toolchain (which isn't new enough to build swift-foundation). This turns macOS GitHub action CI back off for this repo until we have an action that will use a new enough toolchain.