### PR TITLE
Convert String/Predicate/ProcessInfo/RecurrenceRule tests to swift-testing

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FilePlayground.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FilePlayground.swift
@@ -144,18 +144,18 @@ struct FilePlayground {
     
     func test(captureDelegateCalls: Bool = false, sourceLocation: SourceLocation = #_sourceLocation, _ tester: sending (FileManager) throws -> Void) async throws {
         let capturingDelegate = CapturingFileManagerDelegate()
-        let fileManager = FileManager()
         let tempDir = String.temporaryDirectoryPath
-        try directory.build(in: tempDir, using: fileManager)
-        if captureDelegateCalls {
-            // Add the delegate after the call to `build` to ensure that the builder doesn't mutate the delegate
-            fileManager.delegate = capturingDelegate
-        }
+        try directory.build(in: tempDir, using: FileManager.default)
         let createdDir = tempDir.appendingPathComponent(directory.name)
-        try await CurrentWorkingDirectoryActor.withCurrentWorkingDirectory(createdDir, fileManager: fileManager, sourceLocation: sourceLocation) {
+        try await CurrentWorkingDirectoryActor.withCurrentWorkingDirectory(createdDir, sourceLocation: sourceLocation) {
+            let fileManager = FileManager()
+            if captureDelegateCalls {
+                // Add the delegate after the call to `build` to ensure that the builder doesn't mutate the delegate
+                fileManager.delegate = capturingDelegate
+            }
             try tester(fileManager)
         }
-        try fileManager.removeItem(atPath: createdDir)
+        try FileManager.default.removeItem(atPath: createdDir)
         extendLifetime(capturingDelegate) // Ensure capturingDelegate lives beyond the tester body
     }
 }

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -542,6 +542,7 @@ private struct GregorianCalendarRecurrenceRuleTests {
     
     @Test func yearlyRecurrenceWithWeekNumberExpansion() {
         var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .gmt
         calendar.firstWeekday = 2 // Week starts on Monday
         calendar.minimumDaysInFirstWeek = 4
         
@@ -569,6 +570,7 @@ private struct GregorianCalendarRecurrenceRuleTests {
     
     @Test func yearlyRecurrenceWithWeekNumberExpansionCountingBack() {
         var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .gmt
         calendar.firstWeekday = 2 // Week starts on Monday
         
         let start = Date(timeIntervalSince1970: 1704117600.0) // 2024-01-01T14:00:00-0000

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -10,17 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(TestSupport)
-import TestSupport
+import Testing
+
+#if canImport(FoundationEssentials)
+@testable import FoundationEssentials
+#else
+@testable import Foundation
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@testable import Foundation
-#else
-@testable import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
-final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
+@Suite("GregorianCalendar RecurrenceRule")
+private struct GregorianCalendarRecurrenceRuleTests {
     /// A Gregorian calendar in GMT with no time zone changes
     var gregorian: Calendar = {
         var gregorian = Calendar(identifier: .gregorian)
@@ -28,17 +27,21 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         return gregorian
     }()
   
-    func testRoundtripEncoding() throws {
+    @Test func roundtripEncoding() throws {
         // These are not necessarily valid recurrence rule, they are constructed
         // in a way to test all encoding paths
-        var recurrenceRule1 = Calendar.RecurrenceRule(calendar: .current, frequency: .daily)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = .init(identifier: "en_001")
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        
+        var recurrenceRule1 = Calendar.RecurrenceRule(calendar: calendar, frequency: .daily)
         recurrenceRule1.interval = 2
         recurrenceRule1.months = [1, 2, Calendar.RecurrenceRule.Month(4, isLeap: true)]
         recurrenceRule1.weeks = [2, 3]
         recurrenceRule1.weekdays = [.every(.monday), .nth(1, .wednesday)]
         recurrenceRule1.end = .afterOccurrences(5)
         
-        var recurrenceRule2 = Calendar.RecurrenceRule(calendar: .init(identifier: .gregorian), frequency: .daily)
+        var recurrenceRule2 = Calendar.RecurrenceRule(calendar: calendar, frequency: .daily)
         recurrenceRule2.months = [2, 10]
         recurrenceRule2.weeks = [1, -1]
         recurrenceRule2.setPositions = [1]
@@ -55,12 +58,12 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         let decoded1 = try JSONDecoder().decode(Calendar.RecurrenceRule.self, from: recurrenceRule1JSON)
         let decoded2 = try JSONDecoder().decode(Calendar.RecurrenceRule.self, from: recurrenceRule2JSON)
         
-        XCTAssertEqual(recurrenceRule1, decoded1)
-        XCTAssertEqual(recurrenceRule2, decoded2)
-        XCTAssertNotEqual(recurrenceRule1, recurrenceRule2)
+        #expect(recurrenceRule1 == decoded1)
+        #expect(recurrenceRule2 == decoded2)
+        #expect(recurrenceRule1 != recurrenceRule2)
     }
     
-    func testSimpleDailyRecurrence() {
+    @Test func simpleDailyRecurrence() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -102,10 +105,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1287583200.0), // 2010-10-20T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testSimpleDailyRecurrenceWithCount() {
+    @Test func simpleDailyRecurrenceWithCount() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -121,10 +124,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1285336800.0), // 2010-09-24T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testDailyRecurrenceWithDaysOfTheWeek() {
+    @Test func dailyRecurrenceWithDaysOfTheWeek() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -145,10 +148,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1287410400.0), // 2010-10-18T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testDailyRecurrenceWithDaysOfTheWeekAndMonth() {
+    @Test func dailyRecurrenceWithDaysOfTheWeekAndMonth() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -164,10 +167,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1285596000.0), // 2010-09-27T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testDailyRecurrenceWithMonth() {
+    @Test func dailyRecurrenceWithMonth() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -190,10 +193,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1285855200.0), // 2010-09-30T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testDailyRecurrenceEveryThreeDays() {
+    @Test func dailyRecurrenceEveryThreeDays() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -216,11 +219,11 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1287410400.0), // 2010-10-18T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
         
     }
     
-    func testSimpleWeeklyRecurrence() {
+    @Test func simpleWeeklyRecurrence() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -237,10 +240,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1287496800.0), // 2010-10-19T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testWeeklyRecurrenceEveryOtherWeek() {
+    @Test func weeklyRecurrenceEveryOtherWeek() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -256,10 +259,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1287496800.0), // 2010-10-19T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testWeeklyRecurrenceWithDaysOfWeek() {
+    @Test func weeklyRecurrenceWithDaysOfWeek() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -280,10 +283,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1287410400.0), // 2010-10-18T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testWeeklyRecurrenceWithDaysOfWeekAndMonth() {
+    @Test func weeklyRecurrenceWithDaysOfWeekAndMonth() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -299,9 +302,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1285596000.0), // 2010-09-27T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
-    func testWeeklyRecurrenceWithDaysOfWeekAndSetPositions() {
+    
+    @Test func weeklyRecurrenceWithDaysOfWeekAndSetPositions() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1287619200.0) // 2010-10-21T00:00:00-0000
         
@@ -319,10 +323,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1287151200.0), // 2010-10-15T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testMonthlyRecurrenceWithWeekdays() {
+    @Test func monthlyRecurrenceWithWeekdays() {
         // Find the first monday and last friday of each month for a given range
         let start = Date(timeIntervalSince1970: 1641045600.0) // 2022-01-01T14:00:00-0000
         let end   = Date(timeIntervalSince1970: 1677679200.0) // 2023-03-01T14:00:00-0000
@@ -364,10 +368,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1677247200.0), // 2023-02-24T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testYearlyRecurrenceOnLeapDay() {
+    @Test func yearlyRecurrenceOnLeapDay() {
         let start   = Date(timeIntervalSince1970: 1704067200.0) // 2024-01-01T00:00:00-0000
         let end     = Date(timeIntervalSince1970: 1956528000.0) // 2032-01-01T00:00:00-0000
         let leapDay = Date(timeIntervalSince1970: 1709200800.0) // 2024-02-29T10:00:00-0000
@@ -387,7 +391,7 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1898589600.0), // 2030-03-01T10:00:00-0000
             Date(timeIntervalSince1970: 1930125600.0), // 2031-03-01T10:00:00-0000
         ]
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
         
         rule.matchingPolicy = .nextTime
         results = Array(rule.recurrences(of: leapDay, in: start..<end))
@@ -401,7 +405,7 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1898553600.0), // 2030-03-01T00:00:00-0000
             Date(timeIntervalSince1970: 1930089600.0), // 2031-03-01T00:00:00-0000
         ]
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
         
         rule.matchingPolicy = .previousTimePreservingSmallerComponents
         results = Array(rule.recurrences(of: leapDay, in: start..<end))
@@ -415,7 +419,7 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1898503200.0), // 2030-02-28T10:00:00-0000
             Date(timeIntervalSince1970: 1930039200.0), // 2031-02-28T10:00:00-0000
         ]
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
         
         rule.matchingPolicy = .strict
         results = Array(rule.recurrences(of: leapDay, in: start..<end))
@@ -423,10 +427,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1709200800.0), // 2024-02-29T10:00:00-0000
             Date(timeIntervalSince1970: 1835431200.0), // 2028-02-29T10:00:00-0000
         ]
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
 
-    func testYearlyRecurrenceMovingToFeb29() {
+    @Test func yearlyRecurrenceMovingToFeb29() {
         /// Rule for an event that repeats on February 29th of each year, or closest date after
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .yearly, matchingPolicy: .nextTimePreservingSmallerComponents)
         rule.months = [2]
@@ -437,19 +441,19 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         var birthdays = rule.recurrences(of: rangeStart, in: rangeStart..<rangeEnd).makeIterator()
         //                               ^ Since the rule will change the month and day, we only borrow the time of day from the initial date
 
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 951782400.0)) // 2000-02-29T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 983404800.0)) // 2001-03-01T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 1014940800.0)) // 2002-03-01T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 1046476800.0)) // 2003-03-01T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 1078012800.0)) // 2004-02-29T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 1109635200.0)) // 2005-03-01T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 1141171200.0)) // 2006-03-01T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 1172707200.0)) // 2007-03-01T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 1204243200.0)) // 2008-02-29T00:00:00-0000
-        XCTAssertEqual(birthdays.next(), Date(timeIntervalSince1970: 1235865600.0)) // 2009-03-01T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 951782400.0)) // 2000-02-29T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 983404800.0)) // 2001-03-01T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 1014940800.0)) // 2002-03-01T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 1046476800.0)) // 2003-03-01T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 1078012800.0)) // 2004-02-29T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 1109635200.0)) // 2005-03-01T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 1141171200.0)) // 2006-03-01T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 1172707200.0)) // 2007-03-01T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 1204243200.0)) // 2008-02-29T00:00:00-0000
+        #expect(birthdays.next() == Date(timeIntervalSince1970: 1235865600.0)) // 2009-03-01T00:00:00-0000
     }
     
-    func testYearlyRecurrenceWithMonthExpansion() {
+    @Test func yearlyRecurrenceWithMonthExpansion() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1350777600.0) // 2012-10-21T00:00:00-0000
         
@@ -466,9 +470,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1337608800.0), // 2012-05-21T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
-    func testYearlyRecurrenceWithDayOfMonthExpansion() {
+    
+    @Test func yearlyRecurrenceWithDayOfMonthExpansion() {
         let start = Date(timeIntervalSince1970: 1695304800.0) // 2023-09-21T14:00:00-0000
         let end   = Date(timeIntervalSince1970: 1729519200.0) // 2024-10-21T14:00:00-0000
         
@@ -484,10 +489,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1727704800.0), // 2024-09-30T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testYearlyRecurrenceWithMonthAndDayOfMonthExpansion() {
+    @Test func yearlyRecurrenceWithMonthAndDayOfMonthExpansion() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1350777600.0) // 2012-10-21T00:00:00-0000
         
@@ -509,9 +514,9 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1336658400.0), // 2012-05-10T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }    
-    func testYearlyRecurrenceWithMonthAndWeekdayExpansion() {
+    @Test func yearlyRecurrenceWithMonthAndWeekdayExpansion() {
         let start = Date(timeIntervalSince1970: 1704117600.0) // 2024-01-01T14:00:00-0000
         let end   = Date(timeIntervalSince1970: 1767225600.0) // 2026-01-01T00:00:00-0000
         
@@ -532,10 +537,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1758895200.0), // 2025-09-26T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testYearlyRecurrenceWithWeekNumberExpansion() {
+    @Test func yearlyRecurrenceWithWeekNumberExpansion() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.firstWeekday = 2 // Week starts on Monday
         calendar.minimumDaysInFirstWeek = 4
@@ -559,10 +564,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1452866400.0), // 2016-01-15T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testYearlyRecurrenceWithWeekNumberExpansionCountingBack() {
+    @Test func yearlyRecurrenceWithWeekNumberExpansionCountingBack() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.firstWeekday = 2 // Week starts on Monday
         
@@ -581,10 +586,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1766584800.0), // 2025-12-24T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testYearlyRecurrenceWithDayOfYearExpansion() {
+    @Test func yearlyRecurrenceWithDayOfYearExpansion() {
         let start = Date(timeIntervalSince1970: 1695254400.0) // 2023-09-21T00:00:00-0000
         let end   = Date(timeIntervalSince1970: 1729468800.0) // 2024-10-21T00:00:00-0000
         
@@ -599,10 +604,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1704117600.0), // 2024-01-01T14:00:00-0000
         ]
         
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testHourlyRecurrenceWithWeekdayFilter() {
+    @Test func hourlyRecurrenceWithWeekdayFilter() {
         // Repeat hourly, but filter to Sundays
         let start = Date(timeIntervalSince1970: 1590314400.0) // 2020-05-24T10:00:00-0000
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .hourly)
@@ -628,9 +633,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1590886800.0), // 2020-05-31T01:00:00-0000
         ]
 
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
-    func testHourlyRecurrenceWithHourAndWeekdayFilter() {
+    
+    @Test func hourlyRecurrenceWithHourAndWeekdayFilter() {
         // Repeat hourly, filter to 10am on the last Sunday of the month
         let start = Date(timeIntervalSince1970: 1590314400.0) // 2020-05-24T10:00:00-0000
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .hourly)
@@ -645,9 +651,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1598785200.0), // 2020-08-30T11:00:00-0000
         ]
 
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
-    func testDailyRecurrenceWithHourlyExpansions() {
+    
+    @Test func dailyRecurrenceWithHourlyExpansions() {
         // Repeat hourly, filter to 10am on the last Sunday of the month
         let start = Date(timeIntervalSince1970: 1590307200.0) // 2020-05-24T08:00:00-0000
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .daily)
@@ -668,11 +675,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
             Date(timeIntervalSince1970: 1590397200.0), // 2020-05-25T09:00:00-0000
             Date(timeIntervalSince1970: 1590397230.0), // 2020-05-25T09:00:30-0000
         ]
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
    }
    
-    
-   func testEmptySequence() {
+   @Test func emptySequence() {
         // Construct a recurrence rule which requests matches on the 32nd of May
         let start = Date(timeIntervalSince1970: 1704067200.0) // 2024-01-01T00:00:00-0000
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .yearly)
@@ -681,12 +687,12 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         rule.matchingPolicy = .strict
 
         for _ in rule.recurrences(of: start) {
-            XCTFail("Recurrence rule is not expected to produce results")
+            Issue.record("Recurrence rule is not expected to produce results")
         }
         // If we get here, there isn't an infinite loop
    }
     
-   func testOutOfRangeComponents() {
+   @Test func outOfRangeComponents() {
         let start = Date(timeIntervalSince1970: 1695304800.0) // 2023-09-21T14:00:00-0000
         let end   = Date(timeIntervalSince1970: 1729519200.0) // 2024-10-21T14:00:00-0000
         
@@ -696,73 +702,73 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         let eventStart = Date(timeIntervalSince1970: 1285077600.0) // 2010-09-21T14:00:00-0000
         let results = Array(rule.recurrences(of: eventStart, in: start..<end))
         
-        XCTAssertEqual(results, [])
+        #expect(results == [])
     }
     
-    func testFirstMondaysStrictMatching() {
+    @Test func firstMondaysStrictMatching() {
         let startDate = Date(timeIntervalSince1970: 1706659200.0) // 2024-01-31T00:00:00-0000
         
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .monthly, matchingPolicy: .strict)
         rule.weekdays = [.nth(1, .monday)]
         
         var dates = rule.recurrences(of: startDate).makeIterator()
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1707091200.0)) // 2024-02-05T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1709510400.0)) // 2024-03-04T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1711929600.0)) // 2024-04-01T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1714953600.0)) // 2024-05-06T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1707091200.0)) // 2024-02-05T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1709510400.0)) // 2024-03-04T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1711929600.0)) // 2024-04-01T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1714953600.0)) // 2024-05-06T00:00:00-0000
     }
     
-    func testFifthFridaysStrictMatching() {
+    @Test func fifthFridaysStrictMatching() {
         let startDate = Date(timeIntervalSince1970: 1706659200.0) // 2024-01-31T00:00:00-0000
         
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .monthly, matchingPolicy: .strict)
         rule.weekdays = [.nth(5, .friday)]
         
         var dates = rule.recurrences(of: startDate).makeIterator()
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1711670400.0)) // 2024-03-29T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1717113600.0)) // 2024-05-31T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1724976000.0)) // 2024-08-30T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1732838400.0)) // 2024-11-29T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1711670400.0)) // 2024-03-29T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1717113600.0)) // 2024-05-31T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1724976000.0)) // 2024-08-30T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1732838400.0)) // 2024-11-29T00:00:00-0000
     }
 
-    func testYearlyRecurrenceWeekdayExpansionStrictMatching() {
+    @Test func yearlyRecurrenceWeekdayExpansionStrictMatching() {
         let startDate = Date(timeIntervalSince1970: 1709164800.0) // 2024-02-29T00:00:00-0000
         
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .yearly, matchingPolicy: .strict)
         rule.weekdays = [.nth(5, .friday)]
         
         var dates = rule.recurrences(of: startDate).makeIterator()
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1738281600.0)) // 2025-01-31T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1769731200.0)) // 2026-01-30T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1738281600.0)) // 2025-01-31T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1769731200.0)) // 2026-01-30T00:00:00-0000
     }
 
-    func testYearlyRecurrenceDayOfYearExpansionStrictMatching() {
+    @Test func yearlyRecurrenceDayOfYearExpansionStrictMatching() {
         let startDate = Date(timeIntervalSince1970: 1709164800.0) // 2024-02-29T00:00:00-0000
         
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .yearly, matchingPolicy: .strict)
         rule.daysOfTheYear = [61]
         
         var dates = rule.recurrences(of: startDate).makeIterator()
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1709251200.0)) // 2024-03-01T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1740873600.0)) // 2025-03-02T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1772409600.0)) // 2026-03-02T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1803945600.0)) // 2027-03-02T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1835481600.0)) // 2028-03-01T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1709251200.0)) // 2024-03-01T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1740873600.0)) // 2025-03-02T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1772409600.0)) // 2026-03-02T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1803945600.0)) // 2027-03-02T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1835481600.0)) // 2028-03-01T00:00:00-0000
     }
 
-    func testYearlyRecurrenceWeekExpansionStrictMatching() {
+    @Test func yearlyRecurrenceWeekExpansionStrictMatching() {
         let startDate = Date(timeIntervalSince1970: 1709164800.0) // 2024-02-29T00:00:00-0000
         
         var rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .yearly, matchingPolicy: .strict)
         rule.weeks = [2]
         
         var dates = rule.recurrences(of: startDate).makeIterator()
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1736553600.0)) // 2025-01-11T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1767484800.0)) // 2026-01-04T00:00:00-0000
-        XCTAssertEqual(dates.next(), Date(timeIntervalSince1970: 1799020800.0)) // 2027-01-04T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1736553600.0)) // 2025-01-11T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1767484800.0)) // 2026-01-04T00:00:00-0000
+        #expect(dates.next() == Date(timeIntervalSince1970: 1799020800.0)) // 2027-01-04T00:00:00-0000
     }
 
-    func testWeekdayFilter() {
+    @Test func weekdayFilter() {
         var alarms = Calendar.RecurrenceRule(calendar: gregorian, frequency: .daily)
         alarms.weekdays = [.every(.monday), .every(.tuesday), .every(.wednesday), .every(.thursday), .every(.friday)]
         alarms.hours = [7, 8]
@@ -771,25 +777,25 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         let start = Date(timeIntervalSince1970: 1695304800.0) // 2023-09-21T14:00:00-0000
         var results = alarms.recurrences(of: start).makeIterator()
 
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695366000.0)) // 2023-09-22T07:00:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695366900.0)) // 2023-09-22T07:15:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695367800.0)) // 2023-09-22T07:30:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695368700.0)) // 2023-09-22T07:45:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695369600.0)) // 2023-09-22T08:00:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695370500.0)) // 2023-09-22T08:15:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695371400.0)) // 2023-09-22T08:30:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695372300.0)) // 2023-09-22T08:45:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695625200.0)) // 2023-09-25T07:00:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695626100.0)) // 2023-09-25T07:15:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695627000.0)) // 2023-09-25T07:30:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695627900.0)) // 2023-09-25T07:45:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695628800.0)) // 2023-09-25T08:00:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695629700.0)) // 2023-09-25T08:15:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695630600.0)) // 2023-09-25T08:30:00-0000
-        XCTAssertEqual(results.next(), Date(timeIntervalSince1970: 1695631500.0)) // 2023-09-25T08:45:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695366000.0)) // 2023-09-22T07:00:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695366900.0)) // 2023-09-22T07:15:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695367800.0)) // 2023-09-22T07:30:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695368700.0)) // 2023-09-22T07:45:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695369600.0)) // 2023-09-22T08:00:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695370500.0)) // 2023-09-22T08:15:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695371400.0)) // 2023-09-22T08:30:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695372300.0)) // 2023-09-22T08:45:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695625200.0)) // 2023-09-25T07:00:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695626100.0)) // 2023-09-25T07:15:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695627000.0)) // 2023-09-25T07:30:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695627900.0)) // 2023-09-25T07:45:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695628800.0)) // 2023-09-25T08:00:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695629700.0)) // 2023-09-25T08:15:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695630600.0)) // 2023-09-25T08:30:00-0000
+        #expect(results.next() == Date(timeIntervalSince1970: 1695631500.0)) // 2023-09-25T08:45:00-0000
     }
 
-    func testRangeExcludesUpperBounds() {
+    @Test func rangeExcludesUpperBounds() {
         let start = Date(timeIntervalSince1970: 1695304800.0) // 2023-09-21T14:00:00-0000
         let end   = Date(timeIntervalSince1970: 1697896800.0) // 2023-10-21T14:00:00-0000
 
@@ -801,10 +807,10 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
         let expectedResults: [Date] = [
             Date(timeIntervalSince1970: 1695304800.0), // 2023-09-21T14:00:00-0000
         ]
-        XCTAssertEqual(results, expectedResults)
+        #expect(results == expectedResults)
     }
     
-    func testDailyRecurrenceRuleWithNonzeroNanosecondComponent() {
+    @Test func dailyRecurrenceRuleWithNonzeroNanosecondComponent() {
         let referenceStart = Date(timeIntervalSinceReferenceDate: 1746627600) // 2025-05-07T07:20:00.000-07:00
         let referenceEnd = Date(timeIntervalSinceReferenceDate: 1746714000) // 2025-05-08T07:20:00.000-07:00
         
@@ -817,7 +823,7 @@ final class GregorianCalendarRecurrenceRuleTests: XCTestCase {
                 start,
                 referenceEnd.addingTimeInterval(nsec)
             ]
-            XCTAssertEqual(results, expectedResults, "Failed for nanoseconds \(nsec)")
+            #expect(results == expectedResults, "Failed for nanoseconds \(nsec)")
         }
     }
 }

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -11,8 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
+import Testing
+import Foundation
 
-final class NSPredicateConversionTests: XCTestCase {
+@Suite("NSPredicate Conversion")
+private struct NSPredicateConversionTests {
     private func convert<T: NSObject>(_ predicate: Predicate<T>) -> NSPredicate? {
         NSPredicate(predicate)
     }
@@ -59,64 +62,64 @@ final class NSPredicateConversionTests: XCTestCase {
         var b: [Int]
     }
     
-    func testBasics() {
+    @Test func basics() throws {
         let obj = ObjCObject()
         let compareTo = 2
         var predicate = #Predicate<ObjCObject> {
             $0.a == compareTo
         }
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "a == 2"))
-        XCTAssertFalse(converted!.evaluate(with: obj))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "a == 2"))
+        #expect(!converted.evaluate(with: obj))
         
         predicate = #Predicate<ObjCObject> {
             $0.a + 2 == 4
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "a + 2 == 4"))
-        XCTAssertFalse(converted!.evaluate(with: obj))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "a + 2 == 4"))
+        #expect(!converted.evaluate(with: obj))
         
         predicate = #Predicate<ObjCObject> {
             $0.b.count == 5
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "b.length == 5"))
-        XCTAssertTrue(converted!.evaluate(with: obj))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "b.length == 5"))
+        #expect(converted.evaluate(with: obj))
         
         predicate = #Predicate<ObjCObject> {
             $0.g.count == 5
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "g.@count == 5"))
-        XCTAssertTrue(converted!.evaluate(with: obj))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "g.@count == 5"))
+        #expect(converted.evaluate(with: obj))
         
         predicate = #Predicate<ObjCObject> { object in
             object.g.filter {
                 $0 == object.d
             }.count > 0
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "SUBQUERY(g, $_local_1, $_local_1 == d).@count > 0"))
-        XCTAssertFalse(converted!.evaluate(with: obj))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "SUBQUERY(g, $_local_1, $_local_1 == d).@count > 0"))
+        #expect(!converted.evaluate(with: obj))
     }
     
-    func testEquality() {
+    @Test func equality() throws {
         var predicate = #Predicate<ObjCObject> {
             $0.a == 0
         }
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "a == 0"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "a == 0"))
+        #expect(!converted.evaluate(with: ObjCObject()))
         
         predicate = #Predicate<ObjCObject> {
             $0.a != 0
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "a != 0"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "a != 0"))
+        #expect(converted.evaluate(with: ObjCObject()))
     }
     
-    func testRanges() {
+    @Test func ranges() throws {
         let now = Date.now
         let range = now ..< now
         let closedRange = now ... now
@@ -128,283 +131,283 @@ final class NSPredicateConversionTests: XCTestCase {
         var predicate = #Predicate<ObjCObject> {
             ($0.i ... $0.i).contains($0.i)
         }
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "i BETWEEN {i, i}"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "i BETWEEN {i, i}"))
+        #expect(converted.evaluate(with: ObjCObject()))
         
         // Non-closed Range Operator
         predicate = #Predicate<ObjCObject> {
             ($0.i ..< $0.i).contains($0.i)
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "i >= i AND i < i"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "i >= i AND i < i"))
+        #expect(!converted.evaluate(with: ObjCObject()))
         
         // Various values
         predicate = #Predicate<ObjCObject> {
             range.contains($0.i)
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "i >= %@ AND i < %@", now as NSDate, now as NSDate))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "i >= %@ AND i < %@", now as NSDate, now as NSDate))
+        #expect(!converted.evaluate(with: ObjCObject()))
         predicate = #Predicate<ObjCObject> {
             closedRange.contains($0.i)
         }
-        converted = convert(predicate)
+        converted = try #require(convert(predicate))
         let other = NSPredicate(format: "i BETWEEN %@", [now, now])
-        XCTAssertEqual(converted, other)
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        #expect(converted == other)
+        #expect(!converted.evaluate(with: ObjCObject()))
         predicate = #Predicate<ObjCObject> {
             from.contains($0.i)
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "i >= %@", now as NSDate))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "i >= %@", now as NSDate))
+        #expect(converted.evaluate(with: ObjCObject()))
         predicate = #Predicate<ObjCObject> {
             through.contains($0.i)
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "i <= %@", now as NSDate))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "i <= %@", now as NSDate))
+        #expect(!converted.evaluate(with: ObjCObject()))
         predicate = #Predicate<ObjCObject> {
             upTo.contains($0.i)
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "i < %@", now as NSDate))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "i < %@", now as NSDate))
+        #expect(!converted.evaluate(with: ObjCObject()))
     }
     
-    func testNonObjC() {
+    @Test func nonObjC() throws {
         let predicate = #Predicate<ObjCObject> {
             $0.nonObjCKeypath == 2
         }
-        XCTAssertNil(convert(predicate))
+        #expect(convert(predicate) == nil)
     }
     
-    func testNonObjCConstantKeyPath() {
+    @Test func nonObjCConstantKeyPath() throws {
         let nonObjC = NonObjCStruct(a: 1, b: [1, 2, 3])
         var predicate = #Predicate<ObjCObject> {
             $0.a == nonObjC.a
         }
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "a == 1"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "a == 1"))
+        #expect(converted.evaluate(with: ObjCObject()))
         
         
         predicate = #Predicate<ObjCObject> {
             $0.f == nonObjC.b.contains([1, 2])
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "f == YES"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "f == YES"))
+        #expect(converted.evaluate(with: ObjCObject()))
     }
     
-    func testSubscripts() {
+    @Test func subscripts() throws {
         let obj = ObjCObject()
         var predicate = #Predicate<ObjCObject> {
             $0.g[0] == 2
         }
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "(SELF.g)[0] == 2"))
-        XCTAssertFalse(converted!.evaluate(with: obj))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "(SELF.g)[0] == 2"))
+        #expect(!converted.evaluate(with: obj))
         
         predicate = #Predicate<ObjCObject> {
             $0.h["A"] == 1
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "(SELF.h)['A'] == 1"))
-        XCTAssertTrue(converted!.evaluate(with: obj))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "(SELF.h)['A'] == 1"))
+        #expect(converted.evaluate(with: obj))
     }
     
-    func testStringSearching() {
+    @Test func stringSearching() throws {
         let obj = ObjCObject()
         var predicate = #Predicate<ObjCObject> {
             $0.b.contains("foo")
         }
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "b CONTAINS 'foo'"))
-        XCTAssertFalse(converted!.evaluate(with: obj))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "b CONTAINS 'foo'"))
+        #expect(!converted.evaluate(with: obj))
         
         
         predicate = #Predicate<ObjCObject> {
             $0.b.starts(with: "foo")
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "b BEGINSWITH 'foo'"))
-        XCTAssertFalse(converted!.evaluate(with: obj))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "b BEGINSWITH 'foo'"))
+        #expect(!converted.evaluate(with: obj))
     }
     
-    func testExpressionEnforcement() {
+    @Test func expressionEnforcement() throws {
         var predicate = #Predicate<ObjCObject> { _ in
             true
         }
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "YES == YES"))
-        XCTAssertTrue(converted!.evaluate(with: "Hello"))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "YES == YES"))
+        #expect(converted.evaluate(with: "Hello"))
         
         predicate = #Predicate<ObjCObject> { _ in
             false
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "NO == YES"))
-        XCTAssertFalse(converted!.evaluate(with: "Hello"))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "NO == YES"))
+        #expect(!converted.evaluate(with: "Hello"))
         
         predicate = #Predicate<ObjCObject> { _ in
             true && false
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "(YES == YES) && (NO == YES)"))
-        XCTAssertFalse(converted!.evaluate(with: "Hello"))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "(YES == YES) && (NO == YES)"))
+        #expect(!converted.evaluate(with: "Hello"))
         
         predicate = #Predicate<ObjCObject> {
             $0.f
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "f == YES"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "f == YES"))
+        #expect(converted.evaluate(with: ObjCObject()))
         
         predicate = #Predicate<ObjCObject> {
             ($0.f && true) == false
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(f == YES AND YES == YES, YES, NO) == NO"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "TERNARY(f == YES AND YES == YES, YES, NO) == NO"))
+        #expect(!converted.evaluate(with: ObjCObject()))
     }
     
-    func testConditional() {
+    @Test func conditional() throws {
         let predicate = #Predicate<ObjCObject> {
             $0.f ? true : false
         }
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(f == YES, YES, NO) == YES"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "TERNARY(f == YES, YES, NO) == YES"))
+        #expect(converted.evaluate(with: ObjCObject()))
     }
     
-    func testOptionals() {
+    @Test func optionals() throws {
         var predicate = #Predicate<ObjCObject> {
             ($0.j ?? "").isEmpty
         }
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(j != NULL, j, '').length == 0"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "TERNARY(j != NULL, j, '').length == 0"))
+        #expect(converted.evaluate(with: ObjCObject()))
         
         predicate = #Predicate<ObjCObject> {
             ($0.j?.count ?? -1) > 1
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(TERNARY(j != nil, j.length, nil) != nil, TERNARY(j != nil, j.length, nil), 1 * -1) > 1"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "TERNARY(TERNARY(j != nil, j.length, nil) != nil, TERNARY(j != nil, j.length, nil), 1 * -1) > 1"))
+        #expect(!converted.evaluate(with: ObjCObject()))
         
         predicate = #Predicate<ObjCObject> {
             $0.j == nil
         }
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "j == nil"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "j == nil"))
+        #expect(converted.evaluate(with: ObjCObject()))
     }
     
-    func testUUID() {
+    @Test func uuid() throws {
         let obj = ObjCObject()
         let uuid = obj.k
         let predicate = #Predicate<ObjCObject> {
             $0.k == uuid
         }
         
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "k == %@", uuid as NSUUID))
-        XCTAssertTrue(converted!.evaluate(with: obj))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "k == %@", uuid as NSUUID))
+        #expect(converted.evaluate(with: obj))
         let obj2 = ObjCObject()
-        XCTAssertNotEqual(obj2.k, uuid)
-        XCTAssertFalse(converted!.evaluate(with: obj2))
+        #expect(obj2.k != uuid)
+        #expect(!converted.evaluate(with: obj2))
     }
     
-    func testDate() {
+    @Test func date() throws {
         let now = Date.now
         let predicate = #Predicate<ObjCObject> {
             $0.i > now
         }
         
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "i > %@", now as NSDate))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "i > %@", now as NSDate))
+        #expect(converted.evaluate(with: ObjCObject()))
     }
     
-    func testData() {
+    @Test func data() throws {
         let data = Data([1, 2, 3])
         let predicate = #Predicate<ObjCObject> {
             $0.l == data
         }
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "l == %@", data as NSData))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "l == %@", data as NSData))
+        #expect(converted.evaluate(with: ObjCObject()))
     }
     
-    func testURL() {
+    @Test func url() throws {
         let url = URL(string: "http://apple.com")!
         let predicate = #Predicate<ObjCObject> {
             $0.m == url
         }
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "m == %@", url as NSURL))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "m == %@", url as NSURL))
+        #expect(converted.evaluate(with: ObjCObject()))
     }
     
-    func testSequenceContainsWhere() {
+    @Test func sequenceContainsWhere() throws {
         let predicate = #Predicate<ObjCObject> {
             $0.g.contains { $0 == 2 }
         }
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "SUBQUERY(g, $_local_1, $_local_1 == 2).@count != 0"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "SUBQUERY(g, $_local_1, $_local_1 == 2).@count != 0"))
+        #expect(!converted.evaluate(with: ObjCObject()))
     }
     
-    func testSequenceAllSatisfy() {
+    @Test func sequenceAllSatisfy() throws {
         let predicate = #Predicate<ObjCObject> {
             $0.g.allSatisfy { $0 == 2 }
         }
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "SUBQUERY(g, $_local_1, NOT ($_local_1 == 2)).@count == 0"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "SUBQUERY(g, $_local_1, NOT ($_local_1 == 2)).@count == 0"))
+        #expect(!converted.evaluate(with: ObjCObject()))
     }
     
-    func testMaxMin() {
+    @Test func maxMin() throws {
         let predicate = #Predicate<ObjCObject> {
             $0.g.max() == $0.g.min()
         }
         
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "g.@max.#self == g.@min.#self"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "g.@max.#self == g.@min.#self"))
+        #expect(!converted.evaluate(with: ObjCObject()))
     }
     
-    func testStringComparison() {
+    @Test func stringComparison() throws {
         let equal = ComparisonResult.orderedSame
         var predicate = #Predicate<ObjCObject> {
             $0.b.caseInsensitiveCompare("ABC") == equal
         }
         
-        var converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(b ==[c] 'ABC', 0, TERNARY(b <[c] 'ABC', -1, 1)) == 0"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        var converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "TERNARY(b ==[c] 'ABC', 0, TERNARY(b <[c] 'ABC', -1, 1)) == 0"))
+        #expect(!converted.evaluate(with: ObjCObject()))
         
         predicate = #Predicate<ObjCObject> {
             $0.b.localizedCompare("ABC") == equal
         }
         
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(b ==[l] 'ABC', 0, TERNARY(b <[l] 'ABC', -1, 1)) == 0"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "TERNARY(b ==[l] 'ABC', 0, TERNARY(b <[l] 'ABC', -1, 1)) == 0"))
+        #expect(!converted.evaluate(with: ObjCObject()))
         
         predicate = #Predicate<ObjCObject> {
             $0.b.localizedStandardContains("ABC")
         }
         
-        converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "b CONTAINS[cdl] 'ABC'"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "b CONTAINS[cdl] 'ABC'"))
+        #expect(!converted.evaluate(with: ObjCObject()))
     }
     
-    func testNested() {
+    @Test func nested() throws {
         let predicateA = Predicate<ObjCObject> {
             PredicateExpressions.build_Equal(
                 lhs: PredicateExpressions.build_KeyPath(
@@ -432,30 +435,30 @@ final class NSPredicateConversionTests: XCTestCase {
             )
         }
         
-        let converted = convert(predicateB)
-        XCTAssertEqual(converted, NSPredicate(format: "a == 3 AND a > 2"))
-        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicateB))
+        #expect(converted == NSPredicate(format: "a == 3 AND a > 2"))
+        #expect(!converted.evaluate(with: ObjCObject()))
     }
     
-    func testRegex() {
+    @Test func regex() throws {
         let regex = #/[e-f][l-m]/#
         let predicate = #Predicate<ObjCObject> {
             $0.b.contains(regex)
         }
-        let converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "b MATCHES '.*[e-f][l-m].*'"))
-        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        let converted = try #require(convert(predicate))
+        #expect(converted == NSPredicate(format: "b MATCHES '.*[e-f][l-m].*'"))
+        #expect(converted.evaluate(with: ObjCObject()))
     }
     
-    func testExpression() {
+    @Test func expression() throws {
         let expression = #Expression<ObjCObject, Int> {
             $0.a
         }
-        let converted = convert(expression)
-        XCTAssertEqual(converted, NSExpression(format: "a"))
+        let converted = try #require(convert(expression))
+        #expect(converted == NSExpression(format: "a"))
         let obj = ObjCObject()
-        let value = converted!.expressionValue(with: obj, context: nil)
-        XCTAssertEqual(value as? Int, obj.a, "Expression produced \(String(describing: value)) instead of \(obj.a)")
+        let value = converted.expressionValue(with: obj, context: nil)
+        #expect(value as? Int == obj.a, "Expression produced \(String(describing: value)) instead of \(obj.a)")
     }
 }
 

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -10,35 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(TestSupport)
-import TestSupport
+import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
 #endif
 
 #if canImport(RegexBuilder)
 import RegexBuilder
 #endif
 
-#if !FOUNDATION_FRAMEWORK
-// Resolve ambiguity between Foundation.#Predicate and FoundationEssentials.#Predicate
-@freestanding(expression)
-@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
-macro Predicate<each Input>(_ body: (repeat each Input) -> Bool) -> Predicate<repeat each Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
-@freestanding(expression)
-@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
-macro Expression<each Input, Output>(_ body: (repeat each Input) -> Output) -> Expression<repeat each Input, Output> = #externalMacro(module: "FoundationMacros", type: "ExpressionMacro")
-#endif
-
-// Work around an issue issue on older Swift compilers
-#if compiler(>=6.0)
-
-final class PredicateTests: XCTestCase {
-    
-    override func setUp() async throws {
-        guard #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) else {
-            throw XCTSkip("This test is not available on this OS version")
-        }
-    }
-    
+@Suite("Predicate")
+private struct PredicateTests {
     struct Object {
         var a: Int
         var b: String
@@ -55,96 +40,89 @@ final class PredicateTests: XCTestCase {
         var a: Bool
     }
     
-    func testBasic() throws {
+    @Test func basic() throws {
         let compareTo = 2
         let predicate = #Predicate<Object> {
             $0.a == compareTo
         }
-        try XCTAssertFalse(predicate.evaluate(Object(a: 1, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
-        try XCTAssertTrue(predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+        #expect(try !predicate.evaluate(Object(a: 1, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
-    func testVariadic() throws {
+    @Test func variadic() throws {
         let predicate = #Predicate<Object, Int> {
             $0.a == $1 + 1
         }
-        XCTAssert(try predicate.evaluate(Object(a: 3, b: "", c: 0, d: 0, e: "c", f: true, g: []), 2))
+        #expect(try predicate.evaluate(Object(a: 3, b: "", c: 0, d: 0, e: "c", f: true, g: []), 2))
     }
     
-    func testArithmetic() throws {
+    @Test func arithmetic() throws {
         let predicate = #Predicate<Object> {
             $0.a + 2 == 4
         }
-        XCTAssert(try predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
-    func testDivision() throws {
+    @Test func division() throws {
         let predicate = #Predicate<Object> {
             $0.a / 2 == 3
         }
         let predicate2 = #Predicate<Object> {
             $0.c / 2.1 <= 3.0
         }
-        XCTAssert(try predicate.evaluate(Object(a: 6, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
-        XCTAssert(try predicate2.evaluate(Object(a: 2, b: "", c: 6.0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 6, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate2.evaluate(Object(a: 2, b: "", c: 6.0, d: 0, e: "c", f: true, g: [])))
     }
     
-    func testBuildDivision() throws {
-        let predicate = #Predicate<Object> {
-            $0.a / 2 == 3
-        }
-        XCTAssert(try predicate.evaluate(Object(a: 6, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
-    }
-    
-    func testUnaryMinus() throws {
+    @Test func unaryMinus() throws {
         let predicate = #Predicate<Object> {
             -$0.a == 17
         }
-        XCTAssert(try predicate.evaluate(Object(a: -17, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: -17, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
-    func testCount() throws {
+    @Test func count() throws {
         let predicate = #Predicate<Object> {
             $0.g.count == 5
         }
-        XCTAssert(try predicate.evaluate(Object(a: 0, b: "", c: 0, d: 0, e: "c", f: true, g: [2, 3, 5, 7, 11])))
+        #expect(try predicate.evaluate(Object(a: 0, b: "", c: 0, d: 0, e: "c", f: true, g: [2, 3, 5, 7, 11])))
     }
     
-    func testFilter() throws {
+    @Test func filter() throws {
         let predicate = #Predicate<Object> { object in
             !object.g.filter {
                 $0 == object.d
             }.isEmpty
         }
-        XCTAssert(try predicate.evaluate(Object(a: 0, b: "", c: 0.0, d: 17, e: "c", f: true, g: [3, 5, 7, 11, 13, 17, 19])))
+        #expect(try predicate.evaluate(Object(a: 0, b: "", c: 0.0, d: 17, e: "c", f: true, g: [3, 5, 7, 11, 13, 17, 19])))
     }
     
-    func testContains() throws {
+    @Test func contains() throws {
         let predicate = #Predicate<Object> {
             $0.g.contains($0.a)
         }
-        XCTAssert(try predicate.evaluate(Object(a: 13, b: "", c: 0.0, d: 0, e: "c", f: true, g: [2, 3, 5, 11, 13, 17])))
+        #expect(try predicate.evaluate(Object(a: 13, b: "", c: 0.0, d: 0, e: "c", f: true, g: [2, 3, 5, 11, 13, 17])))
     }
     
-    func testContainsWhere() throws {
+    @Test func containsWhere() throws {
         let predicate = #Predicate<Object> { object in
             object.g.contains {
                 $0 % object.a == 0
             }
         }
-        XCTAssert(try predicate.evaluate(Object(a: 2, b: "", c: 0.0, d: 0, e: "c", f: true, g: [3, 5, 7, 2, 11, 13])))
+        #expect(try predicate.evaluate(Object(a: 2, b: "", c: 0.0, d: 0, e: "c", f: true, g: [3, 5, 7, 2, 11, 13])))
     }
     
-    func testAllSatisfy() throws {
+    @Test func allSatisfy() throws {
         let predicate = #Predicate<Object> { object in
             object.g.allSatisfy {
                 $0 % object.d != 0
             }
         }
-        XCTAssert(try predicate.evaluate(Object(a: 0, b: "", c: 0.0, d: 2, e: "c", f: true, g: [3, 5, 7, 11, 13, 17, 19])))
+        #expect(try predicate.evaluate(Object(a: 0, b: "", c: 0.0, d: 2, e: "c", f: true, g: [3, 5, 7, 11, 13, 17, 19])))
     }
     
-    func testOptional() throws {
+    @Test func optional() throws {
         struct Wrapper<T> {
             let wrapped: T?
         }
@@ -154,38 +132,40 @@ final class PredicateTests: XCTestCase {
         let predicate2 = #Predicate<Wrapper<Int>> {
             $0.wrapped! == 19
         }
-        XCTAssert(try predicate.evaluate(Wrapper<Int>(wrapped: 4)))
-        XCTAssert(try predicate.evaluate(Wrapper<Int>(wrapped: nil)))
-        XCTAssert(try predicate2.evaluate(Wrapper<Int>(wrapped: 19)))
-        XCTAssertThrowsError(try predicate2.evaluate(Wrapper<Int>(wrapped: nil)))
+        #expect(try predicate.evaluate(Wrapper<Int>(wrapped: 4)))
+        #expect(try predicate.evaluate(Wrapper<Int>(wrapped: nil)))
+        #expect(try predicate2.evaluate(Wrapper<Int>(wrapped: 19)))
+        #expect(throws: (any Error).self) {
+            try predicate2.evaluate(Wrapper<Int>(wrapped: nil))
+        }
         
         struct _NonCodableType : Equatable {}
         let predicate3 = #Predicate<Wrapper<_NonCodableType>> {
             $0.wrapped == nil
         }
-        XCTAssertFalse(try predicate3.evaluate(Wrapper(wrapped: _NonCodableType())))
-        XCTAssertTrue(try predicate3.evaluate(Wrapper(wrapped: nil)))
+        #expect(try !predicate3.evaluate(Wrapper(wrapped: _NonCodableType())))
+        #expect(try predicate3.evaluate(Wrapper(wrapped: nil)))
     }
     
-    func testConditional() throws {
+    @Test func conditional() throws {
         let predicate = #Predicate<Bool, String, String> {
             ($0 ? $1 : $2) == "if branch"
         }
-        XCTAssert(try predicate.evaluate(true, "if branch", "else branch"))
+        #expect(try predicate.evaluate(true, "if branch", "else branch"))
     }
     
-    func testClosedRange() throws {
+    @Test func closedRange() throws {
         let predicate = #Predicate<Object> {
             (3...5).contains($0.a)
         }
         let predicate2 = #Predicate<Object> {
             ($0.a ... $0.d).contains(4)
         }
-        XCTAssert(try predicate.evaluate(Object(a: 4, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
-        XCTAssert(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 4, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
     
-    func testRange() throws {
+    @Test func range() throws {
         let predicate = #Predicate<Object> {
             (3 ..< 5).contains($0.a)
         }
@@ -193,50 +173,56 @@ final class PredicateTests: XCTestCase {
         let predicate2 = #Predicate<Object> {
             ($0.a ..< $0.d).contains(toMatch)
         }
-        XCTAssert(try predicate.evaluate(Object(a: 4, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
-        XCTAssert(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 4, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
     
-    func testRangeContains() throws {
+    @Test func rangeContains() throws {
         let date = Date.distantPast
         let predicate = #Predicate<Object> {
             (date ..< date).contains($0.h)
         }
         
-        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
+        #expect(try !predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
     
-    func testTypes() throws {
+    @Test func types() throws {
         let predicate = #Predicate<Object> {
             ($0.i as? Int).flatMap { $0 == 3 } ?? false
         }
         let predicate2 = #Predicate<Object> {
             $0.i is Int
         }
-        XCTAssert(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
-        XCTAssert(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate2.evaluate(Object(a: 3, b: "", c: 0.0, d: 5, e: "c", f: true, g: [])))
     }
     
-    func testSubscripts() throws {
+    @Test func subscripts() throws {
         var predicate = #Predicate<Object> {
             $0.g[0] == 0
         }
         
-        XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0])))
-        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1])))
-        XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0])))
+        #expect(try !predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1])))
+        #expect(throws: (any Error).self) {
+            try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: []))
+        }
         
         predicate = #Predicate<Object> {
             $0.g[0 ..< 2].isEmpty
         }
         
-        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0, 1, 2])))
-        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0, 1])))
-        XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0])))
-        XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
+        #expect(try !predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0, 1, 2])))
+        #expect(try !predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0, 1])))
+        #expect(throws: (any Error).self) {
+            try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0]))
+        }
+        #expect(throws: (any Error).self) {
+            try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: []))
+        }
     }
     
-    func testLazyDefaultValueSubscript() throws {
+    @Test func lazyDefaultValueSubscript() throws {
         struct Foo : Codable, Sendable {
             var property: Int {
                 fatalError("This property should not have been accessed")
@@ -247,46 +233,46 @@ final class PredicateTests: XCTestCase {
         let predicate = #Predicate<[String : Int]> {
             $0["key", default: foo.property] == 1
         }
-        XCTAssertFalse(try predicate.evaluate(["key" : 2]))
+        #expect(try !predicate.evaluate(["key" : 2]))
     }
     
-    func testStaticValues() throws {
-        func assertPredicate<T>(_ pred: Predicate<T>, value: T, expected: Bool) throws {
-            XCTAssertEqual(try pred.evaluate(value), expected)
+    @Test func staticValues() throws {
+        func assertPredicate<T>(_ pred: Predicate<T>, value: T, expected: Bool, sourceLocation: SourceLocation = #_sourceLocation) throws {
+            #expect(try pred.evaluate(value) == expected, sourceLocation: sourceLocation)
         }
         
         try assertPredicate(.true, value: "Hello", expected: true)
         try assertPredicate(.false, value: "Hello", expected: false)
     }
     
-    func testMaxMin() throws {
+    @Test func maxMin() throws {
         var predicate = #Predicate<Object> {
             $0.g.max() == 2
         }
-        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
-        XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 2])))
+        #expect(try !predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 2])))
         
         predicate = #Predicate<Object> {
             $0.g.min() == 2
         }
-        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
-        XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [2, 3])))
+        #expect(try !predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [2, 3])))
     }
     
     #if FOUNDATION_FRAMEWORK
     
-    func testCaseInsensitiveCompare() throws {
+    @Test func caseInsensitiveCompare() throws {
         let equal = ComparisonResult.orderedSame
         let predicate = #Predicate<Object> {
             $0.b.caseInsensitiveCompare("ABC") == equal
         }
-        XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
-        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "def", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try predicate.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try !predicate.evaluate(Object(a: 3, b: "def", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
     }
     
     #endif
     
-    func testBuildDynamically() throws {
+    @Test func buildDynamically() throws {
         func _build(_ equal: Bool) -> Predicate<Int> {
             Predicate<Int> {
                 if equal {
@@ -303,11 +289,11 @@ final class PredicateTests: XCTestCase {
             }
         }
         
-        XCTAssertTrue(try _build(true).evaluate(1))
-        XCTAssertFalse(try _build(false).evaluate(1))
+        #expect(try _build(true).evaluate(1))
+        #expect(try !_build(false).evaluate(1))
     }
     
-    func testResilientKeyPaths() {
+    @Test func resilientKeyPaths() {
         // Local, non-resilient type
         struct Foo {
             let a: String   // Non-resilient
@@ -321,36 +307,26 @@ final class PredicateTests: XCTestCase {
         }
     }
 
-    #if compiler(>=5.11)
-    func testRegex() throws {
-        guard #available(FoundationPredicateRegex 0.4, *) else {
-            throw XCTSkip("This test is not available on this OS version")
-        }
-        
+    @Test
+    @available(FoundationPredicateRegex 0.4, *)
+    func regex() throws {
         let literalRegex = #/[AB0-9]\/?[^\n]+/#
         var predicate = #Predicate<Object> {
             $0.b.contains(literalRegex)
         }
-        XCTAssertTrue(try predicate.evaluate(Object(a: 0, b: "_0/bc", c: 0, d: 0, e: " ", f: true, g: [])))
-        XCTAssertFalse(try predicate.evaluate(Object(a: 0, b: "_C/bc", c: 0, d: 0, e: " ", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 0, b: "_0/bc", c: 0, d: 0, e: " ", f: true, g: [])))
+        #expect(try !predicate.evaluate(Object(a: 0, b: "_C/bc", c: 0, d: 0, e: " ", f: true, g: [])))
         predicate = #Predicate<Object> {
             $0.b.contains(#/[AB0-9]\/?[^\n]+/#)
         }
-        XCTAssertTrue(try predicate.evaluate(Object(a: 0, b: "_0/bc", c: 0, d: 0, e: " ", f: true, g: [])))
-        XCTAssertFalse(try predicate.evaluate(Object(a: 0, b: "_C/bc", c: 0, d: 0, e: " ", f: true, g: [])))
+        #expect(try predicate.evaluate(Object(a: 0, b: "_0/bc", c: 0, d: 0, e: " ", f: true, g: [])))
+        #expect(try !predicate.evaluate(Object(a: 0, b: "_C/bc", c: 0, d: 0, e: " ", f: true, g: [])))
     }
     
-    func testRegex_RegexBuilder() throws {
-        #if !canImport(RegexBuilder)
-        throw XCTSkip("RegexBuilder is unavavailable on this platform")
-        #elseif !os(Linux) && !os(Android) && !FOUNDATION_FRAMEWORK
-        // Disable this test in swift-foundation macOS CI because of incorrect availability annotations in the StringProcessing module
-        throw XCTSkip("This test is currently disabled on this platform")
-        #else
-        guard #available(FoundationPredicateRegex 0.4, *) else {
-            throw XCTSkip("This test is not available on this OS version")
-        }
-        
+    #if canImport(RegexBuilder)
+    @Test
+    @available(FoundationPredicateRegex 0.4, *)
+    func regex_RegexBuilder() throws {
         let builtRegex = Regex {
             ChoiceOf {
                 "A"
@@ -363,17 +339,14 @@ final class PredicateTests: XCTestCase {
         let predicate = #Predicate<Object> {
             $0.b.contains(builtRegex)
         }
-        XCTAssertTrue(try predicate.evaluate(Object(a: 0, b: "_0/bc", c: 0, d: 0, e: " ", f: true, g: [])))
-        XCTAssertFalse(try predicate.evaluate(Object(a: 0, b: "_C/bc", c: 0, d: 0, e: " ", f: true, g: [])))
-        #endif
+        #expect(try predicate.evaluate(Object(a: 0, b: "_0/bc", c: 0, d: 0, e: " ", f: true, g: [])))
+        #expect(try !predicate.evaluate(Object(a: 0, b: "_C/bc", c: 0, d: 0, e: " ", f: true, g: [])))
     }
     #endif
     
-    func testDebugDescription() throws {
-        guard #available(FoundationPredicate 0.3, *) else {
-            throw XCTSkip("This test is not available on this OS version")
-        }
-        
+    @Test
+    @available(FoundationPredicate 0.3, *)
+    func debugDescription() throws {
         let date = Date.now
         let predicate = #Predicate<Object> {
             if let num = $0.i as? Int {
@@ -382,19 +355,15 @@ final class PredicateTests: XCTestCase {
                 $0.h == date
             }
         }
-#if FOUNDATION_FRAMEWORK
-        let moduleName = "Foundation"
-        let testModuleName = "Unit"
-#else
-        let moduleName = "FoundationEssentials"
-        let testModuleName = "FoundationEssentialsTests"
-#endif
-        XCTAssertEqual(
-            predicate.description,
+        
+        let dateName = _typeName(Date.self)
+        let objectName = _typeName(Object.self)
+        #expect(
+            predicate.description ==
             """
             capture1 (Swift.Int): 3
-            capture2 (\(moduleName).Date): <Date \(date.timeIntervalSince1970)>
-            Predicate<\(testModuleName).PredicateTests.Object> { input1 in
+            capture2 (\(dateName)): <Date \(date.timeIntervalSince1970)>
+            Predicate<\(objectName)> { input1 in
                 (input1.i as? Swift.Int).flatMap({ variable1 in
                     variable1 == capture1
                 }) ?? (input1.h == capture2)
@@ -403,18 +372,17 @@ final class PredicateTests: XCTestCase {
         )
         
         let debugDescription = predicate.debugDescription.replacing(#/Variable\([0-9]+\)/#, with: "Variable(#)")
-        XCTAssertEqual(
-            debugDescription,
-            "\(moduleName).Predicate<Pack{\(testModuleName).PredicateTests.Object}>(variable: (Variable(#)), expression: NilCoalesce(lhs: OptionalFlatMap(wrapped: ConditionalCast(input: KeyPath(root: Variable(#), keyPath: \\Object.i), desiredType: Swift.Int), variable: Variable(#), transform: Equal(lhs: Variable(#), rhs: Value<Swift.Int>(3))), rhs: Equal(lhs: KeyPath(root: Variable(#), keyPath: \\Object.h), rhs: Value<\(moduleName).Date>(\(date.debugDescription)))))"
+        let predicateName = _typeName(Predicate<Object>.self)
+        #expect(
+            debugDescription ==
+            "\(predicateName)(variable: (Variable(#)), expression: NilCoalesce(lhs: OptionalFlatMap(wrapped: ConditionalCast(input: KeyPath(root: Variable(#), keyPath: \\Object.i), desiredType: Swift.Int), variable: Variable(#), transform: Equal(lhs: Variable(#), rhs: Value<Swift.Int>(3))), rhs: Equal(lhs: KeyPath(root: Variable(#), keyPath: \\Object.h), rhs: Value<\(dateName)>(\(date.debugDescription)))))"
         )
     }
 
     #if FOUNDATION_FRAMEWORK
-    func testNested() throws {
-        guard #available(FoundationPredicate 0.3, *) else {
-            throw XCTSkip("This test is not available on this OS version")
-        }
-
+    @Test
+    @available(FoundationPredicate 0.3, *)
+    func nested() throws {
         let predicateA = #Predicate<Object> {
             $0.a == 3
         }
@@ -423,26 +391,22 @@ final class PredicateTests: XCTestCase {
             predicateA.evaluate($0) && $0.a > 2
         }
 
-        XCTAssertTrue(try predicateA.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
-        XCTAssertFalse(try predicateA.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
-        XCTAssertTrue(try predicateB.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
-        XCTAssertFalse(try predicateB.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
-        XCTAssertFalse(try predicateB.evaluate(Object(a: 4, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try predicateA.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try !predicateA.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try predicateB.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try !predicateB.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        #expect(try !predicateB.evaluate(Object(a: 4, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
     }
     #endif
     
-    func testExpression() throws {
-        guard #available(FoundationPredicate 0.4, *) else {
-            throw XCTSkip("This test is not available on this OS version")
-        }
-        
+    @Test
+    @available(FoundationPredicate 0.4, *)
+    func expression() throws {
         let expression = #Expression<Int, Int> {
             $0 + 1
         }
         for i in 0 ..< 10 {
-            XCTAssertEqual(try expression.evaluate(i), i + 1)
+            #expect(try expression.evaluate(i) == i + 1)
         }
     }
 }
-
-#endif // compiler(>=6.0)

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -10,12 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(TestSupport)
-import TestSupport
-#endif
+import Testing
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #else
 @testable import Foundation
 #endif
@@ -26,16 +24,16 @@ import Darwin
 @preconcurrency import Glibc
 #endif
 
-/// Since we can't really mock system settings like OS name,
-/// these tests simply check that the values returned are not empty
-final class ProcessInfoTests : XCTestCase {
-    func testArguments() {
+// Since we can't really mock system settings like OS name,
+// these tests simply check that the values returned are not empty
+@Suite("ProcessInfo")
+private struct ProcessInfoTests {
+    @Test func arguments() {
         let args = ProcessInfo.processInfo.arguments
-        XCTAssertTrue(
-            !args.isEmpty,"arguments should not have been empty")
+        #expect(!args.isEmpty, "arguments should not have been empty")
     }
 
-    func testEnvironment() {
+    @Test func environment() {
 #if os(Windows)
         func setenv(_ key: String, _ value: String, _ overwrite: Int) -> Int32 {
           assert(overwrite == 1)
@@ -47,66 +45,56 @@ final class ProcessInfoTests : XCTestCase {
         }
 #endif
         let env = ProcessInfo.processInfo.environment
-        XCTAssertTrue(
-            !env.isEmpty, "environment should not have been empty")
+        #expect(!env.isEmpty, "environment should not have been empty")
         
-        let preset = ProcessInfo.processInfo.environment["test"]
+        #expect(ProcessInfo.processInfo.environment["test"] == nil)
         setenv("test", "worked", 1)
-        let postset = ProcessInfo.processInfo.environment["test"]
-        XCTAssertNil(preset)
-        XCTAssertEqual(postset, "worked")
+        #expect(ProcessInfo.processInfo.environment["test"] == "worked")
     }
 
-    func testProcessIdentifier() {
+    @Test func processIdentifier() {
         let pid = ProcessInfo.processInfo.processIdentifier
-        XCTAssertEqual(
-            pid, getpid(), "ProcessInfo disagrees with getpid()")
+        #expect(pid == getpid(), "ProcessInfo disagrees with getpid()")
     }
 
-    func testGlobalUniqueString() {
-        let unique = ProcessInfo.processInfo.globallyUniqueString
-        XCTAssertNotEqual(
-            unique,
-            ProcessInfo.processInfo.globallyUniqueString,
-            "globallyUniqueString should never return the same string twice")
+    @Test func globalUniqueString() {
+        let a = ProcessInfo.processInfo.globallyUniqueString
+        let b = ProcessInfo.processInfo.globallyUniqueString
+        #expect(a != b, "globallyUniqueString should never return the same string twice")
     }
 
-    func testOperatingSystemVersionString() {
+    @Test func operatingSystemVersionString() {
         let version = ProcessInfo.processInfo.operatingSystemVersionString
-        XCTAssertFalse(version.isEmpty, "ProcessInfo returned empty string for operation system version")
+        #expect(!version.isEmpty, "ProcessInfo returned empty string for operation system version")
         #if os(Windows)
-        XCTAssertTrue(version.starts(with: "Windows"), "'\(version)' did not start with 'Windows'")
+        #expect(version.starts(with: "Windows"), "'\(version)' did not start with 'Windows'")
         #endif
     }
 
-    func testProcessorCount() {
+    @Test func processorCount() {
         let count = ProcessInfo.processInfo.processorCount
-        XCTAssertTrue(count > 0, "ProcessInfo doesn't think we have any processors")
+        #expect(count > 0, "ProcessInfo doesn't think we have any processors")
     }
 
-    func testActiveProcessorCount() {
+    @Test func activeProcessorCount() {
         let count = ProcessInfo.processInfo.activeProcessorCount
-        XCTAssertTrue(count > 0, "ProcessInfo doesn't think we have any active processors")
+        #expect(count > 0, "ProcessInfo doesn't think we have any active processors")
     }
 
-    func testPhysicalMemory() {
+    @Test func physicalMemory() {
         let memory = ProcessInfo.processInfo.physicalMemory
-        XCTAssertTrue(memory > 0, "ProcessInfo doesn't think we have any memory")
+        #expect(memory > 0, "ProcessInfo doesn't think we have any memory")
     }
 
-    func testSystemUpTime() async throws {
+    @Test func systemUpTime() async throws {
         let now = ProcessInfo.processInfo.systemUptime
-        XCTAssertTrue(
-            now > 1, "ProcessInfo returned an unrealistically low system uptime")
+        #expect(now > 1, "ProcessInfo returned an unrealistically low system uptime")
         // Sleep for 0.1s
         try await Task.sleep(for: .milliseconds(100))
-        XCTAssertTrue(
-            ProcessInfo.processInfo.systemUptime > now,
-            "ProcessInfo returned the same system uptime with 400")
-
+        #expect(ProcessInfo.processInfo.systemUptime > now, "ProcessInfo returned the same system uptime with 400")
     }
 
-    func testOperatingSystemVersion() throws {
+    @Test func operatingSystemVersion() throws {
         #if canImport(Darwin)
         let version = ProcessInfo.processInfo.operatingSystemVersion
         #if os(visionOS)
@@ -114,97 +102,96 @@ final class ProcessInfoTests : XCTestCase {
         #else
         let expectedMinMajorVersion = 2
         #endif
-        XCTAssertGreaterThanOrEqual(version.majorVersion, expectedMinMajorVersion, "Unrealistic major system version")
+        #expect(version.majorVersion >= expectedMinMajorVersion, "Unrealistic major system version")
         #elseif os(Windows) || os(Linux) || os(Android)
         let minVersion = OperatingSystemVersion(majorVersion: 1, minorVersion: 0, patchVersion: 0)
-        XCTAssertTrue(ProcessInfo.processInfo.isOperatingSystemAtLeast(minVersion))
-        #else
-        throw XCTSkip("This test is not supported on this platform")
+        #expect(ProcessInfo.processInfo.isOperatingSystemAtLeast(minVersion))
         #endif
     }
 
-    func testOperatingSystemIsAtLeastVersion() throws {
-        #if !canImport(Darwin)
-        throw XCTSkip("This test is not supported on this platform")
-        #else
+    #if canImport(Darwin)
+    @Test
+    #else
+    @Test(.disabled("This test is not supported on this platform"))
+    #endif
+    func operatingSystemIsAtLeastVersion() throws {
         #if os(watchOS)
-        XCTAssertTrue(ProcessInfo.processInfo
+        #expect(ProcessInfo.processInfo
             .isOperatingSystemAtLeast(
                 OperatingSystemVersion(majorVersion: 1, minorVersion: 12, patchVersion: 0)
             ),
         "ProcessInfo thinks 1.12 is > than 2.something")
-        XCTAssertTrue(ProcessInfo.processInfo
+        #expect(ProcessInfo.processInfo
             .isOperatingSystemAtLeast(
                 OperatingSystemVersion(majorVersion: 1, minorVersion: 0, patchVersion: 0)
             ),
         "ProcessInfo thinks we are on watchOS 1")
         #elseif os(macOS) || (os(iOS) && !os(visionOS))
-        XCTAssertTrue(ProcessInfo.processInfo
+        #expect(ProcessInfo.processInfo
             .isOperatingSystemAtLeast(
                 OperatingSystemVersion(majorVersion: 6, minorVersion: 12, patchVersion: 0)
             ),
         "ProcessInfo thinks 6.12 is > than 10.something")
-        XCTAssertTrue(ProcessInfo.processInfo
+        #expect(ProcessInfo.processInfo
             .isOperatingSystemAtLeast(
                 OperatingSystemVersion(majorVersion: 6, minorVersion: 0, patchVersion: 0)
             ),
         "ProcessInfo thinks we are on System 5")
         #endif
-        XCTAssertFalse(ProcessInfo.processInfo
+        #expect(!ProcessInfo.processInfo
             .isOperatingSystemAtLeast(
                 OperatingSystemVersion(majorVersion: 70, minorVersion: 0, patchVersion: 0)
             ),
         "ProcessInfo thinks we are on System 70")
-        #endif
     }
 
 #if os(macOS)
-    func testUserName() {
-        XCTAssertFalse(ProcessInfo.processInfo.userName.isEmpty)
+    @Test func userName() {
+        #expect(!ProcessInfo.processInfo.userName.isEmpty)
     }
 
-    func testFullUserName() {
-        XCTAssertFalse(ProcessInfo.processInfo.fullUserName.isEmpty)
+    @Test func fullUserName() {
+        #expect(!ProcessInfo.processInfo.fullUserName.isEmpty)
     }
 #endif
     
-    func testProcessName() {
+    @Test func processName() {
 #if FOUNDATION_FRAMEWORK
         let targetName = "TestHost"
 #elseif os(Linux) || os(Windows) || os(Android) || os(FreeBSD)
         let targetName = "swift-foundationPackageTests.xctest"
 #else
-        let targetName = "xctest"
+        let targetName = "swiftpm-testing-helper"
 #endif
         let processInfo = ProcessInfo.processInfo
         let originalProcessName = processInfo.processName
-        XCTAssertEqual(originalProcessName, targetName)
+        #expect(originalProcessName == targetName)
         
         // Try assigning a new process name.
         let newProcessName = "TestProcessName"
         processInfo.processName = newProcessName
-        XCTAssertEqual(processInfo.processName, newProcessName)
+        #expect(processInfo.processName == newProcessName)
         
         // Assign back to the original process name.
         processInfo.processName = originalProcessName
-        XCTAssertEqual(processInfo.processName, originalProcessName)
+        #expect(processInfo.processName == originalProcessName)
     }
 
-    func testWindowsEnvironmentDoesNotContainMagicValues() {
+    @Test func windowsEnvironmentDoesNotContainMagicValues() {
         // Windows GetEnvironmentStringsW API can return
         // magic environment variables set by the cmd shell
         // that starts with `=`
         // This test makes sure we don't include these
         // magic variables
         let env = ProcessInfo.processInfo.environment
-        XCTAssertNil(env[""])
+        #expect(env[""] == nil)
     }
 }
 
 // MARK: - ThermalState and PowerState tests
 #if FOUNDATION_FRAMEWORK
 extension ProcessInfoTests {
-    func testThermalPowerState() {
+    @Test func thermalPowerState() {
         // This test simply makes sure we can deliver the correct
         // thermal and power state for all platforms.
         // Fake a new value

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -22,6 +22,8 @@ import FoundationEssentials
 import Darwin
 #elseif canImport(Glibc)
 @preconcurrency import Glibc
+#elseif canImport(CRT)
+import CRT
 #endif
 
 // Since we can't really mock system settings like OS name,

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -1208,7 +1208,7 @@ private struct StringTests {
     }
     
 #if FOUNDATION_FRAMEWORK
-    @Test func extendedAttributeData() throws {
+    @Test func extendedAttributeEncodings() throws {
         // XAttr is supported on some platforms, but not all. For now we just test this code on Darwin.
         let encs : [String._Encoding] = [
             .ascii,

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -10,22 +10,33 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Testing
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(WASI)
+import WASILibc
+#elseif os(Windows)
+import CRT
+#endif
+
 #if FOUNDATION_FRAMEWORK
 @testable import Foundation
 #else
 @testable import FoundationEssentials
-#endif // FOUNDATION_FRAMEWORK
-
-#if canImport(TestSupport)
-import TestSupport
 #endif
 
-final class StringTests : XCTestCase {
+@Suite("String")
+private struct StringTests {
     // MARK: - Case mapping
 
-    func testCapitalize() {
-        func test(_ string: String, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
-            XCTAssertEqual(string._capitalized(), expected, file: file, line: line)
+    @Test func testCapitalize() {
+        func test(_ string: String, _ expected: String, sourceLocation: SourceLocation = #_sourceLocation) {
+            #expect(string.capitalized == expected, sourceLocation: sourceLocation)
         }
 
         test("iı", "Iı")
@@ -63,9 +74,9 @@ final class StringTests : XCTestCase {
         test("ぁぃぅぇぉ ど ゕゖくけこ", "ぁぃぅぇぉ ど ゕゖくけこ")
     }
 
-    func testTrimmingWhitespace() {
-        func test(_ str: String, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
-            XCTAssertEqual(str._trimmingWhitespace(), expected, file: file, line: line)
+    @Test func testTrimmingWhitespace() {
+        func test(_ string: String, _ expected: String, sourceLocation: SourceLocation = #_sourceLocation) {
+            #expect(string._trimmingWhitespace() == expected, sourceLocation: sourceLocation)
         }
         test(" \tABCDEFGAbc \t \t  ", "ABCDEFGAbc")
         test("ABCDEFGAbc \t \t  ", "ABCDEFGAbc")
@@ -79,12 +90,12 @@ final class StringTests : XCTestCase {
         test(" \u{202F}\u{00A0} X \u{202F}\u{00A0}", "X") // NBSP and narrow NBSP
     }
 
-    func testTrimmingCharactersWithPredicate() {
-        func test(_ str: String, while predicate: (Character) -> Bool, _ expected: Substring, file: StaticString = #filePath, line: UInt = #line) {
-            XCTAssertEqual(str._trimmingCharacters(while: predicate), expected, file: file, line: line)
-        }
-
+    @Test func testTrimmingCharactersWithPredicate() {
         typealias TrimmingPredicate = (Character) -> Bool
+        
+        func test(_ str: String, while predicate: TrimmingPredicate, _ expected: Substring, sourceLocation: SourceLocation = #_sourceLocation) {
+            #expect(str._trimmingCharacters(while: predicate) == expected, sourceLocation: sourceLocation)
+        }
 
         let isNewline: TrimmingPredicate = { $0.isNewline }
 
@@ -136,7 +147,7 @@ final class StringTests : XCTestCase {
         test("11 B\u{0662}\u{0661}", while: alwaysTrim, "")
     }
 
-    func _testRangeOfString(_ tested: String, string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
+    func _testRangeOfString(_ tested: String, string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, sourceLocation: SourceLocation = #_sourceLocation) {
         let result = tested._range(of: string, anchored: anchored, backwards: backwards)
         var exp: Range<String.Index>?
         if let expectation {
@@ -145,20 +156,20 @@ final class StringTests : XCTestCase {
             exp = nil
         }
 
-        var message: String
+        var message: Comment
         if let result {
             let readableRange = tested.distance(from: tested.startIndex, to: result.lowerBound)..<tested.distance(from: tested.startIndex, to: result.upperBound)
             message = "Actual: \(readableRange)"
         } else {
             message = "Actual: nil"
         }
-        XCTAssertEqual(result, exp, message, file: file, line: line)
+        #expect(result == exp, message, sourceLocation: sourceLocation)
     }
 
-    func testRangeOfString() {
+    @Test func testRangeOfString() {
         var tested: String
-        func testASCII(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
-            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
+        func testASCII(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, sourceLocation: SourceLocation = #_sourceLocation) {
+            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, sourceLocation: sourceLocation)
         }
 
         tested = "ABCDEFGAbcABCDE"
@@ -205,10 +216,10 @@ final class StringTests : XCTestCase {
         testASCII("ABCDER", anchored: false, backwards: false, nil)
     }
 
-    func testRangeOfString_graphemeCluster() {
+    @Test func testRangeOfString_graphemeCluster() {
         var tested: String
-        func test(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
-            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
+        func test(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, sourceLocation: SourceLocation = #_sourceLocation) {
+            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, sourceLocation: sourceLocation)
         }
 
         do {
@@ -240,9 +251,9 @@ final class StringTests : XCTestCase {
         }
     }
 
-    func testRangeOfString_lineSeparator() {
-        func test(_ tested: String, _ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
-            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
+    @Test func testRangeOfString_lineSeparator() {
+        func test(_ tested: String, _ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, sourceLocation: SourceLocation = #_sourceLocation) {
+            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, sourceLocation: sourceLocation)
         }
         test("\r\n \r", "\r", anchored: false, backwards: false, 2..<3)
         test("\r\n \r", "\r", anchored: true, backwards: false, nil)
@@ -255,13 +266,13 @@ final class StringTests : XCTestCase {
         test("\r \r\n \r", "\r", anchored: true, backwards: true, 4..<5)
     }
 
-    func testTryFromUTF16() {
-        func test(_ utf16Buffer: [UInt16], expected: String?, file: StaticString = #filePath, line: UInt = #line) {
+    @Test func testTryFromUTF16() {
+        func test(_ utf16Buffer: [UInt16], expected: String?, sourceLocation: SourceLocation = #_sourceLocation) {
             let result = utf16Buffer.withUnsafeBufferPointer {
                 String(_utf16: $0)
             }
 
-            XCTAssertEqual(result, expected, file: file, line: line)
+            #expect(result == expected, sourceLocation: sourceLocation)
         }
 
         test([], expected: "")
@@ -283,15 +294,14 @@ final class StringTests : XCTestCase {
         test([ 0xD800, 0x42 ], expected: nil)
     }
 
-    func testTryFromUTF16_roundtrip() {
+    @Test func testTryFromUTF16_roundtrip() {
 
-        func test(_ string: String, file: StaticString = #filePath, line: UInt = #line) {
+        func test(_ string: String, sourceLocation: SourceLocation = #_sourceLocation) {
             let utf16Array = Array(string.utf16)
             let res = utf16Array.withUnsafeBufferPointer {
                 String(_utf16: $0)
             }
-            XCTAssertNotNil(res, file: file, line: line)
-            XCTAssertEqual(res, string, file: file, line: line)
+            #expect(res == string, sourceLocation: sourceLocation)
         }
 
         // BMP: consists code points up to U+FFFF
@@ -308,35 +318,35 @@ final class StringTests : XCTestCase {
         test("🏳️‍🌈AB👩‍👩‍👧‍👦ab🕵️‍♀️")
     }
 
-    func testRangeRegexB() throws {
+    @Test func testRangeRegexB() throws {
         let str = "self.name"
         let range = try str[...]._range(of: "\\bname"[...], options: .regularExpression)
         let start = str.index(str.startIndex, offsetBy: 5)
         let end = str.index(str.startIndex, offsetBy: 9)
-        XCTAssertEqual(range, start ..< end)
+        #expect(range == start ..< end)
     }
     
-    func testParagraphLineRangeOfSeparator() {
+    @Test func testParagraphLineRangeOfSeparator() {
         for separator in ["\n", "\r", "\r\n", "\u{2029}", "\u{2028}", "\u{85}"] {
             let range = separator.startIndex ..< separator.endIndex
             let paragraphResult = separator._paragraphBounds(around: range)
             let lineResult = separator._lineBounds(around: range)
-            XCTAssertEqual(paragraphResult.start ..< paragraphResult.end, range)
-            XCTAssertEqual(lineResult.start ..< lineResult.end, range)
+            #expect(paragraphResult.start ..< paragraphResult.end == range)
+            #expect(lineResult.start ..< lineResult.end == range)
         }
     }
     
-    func testAlmostMatchingSeparator() {
+    @Test func testAlmostMatchingSeparator() {
         let string = "A\u{200D}B" // U+200D Zero Width Joiner (ZWJ) matches U+2028 Line Separator except for the final UTF-8 scalar
         let lineResult = string._lineBounds(around: string.startIndex ..< string.startIndex)
-        XCTAssertEqual(lineResult.start, string.startIndex)
-        XCTAssertEqual(lineResult.end, string.endIndex)
-        XCTAssertEqual(lineResult.contentsEnd, string.endIndex)
+        #expect(lineResult.start == string.startIndex)
+        #expect(lineResult.end == string.endIndex)
+        #expect(lineResult.contentsEnd == string.endIndex)
     }
     
-    func testFileSystemRepresentation() {
-        func assertCString(_ ptr: UnsafePointer<CChar>, equals other: String, file: StaticString = #filePath, line: UInt = #line) {
-            XCTAssertEqual(String(cString: ptr), other, file: file, line: line)
+    @Test func testFileSystemRepresentation() throws {
+        func assertCString(_ ptr: UnsafePointer<CChar>, equals other: String, sourceLocation: SourceLocation = #_sourceLocation) {
+            #expect(String(cString: ptr) == other, sourceLocation: sourceLocation)
         }
 
 #if os(Windows)
@@ -344,448 +354,445 @@ final class StringTests : XCTestCase {
 #else
         let original = "/Path1/Path Two/Path Three/Some Really Long File Name Section.txt"
 #endif
-        original.withFileSystemRepresentation {
-            XCTAssertNotNil($0)
-            assertCString($0!, equals: original)
+        try original.withFileSystemRepresentation {
+            assertCString(try #require($0), equals: original)
         }
         
         let withWhitespace = original + "\u{2000}\u{2001}"
-        withWhitespace.withFileSystemRepresentation {
-            XCTAssertNotNil($0)
-            assertCString($0!, equals: withWhitespace)
+        try withWhitespace.withFileSystemRepresentation {
+            assertCString(try #require($0), equals: withWhitespace)
         }
         
         let withHangul = original + "\u{AC00}\u{AC01}"
-        withHangul.withFileSystemRepresentation { buf1 in
-            XCTAssertNotNil(buf1)
-            buf1!.withMemoryRebound(to: UInt8.self, capacity: strlen(buf1!)) { buf1Rebound in
+        try withHangul.withFileSystemRepresentation { buf1 in
+            let buf1 = try #require(buf1)
+            try buf1.withMemoryRebound(to: UInt8.self, capacity: strlen(buf1)) { buf1Rebound in
                 let fsr = String(decodingCString: buf1Rebound, as: UTF8.self)
-                fsr.withFileSystemRepresentation { buf2 in
-                    XCTAssertNotNil(buf2)
-                    XCTAssertEqual(strcmp(buf1!, buf2!), 0)
+                try fsr.withFileSystemRepresentation { buf2 in
+                    let buf2 = try #require(buf2)
+                    #expect(strcmp(buf1, buf2) == 0)
                 }
             }
         }
         
         let withNullSuffix = original + "\u{0000}\u{0000}"
-        withNullSuffix.withFileSystemRepresentation {
-            XCTAssertNotNil($0)
-            assertCString($0!, equals: original)
+        try withNullSuffix.withFileSystemRepresentation {
+            assertCString(try #require($0), equals: original)
         }
         
 #if canImport(Darwin) || FOUNDATION_FRAMEWORK
         // The buffer should dynamically grow and not be limited to a size of PATH_MAX
         Array(repeating: "A", count: Int(PATH_MAX) - 1).joined().withFileSystemRepresentation { ptr in
-            XCTAssertNotNil(ptr)
+            #expect(ptr != nil)
         }
         
         Array(repeating: "A", count: Int(PATH_MAX)).joined().withFileSystemRepresentation { ptr in
-            XCTAssertNotNil(ptr)
+            #expect(ptr != nil)
         }
         
         // The buffer should fit the scalars that expand the most during decomposition
         for string in ["\u{1D160}", "\u{0CCB}", "\u{0390}"] {
             string.withFileSystemRepresentation { ptr in
-                XCTAssertNotNil(ptr, "Could not create file system representation for \(string.debugDescription)")
+                #expect(ptr != nil, "Could not create file system representation for \(string.debugDescription)")
             }
         }
 #endif
     }
 
-    func testLastPathComponent() {
-        XCTAssertEqual("".lastPathComponent, "")
-        XCTAssertEqual("a".lastPathComponent, "a")
-        XCTAssertEqual("/a".lastPathComponent, "a")
-        XCTAssertEqual("a/".lastPathComponent, "a")
-        XCTAssertEqual("/a/".lastPathComponent, "a")
+    @Test func testLastPathComponent() {
+        #expect("".lastPathComponent == "")
+        #expect("a".lastPathComponent == "a")
+        #expect("/a".lastPathComponent == "a")
+        #expect("a/".lastPathComponent == "a")
+        #expect("/a/".lastPathComponent == "a")
 
-        XCTAssertEqual("a/b".lastPathComponent, "b")
-        XCTAssertEqual("/a/b".lastPathComponent, "b")
-        XCTAssertEqual("a/b/".lastPathComponent, "b")
-        XCTAssertEqual("/a/b/".lastPathComponent, "b")
+        #expect("a/b".lastPathComponent == "b")
+        #expect("/a/b".lastPathComponent == "b")
+        #expect("a/b/".lastPathComponent == "b")
+        #expect("/a/b/".lastPathComponent == "b")
 
-        XCTAssertEqual("a//".lastPathComponent, "a")
-        XCTAssertEqual("a////".lastPathComponent, "a")
-        XCTAssertEqual("/a//".lastPathComponent, "a")
-        XCTAssertEqual("/a////".lastPathComponent, "a")
-        XCTAssertEqual("//a//".lastPathComponent, "a")
-        XCTAssertEqual("/a/b//".lastPathComponent, "b")
-        XCTAssertEqual("//a//b////".lastPathComponent, "b")
+        #expect("a//".lastPathComponent == "a")
+        #expect("a////".lastPathComponent == "a")
+        #expect("/a//".lastPathComponent == "a")
+        #expect("/a////".lastPathComponent == "a")
+        #expect("//a//".lastPathComponent == "a")
+        #expect("/a/b//".lastPathComponent == "b")
+        #expect("//a//b////".lastPathComponent == "b")
 
-        XCTAssertEqual("/".lastPathComponent, "/")
-        XCTAssertEqual("//".lastPathComponent, "/")
-        XCTAssertEqual("/////".lastPathComponent, "/")
-        XCTAssertEqual("/./..//./..//".lastPathComponent, "..")
-        XCTAssertEqual("/😎/😂/❤️/".lastPathComponent, "❤️")
+        #expect("/".lastPathComponent == "/")
+        #expect("//".lastPathComponent == "/")
+        #expect("/////".lastPathComponent == "/")
+        #expect("/./..//./..//".lastPathComponent == "..")
+        #expect("/😎/😂/❤️/".lastPathComponent == "❤️")
     }
 
-    func testRemovingDotSegments() {
-        XCTAssertEqual(".".removingDotSegments, "")
-        XCTAssertEqual("..".removingDotSegments, "")
-        XCTAssertEqual("../".removingDotSegments, "")
-        XCTAssertEqual("../.".removingDotSegments, "")
-        XCTAssertEqual("../..".removingDotSegments, "")
-        XCTAssertEqual("../../".removingDotSegments, "")
-        XCTAssertEqual("../../.".removingDotSegments, "")
-        XCTAssertEqual("../../..".removingDotSegments, "")
-        XCTAssertEqual("../../../".removingDotSegments, "")
-        XCTAssertEqual("../.././".removingDotSegments, "")
-        XCTAssertEqual("../../a".removingDotSegments, "a")
-        XCTAssertEqual("../../a/".removingDotSegments, "a/")
-        XCTAssertEqual(".././".removingDotSegments, "")
-        XCTAssertEqual(".././.".removingDotSegments, "")
-        XCTAssertEqual(".././..".removingDotSegments, "")
-        XCTAssertEqual(".././../".removingDotSegments, "")
-        XCTAssertEqual("../././".removingDotSegments, "")
-        XCTAssertEqual(".././a".removingDotSegments, "a")
-        XCTAssertEqual(".././a/".removingDotSegments, "a/")
-        XCTAssertEqual("../a".removingDotSegments, "a")
-        XCTAssertEqual("../a/".removingDotSegments, "a/")
-        XCTAssertEqual("../a/.".removingDotSegments, "a/")
-        XCTAssertEqual("../a/..".removingDotSegments, "/")
-        XCTAssertEqual("../a/../".removingDotSegments, "/")
-        XCTAssertEqual("../a/./".removingDotSegments, "a/")
-        XCTAssertEqual("../a/b".removingDotSegments, "a/b")
-        XCTAssertEqual("../a/b/".removingDotSegments, "a/b/")
-        XCTAssertEqual("./".removingDotSegments, "")
-        XCTAssertEqual("./.".removingDotSegments, "")
-        XCTAssertEqual("./..".removingDotSegments, "")
-        XCTAssertEqual("./../".removingDotSegments, "")
-        XCTAssertEqual("./../.".removingDotSegments, "")
-        XCTAssertEqual("./../..".removingDotSegments, "")
-        XCTAssertEqual("./../../".removingDotSegments, "")
-        XCTAssertEqual("./.././".removingDotSegments, "")
-        XCTAssertEqual("./../a".removingDotSegments, "a")
-        XCTAssertEqual("./../a/".removingDotSegments, "a/")
-        XCTAssertEqual("././".removingDotSegments, "")
-        XCTAssertEqual("././.".removingDotSegments, "")
-        XCTAssertEqual("././..".removingDotSegments, "")
-        XCTAssertEqual("././../".removingDotSegments, "")
-        XCTAssertEqual("./././".removingDotSegments, "")
-        XCTAssertEqual("././a".removingDotSegments, "a")
-        XCTAssertEqual("././a/".removingDotSegments, "a/")
-        XCTAssertEqual("./a".removingDotSegments, "a")
-        XCTAssertEqual("./a/".removingDotSegments, "a/")
-        XCTAssertEqual("./a/.".removingDotSegments, "a/")
-        XCTAssertEqual("./a/..".removingDotSegments, "/")
-        XCTAssertEqual("./a/../".removingDotSegments, "/")
-        XCTAssertEqual("./a/./".removingDotSegments, "a/")
-        XCTAssertEqual("./a/b".removingDotSegments, "a/b")
-        XCTAssertEqual("./a/b/".removingDotSegments, "a/b/")
-        XCTAssertEqual("/".removingDotSegments, "/")
-        XCTAssertEqual("/.".removingDotSegments, "/")
-        XCTAssertEqual("/..".removingDotSegments, "/")
-        XCTAssertEqual("/../".removingDotSegments, "/")
-        XCTAssertEqual("/../.".removingDotSegments, "/")
-        XCTAssertEqual("/../..".removingDotSegments, "/")
-        XCTAssertEqual("/../../".removingDotSegments, "/")
-        XCTAssertEqual("/../../.".removingDotSegments, "/")
-        XCTAssertEqual("/../../..".removingDotSegments, "/")
-        XCTAssertEqual("/../../../".removingDotSegments, "/")
-        XCTAssertEqual("/../.././".removingDotSegments, "/")
-        XCTAssertEqual("/../../a".removingDotSegments, "/a")
-        XCTAssertEqual("/../../a/".removingDotSegments, "/a/")
-        XCTAssertEqual("/.././".removingDotSegments, "/")
-        XCTAssertEqual("/.././.".removingDotSegments, "/")
-        XCTAssertEqual("/.././..".removingDotSegments, "/")
-        XCTAssertEqual("/.././../".removingDotSegments, "/")
-        XCTAssertEqual("/../././".removingDotSegments, "/")
-        XCTAssertEqual("/.././a".removingDotSegments, "/a")
-        XCTAssertEqual("/.././a/".removingDotSegments, "/a/")
-        XCTAssertEqual("/../a".removingDotSegments, "/a")
-        XCTAssertEqual("/../a/".removingDotSegments, "/a/")
-        XCTAssertEqual("/../a/.".removingDotSegments, "/a/")
-        XCTAssertEqual("/../a/..".removingDotSegments, "/")
-        XCTAssertEqual("/../a/../".removingDotSegments, "/")
-        XCTAssertEqual("/../a/./".removingDotSegments, "/a/")
-        XCTAssertEqual("/../a/b".removingDotSegments, "/a/b")
-        XCTAssertEqual("/../a/b/".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/./".removingDotSegments, "/")
-        XCTAssertEqual("/./.".removingDotSegments, "/")
-        XCTAssertEqual("/./..".removingDotSegments, "/")
-        XCTAssertEqual("/./../".removingDotSegments, "/")
-        XCTAssertEqual("/./../.".removingDotSegments, "/")
-        XCTAssertEqual("/./../..".removingDotSegments, "/")
-        XCTAssertEqual("/./../../".removingDotSegments, "/")
-        XCTAssertEqual("/./.././".removingDotSegments, "/")
-        XCTAssertEqual("/./../a".removingDotSegments, "/a")
-        XCTAssertEqual("/./../a/".removingDotSegments, "/a/")
-        XCTAssertEqual("/././".removingDotSegments, "/")
-        XCTAssertEqual("/././.".removingDotSegments, "/")
-        XCTAssertEqual("/././..".removingDotSegments, "/")
-        XCTAssertEqual("/././../".removingDotSegments, "/")
-        XCTAssertEqual("/./././".removingDotSegments, "/")
-        XCTAssertEqual("/././a".removingDotSegments, "/a")
-        XCTAssertEqual("/././a/".removingDotSegments, "/a/")
-        XCTAssertEqual("/./a".removingDotSegments, "/a")
-        XCTAssertEqual("/./a/".removingDotSegments, "/a/")
-        XCTAssertEqual("/./a/.".removingDotSegments, "/a/")
-        XCTAssertEqual("/./a/..".removingDotSegments, "/")
-        XCTAssertEqual("/./a/../".removingDotSegments, "/")
-        XCTAssertEqual("/./a/./".removingDotSegments, "/a/")
-        XCTAssertEqual("/./a/b".removingDotSegments, "/a/b")
-        XCTAssertEqual("/./a/b/".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a".removingDotSegments, "/a")
-        XCTAssertEqual("/a/".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/.".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/..".removingDotSegments, "/")
-        XCTAssertEqual("/a/../".removingDotSegments, "/")
-        XCTAssertEqual("/a/../.".removingDotSegments, "/")
-        XCTAssertEqual("/a/../..".removingDotSegments, "/")
-        XCTAssertEqual("/a/../../".removingDotSegments, "/")
-        XCTAssertEqual("/a/.././".removingDotSegments, "/")
-        XCTAssertEqual("/a/../b".removingDotSegments, "/b")
-        XCTAssertEqual("/a/../b/".removingDotSegments, "/b/")
-        XCTAssertEqual("/a/./".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/./.".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/./..".removingDotSegments, "/")
-        XCTAssertEqual("/a/./../".removingDotSegments, "/")
-        XCTAssertEqual("/a/././".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/./b".removingDotSegments, "/a/b")
-        XCTAssertEqual("/a/./b/".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b".removingDotSegments, "/a/b")
-        XCTAssertEqual("/a/b/".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b/.".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b/..".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/b/../".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/b/../.".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/b/../..".removingDotSegments, "/")
-        XCTAssertEqual("/a/b/../../".removingDotSegments, "/")
-        XCTAssertEqual("/a/b/.././".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/b/../c".removingDotSegments, "/a/c")
-        XCTAssertEqual("/a/b/../c/".removingDotSegments, "/a/c/")
-        XCTAssertEqual("/a/b/./".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b/./.".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b/./..".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/b/./../".removingDotSegments, "/a/")
-        XCTAssertEqual("/a/b/././".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b/./c".removingDotSegments, "/a/b/c")
-        XCTAssertEqual("/a/b/./c/".removingDotSegments, "/a/b/c/")
-        XCTAssertEqual("/a/b/c".removingDotSegments, "/a/b/c")
-        XCTAssertEqual("/a/b/c/".removingDotSegments, "/a/b/c/")
-        XCTAssertEqual("/a/b/c/.".removingDotSegments, "/a/b/c/")
-        XCTAssertEqual("/a/b/c/..".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b/c/../".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b/c/./".removingDotSegments, "/a/b/c/")
-        XCTAssertEqual("a".removingDotSegments, "a")
-        XCTAssertEqual("a/".removingDotSegments, "a/")
-        XCTAssertEqual("a/.".removingDotSegments, "a/")
-        XCTAssertEqual("a/..".removingDotSegments, "/")
-        XCTAssertEqual("a/../".removingDotSegments, "/")
-        XCTAssertEqual("a/../.".removingDotSegments, "/")
-        XCTAssertEqual("a/../..".removingDotSegments, "/")
-        XCTAssertEqual("a/../../".removingDotSegments, "/")
-        XCTAssertEqual("a/.././".removingDotSegments, "/")
-        XCTAssertEqual("a/../b".removingDotSegments, "/b")
-        XCTAssertEqual("a/../b/".removingDotSegments, "/b/")
-        XCTAssertEqual("a/./".removingDotSegments, "a/")
-        XCTAssertEqual("a/./.".removingDotSegments, "a/")
-        XCTAssertEqual("a/./..".removingDotSegments, "/")
-        XCTAssertEqual("a/./../".removingDotSegments, "/")
-        XCTAssertEqual("a/././".removingDotSegments, "a/")
-        XCTAssertEqual("a/./b".removingDotSegments, "a/b")
-        XCTAssertEqual("a/./b/".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b".removingDotSegments, "a/b")
-        XCTAssertEqual("a/b/".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b/.".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b/..".removingDotSegments, "a/")
-        XCTAssertEqual("a/b/../".removingDotSegments, "a/")
-        XCTAssertEqual("a/b/../.".removingDotSegments, "a/")
-        XCTAssertEqual("a/b/../..".removingDotSegments, "/")
-        XCTAssertEqual("a/b/../../".removingDotSegments, "/")
-        XCTAssertEqual("a/b/.././".removingDotSegments, "a/")
-        XCTAssertEqual("a/b/../c".removingDotSegments, "a/c")
-        XCTAssertEqual("a/b/../c/".removingDotSegments, "a/c/")
-        XCTAssertEqual("a/b/./".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b/./.".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b/./..".removingDotSegments, "a/")
-        XCTAssertEqual("a/b/./../".removingDotSegments, "a/")
-        XCTAssertEqual("a/b/././".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b/./c".removingDotSegments, "a/b/c")
-        XCTAssertEqual("a/b/./c/".removingDotSegments, "a/b/c/")
-        XCTAssertEqual("a/b/c".removingDotSegments, "a/b/c")
-        XCTAssertEqual("a/b/c/".removingDotSegments, "a/b/c/")
-        XCTAssertEqual("a/b/c/.".removingDotSegments, "a/b/c/")
-        XCTAssertEqual("a/b/c/..".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b/c/../".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b/c/./".removingDotSegments, "a/b/c/")
+    @Test func testRemovingDotSegments() {
+        #expect(".".removingDotSegments == "")
+        #expect("..".removingDotSegments == "")
+        #expect("../".removingDotSegments == "")
+        #expect("../.".removingDotSegments == "")
+        #expect("../..".removingDotSegments == "")
+        #expect("../../".removingDotSegments == "")
+        #expect("../../.".removingDotSegments == "")
+        #expect("../../..".removingDotSegments == "")
+        #expect("../../../".removingDotSegments == "")
+        #expect("../.././".removingDotSegments == "")
+        #expect("../../a".removingDotSegments == "a")
+        #expect("../../a/".removingDotSegments == "a/")
+        #expect(".././".removingDotSegments == "")
+        #expect(".././.".removingDotSegments == "")
+        #expect(".././..".removingDotSegments == "")
+        #expect(".././../".removingDotSegments == "")
+        #expect("../././".removingDotSegments == "")
+        #expect(".././a".removingDotSegments == "a")
+        #expect(".././a/".removingDotSegments == "a/")
+        #expect("../a".removingDotSegments == "a")
+        #expect("../a/".removingDotSegments == "a/")
+        #expect("../a/.".removingDotSegments == "a/")
+        #expect("../a/..".removingDotSegments == "/")
+        #expect("../a/../".removingDotSegments == "/")
+        #expect("../a/./".removingDotSegments == "a/")
+        #expect("../a/b".removingDotSegments == "a/b")
+        #expect("../a/b/".removingDotSegments == "a/b/")
+        #expect("./".removingDotSegments == "")
+        #expect("./.".removingDotSegments == "")
+        #expect("./..".removingDotSegments == "")
+        #expect("./../".removingDotSegments == "")
+        #expect("./../.".removingDotSegments == "")
+        #expect("./../..".removingDotSegments == "")
+        #expect("./../../".removingDotSegments == "")
+        #expect("./.././".removingDotSegments == "")
+        #expect("./../a".removingDotSegments == "a")
+        #expect("./../a/".removingDotSegments == "a/")
+        #expect("././".removingDotSegments == "")
+        #expect("././.".removingDotSegments == "")
+        #expect("././..".removingDotSegments == "")
+        #expect("././../".removingDotSegments == "")
+        #expect("./././".removingDotSegments == "")
+        #expect("././a".removingDotSegments == "a")
+        #expect("././a/".removingDotSegments == "a/")
+        #expect("./a".removingDotSegments == "a")
+        #expect("./a/".removingDotSegments == "a/")
+        #expect("./a/.".removingDotSegments == "a/")
+        #expect("./a/..".removingDotSegments == "/")
+        #expect("./a/../".removingDotSegments == "/")
+        #expect("./a/./".removingDotSegments == "a/")
+        #expect("./a/b".removingDotSegments == "a/b")
+        #expect("./a/b/".removingDotSegments == "a/b/")
+        #expect("/".removingDotSegments == "/")
+        #expect("/.".removingDotSegments == "/")
+        #expect("/..".removingDotSegments == "/")
+        #expect("/../".removingDotSegments == "/")
+        #expect("/../.".removingDotSegments == "/")
+        #expect("/../..".removingDotSegments == "/")
+        #expect("/../../".removingDotSegments == "/")
+        #expect("/../../.".removingDotSegments == "/")
+        #expect("/../../..".removingDotSegments == "/")
+        #expect("/../../../".removingDotSegments == "/")
+        #expect("/../.././".removingDotSegments == "/")
+        #expect("/../../a".removingDotSegments == "/a")
+        #expect("/../../a/".removingDotSegments == "/a/")
+        #expect("/.././".removingDotSegments == "/")
+        #expect("/.././.".removingDotSegments == "/")
+        #expect("/.././..".removingDotSegments == "/")
+        #expect("/.././../".removingDotSegments == "/")
+        #expect("/../././".removingDotSegments == "/")
+        #expect("/.././a".removingDotSegments == "/a")
+        #expect("/.././a/".removingDotSegments == "/a/")
+        #expect("/../a".removingDotSegments == "/a")
+        #expect("/../a/".removingDotSegments == "/a/")
+        #expect("/../a/.".removingDotSegments == "/a/")
+        #expect("/../a/..".removingDotSegments == "/")
+        #expect("/../a/../".removingDotSegments == "/")
+        #expect("/../a/./".removingDotSegments == "/a/")
+        #expect("/../a/b".removingDotSegments == "/a/b")
+        #expect("/../a/b/".removingDotSegments == "/a/b/")
+        #expect("/./".removingDotSegments == "/")
+        #expect("/./.".removingDotSegments == "/")
+        #expect("/./..".removingDotSegments == "/")
+        #expect("/./../".removingDotSegments == "/")
+        #expect("/./../.".removingDotSegments == "/")
+        #expect("/./../..".removingDotSegments == "/")
+        #expect("/./../../".removingDotSegments == "/")
+        #expect("/./.././".removingDotSegments == "/")
+        #expect("/./../a".removingDotSegments == "/a")
+        #expect("/./../a/".removingDotSegments == "/a/")
+        #expect("/././".removingDotSegments == "/")
+        #expect("/././.".removingDotSegments == "/")
+        #expect("/././..".removingDotSegments == "/")
+        #expect("/././../".removingDotSegments == "/")
+        #expect("/./././".removingDotSegments == "/")
+        #expect("/././a".removingDotSegments == "/a")
+        #expect("/././a/".removingDotSegments == "/a/")
+        #expect("/./a".removingDotSegments == "/a")
+        #expect("/./a/".removingDotSegments == "/a/")
+        #expect("/./a/.".removingDotSegments == "/a/")
+        #expect("/./a/..".removingDotSegments == "/")
+        #expect("/./a/../".removingDotSegments == "/")
+        #expect("/./a/./".removingDotSegments == "/a/")
+        #expect("/./a/b".removingDotSegments == "/a/b")
+        #expect("/./a/b/".removingDotSegments == "/a/b/")
+        #expect("/a".removingDotSegments == "/a")
+        #expect("/a/".removingDotSegments == "/a/")
+        #expect("/a/.".removingDotSegments == "/a/")
+        #expect("/a/..".removingDotSegments == "/")
+        #expect("/a/../".removingDotSegments == "/")
+        #expect("/a/../.".removingDotSegments == "/")
+        #expect("/a/../..".removingDotSegments == "/")
+        #expect("/a/../../".removingDotSegments == "/")
+        #expect("/a/.././".removingDotSegments == "/")
+        #expect("/a/../b".removingDotSegments == "/b")
+        #expect("/a/../b/".removingDotSegments == "/b/")
+        #expect("/a/./".removingDotSegments == "/a/")
+        #expect("/a/./.".removingDotSegments == "/a/")
+        #expect("/a/./..".removingDotSegments == "/")
+        #expect("/a/./../".removingDotSegments == "/")
+        #expect("/a/././".removingDotSegments == "/a/")
+        #expect("/a/./b".removingDotSegments == "/a/b")
+        #expect("/a/./b/".removingDotSegments == "/a/b/")
+        #expect("/a/b".removingDotSegments == "/a/b")
+        #expect("/a/b/".removingDotSegments == "/a/b/")
+        #expect("/a/b/.".removingDotSegments == "/a/b/")
+        #expect("/a/b/..".removingDotSegments == "/a/")
+        #expect("/a/b/../".removingDotSegments == "/a/")
+        #expect("/a/b/../.".removingDotSegments == "/a/")
+        #expect("/a/b/../..".removingDotSegments == "/")
+        #expect("/a/b/../../".removingDotSegments == "/")
+        #expect("/a/b/.././".removingDotSegments == "/a/")
+        #expect("/a/b/../c".removingDotSegments == "/a/c")
+        #expect("/a/b/../c/".removingDotSegments == "/a/c/")
+        #expect("/a/b/./".removingDotSegments == "/a/b/")
+        #expect("/a/b/./.".removingDotSegments == "/a/b/")
+        #expect("/a/b/./..".removingDotSegments == "/a/")
+        #expect("/a/b/./../".removingDotSegments == "/a/")
+        #expect("/a/b/././".removingDotSegments == "/a/b/")
+        #expect("/a/b/./c".removingDotSegments == "/a/b/c")
+        #expect("/a/b/./c/".removingDotSegments == "/a/b/c/")
+        #expect("/a/b/c".removingDotSegments == "/a/b/c")
+        #expect("/a/b/c/".removingDotSegments == "/a/b/c/")
+        #expect("/a/b/c/.".removingDotSegments == "/a/b/c/")
+        #expect("/a/b/c/..".removingDotSegments == "/a/b/")
+        #expect("/a/b/c/../".removingDotSegments == "/a/b/")
+        #expect("/a/b/c/./".removingDotSegments == "/a/b/c/")
+        #expect("a".removingDotSegments == "a")
+        #expect("a/".removingDotSegments == "a/")
+        #expect("a/.".removingDotSegments == "a/")
+        #expect("a/..".removingDotSegments == "/")
+        #expect("a/../".removingDotSegments == "/")
+        #expect("a/../.".removingDotSegments == "/")
+        #expect("a/../..".removingDotSegments == "/")
+        #expect("a/../../".removingDotSegments == "/")
+        #expect("a/.././".removingDotSegments == "/")
+        #expect("a/../b".removingDotSegments == "/b")
+        #expect("a/../b/".removingDotSegments == "/b/")
+        #expect("a/./".removingDotSegments == "a/")
+        #expect("a/./.".removingDotSegments == "a/")
+        #expect("a/./..".removingDotSegments == "/")
+        #expect("a/./../".removingDotSegments == "/")
+        #expect("a/././".removingDotSegments == "a/")
+        #expect("a/./b".removingDotSegments == "a/b")
+        #expect("a/./b/".removingDotSegments == "a/b/")
+        #expect("a/b".removingDotSegments == "a/b")
+        #expect("a/b/".removingDotSegments == "a/b/")
+        #expect("a/b/.".removingDotSegments == "a/b/")
+        #expect("a/b/..".removingDotSegments == "a/")
+        #expect("a/b/../".removingDotSegments == "a/")
+        #expect("a/b/../.".removingDotSegments == "a/")
+        #expect("a/b/../..".removingDotSegments == "/")
+        #expect("a/b/../../".removingDotSegments == "/")
+        #expect("a/b/.././".removingDotSegments == "a/")
+        #expect("a/b/../c".removingDotSegments == "a/c")
+        #expect("a/b/../c/".removingDotSegments == "a/c/")
+        #expect("a/b/./".removingDotSegments == "a/b/")
+        #expect("a/b/./.".removingDotSegments == "a/b/")
+        #expect("a/b/./..".removingDotSegments == "a/")
+        #expect("a/b/./../".removingDotSegments == "a/")
+        #expect("a/b/././".removingDotSegments == "a/b/")
+        #expect("a/b/./c".removingDotSegments == "a/b/c")
+        #expect("a/b/./c/".removingDotSegments == "a/b/c/")
+        #expect("a/b/c".removingDotSegments == "a/b/c")
+        #expect("a/b/c/".removingDotSegments == "a/b/c/")
+        #expect("a/b/c/.".removingDotSegments == "a/b/c/")
+        #expect("a/b/c/..".removingDotSegments == "a/b/")
+        #expect("a/b/c/../".removingDotSegments == "a/b/")
+        #expect("a/b/c/./".removingDotSegments == "a/b/c/")
 
         // None of the inputs below contain "." or ".." and should therefore be treated as regular path components
 
-        XCTAssertEqual("...".removingDotSegments, "...")
-        XCTAssertEqual(".../".removingDotSegments, ".../")
-        XCTAssertEqual(".../...".removingDotSegments, ".../...")
-        XCTAssertEqual(".../.../".removingDotSegments, ".../.../")
-        XCTAssertEqual(".../..a".removingDotSegments, ".../..a")
-        XCTAssertEqual(".../..a/".removingDotSegments, ".../..a/")
-        XCTAssertEqual(".../.a".removingDotSegments, ".../.a")
-        XCTAssertEqual(".../.a/".removingDotSegments, ".../.a/")
-        XCTAssertEqual(".../a.".removingDotSegments, ".../a.")
-        XCTAssertEqual(".../a..".removingDotSegments, ".../a..")
-        XCTAssertEqual(".../a../".removingDotSegments, ".../a../")
-        XCTAssertEqual(".../a./".removingDotSegments, ".../a./")
-        XCTAssertEqual("..a".removingDotSegments, "..a")
-        XCTAssertEqual("..a/".removingDotSegments, "..a/")
-        XCTAssertEqual("..a/...".removingDotSegments, "..a/...")
-        XCTAssertEqual("..a/.../".removingDotSegments, "..a/.../")
-        XCTAssertEqual("..a/..b".removingDotSegments, "..a/..b")
-        XCTAssertEqual("..a/..b/".removingDotSegments, "..a/..b/")
-        XCTAssertEqual("..a/.b".removingDotSegments, "..a/.b")
-        XCTAssertEqual("..a/.b/".removingDotSegments, "..a/.b/")
-        XCTAssertEqual("..a/b.".removingDotSegments, "..a/b.")
-        XCTAssertEqual("..a/b..".removingDotSegments, "..a/b..")
-        XCTAssertEqual("..a/b../".removingDotSegments, "..a/b../")
-        XCTAssertEqual("..a/b./".removingDotSegments, "..a/b./")
-        XCTAssertEqual(".a".removingDotSegments, ".a")
-        XCTAssertEqual(".a/".removingDotSegments, ".a/")
-        XCTAssertEqual(".a/...".removingDotSegments, ".a/...")
-        XCTAssertEqual(".a/.../".removingDotSegments, ".a/.../")
-        XCTAssertEqual(".a/..b".removingDotSegments, ".a/..b")
-        XCTAssertEqual(".a/..b/".removingDotSegments, ".a/..b/")
-        XCTAssertEqual(".a/.b".removingDotSegments, ".a/.b")
-        XCTAssertEqual(".a/.b/".removingDotSegments, ".a/.b/")
-        XCTAssertEqual(".a/b.".removingDotSegments, ".a/b.")
-        XCTAssertEqual(".a/b..".removingDotSegments, ".a/b..")
-        XCTAssertEqual(".a/b../".removingDotSegments, ".a/b../")
-        XCTAssertEqual(".a/b./".removingDotSegments, ".a/b./")
-        XCTAssertEqual("/".removingDotSegments, "/")
-        XCTAssertEqual("/...".removingDotSegments, "/...")
-        XCTAssertEqual("/.../".removingDotSegments, "/.../")
-        XCTAssertEqual("/..a".removingDotSegments, "/..a")
-        XCTAssertEqual("/..a/".removingDotSegments, "/..a/")
-        XCTAssertEqual("/.a".removingDotSegments, "/.a")
-        XCTAssertEqual("/.a/".removingDotSegments, "/.a/")
-        XCTAssertEqual("/a.".removingDotSegments, "/a.")
-        XCTAssertEqual("/a..".removingDotSegments, "/a..")
-        XCTAssertEqual("/a../".removingDotSegments, "/a../")
-        XCTAssertEqual("/a./".removingDotSegments, "/a./")
-        XCTAssertEqual("a.".removingDotSegments, "a.")
-        XCTAssertEqual("a..".removingDotSegments, "a..")
-        XCTAssertEqual("a../".removingDotSegments, "a../")
-        XCTAssertEqual("a../...".removingDotSegments, "a../...")
-        XCTAssertEqual("a../.../".removingDotSegments, "a../.../")
-        XCTAssertEqual("a../..b".removingDotSegments, "a../..b")
-        XCTAssertEqual("a../..b/".removingDotSegments, "a../..b/")
-        XCTAssertEqual("a../.b".removingDotSegments, "a../.b")
-        XCTAssertEqual("a../.b/".removingDotSegments, "a../.b/")
-        XCTAssertEqual("a../b.".removingDotSegments, "a../b.")
-        XCTAssertEqual("a../b..".removingDotSegments, "a../b..")
-        XCTAssertEqual("a../b../".removingDotSegments, "a../b../")
-        XCTAssertEqual("a../b./".removingDotSegments, "a../b./")
-        XCTAssertEqual("a./".removingDotSegments, "a./")
-        XCTAssertEqual("a./...".removingDotSegments, "a./...")
-        XCTAssertEqual("a./.../".removingDotSegments, "a./.../")
-        XCTAssertEqual("a./..b".removingDotSegments, "a./..b")
-        XCTAssertEqual("a./..b/".removingDotSegments, "a./..b/")
-        XCTAssertEqual("a./.b".removingDotSegments, "a./.b")
-        XCTAssertEqual("a./.b/".removingDotSegments, "a./.b/")
-        XCTAssertEqual("a./b.".removingDotSegments, "a./b.")
-        XCTAssertEqual("a./b..".removingDotSegments, "a./b..")
-        XCTAssertEqual("a./b../".removingDotSegments, "a./b../")
-        XCTAssertEqual("a./b./".removingDotSegments, "a./b./")
+        #expect("...".removingDotSegments == "...")
+        #expect(".../".removingDotSegments == ".../")
+        #expect(".../...".removingDotSegments == ".../...")
+        #expect(".../.../".removingDotSegments == ".../.../")
+        #expect(".../..a".removingDotSegments == ".../..a")
+        #expect(".../..a/".removingDotSegments == ".../..a/")
+        #expect(".../.a".removingDotSegments == ".../.a")
+        #expect(".../.a/".removingDotSegments == ".../.a/")
+        #expect(".../a.".removingDotSegments == ".../a.")
+        #expect(".../a..".removingDotSegments == ".../a..")
+        #expect(".../a../".removingDotSegments == ".../a../")
+        #expect(".../a./".removingDotSegments == ".../a./")
+        #expect("..a".removingDotSegments == "..a")
+        #expect("..a/".removingDotSegments == "..a/")
+        #expect("..a/...".removingDotSegments == "..a/...")
+        #expect("..a/.../".removingDotSegments == "..a/.../")
+        #expect("..a/..b".removingDotSegments == "..a/..b")
+        #expect("..a/..b/".removingDotSegments == "..a/..b/")
+        #expect("..a/.b".removingDotSegments == "..a/.b")
+        #expect("..a/.b/".removingDotSegments == "..a/.b/")
+        #expect("..a/b.".removingDotSegments == "..a/b.")
+        #expect("..a/b..".removingDotSegments == "..a/b..")
+        #expect("..a/b../".removingDotSegments == "..a/b../")
+        #expect("..a/b./".removingDotSegments == "..a/b./")
+        #expect(".a".removingDotSegments == ".a")
+        #expect(".a/".removingDotSegments == ".a/")
+        #expect(".a/...".removingDotSegments == ".a/...")
+        #expect(".a/.../".removingDotSegments == ".a/.../")
+        #expect(".a/..b".removingDotSegments == ".a/..b")
+        #expect(".a/..b/".removingDotSegments == ".a/..b/")
+        #expect(".a/.b".removingDotSegments == ".a/.b")
+        #expect(".a/.b/".removingDotSegments == ".a/.b/")
+        #expect(".a/b.".removingDotSegments == ".a/b.")
+        #expect(".a/b..".removingDotSegments == ".a/b..")
+        #expect(".a/b../".removingDotSegments == ".a/b../")
+        #expect(".a/b./".removingDotSegments == ".a/b./")
+        #expect("/".removingDotSegments == "/")
+        #expect("/...".removingDotSegments == "/...")
+        #expect("/.../".removingDotSegments == "/.../")
+        #expect("/..a".removingDotSegments == "/..a")
+        #expect("/..a/".removingDotSegments == "/..a/")
+        #expect("/.a".removingDotSegments == "/.a")
+        #expect("/.a/".removingDotSegments == "/.a/")
+        #expect("/a.".removingDotSegments == "/a.")
+        #expect("/a..".removingDotSegments == "/a..")
+        #expect("/a../".removingDotSegments == "/a../")
+        #expect("/a./".removingDotSegments == "/a./")
+        #expect("a.".removingDotSegments == "a.")
+        #expect("a..".removingDotSegments == "a..")
+        #expect("a../".removingDotSegments == "a../")
+        #expect("a../...".removingDotSegments == "a../...")
+        #expect("a../.../".removingDotSegments == "a../.../")
+        #expect("a../..b".removingDotSegments == "a../..b")
+        #expect("a../..b/".removingDotSegments == "a../..b/")
+        #expect("a../.b".removingDotSegments == "a../.b")
+        #expect("a../.b/".removingDotSegments == "a../.b/")
+        #expect("a../b.".removingDotSegments == "a../b.")
+        #expect("a../b..".removingDotSegments == "a../b..")
+        #expect("a../b../".removingDotSegments == "a../b../")
+        #expect("a../b./".removingDotSegments == "a../b./")
+        #expect("a./".removingDotSegments == "a./")
+        #expect("a./...".removingDotSegments == "a./...")
+        #expect("a./.../".removingDotSegments == "a./.../")
+        #expect("a./..b".removingDotSegments == "a./..b")
+        #expect("a./..b/".removingDotSegments == "a./..b/")
+        #expect("a./.b".removingDotSegments == "a./.b")
+        #expect("a./.b/".removingDotSegments == "a./.b/")
+        #expect("a./b.".removingDotSegments == "a./b.")
+        #expect("a./b..".removingDotSegments == "a./b..")
+        #expect("a./b../".removingDotSegments == "a./b../")
+        #expect("a./b./".removingDotSegments == "a./b./")
 
         // Repeated slashes should not be resolved when only removing dot segments
 
-        XCTAssertEqual("../..//".removingDotSegments, "/")
-        XCTAssertEqual(".././/".removingDotSegments, "/")
-        XCTAssertEqual("..//".removingDotSegments, "/")
-        XCTAssertEqual("..//.".removingDotSegments, "/")
-        XCTAssertEqual("..//..".removingDotSegments, "/")
-        XCTAssertEqual("..//../".removingDotSegments, "/")
-        XCTAssertEqual("..//./".removingDotSegments, "/")
-        XCTAssertEqual("..///".removingDotSegments, "//")
-        XCTAssertEqual("..//a".removingDotSegments, "/a")
-        XCTAssertEqual("..//a/".removingDotSegments, "/a/")
-        XCTAssertEqual("../a//".removingDotSegments, "a//")
-        XCTAssertEqual("./..//".removingDotSegments, "/")
-        XCTAssertEqual("././/".removingDotSegments, "/")
-        XCTAssertEqual(".//".removingDotSegments, "/")
-        XCTAssertEqual(".//.".removingDotSegments, "/")
-        XCTAssertEqual(".//..".removingDotSegments, "/")
-        XCTAssertEqual(".//../".removingDotSegments, "/")
-        XCTAssertEqual(".//./".removingDotSegments, "/")
-        XCTAssertEqual(".///".removingDotSegments, "//")
-        XCTAssertEqual(".//a".removingDotSegments, "/a")
-        XCTAssertEqual(".//a/".removingDotSegments, "/a/")
-        XCTAssertEqual("./a//".removingDotSegments, "a//")
-        XCTAssertEqual("/../..//".removingDotSegments, "//")
-        XCTAssertEqual("/.././/".removingDotSegments, "//")
-        XCTAssertEqual("/..//".removingDotSegments, "//")
-        XCTAssertEqual("/..//.".removingDotSegments, "//")
-        XCTAssertEqual("/..//..".removingDotSegments, "/")
-        XCTAssertEqual("/..//../".removingDotSegments, "/")
-        XCTAssertEqual("/..//./".removingDotSegments, "//")
-        XCTAssertEqual("/..///".removingDotSegments, "///")
-        XCTAssertEqual("/..//a".removingDotSegments, "//a")
-        XCTAssertEqual("/..//a/".removingDotSegments, "//a/")
-        XCTAssertEqual("/../a//".removingDotSegments, "/a//")
-        XCTAssertEqual("/./..//".removingDotSegments, "//")
-        XCTAssertEqual("/././/".removingDotSegments, "//")
-        XCTAssertEqual("/.//".removingDotSegments, "//")
-        XCTAssertEqual("/.//.".removingDotSegments, "//")
-        XCTAssertEqual("/.//..".removingDotSegments, "/")
-        XCTAssertEqual("/.//../".removingDotSegments, "/")
-        XCTAssertEqual("/.//./".removingDotSegments, "//")
-        XCTAssertEqual("/.///".removingDotSegments, "///")
-        XCTAssertEqual("/.//a".removingDotSegments, "//a")
-        XCTAssertEqual("/.//a/".removingDotSegments, "//a/")
-        XCTAssertEqual("/./a//".removingDotSegments, "/a//")
-        XCTAssertEqual("//".removingDotSegments, "//")
-        XCTAssertEqual("//.".removingDotSegments, "//")
-        XCTAssertEqual("//..".removingDotSegments, "/")
-        XCTAssertEqual("//../".removingDotSegments, "/")
-        XCTAssertEqual("//./".removingDotSegments, "//")
-        XCTAssertEqual("///".removingDotSegments, "///")
-        XCTAssertEqual("//a".removingDotSegments, "//a")
-        XCTAssertEqual("//a/".removingDotSegments, "//a/")
-        XCTAssertEqual("/a/..//".removingDotSegments, "//")
-        XCTAssertEqual("/a/.//".removingDotSegments, "/a//")
-        XCTAssertEqual("/a//".removingDotSegments, "/a//")
-        XCTAssertEqual("/a//.".removingDotSegments, "/a//")
-        XCTAssertEqual("/a//..".removingDotSegments, "/a/")
-        XCTAssertEqual("/a//../".removingDotSegments, "/a/")
-        XCTAssertEqual("/a//./".removingDotSegments, "/a//")
-        XCTAssertEqual("/a///".removingDotSegments, "/a///")
-        XCTAssertEqual("/a//b".removingDotSegments, "/a//b")
-        XCTAssertEqual("/a//b/".removingDotSegments, "/a//b/")
-        XCTAssertEqual("/a/b/..//".removingDotSegments, "/a//")
-        XCTAssertEqual("/a/b/.//".removingDotSegments, "/a/b//")
-        XCTAssertEqual("/a/b//".removingDotSegments, "/a/b//")
-        XCTAssertEqual("/a/b//.".removingDotSegments, "/a/b//")
-        XCTAssertEqual("/a/b//..".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b//../".removingDotSegments, "/a/b/")
-        XCTAssertEqual("/a/b//./".removingDotSegments, "/a/b//")
-        XCTAssertEqual("/a/b///".removingDotSegments, "/a/b///")
-        XCTAssertEqual("/a/b//c".removingDotSegments, "/a/b//c")
-        XCTAssertEqual("/a/b//c/".removingDotSegments, "/a/b//c/")
-        XCTAssertEqual("/a/b/c//".removingDotSegments, "/a/b/c//")
-        XCTAssertEqual("a/..//".removingDotSegments, "//")
-        XCTAssertEqual("a/.//".removingDotSegments, "a//")
-        XCTAssertEqual("a//".removingDotSegments, "a//")
-        XCTAssertEqual("a//.".removingDotSegments, "a//")
-        XCTAssertEqual("a//..".removingDotSegments, "a/")
-        XCTAssertEqual("a//../".removingDotSegments, "a/")
-        XCTAssertEqual("a//./".removingDotSegments, "a//")
-        XCTAssertEqual("a///".removingDotSegments, "a///")
-        XCTAssertEqual("a//b".removingDotSegments, "a//b")
-        XCTAssertEqual("a//b/".removingDotSegments, "a//b/")
-        XCTAssertEqual("a/b/..//".removingDotSegments, "a//")
-        XCTAssertEqual("a/b/.//".removingDotSegments, "a/b//")
-        XCTAssertEqual("a/b//".removingDotSegments, "a/b//")
-        XCTAssertEqual("a/b//.".removingDotSegments, "a/b//")
-        XCTAssertEqual("a/b//..".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b//../".removingDotSegments, "a/b/")
-        XCTAssertEqual("a/b//./".removingDotSegments, "a/b//")
-        XCTAssertEqual("a/b///".removingDotSegments, "a/b///")
-        XCTAssertEqual("a/b//c".removingDotSegments, "a/b//c")
-        XCTAssertEqual("a/b//c/".removingDotSegments, "a/b//c/")
-        XCTAssertEqual("a/b/c//".removingDotSegments, "a/b/c//")
+        #expect("../..//".removingDotSegments == "/")
+        #expect(".././/".removingDotSegments == "/")
+        #expect("..//".removingDotSegments == "/")
+        #expect("..//.".removingDotSegments == "/")
+        #expect("..//..".removingDotSegments == "/")
+        #expect("..//../".removingDotSegments == "/")
+        #expect("..//./".removingDotSegments == "/")
+        #expect("..///".removingDotSegments == "//")
+        #expect("..//a".removingDotSegments == "/a")
+        #expect("..//a/".removingDotSegments == "/a/")
+        #expect("../a//".removingDotSegments == "a//")
+        #expect("./..//".removingDotSegments == "/")
+        #expect("././/".removingDotSegments == "/")
+        #expect(".//".removingDotSegments == "/")
+        #expect(".//.".removingDotSegments == "/")
+        #expect(".//..".removingDotSegments == "/")
+        #expect(".//../".removingDotSegments == "/")
+        #expect(".//./".removingDotSegments == "/")
+        #expect(".///".removingDotSegments == "//")
+        #expect(".//a".removingDotSegments == "/a")
+        #expect(".//a/".removingDotSegments == "/a/")
+        #expect("./a//".removingDotSegments == "a//")
+        #expect("/../..//".removingDotSegments == "//")
+        #expect("/.././/".removingDotSegments == "//")
+        #expect("/..//".removingDotSegments == "//")
+        #expect("/..//.".removingDotSegments == "//")
+        #expect("/..//..".removingDotSegments == "/")
+        #expect("/..//../".removingDotSegments == "/")
+        #expect("/..//./".removingDotSegments == "//")
+        #expect("/..///".removingDotSegments == "///")
+        #expect("/..//a".removingDotSegments == "//a")
+        #expect("/..//a/".removingDotSegments == "//a/")
+        #expect("/../a//".removingDotSegments == "/a//")
+        #expect("/./..//".removingDotSegments == "//")
+        #expect("/././/".removingDotSegments == "//")
+        #expect("/.//".removingDotSegments == "//")
+        #expect("/.//.".removingDotSegments == "//")
+        #expect("/.//..".removingDotSegments == "/")
+        #expect("/.//../".removingDotSegments == "/")
+        #expect("/.//./".removingDotSegments == "//")
+        #expect("/.///".removingDotSegments == "///")
+        #expect("/.//a".removingDotSegments == "//a")
+        #expect("/.//a/".removingDotSegments == "//a/")
+        #expect("/./a//".removingDotSegments == "/a//")
+        #expect("//".removingDotSegments == "//")
+        #expect("//.".removingDotSegments == "//")
+        #expect("//..".removingDotSegments == "/")
+        #expect("//../".removingDotSegments == "/")
+        #expect("//./".removingDotSegments == "//")
+        #expect("///".removingDotSegments == "///")
+        #expect("//a".removingDotSegments == "//a")
+        #expect("//a/".removingDotSegments == "//a/")
+        #expect("/a/..//".removingDotSegments == "//")
+        #expect("/a/.//".removingDotSegments == "/a//")
+        #expect("/a//".removingDotSegments == "/a//")
+        #expect("/a//.".removingDotSegments == "/a//")
+        #expect("/a//..".removingDotSegments == "/a/")
+        #expect("/a//../".removingDotSegments == "/a/")
+        #expect("/a//./".removingDotSegments == "/a//")
+        #expect("/a///".removingDotSegments == "/a///")
+        #expect("/a//b".removingDotSegments == "/a//b")
+        #expect("/a//b/".removingDotSegments == "/a//b/")
+        #expect("/a/b/..//".removingDotSegments == "/a//")
+        #expect("/a/b/.//".removingDotSegments == "/a/b//")
+        #expect("/a/b//".removingDotSegments == "/a/b//")
+        #expect("/a/b//.".removingDotSegments == "/a/b//")
+        #expect("/a/b//..".removingDotSegments == "/a/b/")
+        #expect("/a/b//../".removingDotSegments == "/a/b/")
+        #expect("/a/b//./".removingDotSegments == "/a/b//")
+        #expect("/a/b///".removingDotSegments == "/a/b///")
+        #expect("/a/b//c".removingDotSegments == "/a/b//c")
+        #expect("/a/b//c/".removingDotSegments == "/a/b//c/")
+        #expect("/a/b/c//".removingDotSegments == "/a/b/c//")
+        #expect("a/..//".removingDotSegments == "//")
+        #expect("a/.//".removingDotSegments == "a//")
+        #expect("a//".removingDotSegments == "a//")
+        #expect("a//.".removingDotSegments == "a//")
+        #expect("a//..".removingDotSegments == "a/")
+        #expect("a//../".removingDotSegments == "a/")
+        #expect("a//./".removingDotSegments == "a//")
+        #expect("a///".removingDotSegments == "a///")
+        #expect("a//b".removingDotSegments == "a//b")
+        #expect("a//b/".removingDotSegments == "a//b/")
+        #expect("a/b/..//".removingDotSegments == "a//")
+        #expect("a/b/.//".removingDotSegments == "a/b//")
+        #expect("a/b//".removingDotSegments == "a/b//")
+        #expect("a/b//.".removingDotSegments == "a/b//")
+        #expect("a/b//..".removingDotSegments == "a/b/")
+        #expect("a/b//../".removingDotSegments == "a/b/")
+        #expect("a/b//./".removingDotSegments == "a/b//")
+        #expect("a/b///".removingDotSegments == "a/b///")
+        #expect("a/b//c".removingDotSegments == "a/b//c")
+        #expect("a/b//c/".removingDotSegments == "a/b//c/")
+        #expect("a/b/c//".removingDotSegments == "a/b/c//")
     }
 
-    func testPathExtension() {
+    @Test func testPathExtension() {
         let stringNoExtension = "0123456789"
         let stringWithExtension = "\(stringNoExtension).foo"
-        XCTAssertEqual(stringNoExtension.appendingPathExtension("foo"), stringWithExtension)
+        #expect(stringNoExtension.appendingPathExtension("foo") == stringWithExtension)
 
         var invalidExtensions = [String]()
         for scalar in String.invalidExtensionScalars {
@@ -795,71 +802,71 @@ final class StringTests : XCTestCase {
         }
         let invalidExtensionStrings = invalidExtensions.map { "\(stringNoExtension).\($0)" }
 
-        XCTAssertEqual(stringNoExtension.pathExtension, "")
-        XCTAssertEqual(stringWithExtension.pathExtension, "foo")
-        XCTAssertEqual(stringNoExtension.deletingPathExtension(), stringNoExtension)
-        XCTAssertEqual(stringWithExtension.deletingPathExtension(), stringNoExtension)
+        #expect(stringNoExtension.pathExtension == "")
+        #expect(stringWithExtension.pathExtension == "foo")
+        #expect(stringNoExtension.deletingPathExtension() == stringNoExtension)
+        #expect(stringWithExtension.deletingPathExtension() == stringNoExtension)
 
         for invalidExtensionString in invalidExtensionStrings {
             if invalidExtensionString.last == "/" {
                 continue
             }
-            XCTAssertEqual(invalidExtensionString.pathExtension, "")
-            XCTAssertEqual(invalidExtensionString.deletingPathExtension(), invalidExtensionString)
+            #expect(invalidExtensionString.pathExtension == "")
+            #expect(invalidExtensionString.deletingPathExtension() == invalidExtensionString)
         }
 
         for invalidExtension in invalidExtensions {
-            XCTAssertEqual(stringNoExtension.appendingPathExtension(invalidExtension), stringNoExtension)
+            #expect(stringNoExtension.appendingPathExtension(invalidExtension) == stringNoExtension)
         }
     }
 
-    func testAppendingPathExtension() {
-        XCTAssertEqual("".appendingPathExtension("foo"), ".foo")
-        XCTAssertEqual("/".appendingPathExtension("foo"), "/.foo")
-        XCTAssertEqual("//".appendingPathExtension("foo"), "/.foo/")
-        XCTAssertEqual("/path".appendingPathExtension("foo"), "/path.foo")
-        XCTAssertEqual("/path.zip".appendingPathExtension("foo"), "/path.zip.foo")
-        XCTAssertEqual("/path/".appendingPathExtension("foo"), "/path.foo/")
-        XCTAssertEqual("/path//".appendingPathExtension("foo"), "/path.foo/")
-        XCTAssertEqual("path".appendingPathExtension("foo"), "path.foo")
-        XCTAssertEqual("path/".appendingPathExtension("foo"), "path.foo/")
-        XCTAssertEqual("path//".appendingPathExtension("foo"), "path.foo/")
+    @Test func testAppendingPathExtension() {
+        #expect("".appendingPathExtension("foo") == ".foo")
+        #expect("/".appendingPathExtension("foo") == "/.foo")
+        #expect("//".appendingPathExtension("foo") == "/.foo/")
+        #expect("/path".appendingPathExtension("foo") == "/path.foo")
+        #expect("/path.zip".appendingPathExtension("foo") == "/path.zip.foo")
+        #expect("/path/".appendingPathExtension("foo") == "/path.foo/")
+        #expect("/path//".appendingPathExtension("foo") == "/path.foo/")
+        #expect("path".appendingPathExtension("foo") == "path.foo")
+        #expect("path/".appendingPathExtension("foo") == "path.foo/")
+        #expect("path//".appendingPathExtension("foo") == "path.foo/")
     }
 
-    func testDeletingPathExtenstion() {
-        XCTAssertEqual("".deletingPathExtension(), "")
-        XCTAssertEqual("/".deletingPathExtension(), "/")
-        XCTAssertEqual("/foo/bar".deletingPathExtension(), "/foo/bar")
-        XCTAssertEqual("/foo/bar.zip".deletingPathExtension(), "/foo/bar")
-        XCTAssertEqual("/foo/bar.baz.zip".deletingPathExtension(), "/foo/bar.baz")
-        XCTAssertEqual(".".deletingPathExtension(), ".")
-        XCTAssertEqual(".zip".deletingPathExtension(), ".zip")
-        XCTAssertEqual("zip.".deletingPathExtension(), "zip.")
-        XCTAssertEqual(".zip.".deletingPathExtension(), ".zip.")
-        XCTAssertEqual("/foo/bar/.zip".deletingPathExtension(), "/foo/bar/.zip")
-        XCTAssertEqual("..".deletingPathExtension(), "..")
-        XCTAssertEqual("..zip".deletingPathExtension(), "..zip")
-        XCTAssertEqual("/foo/bar/..zip".deletingPathExtension(), "/foo/bar/..zip")
-        XCTAssertEqual("/foo/bar/baz..zip".deletingPathExtension(), "/foo/bar/baz.")
-        XCTAssertEqual("...".deletingPathExtension(), "...")
-        XCTAssertEqual("...zip".deletingPathExtension(), "...zip")
-        XCTAssertEqual("/foo/bar/...zip".deletingPathExtension(), "/foo/bar/...zip")
-        XCTAssertEqual("/foo/bar/baz...zip".deletingPathExtension(), "/foo/bar/baz..")
-        XCTAssertEqual("/foo.bar/bar.baz/baz.zip".deletingPathExtension(), "/foo.bar/bar.baz/baz")
-        XCTAssertEqual("/.././.././a.zip".deletingPathExtension(), "/.././.././a")
-        XCTAssertEqual("/.././.././.".deletingPathExtension(), "/.././.././.")
+    @Test func testDeletingPathExtenstion() {
+        #expect("".deletingPathExtension() == "")
+        #expect("/".deletingPathExtension() == "/")
+        #expect("/foo/bar".deletingPathExtension() == "/foo/bar")
+        #expect("/foo/bar.zip".deletingPathExtension() == "/foo/bar")
+        #expect("/foo/bar.baz.zip".deletingPathExtension() == "/foo/bar.baz")
+        #expect(".".deletingPathExtension() == ".")
+        #expect(".zip".deletingPathExtension() == ".zip")
+        #expect("zip.".deletingPathExtension() == "zip.")
+        #expect(".zip.".deletingPathExtension() == ".zip.")
+        #expect("/foo/bar/.zip".deletingPathExtension() == "/foo/bar/.zip")
+        #expect("..".deletingPathExtension() == "..")
+        #expect("..zip".deletingPathExtension() == "..zip")
+        #expect("/foo/bar/..zip".deletingPathExtension() == "/foo/bar/..zip")
+        #expect("/foo/bar/baz..zip".deletingPathExtension() == "/foo/bar/baz.")
+        #expect("...".deletingPathExtension() == "...")
+        #expect("...zip".deletingPathExtension() == "...zip")
+        #expect("/foo/bar/...zip".deletingPathExtension() == "/foo/bar/...zip")
+        #expect("/foo/bar/baz...zip".deletingPathExtension() == "/foo/bar/baz..")
+        #expect("/foo.bar/bar.baz/baz.zip".deletingPathExtension() == "/foo.bar/bar.baz/baz")
+        #expect("/.././.././a.zip".deletingPathExtension() == "/.././.././a")
+        #expect("/.././.././.".deletingPathExtension() == "/.././.././.")
 
-        XCTAssertEqual("path.foo".deletingPathExtension(), "path")
-        XCTAssertEqual("path.foo.zip".deletingPathExtension(), "path.foo")
-        XCTAssertEqual("/path.foo".deletingPathExtension(), "/path")
-        XCTAssertEqual("/path.foo.zip".deletingPathExtension(), "/path.foo")
-        XCTAssertEqual("path.foo/".deletingPathExtension(), "path/")
-        XCTAssertEqual("path.foo//".deletingPathExtension(), "path/")
-        XCTAssertEqual("/path.foo/".deletingPathExtension(), "/path/")
-        XCTAssertEqual("/path.foo//".deletingPathExtension(), "/path/")
+        #expect("path.foo".deletingPathExtension() == "path")
+        #expect("path.foo.zip".deletingPathExtension() == "path.foo")
+        #expect("/path.foo".deletingPathExtension() == "/path")
+        #expect("/path.foo.zip".deletingPathExtension() == "/path.foo")
+        #expect("path.foo/".deletingPathExtension() == "path/")
+        #expect("path.foo//".deletingPathExtension() == "path/")
+        #expect("/path.foo/".deletingPathExtension() == "/path/")
+        #expect("/path.foo//".deletingPathExtension() == "/path/")
     }
 
-    func testPathComponents() {
+    @Test func testPathComponents() {
         let tests: [(String, [String])] = [
             ("", []),
             ("/", ["/"]),
@@ -883,11 +890,11 @@ final class StringTests : XCTestCase {
         ]
         for (input, expected) in tests {
             let result = input.pathComponents
-            XCTAssertEqual(result, expected)
+            #expect(result == expected)
         }
     }
 
-    func test_dataUsingEncoding() {
+    @Test func dataUsingEncoding() {
         let s = "hello 🧮"
         
         // Verify things work on substrings too
@@ -898,27 +905,27 @@ final class StringTests : XCTestCase {
         
         let utf16BEExpected = Data([0, 104, 0, 101, 0, 108, 0, 108, 0, 111, 0, 32, 216, 62, 221, 238])
         let utf16BEOutput = s.data(using: String._Encoding.utf16BigEndian)
-        XCTAssertEqual(utf16BEOutput, utf16BEExpected)
+        #expect(utf16BEOutput == utf16BEExpected)
         
         let utf16BEOutputSubstring = subString.data(using: String._Encoding.utf16BigEndian)
-        XCTAssertEqual(utf16BEOutputSubstring, utf16BEExpected)
+        #expect(utf16BEOutputSubstring == utf16BEExpected)
         
         let utf16LEExpected = Data([104, 0, 101, 0, 108, 0, 108, 0, 111, 0, 32, 0, 62, 216, 238, 221])
         let utf16LEOutput = s.data(using: String._Encoding.utf16LittleEndian)
-        XCTAssertEqual(utf16LEOutput, utf16LEExpected)
+        #expect(utf16LEOutput == utf16LEExpected)
 
         let utf16LEOutputSubstring = subString.data(using: String._Encoding.utf16LittleEndian)
-        XCTAssertEqual(utf16LEOutputSubstring, utf16LEExpected)
+        #expect(utf16LEOutputSubstring == utf16LEExpected)
 
         // UTF32 - specific endianness
         
         let utf32BEExpected = Data([0, 0, 0, 104, 0, 0, 0, 101, 0, 0, 0, 108, 0, 0, 0, 108, 0, 0, 0, 111, 0, 0, 0, 32, 0, 1, 249, 238])
         let utf32BEOutput = s.data(using: String._Encoding.utf32BigEndian)
-        XCTAssertEqual(utf32BEOutput, utf32BEExpected)
+        #expect(utf32BEOutput == utf32BEExpected)
 
         let utf32LEExpected = Data([104, 0, 0, 0, 101, 0, 0, 0, 108, 0, 0, 0, 108, 0, 0, 0, 111, 0, 0, 0, 32, 0, 0, 0, 238, 249, 1, 0])
         let utf32LEOutput = s.data(using: String._Encoding.utf32LittleEndian)
-        XCTAssertEqual(utf32LEOutput, utf32LEExpected)
+        #expect(utf32LEOutput == utf32LEExpected)
         
         
         // UTF16 and 32, platform endianness
@@ -934,12 +941,12 @@ final class StringTests : XCTestCase {
         
         if bom.littleEndian == bom {
             // We are on a little endian system. Expect a LE BOM
-            XCTAssertEqual(utf16Output, utf16LEWithBOM)
-            XCTAssertEqual(utf32Output, utf32LEWithBOM)
+            #expect(utf16Output == utf16LEWithBOM)
+            #expect(utf32Output == utf32LEWithBOM)
         } else if bom.bigEndian == bom {
             // We are on a big endian system. Expect a BE BOM
-            XCTAssertEqual(utf16Output, utf16BEWithBOM)
-            XCTAssertEqual(utf32Output, utf32BEWithBOM)
+            #expect(utf16Output == utf16BEWithBOM)
+            #expect(utf32Output == utf32BEWithBOM)
         } else {
             fatalError("Unknown endianness")
         }
@@ -947,73 +954,73 @@ final class StringTests : XCTestCase {
         // UTF16
         
         let utf16BEString = String(bytes: utf16BEExpected, encoding: String._Encoding.utf16BigEndian)
-        XCTAssertEqual(s, utf16BEString)
+        #expect(s == utf16BEString)
         
         let utf16LEString = String(bytes: utf16LEExpected, encoding: String._Encoding.utf16LittleEndian)
-        XCTAssertEqual(s, utf16LEString)
+        #expect(s == utf16LEString)
         
         let utf16LEBOMString = String(bytes: utf16LEWithBOM, encoding: String._Encoding.utf16)
-        XCTAssertEqual(s, utf16LEBOMString)
+        #expect(s == utf16LEBOMString)
         
         let utf16BEBOMString = String(bytes: utf16BEWithBOM, encoding: String._Encoding.utf16)
-        XCTAssertEqual(s, utf16BEBOMString)
+        #expect(s == utf16BEBOMString)
         
         // No BOM, no encoding specified. We assume the data is big endian, which leads to garbage (but not nil).
         let utf16LENoBOMString = String(bytes: utf16LEExpected, encoding: String._Encoding.utf16)
-        XCTAssertNotNil(utf16LENoBOMString)
+        #expect(utf16LENoBOMString != nil)
 
         // No BOM, no encoding specified. We assume the data is big endian, which leads to an expected value.
         let utf16BENoBOMString = String(bytes: utf16BEExpected, encoding: String._Encoding.utf16)
-        XCTAssertEqual(s, utf16BENoBOMString)
+        #expect(s == utf16BENoBOMString)
 
         // UTF32
         
         let utf32BEString = String(bytes: utf32BEExpected, encoding: String._Encoding.utf32BigEndian)
-        XCTAssertEqual(s, utf32BEString)
+        #expect(s == utf32BEString)
         
         let utf32LEString = String(bytes: utf32LEExpected, encoding: String._Encoding.utf32LittleEndian)
-        XCTAssertEqual(s, utf32LEString)
+        #expect(s == utf32LEString)
         
         
         let utf32BEBOMString = String(bytes: utf32BEWithBOM, encoding: String._Encoding.utf32)
-        XCTAssertEqual(s, utf32BEBOMString)
+        #expect(s == utf32BEBOMString)
         
         let utf32LEBOMString = String(bytes: utf32LEWithBOM, encoding: String._Encoding.utf32)
-        XCTAssertEqual(s, utf32LEBOMString)
+        #expect(s == utf32LEBOMString)
         
         // No BOM, no encoding specified. We assume the data is big endian, which leads to a nil.
         let utf32LENoBOMString = String(bytes: utf32LEExpected, encoding: String._Encoding.utf32)
-        XCTAssertNil(utf32LENoBOMString)
+        #expect(utf32LENoBOMString == nil)
         
         // No BOM, no encoding specified. We assume the data is big endian, which leads to an expected value.
         let utf32BENoBOMString = String(bytes: utf32BEExpected, encoding: String._Encoding.utf32)
-        XCTAssertEqual(s, utf32BENoBOMString)
+        #expect(s == utf32BENoBOMString)
 
         // Check what happens when we mismatch a string with a BOM and the encoding. The bytes are interpreted according to the specified encoding regardless of the BOM, the BOM is preserved, and the String will look garbled. However the bytes are preserved as-is. This is the expected behavior for UTF16.
         let utf16LEBOMStringMismatch = String(bytes: utf16LEWithBOM, encoding: String._Encoding.utf16BigEndian)
         let utf16LEBOMStringMismatchBytes = utf16LEBOMStringMismatch?.data(using: String._Encoding.utf16BigEndian)
-        XCTAssertEqual(utf16LEWithBOM, utf16LEBOMStringMismatchBytes)
+        #expect(utf16LEWithBOM == utf16LEBOMStringMismatchBytes)
         
         let utf16BEBOMStringMismatch = String(bytes: utf16BEWithBOM, encoding: String._Encoding.utf16LittleEndian)
         let utf16BEBomStringMismatchBytes = utf16BEBOMStringMismatch?.data(using: String._Encoding.utf16LittleEndian)
-        XCTAssertEqual(utf16BEWithBOM, utf16BEBomStringMismatchBytes)
+        #expect(utf16BEWithBOM == utf16BEBomStringMismatchBytes)
 
         // For a UTF32 mismatch, the string creation simply returns nil.
         let utf32LEBOMStringMismatch = String(bytes: utf32LEWithBOM, encoding: String._Encoding.utf32BigEndian)
-        XCTAssertNil(utf32LEBOMStringMismatch)
+        #expect(utf32LEBOMStringMismatch == nil)
         
         let utf32BEBOMStringMismatch = String(bytes: utf32BEWithBOM, encoding: String._Encoding.utf32LittleEndian)
-        XCTAssertNil(utf32BEBOMStringMismatch)
+        #expect(utf32BEBOMStringMismatch == nil)
         
         // UTF-8 With BOM
         
         let utf8BOM = Data([0xEF, 0xBB, 0xBF])
         let helloWorld = Data("Hello, world".utf8)
-        XCTAssertEqual(String(bytes: utf8BOM + helloWorld, encoding: String._Encoding.utf8), "Hello, world")
-        XCTAssertEqual(String(bytes: helloWorld + utf8BOM, encoding: String._Encoding.utf8), "Hello, world\u{FEFF}")
+        #expect(String(bytes: utf8BOM + helloWorld, encoding: String._Encoding.utf8) == "Hello, world")
+        #expect(String(bytes: helloWorld + utf8BOM, encoding: String._Encoding.utf8) == "Hello, world\u{FEFF}")
     }
 
-    func test_dataUsingEncoding_preservingBOM() {
+    @Test func dataUsingEncoding_preservingBOM() {
         func roundTrip(_ data: Data) -> Bool {
             let str = String(data: data, encoding: .utf8)!
             let strAsUTF16BE = str.data(using: String._Encoding.utf16BigEndian)!
@@ -1024,32 +1031,32 @@ final class StringTests : XCTestCase {
         // Verify that the BOM is preserved through a UTF8/16 transformation.
 
         // ASCII '2' followed by UTF8 BOM
-        XCTAssertTrue(roundTrip(Data([ 0x32, 0xef, 0xbb, 0xbf ])))
+        #expect(roundTrip(Data([ 0x32, 0xef, 0xbb, 0xbf ])))
         
         // UTF8 BOM followed by ASCII '4'
-        XCTAssertTrue(roundTrip(Data([ 0xef, 0xbb, 0xbf, 0x34 ])))
+        #expect(roundTrip(Data([ 0xef, 0xbb, 0xbf, 0x34 ])))
     }
     
-    func test_dataUsingEncoding_ascii() {
-        XCTAssertEqual("abc".data(using: .ascii), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
-        XCTAssertEqual("abc".data(using: .nonLossyASCII), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
-        XCTAssertEqual("e\u{301}\u{301}f".data(using: String._Encoding.ascii), nil)
-        XCTAssertEqual("e\u{301}\u{301}f".data(using: String._Encoding.nonLossyASCII), nil)
+    @Test func dataUsingEncoding_ascii() {
+        #expect("abc".data(using: .ascii) == Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
+        #expect("abc".data(using: .nonLossyASCII) == Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
+        #expect("e\u{301}\u{301}f".data(using: String._Encoding.ascii) == nil)
+        #expect("e\u{301}\u{301}f".data(using: String._Encoding.nonLossyASCII) == nil)
         
-        XCTAssertEqual("abc".data(using: .ascii, allowLossyConversion: true), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
-        XCTAssertEqual("abc".data(using: .nonLossyASCII, allowLossyConversion: true), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
-        XCTAssertEqual("e\u{301}\u{301}f".data(using: .ascii, allowLossyConversion: true), Data([UInt8(ascii: "e"), 0xFF, 0xFF, UInt8(ascii: "f")]))
-        XCTAssertEqual("e\u{301}\u{301}f".data(using: .nonLossyASCII, allowLossyConversion: true), Data([UInt8(ascii: "e"), UInt8(ascii: "?"), UInt8(ascii: "?"), UInt8(ascii: "f")]))
+        #expect("abc".data(using: .ascii, allowLossyConversion: true) == Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
+        #expect("abc".data(using: .nonLossyASCII, allowLossyConversion: true) == Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
+        #expect("e\u{301}\u{301}f".data(using: .ascii, allowLossyConversion: true) == Data([UInt8(ascii: "e"), 0xFF, 0xFF, UInt8(ascii: "f")]))
+        #expect("e\u{301}\u{301}f".data(using: .nonLossyASCII, allowLossyConversion: true) == Data([UInt8(ascii: "e"), UInt8(ascii: "?"), UInt8(ascii: "?"), UInt8(ascii: "f")]))
     }
     
-    func test_initWithBytes_ascii() {
-        XCTAssertEqual(String(bytes: "abc".utf8, encoding: String._Encoding.ascii), "abc")
-        XCTAssertEqual(String(bytes: "abc".utf8, encoding: String._Encoding.nonLossyASCII), "abc")
-        XCTAssertEqual(String(bytes: "e\u{301}\u{301}f".utf8, encoding: String._Encoding.ascii), nil)
-        XCTAssertEqual(String(bytes: "e\u{301}\u{301}f".utf8, encoding: String._Encoding.nonLossyASCII), nil)
+    @Test func initWithBytes_ascii() {
+        #expect(String(bytes: "abc".utf8, encoding: String._Encoding.ascii) == "abc")
+        #expect(String(bytes: "abc".utf8, encoding: String._Encoding.nonLossyASCII) == "abc")
+        #expect(String(bytes: "e\u{301}\u{301}f".utf8, encoding: String._Encoding.ascii) == nil)
+        #expect(String(bytes: "e\u{301}\u{301}f".utf8, encoding: String._Encoding.nonLossyASCII) == nil)
     }
 
-    func test_compressingSlashes() {
+    @Test func compressingSlashes() {
         let testCases: [(String, String)] = [
             ("", ""),                       // Empty string
             ("/", "/"),                     // Single slash
@@ -1067,11 +1074,11 @@ final class StringTests : XCTestCase {
         for (testString, expectedResult) in testCases {
             let result = testString
                 ._compressingSlashes()
-            XCTAssertEqual(result, expectedResult)
+            #expect(result == expectedResult)
         }
     }
 
-    func test_pathHasDotDotComponent() {
+    @Test func pathHasDotDotComponent() {
         let testCases: [(String, Bool)] = [
             ("../AB", true),            // Begins with ..
             ("/ABC/..", true),          // Ends with ..
@@ -1094,61 +1101,45 @@ final class StringTests : XCTestCase {
         for (testString, expectedResult) in testCases {
             let result = testString
                 ._hasDotDotComponent()
-            XCTAssertEqual(result, expectedResult)
+            #expect(result == expectedResult)
         }
     }
 
-    func test_init_contentsOfFile_encoding() {
-        withTemporaryStringFile { existingURL, nonExistentURL in
-            do {
-                let content = try String(contentsOfFile: existingURL.path, encoding: String._Encoding.ascii)
-                expectEqual(temporaryFileContents, content)
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
+    @Test func init_contentsOfFile_encoding() throws {
+        try withTemporaryStringFile { existingURL, nonExistentURL in
+            let content = try String(contentsOfFile: existingURL.path, encoding: String._Encoding.ascii)
+            #expect(temporaryFileContents == content)
 
-            do {
-                let _ = try String(contentsOfFile: nonExistentURL.path, encoding: String._Encoding.ascii)
-                XCTFail()
-            } catch {
+            #expect(throws: (any Error).self) {
+                _ = try String(contentsOfFile: nonExistentURL.path, encoding: String._Encoding.ascii)
             }
         }
     }
 
-    func test_init_contentsOfFile_usedEncoding() {
-        withTemporaryStringFile { existingURL, nonExistentURL in
-            do {
-                var usedEncoding: String._Encoding = String._Encoding(rawValue: 0)
-                let content = try String(contentsOfFile: existingURL.path(), usedEncoding: &usedEncoding)
-                expectNotEqual(0, usedEncoding.rawValue)
-                expectEqual(temporaryFileContents, content)
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
+    @Test func init_contentsOfFile_usedEncoding() throws {
+        try withTemporaryStringFile { existingURL, nonExistentURL in
+            var usedEncoding: String._Encoding = String._Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: existingURL.path(), usedEncoding: &usedEncoding)
+            #expect(0 != usedEncoding.rawValue)
+            #expect(temporaryFileContents == content)
         }
 
     }
 
 
-    func test_init_contentsOf_encoding() {
-        withTemporaryStringFile { existingURL, nonExistentURL in
-            do {
-                let content = try String(contentsOf: existingURL, encoding: String._Encoding.ascii)
-                expectEqual(temporaryFileContents, content)
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
+    @Test func init_contentsOf_encoding() throws {
+        try withTemporaryStringFile { existingURL, nonExistentURL in
+            let content = try String(contentsOf: existingURL, encoding: String._Encoding.ascii)
+            #expect(temporaryFileContents == content)
 
-            do {
+            #expect(throws: (any Error).self) {
                 _ = try String(contentsOf: nonExistentURL, encoding: String._Encoding.ascii)
-                XCTFail()
-            } catch {
             }
         }
 
     }
 
-    func test_init_contentsOf_usedEncoding() {
+    @Test func init_contentsOf_usedEncoding() throws {
 #if FOUNDATION_FRAMEWORK
         let encs : [String._Encoding] = [
             .ascii,
@@ -1197,34 +1188,28 @@ final class StringTests : XCTestCase {
 #endif
         
         for encoding in encs {
-            withTemporaryStringFile(encoding: encoding) { existingURL, _ in
-                do {
-                    var usedEncoding = String._Encoding(rawValue: 0)
-                    let content = try String(contentsOf: existingURL, usedEncoding: &usedEncoding)
-                    
-                    expectEqual(encoding, usedEncoding)
-                    expectEqual(temporaryFileContents, content)
-                } catch {
-                    XCTFail("\(error) - encoding \(encoding)")
-                }
+            try withTemporaryStringFile(encoding: encoding) { existingURL, _ in
+                var usedEncoding = String._Encoding(rawValue: 0)
+                let content = try String(contentsOf: existingURL, usedEncoding: &usedEncoding)
+                
+                #expect(encoding == usedEncoding)
+                #expect(temporaryFileContents == content)
             }
         }
         
         // Test non-existent file
-        withTemporaryStringFile { _, nonExistentURL in
+        try withTemporaryStringFile { _, nonExistentURL in
             var usedEncoding: String._Encoding = String._Encoding(rawValue: 0)
-            do {
+            #expect(throws: (any Error).self) {
                 _ = try String(contentsOf: nonExistentURL, usedEncoding: &usedEncoding)
-                XCTFail()
-            } catch {
-                expectEqual(0, usedEncoding.rawValue)
             }
+            #expect(0 == usedEncoding.rawValue)
         }
     }
     
-    func test_extendedAttributeData() {
-        // XAttr is supported on some platforms, but not all. For now we just test this code on Darwin.
 #if FOUNDATION_FRAMEWORK
+    @Test func extendedAttributeData() throws {
+        // XAttr is supported on some platforms, but not all. For now we just test this code on Darwin.
         let encs : [String._Encoding] = [
             .ascii,
             .nextstep,
@@ -1252,84 +1237,74 @@ final class StringTests : XCTestCase {
         
         for encoding in encs {
             // Round trip the 
-            let packageData = extendedAttributeData(for: encoding)
-            XCTAssertNotNil(packageData)
+            let packageData = try #require(extendedAttributeData(for: encoding))
             
-            let back = encodingFromDataForExtendedAttribute(packageData!)!
-            XCTAssertEqual(back, encoding)
+            let back = encodingFromDataForExtendedAttribute(packageData)
+            #expect(back == encoding)
         }
         
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("us-ascii;1536".data(using: .utf8)!)!.rawValue, String._Encoding.ascii.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("x-nextstep;2817".data(using: .utf8)!)!.rawValue, String._Encoding.nextstep.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("euc-jp;2336".data(using: .utf8)!)!.rawValue, String._Encoding.japaneseEUC.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("utf-8;134217984".data(using: .utf8)!)!.rawValue, String._Encoding.utf8.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("iso-8859-1;513".data(using: .utf8)!)!.rawValue, String._Encoding.isoLatin1.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute(";3071".data(using: .utf8)!)!.rawValue, String._Encoding.nonLossyASCII.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("cp932;1056".data(using: .utf8)!)!.rawValue, String._Encoding.shiftJIS.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("iso-8859-2;514".data(using: .utf8)!)!.rawValue, String._Encoding.isoLatin2.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("utf-16;256".data(using: .utf8)!)!.rawValue, String._Encoding.unicode.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("windows-1251;1282".data(using: .utf8)!)!.rawValue, String._Encoding.windowsCP1251.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("windows-1252;1280".data(using: .utf8)!)!.rawValue, String._Encoding.windowsCP1252.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("windows-1253;1283".data(using: .utf8)!)!.rawValue, String._Encoding.windowsCP1253.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("windows-1254;1284".data(using: .utf8)!)!.rawValue, String._Encoding.windowsCP1254.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("windows-1250;1281".data(using: .utf8)!)!.rawValue, String._Encoding.windowsCP1250.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("iso-2022-jp;2080".data(using: .utf8)!)!.rawValue, String._Encoding.iso2022JP.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("macintosh;0".data(using: .utf8)!)!.rawValue, String._Encoding.macOSRoman.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("utf-16;256".data(using: .utf8)!)!.rawValue, String._Encoding.utf16.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("utf-16be;268435712".data(using: .utf8)!)!.rawValue, String._Encoding.utf16BigEndian.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("utf-16le;335544576".data(using: .utf8)!)!.rawValue, String._Encoding.utf16LittleEndian.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("utf-32;201326848".data(using: .utf8)!)!.rawValue, String._Encoding.utf32.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("utf-32be;402653440".data(using: .utf8)!)!.rawValue, String._Encoding.utf32BigEndian.rawValue)
-        XCTAssertEqual(encodingFromDataForExtendedAttribute("utf-32le;469762304".data(using: .utf8)!)!.rawValue, String._Encoding.utf32LittleEndian.rawValue)
-#endif
+        #expect(encodingFromDataForExtendedAttribute("us-ascii;1536".data(using: .utf8)!)!.rawValue == String._Encoding.ascii.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("x-nextstep;2817".data(using: .utf8)!)!.rawValue == String._Encoding.nextstep.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("euc-jp;2336".data(using: .utf8)!)!.rawValue == String._Encoding.japaneseEUC.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("utf-8;134217984".data(using: .utf8)!)!.rawValue == String._Encoding.utf8.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("iso-8859-1;513".data(using: .utf8)!)!.rawValue == String._Encoding.isoLatin1.rawValue)
+        #expect(encodingFromDataForExtendedAttribute(";3071".data(using: .utf8)!)!.rawValue == String._Encoding.nonLossyASCII.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("cp932;1056".data(using: .utf8)!)!.rawValue == String._Encoding.shiftJIS.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("iso-8859-2;514".data(using: .utf8)!)!.rawValue == String._Encoding.isoLatin2.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("utf-16;256".data(using: .utf8)!)!.rawValue == String._Encoding.unicode.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("windows-1251;1282".data(using: .utf8)!)!.rawValue == String._Encoding.windowsCP1251.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("windows-1252;1280".data(using: .utf8)!)!.rawValue == String._Encoding.windowsCP1252.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("windows-1253;1283".data(using: .utf8)!)!.rawValue == String._Encoding.windowsCP1253.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("windows-1254;1284".data(using: .utf8)!)!.rawValue == String._Encoding.windowsCP1254.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("windows-1250;1281".data(using: .utf8)!)!.rawValue == String._Encoding.windowsCP1250.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("iso-2022-jp;2080".data(using: .utf8)!)!.rawValue == String._Encoding.iso2022JP.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("macintosh;0".data(using: .utf8)!)!.rawValue == String._Encoding.macOSRoman.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("utf-16;256".data(using: .utf8)!)!.rawValue == String._Encoding.utf16.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("utf-16be;268435712".data(using: .utf8)!)!.rawValue == String._Encoding.utf16BigEndian.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("utf-16le;335544576".data(using: .utf8)!)!.rawValue == String._Encoding.utf16LittleEndian.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("utf-32;201326848".data(using: .utf8)!)!.rawValue == String._Encoding.utf32.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("utf-32be;402653440".data(using: .utf8)!)!.rawValue == String._Encoding.utf32BigEndian.rawValue)
+        #expect(encodingFromDataForExtendedAttribute("utf-32le;469762304".data(using: .utf8)!)!.rawValue == String._Encoding.utf32LittleEndian.rawValue)
     }
+#endif
 
-    func test_write_toFile() {
-        withTemporaryStringFile { existingURL, nonExistentURL in
+    @Test func write_toFile() throws {
+        try withTemporaryStringFile { existingURL, nonExistentURL in
             let nonExistentPath = nonExistentURL.path()
-            do {
-                let s = "Lorem ipsum dolor sit amet, consectetur adipisicing elit"
-                try s.write(toFile: nonExistentPath, atomically: false, encoding: String._Encoding.ascii)
+            let s = "Lorem ipsum dolor sit amet, consectetur adipisicing elit"
+            try s.write(toFile: nonExistentPath, atomically: false, encoding: String._Encoding.ascii)
 
-                let content = try String(contentsOfFile: nonExistentPath, encoding: String._Encoding.ascii)
+            let content = try String(contentsOfFile: nonExistentPath, encoding: String._Encoding.ascii)
 
-                expectEqual(s, content)
-            } catch {
-
-                XCTFail(error.localizedDescription)
-            }
+            #expect(s == content)
         }
 
     }
 
-    func test_write_to() {
-        withTemporaryStringFile { existingURL, nonExistentURL in
+    @Test func write_to() throws {
+        try withTemporaryStringFile { existingURL, nonExistentURL in
             let nonExistentPath = nonExistentURL.path()
-            do {
-                let s = "Lorem ipsum dolor sit amet, consectetur adipisicing elit"
-                try s.write(to: nonExistentURL, atomically: false, encoding: String._Encoding.ascii)
-
-                let content = try String(contentsOfFile: nonExistentPath, encoding: String._Encoding.ascii)
-
-                expectEqual(s, content)
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
+            let s = "Lorem ipsum dolor sit amet, consectetur adipisicing elit"
+            try s.write(to: nonExistentURL, atomically: false, encoding: String._Encoding.ascii)
+            
+            let content = try String(contentsOfFile: nonExistentPath, encoding: String._Encoding.ascii)
+            
+            #expect(s == content)
         }
 
     }
     
-    func verifyEncoding(_ encoding: String._Encoding, valid: [String], invalid: [String], file: StaticString = #filePath, line: UInt = #line) throws {
+    func verifyEncoding(_ encoding: String._Encoding, valid: [String], invalid: [String], sourceLocation: SourceLocation = #_sourceLocation) throws {
         for string in valid {
-            let data = try XCTUnwrap(string.data(using: encoding), "Failed to encode \(string.debugDescription)", file: file, line: line)
-            XCTAssertNotNil(String(data: data, encoding: encoding), "Failed to decode \(data) (\(string.debugDescription))", file: file, line: line)
+            let data = try #require(string.data(using: encoding), "Failed to encode \(string.debugDescription)", sourceLocation: sourceLocation)
+            #expect(String(data: data, encoding: encoding) != nil, "Failed to decode \(data) (\(string.debugDescription))", sourceLocation: sourceLocation)
         }
         for string in invalid {
-            XCTAssertNil(string.data(using: String._Encoding.macOSRoman), "Incorrectly successfully encoded \(string.debugDescription)", file: file, line: line)
+            #expect(string.data(using: String._Encoding.macOSRoman) == nil, "Incorrectly successfully encoded \(string.debugDescription)", sourceLocation: sourceLocation)
         }
     }
     
-    func testISOLatin1Encoding() throws {
+    @Test func testISOLatin1Encoding() throws {
         try verifyEncoding(.isoLatin1, valid: [
             "abcdefghijklmnopqrstuvwxyz",
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -1346,7 +1321,7 @@ final class StringTests : XCTestCase {
         ])
     }
     
-    func testMacRomanEncoding() throws {
+    @Test func testMacRomanEncoding() throws {
         try verifyEncoding(.macOSRoman, valid: [
             "abcdefghijklmnopqrstuvwxyz",
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -1366,30 +1341,24 @@ final class StringTests : XCTestCase {
 
 let temporaryFileContents = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 
-func withTemporaryStringFile(encoding: String._Encoding = .utf8, _ block: (_ existingURL: URL, _ nonExistentURL: URL) -> ()) {
+func withTemporaryStringFile(encoding: String._Encoding = .utf8, _ block: (_ existingURL: URL, _ nonExistentURL: URL) throws -> ()) throws {
 
     let rootURL = URL.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
     let fileURL = rootURL.appending(path: "NSStringTest.txt", directoryHint: .notDirectory)
-    try! FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
-    defer {
-        do {
-            try FileManager.default.removeItem(at: rootURL)
-        } catch {
-            XCTFail()
-        }
-    }
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
 
-    try! temporaryFileContents.write(to: fileURL, atomically: true, encoding: encoding)
+    try temporaryFileContents.write(to: fileURL, atomically: true, encoding: encoding)
     
     let nonExisting = rootURL.appending(path: "-NonExist", directoryHint: .notDirectory)
-    block(fileURL, nonExisting)
+    try block(fileURL, nonExisting)
+    try FileManager.default.removeItem(at: rootURL)
 }
 
 // MARK: -
 
 #if FOUNDATION_FRAMEWORK
 
-final class StringTestsStdlib: XCTestCase {
+struct StringTestsStdlib {
 
     // The most simple subclass of NSString that CoreFoundation does not know
     // about.
@@ -1434,17 +1403,17 @@ final class StringTestsStdlib: XCTestCase {
         var _value: [UInt16]
     }
 
-    func test_Encodings() {
+    @Test func Encodings() {
         let availableEncodings: [String.Encoding] = String.availableStringEncodings
-        expectNotEqual(0, availableEncodings.count)
+        #expect(0 != availableEncodings.count)
 
         let defaultCStringEncoding = String.defaultCStringEncoding
-        expectTrue(availableEncodings.contains(defaultCStringEncoding))
+        #expect(availableEncodings.contains(defaultCStringEncoding))
 
-        expectNotEqual("", String.localizedName(of: .utf8))
+        #expect("" != String.localizedName(of: .utf8))
     }
 
-    func test_NSStringEncoding() {
+    @Test func NSStringEncoding() {
         // Make sure NSStringEncoding and its values are type-compatible.
         var enc: String.Encoding
         enc = .windowsCP1250
@@ -1452,10 +1421,10 @@ final class StringTestsStdlib: XCTestCase {
         enc = .utf32BigEndian
         enc = .ascii
         enc = .utf8
-        expectEqual(.utf8, enc)
+        #expect(.utf8 == enc)
     }
 
-    func test_NSStringEncoding_Hashable() {
+    @Test func NSStringEncoding_Hashable() {
         let instances: [String.Encoding] = [
             .windowsCP1250,
             .utf32LittleEndian,
@@ -1463,26 +1432,26 @@ final class StringTestsStdlib: XCTestCase {
             .ascii,
             .utf8,
         ]
-        XCTCheckHashable(instances, equalityOracle: { $0 == $1 })
+        checkHashable(instances, equalityOracle: { $0 == $1 })
     }
 
-    func test_localizedStringWithFormat() {
+    @Test func localizedStringWithFormat() {
         let world: NSString = "world"
-        expectEqual("Hello, world!%42", String.localizedStringWithFormat(
+        #expect("Hello, world!%42" == String.localizedStringWithFormat(
             "Hello, %@!%%%ld", world, 42))
 
-        expectEqual("0.5", String.init(format: "%g", locale: Locale(identifier: "en_US"), 0.5))
-        expectEqual("0,5", String.init(format: "%g", locale: Locale(identifier: "uk"), 0.5))
+        #expect("0.5" == String.init(format: "%g", locale: Locale(identifier: "en_US"), 0.5))
+        #expect("0,5" == String.init(format: "%g", locale: Locale(identifier: "uk"), 0.5))
     }
 
-    func test_init_cString_encoding() {
+    @Test func init_cString_encoding() {
         "foo, a basmati bar!".withCString {
-            expectEqual("foo, a basmati bar!",
+            #expect("foo, a basmati bar!" ==
                         String(cString: $0, encoding: String.defaultCStringEncoding))
         }
     }
 
-    func test_init_utf8String() {
+    @Test func init_utf8String() {
         let s = "foo あいう"
         let up = UnsafeMutablePointer<UInt8>.allocate(capacity: 100)
         var i = 0
@@ -1493,25 +1462,25 @@ final class StringTestsStdlib: XCTestCase {
         up[i] = 0
         let cstr = UnsafeMutableRawPointer(up)
             .bindMemory(to: CChar.self, capacity: 100)
-        expectEqual(s, String(utf8String: cstr))
+        #expect(s == String(utf8String: cstr))
         up.deallocate()
     }
 
-    func test_canBeConvertedToEncoding() {
-        expectTrue("foo".canBeConverted(to: .ascii))
-        expectFalse("あいう".canBeConverted(to: .ascii))
+    @Test func canBeConvertedToEncoding() {
+        #expect("foo".canBeConverted(to: .ascii))
+        #expect(!"あいう".canBeConverted(to: .ascii))
     }
 
-    func test_capitalized() {
-        expectEqual("Foo Foo Foo Foo", "foo Foo fOO FOO".capitalized)
-        expectEqual("Жжж", "жжж".capitalized)
+    @Test func capitalized() {
+        #expect("Foo Foo Foo Foo" == "foo Foo fOO FOO".capitalized)
+        #expect("Жжж" == "жжж".capitalized)
     }
 
-    func test_localizedCapitalized() {
-        expectEqual(
-            "Foo Foo Foo Foo",
+    @Test func localizedCapitalized() {
+        #expect(
+            "Foo Foo Foo Foo" ==
             "foo Foo fOO FOO".capitalized(with: Locale(identifier: "en")))
-        expectEqual("Жжж", "жжж".capitalized(with: Locale(identifier: "en")))
+        #expect("Жжж" == "жжж".capitalized(with: Locale(identifier: "en")))
 
         //
         // Special casing.
@@ -1520,12 +1489,12 @@ final class StringTestsStdlib: XCTestCase {
         // U+0069 LATIN SMALL LETTER I
         // to upper case:
         // U+0049 LATIN CAPITAL LETTER I
-        expectEqual("Iii Iii", "iii III".capitalized(with: Locale(identifier: "en")))
+        #expect("Iii Iii" == "iii III".capitalized(with: Locale(identifier: "en")))
 
         // U+0069 LATIN SMALL LETTER I
         // to upper case in Turkish locale:
         // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE
-        expectEqual("\u{0130}ii Iıı", "iii III".capitalized(with: Locale(identifier: "tr")))
+        #expect("\u{0130}ii Iıı" == "iii III".capitalized(with: Locale(identifier: "tr")))
     }
 
     /// Checks that executing the operation in the locale with the given
@@ -1540,31 +1509,29 @@ final class StringTestsStdlib: XCTestCase {
         _ expected: String,
         _ op: (_: Locale?) -> String,
         _ localeID: String? = nil,
-        _ message: @autoclosure () -> String = "",
+        _ message: @autoclosure () -> Comment? = nil,
         showFrame: Bool = true,
-        file: String = #file, line: UInt = #line
+        sourceLocation: SourceLocation = #_sourceLocation
     ) {
 
         let locale = localeID.map {
             Locale(identifier: $0)
         } ?? nil
 
-        expectEqual(
-            expected, op(locale),
-            message())
+        #expect(expected == op(locale), message(), sourceLocation: sourceLocation)
     }
 
-    func test_capitalizedString() {
+    @Test func capitalizedString() {
         expectLocalizedEquality(
             "Foo Foo Foo Foo",
             { loc in "foo Foo fOO FOO".capitalized(with: loc) })
 
         expectLocalizedEquality("Жжж", { loc in "жжж".capitalized(with: loc) })
 
-        expectEqual(
-            "Foo Foo Foo Foo",
+        #expect(
+            "Foo Foo Foo Foo" ==
             "foo Foo fOO FOO".capitalized(with: nil))
-        expectEqual("Жжж", "жжж".capitalized(with: nil))
+        #expect("Жжж" == "жжж".capitalized(with: nil))
 
         //
         // Special casing.
@@ -1585,67 +1552,67 @@ final class StringTestsStdlib: XCTestCase {
             { loc in "iii III".capitalized(with: loc) }, "tr")
     }
 
-    func test_caseInsensitiveCompare() {
-        expectEqual(ComparisonResult.orderedSame,
+    @Test func caseInsensitiveCompare() {
+        #expect(ComparisonResult.orderedSame ==
                     "abCD".caseInsensitiveCompare("AbCd"))
-        expectEqual(ComparisonResult.orderedAscending,
+        #expect(ComparisonResult.orderedAscending ==
                     "abCD".caseInsensitiveCompare("AbCdE"))
 
-        expectEqual(ComparisonResult.orderedSame,
+        #expect(ComparisonResult.orderedSame ==
                     "абвг".caseInsensitiveCompare("АбВг"))
-        expectEqual(ComparisonResult.orderedAscending,
+        #expect(ComparisonResult.orderedAscending ==
                     "абВГ".caseInsensitiveCompare("АбВгД"))
     }
 
-    func test_commonPrefix() {
-        expectEqual("ab",
+    @Test func commonPrefix() {
+        #expect("ab" ==
                     "abcd".commonPrefix(with: "abdc", options: []))
-        expectEqual("abC",
+        #expect("abC" ==
                     "abCd".commonPrefix(with: "abce", options: .caseInsensitive))
 
-        expectEqual("аб",
+        #expect("аб" ==
                     "абвг".commonPrefix(with: "абгв", options: []))
-        expectEqual("абВ",
+        #expect("абВ" ==
                     "абВг".commonPrefix(with: "абвд", options: .caseInsensitive))
     }
 
-    func test_compare() {
-        expectEqual(ComparisonResult.orderedSame,
+    @Test func compare() {
+        #expect(ComparisonResult.orderedSame ==
                     "abc".compare("abc"))
-        expectEqual(ComparisonResult.orderedAscending,
+        #expect(ComparisonResult.orderedAscending ==
                     "абв".compare("где"))
 
-        expectEqual(ComparisonResult.orderedSame,
+        #expect(ComparisonResult.orderedSame ==
                     "abc".compare("abC", options: .caseInsensitive))
-        expectEqual(ComparisonResult.orderedSame,
+        #expect(ComparisonResult.orderedSame ==
                     "абв".compare("абВ", options: .caseInsensitive))
 
         do {
             let s = "abcd"
             let r = s.index(after: s.startIndex)..<s.endIndex
-            expectEqual(ComparisonResult.orderedSame,
+            #expect(ComparisonResult.orderedSame ==
                         s.compare("bcd", range: r))
         }
         do {
             let s = "абвг"
             let r = s.index(after: s.startIndex)..<s.endIndex
-            expectEqual(ComparisonResult.orderedSame,
+            #expect(ComparisonResult.orderedSame ==
                         s.compare("бвг", range: r))
         }
 
-        expectEqual(ComparisonResult.orderedSame,
+        #expect(ComparisonResult.orderedSame ==
                     "abc".compare("abc", locale: nil))
-        expectEqual(ComparisonResult.orderedSame,
+        #expect(ComparisonResult.orderedSame ==
                     "абв".compare("абв", locale: nil))
     }
 
-    func test_completePath() {
-        withTemporaryStringFile { existingURL, nonExistentURL in
+    @Test func completePath() throws {
+        try withTemporaryStringFile { existingURL, nonExistentURL in
             let existingPath = existingURL.path()
             let nonExistentPath = nonExistentURL.path()
             do {
                 let count = nonExistentPath.completePath(caseSensitive: false)
-                expectEqual(0, count)
+                #expect(0 == count)
             }
 
             do {
@@ -1653,8 +1620,8 @@ final class StringTestsStdlib: XCTestCase {
                 let count = nonExistentPath.completePath(
                     into: &outputName, caseSensitive: false)
 
-                expectEqual(0, count)
-                expectEqual("None Found", outputName)
+                #expect(0 == count)
+                #expect("None Found" == outputName)
             }
 
             do {
@@ -1663,14 +1630,14 @@ final class StringTestsStdlib: XCTestCase {
                 let count = nonExistentPath.completePath(
                     into: &outputName, caseSensitive: false, matchesInto: &outputArray)
 
-                expectEqual(0, count)
-                expectEqual("None Found", outputName)
-                expectEqual(["foo", "bar"], outputArray)
+                #expect(0 == count)
+                #expect("None Found" == outputName)
+                #expect(["foo", "bar"] == outputArray)
             }
 
             do {
                 let count = existingPath.completePath(caseSensitive: false)
-                expectEqual(1, count)
+                #expect(1 == count)
             }
 
             do {
@@ -1678,8 +1645,8 @@ final class StringTestsStdlib: XCTestCase {
                 let count = existingPath.completePath(
                     into: &outputName, caseSensitive: false)
 
-                expectEqual(1, count)
-                expectEqual(existingPath, outputName)
+                #expect(1 == count)
+                #expect(existingPath == outputName)
             }
 
             do {
@@ -1688,9 +1655,9 @@ final class StringTestsStdlib: XCTestCase {
                 let count = existingPath.completePath(
                     into: &outputName, caseSensitive: false, matchesInto: &outputArray)
 
-                expectEqual(1, count)
-                expectEqual(existingPath, outputName)
-                expectEqual([existingPath], outputArray)
+                #expect(1 == count)
+                #expect(existingPath == outputName)
+                #expect([existingPath] == outputArray)
             }
 
             do {
@@ -1698,93 +1665,91 @@ final class StringTestsStdlib: XCTestCase {
                 let count = existingPath.completePath(
                     into: &outputName, caseSensitive: false, filterTypes: ["txt"])
 
-                expectEqual(1, count)
-                expectEqual(existingPath, outputName)
+                #expect(1 == count)
+                #expect(existingPath == outputName)
             }
         }
 
     }
 
-    func test_components_separatedBy_characterSet() {
-        expectEqual([""], "".components(
+    @Test func components_separatedBy_characterSet() {
+        #expect([""] == "".components(
             separatedBy: CharacterSet.decimalDigits))
 
-        expectEqual(
-            ["абв", "", "あいう", "abc"],
+        #expect(
+            ["абв", "", "あいう", "abc"] ==
             "абв12あいう3abc".components(
                 separatedBy: CharacterSet.decimalDigits))
 
-        expectEqual(
-            ["абв", "", "あいう", "abc"],
+        #expect(
+            ["абв", "", "あいう", "abc"] ==
             "абв\u{1F601}\u{1F602}あいう\u{1F603}abc"
                 .components(
                     separatedBy: CharacterSet(charactersIn: "\u{1F601}\u{1F602}\u{1F603}")))
 
         // Performs Unicode scalar comparison.
-        expectEqual(
-            ["abcし\u{3099}def"],
+        #expect(
+            ["abcし\u{3099}def"] ==
             "abcし\u{3099}def".components(
                 separatedBy: CharacterSet(charactersIn: "\u{3058}")))
     }
 
-    func test_components_separatedBy_string() {
-        expectEqual([""], "".components(separatedBy: "//"))
+    @Test func components_separatedBy_string() {
+        #expect([""] == "".components(separatedBy: "//"))
 
-        expectEqual(
-            ["абв", "あいう", "abc"],
+        #expect(
+            ["абв", "あいう", "abc"] ==
             "абв//あいう//abc".components(separatedBy: "//"))
 
         // Performs normalization.
-        expectEqual(
-            ["abc", "def"],
+        #expect(
+            ["abc", "def"] ==
             "abcし\u{3099}def".components(separatedBy: "\u{3058}"))
     }
 
-    func test_cString() {
-        XCTAssertNil("абв".cString(using: .ascii))
+    @Test func cString() {
+        #expect("абв".cString(using: .ascii) == nil)
 
         let expectedBytes: [UInt8] = [ 0xd0, 0xb0, 0xd0, 0xb1, 0xd0, 0xb2, 0 ]
         let expectedStr: [CChar] = expectedBytes.map { CChar(bitPattern: $0) }
-        expectEqual(expectedStr,
+        #expect(expectedStr ==
                     "абв".cString(using: .utf8)!)
     }
 
-     func test_data() {
-         XCTAssertNil("あいう".data(using: .ascii, allowLossyConversion: false))
+     @Test func data() throws {
+         #expect("あいう".data(using: .ascii, allowLossyConversion: false) == nil)
 
          do {
-             let data = "あいう".data(using: .utf8)!
-             let expectedBytes: [UInt8] = [
+             let data = try #require("あいう".data(using: .utf8))
+             let expectedBytes = Data([
                 0xe3, 0x81, 0x82, 0xe3, 0x81, 0x84, 0xe3, 0x81, 0x86
-             ]
+             ])
 
-             expectEqualSequence(expectedBytes, data)
+             #expect(expectedBytes == data)
          }
      }
 
-    func test_init() {
+    @Test func initWithData() {
         let bytes: [UInt8] = [0xe3, 0x81, 0x82, 0xe3, 0x81, 0x84, 0xe3, 0x81, 0x86]
         let data = Data(bytes)
 
-        XCTAssertNil(String(data: data, encoding: .nonLossyASCII))
+        #expect(String(data: data, encoding: .nonLossyASCII) == nil)
 
-        XCTAssertEqual(
-            "あいう",
-            String(data: data, encoding: .utf8)!)
+        #expect("あいう" == String(data: data, encoding: .utf8)!)
     }
 
-    func test_decomposedStringWithCanonicalMapping() {
-        expectEqual("abc", "abc".decomposedStringWithCanonicalMapping)
-        expectEqual("\u{305f}\u{3099}くてん", "だくてん".decomposedStringWithCanonicalMapping)
-        expectEqual("\u{ff80}\u{ff9e}ｸﾃﾝ", "ﾀﾞｸﾃﾝ".decomposedStringWithCanonicalMapping)
+    @Test func decomposedStringWithCanonicalMapping() {
+        #expect("abc" == "abc".decomposedStringWithCanonicalMapping)
+        #expect("\u{305f}\u{3099}くてん" == "だくてん".decomposedStringWithCanonicalMapping)
+        #expect("\u{ff80}\u{ff9e}ｸﾃﾝ" == "ﾀﾞｸﾃﾝ".decomposedStringWithCanonicalMapping)
     }
 
-    func test_decomposedStringWithCompatibilityMapping() {
-        expectEqual("abc", "abc".decomposedStringWithCompatibilityMapping)
-        expectEqual("\u{30bf}\u{3099}クテン", "ﾀﾞｸﾃﾝ".decomposedStringWithCompatibilityMapping)
+    @Test func decomposedStringWithCompatibilityMapping() {
+        #expect("abc" == "abc".decomposedStringWithCompatibilityMapping)
+        #expect("\u{30bf}\u{3099}クテン" == "ﾀﾞｸﾃﾝ".decomposedStringWithCompatibilityMapping)
     }
 
-    func test_enumerateLines() {
+    @Test func enumerateLines() {
         var lines: [String] = []
         "abc\n\ndefghi\njklm".enumerateLines {
             (line: String, stop: inout Bool)
@@ -1794,10 +1759,10 @@ final class StringTestsStdlib: XCTestCase {
                 stop = true
             }
         }
-        expectEqual(["abc", "", "defghi"], lines)
+        #expect(["abc", "", "defghi"] == lines)
     }
 
-    func test_enumerateLinguisticTagsIn() {
+    @Test func enumerateLinguisticTagsIn() {
         let s: String = "Абв. Глокая куздра штеко будланула бокра и кудрячит бокрёнка. Абв."
         let startIndex = s.index(s.startIndex, offsetBy: 5)
         let endIndex = s.index(s.startIndex, offsetBy: 62)
@@ -1819,17 +1784,17 @@ final class StringTestsStdlib: XCTestCase {
                 stop = true
             }
         }
-        expectEqual([
+        #expect([
             NSLinguisticTag.word.rawValue,
             NSLinguisticTag.whitespace.rawValue,
             NSLinguisticTag.word.rawValue
-        ], tags)
-        expectEqual(["Глокая", " ", "куздра"], tokens)
+        ] == tags)
+        #expect(["Глокая", " ", "куздра"] == tokens)
         let sentence = String(s[startIndex..<endIndex])
-        expectEqual([sentence, sentence, sentence], sentences)
+        #expect([sentence, sentence, sentence] == sentences)
     }
 
-    func test_enumerateSubstringsIn() {
+    @Test func enumerateSubstringsIn() {
         let s = "え\u{304b}\u{3099}お\u{263a}\u{fe0f}😀😊"
         let startIndex = s.index(s.startIndex, offsetBy: 1)
         let endIndex = s.index(s.startIndex, offsetBy: 5)
@@ -1843,10 +1808,10 @@ final class StringTestsStdlib: XCTestCase {
                  enclosingRange: Range<String.Index>, stop: inout Bool)
                 in
                 substrings.append(substring!)
-                expectEqual(substring, String(s[substringRange]))
-                expectEqual(substring, String(s[enclosingRange]))
+                #expect(substring == String(s[substringRange]))
+                #expect(substring == String(s[enclosingRange]))
             }
-            expectEqual(["\u{304b}\u{3099}", "お", "☺️", "😀"], substrings)
+            #expect(["\u{304b}\u{3099}", "お", "☺️", "😀"] == substrings)
         }
         do {
             var substrings: [String] = []
@@ -1855,21 +1820,21 @@ final class StringTestsStdlib: XCTestCase {
                 (substring_: String?, substringRange: Range<String.Index>,
                  enclosingRange: Range<String.Index>, stop: inout Bool)
                 in
-                XCTAssertNil(substring_)
+                #expect(substring_ == nil)
                 let substring = s[substringRange]
                 substrings.append(String(substring))
-                expectEqual(substring, s[enclosingRange])
+                #expect(substring == s[enclosingRange])
             }
-            expectEqual(["\u{304b}\u{3099}", "お", "☺️", "😀"], substrings)
+            #expect(["\u{304b}\u{3099}", "お", "☺️", "😀"] == substrings)
         }
     }
 
-    func test_fastestEncoding() {
+    @Test func fastestEncoding() {
         let availableEncodings: [String.Encoding] = String.availableStringEncodings
-        expectTrue(availableEncodings.contains("abc".fastestEncoding))
+        #expect(availableEncodings.contains("abc".fastestEncoding))
     }
 
-    func test_getBytes() {
+    @Test func getBytes() {
         let s = "abc абв def где gh жз zzz"
         let startIndex = s.index(s.startIndex, offsetBy: 8)
         let endIndex = s.index(s.startIndex, offsetBy: 22)
@@ -1887,11 +1852,11 @@ final class StringTestsStdlib: XCTestCase {
                                     encoding: .utf8,
                                     options: [],
                                     range: startIndex..<endIndex, remaining: &remainingRange)
-            expectTrue(result)
-            XCTAssertEqual(expectedStr, buffer)
-            expectEqual(11, usedLength)
-            expectEqual(remainingRange.lowerBound, s.index(startIndex, offsetBy: 8))
-            expectEqual(remainingRange.upperBound, endIndex)
+            #expect(result)
+            #expect(expectedStr == buffer)
+            #expect(11 == usedLength)
+            #expect(remainingRange.lowerBound == s.index(startIndex, offsetBy: 8))
+            #expect(remainingRange.upperBound == endIndex)
         }
         do {
             // 'bufferLength' is limiting.  Note that the buffer is not filled
@@ -1908,11 +1873,11 @@ final class StringTestsStdlib: XCTestCase {
                                     encoding: .utf8,
                                     options: [],
                                     range: startIndex..<endIndex, remaining: &remainingRange)
-            expectTrue(result)
-            XCTAssertEqual(expectedStr, buffer)
-            expectEqual(4, usedLength)
-            expectEqual(remainingRange.lowerBound, s.index(startIndex, offsetBy: 4))
-            expectEqual(remainingRange.upperBound, endIndex)
+            #expect(result)
+            #expect(expectedStr == buffer)
+            #expect(4 == usedLength)
+            #expect(remainingRange.lowerBound == s.index(startIndex, offsetBy: 4))
+            #expect(remainingRange.upperBound == endIndex)
         }
         do {
             // 'range' is converted completely.
@@ -1928,11 +1893,11 @@ final class StringTestsStdlib: XCTestCase {
                                     usedLength: &usedLength, encoding: .utf8,
                                     options: [],
                                     range: startIndex..<endIndex, remaining: &remainingRange)
-            expectTrue(result)
-            XCTAssertEqual(expectedStr, buffer)
-            expectEqual(19, usedLength)
-            expectEqual(remainingRange.lowerBound, endIndex)
-            expectEqual(remainingRange.upperBound, endIndex)
+            #expect(result)
+            #expect(expectedStr == buffer)
+            #expect(19 == usedLength)
+            #expect(remainingRange.lowerBound == endIndex)
+            #expect(remainingRange.upperBound == endIndex)
         }
         do {
             // Inappropriate encoding.
@@ -1948,15 +1913,15 @@ final class StringTestsStdlib: XCTestCase {
                                     usedLength: &usedLength, encoding: .ascii,
                                     options: [],
                                     range: startIndex..<endIndex, remaining: &remainingRange)
-            expectTrue(result)
-            XCTAssertEqual(expectedStr, buffer)
-            expectEqual(4, usedLength)
-            expectEqual(remainingRange.lowerBound, s.index(startIndex, offsetBy: 4))
-            expectEqual(remainingRange.upperBound, endIndex)
+            #expect(result)
+            #expect(expectedStr == buffer)
+            #expect(4 == usedLength)
+            #expect(remainingRange.lowerBound == s.index(startIndex, offsetBy: 4))
+            #expect(remainingRange.upperBound == endIndex)
         }
     }
 
-    func test_getCString() {
+    @Test func getCString() {
         let s = "abc あかさた"
         do {
             // A significantly too small buffer
@@ -1965,10 +1930,10 @@ final class StringTestsStdlib: XCTestCase {
                 repeating: CChar(bitPattern: 0xff), count: bufferLength)
             let result = s.getCString(&buffer, maxLength: 100,
                                       encoding: .utf8)
-            expectFalse(result)
+            #expect(!result)
             let result2 = s.getCString(&buffer, maxLength: 1,
                                        encoding: .utf8)
-            expectFalse(result2)
+            #expect(!result2)
         }
         do {
             // The largest buffer that cannot accommodate the string plus null terminator.
@@ -1977,10 +1942,10 @@ final class StringTestsStdlib: XCTestCase {
                 repeating: CChar(bitPattern: 0xff), count: bufferLength)
             let result = s.getCString(&buffer, maxLength: 100,
                                       encoding: .utf8)
-            expectFalse(result)
+            #expect(!result)
             let result2 = s.getCString(&buffer, maxLength: 16,
                                        encoding: .utf8)
-            expectFalse(result2)
+            #expect(!result2)
         }
         do {
             // The smallest buffer where the result can fit.
@@ -1993,12 +1958,12 @@ final class StringTestsStdlib: XCTestCase {
                 repeating: CChar(bitPattern: 0xff), count: bufferLength)
             let result = s.getCString(&buffer, maxLength: 100,
                                       encoding: .utf8)
-            expectTrue(result)
-            XCTAssertEqual(expectedStr, buffer)
+            #expect(result)
+            #expect(expectedStr == buffer)
             let result2 = s.getCString(&buffer, maxLength: 17,
                                        encoding: .utf8)
-            expectTrue(result2)
-            XCTAssertEqual(expectedStr, buffer)
+            #expect(result2)
+            #expect(expectedStr == buffer)
         }
         do {
             // Limit buffer size with 'maxLength'.
@@ -2007,7 +1972,7 @@ final class StringTestsStdlib: XCTestCase {
                 repeating: CChar(bitPattern: 0xff), count: bufferLength)
             let result = s.getCString(&buffer, maxLength: 8,
                                       encoding: .utf8)
-            expectFalse(result)
+            #expect(!result)
         }
         do {
             // String with unpaired surrogates.
@@ -2017,11 +1982,11 @@ final class StringTestsStdlib: XCTestCase {
                 repeating: CChar(bitPattern: 0xff), count: bufferLength)
             let result = illFormedUTF16.getCString(&buffer, maxLength: 100,
                                                    encoding: .utf8)
-            expectFalse(result)
+            #expect(!result)
         }
     }
 
-    func test_getLineStart() {
+    @Test func getLineStart() {
         let s = "Глокая куздра\nштеко будланула\nбокра и кудрячит\nбокрёнка."
         let r = s.index(s.startIndex, offsetBy: 16)..<s.index(s.startIndex, offsetBy: 35)
         do {
@@ -2030,14 +1995,14 @@ final class StringTestsStdlib: XCTestCase {
             var outContentsEndIndex = s.startIndex
             s.getLineStart(&outStartIndex, end: &outLineEndIndex,
                            contentsEnd: &outContentsEndIndex, for: r)
-            expectEqual("штеко будланула\nбокра и кудрячит\n",
+            #expect("штеко будланула\nбокра и кудрячит\n" ==
                         s[outStartIndex..<outLineEndIndex])
-            expectEqual("штеко будланула\nбокра и кудрячит",
+            #expect("штеко будланула\nбокра и кудрячит" ==
                         s[outStartIndex..<outContentsEndIndex])
         }
     }
 
-    func test_getParagraphStart() {
+    @Test func getParagraphStart() {
         let s = "Глокая куздра\nштеко будланула\u{2028}бокра и кудрячит\u{2028}бокрёнка.\n Абв."
         let r = s.index(s.startIndex, offsetBy: 16)..<s.index(s.startIndex, offsetBy: 35)
         do {
@@ -2046,23 +2011,22 @@ final class StringTestsStdlib: XCTestCase {
             var outContentsEndIndex = s.startIndex
             s.getParagraphStart(&outStartIndex, end: &outEndIndex,
                                 contentsEnd: &outContentsEndIndex, for: r)
-            expectEqual("штеко будланула\u{2028}бокра и кудрячит\u{2028}бокрёнка.\n",
+            #expect("штеко будланула\u{2028}бокра и кудрячит\u{2028}бокрёнка.\n" ==
                         s[outStartIndex..<outEndIndex])
-            expectEqual("штеко будланула\u{2028}бокра и кудрячит\u{2028}бокрёнка.",
+            #expect("штеко будланула\u{2028}бокра и кудрячит\u{2028}бокрёнка." ==
                         s[outStartIndex..<outContentsEndIndex])
         }
     }
 
-    func test_hash() {
+    @Test func hash() {
         let s: String = "abc"
         let nsstr: NSString = "abc"
-        expectEqual(nsstr.hash, s.hash)
+        #expect(nsstr.hash == s.hash)
     }
 
-    func test_init_bytes_encoding() {
+    @Test func init_bytes_encoding() {
         let s = "abc あかさた"
-        expectEqual(
-            s, String(bytes: s.utf8, encoding: .utf8))
+        #expect(s == String(bytes: s.utf8, encoding: .utf8))
 
         /*
          FIXME: Test disabled because the NSString documentation is unclear about
@@ -2076,10 +2040,10 @@ final class StringTestsStdlib: XCTestCase {
     }
 
     @available(*, deprecated)
-    func test_init_bytesNoCopy_length_encoding_freeWhenDone() {
+    @Test func init_bytesNoCopy_length_encoding_freeWhenDone() {
         let s = "abc あかさた"
         var bytes: [UInt8] = Array(s.utf8)
-        expectEqual(s, String(bytesNoCopy: &bytes,
+        #expect(s == String(bytesNoCopy: &bytes,
                               length: bytes.count, encoding: .utf8,
                               freeWhenDone: false))
 
@@ -2094,81 +2058,81 @@ final class StringTestsStdlib: XCTestCase {
         // FIXME: add a test where this function actually returns nil.
     }
 
-    func test_init_utf16CodeUnits_count() {
+    @Test func init_utf16CodeUnits_count() {
         let expected = "abc абв \u{0001F60A}"
         let chars: [unichar] = Array(expected.utf16)
 
-        expectEqual(expected, String(utf16CodeUnits: chars, count: chars.count))
+        #expect(expected == String(utf16CodeUnits: chars, count: chars.count))
     }
 
     @available(*, deprecated)
-    func test_init_utf16CodeUnitsNoCopy() {
+    @Test func init_utf16CodeUnitsNoCopy() {
         let expected = "abc абв \u{0001F60A}"
         let chars: [unichar] = Array(expected.utf16)
 
-        expectEqual(expected, String(utf16CodeUnitsNoCopy: chars,
+        #expect(expected == String(utf16CodeUnitsNoCopy: chars,
                                      count: chars.count, freeWhenDone: false))
     }
 
-    func test_init_format() {
-        expectEqual("", String(format: ""))
-        expectEqual(
-            "abc абв \u{0001F60A}", String(format: "abc абв \u{0001F60A}"))
+    @Test func init_format() {
+        #expect("" == String(format: ""))
+        #expect(
+            "abc абв \u{0001F60A}" == String(format: "abc абв \u{0001F60A}"))
 
         let world: NSString = "world"
-        expectEqual("Hello, world!%42",
+        #expect("Hello, world!%42" ==
                     String(format: "Hello, %@!%%%ld", world, 42))
 
         // test for rdar://problem/18317906
-        expectEqual("3.12", String(format: "%.2f", 3.123456789))
-        expectEqual("3.12", NSString(format: "%.2f", 3.123456789))
+        #expect("3.12" == String(format: "%.2f", 3.123456789))
+        #expect("3.12" == NSString(format: "%.2f", 3.123456789))
     }
 
-    func test_init_format_arguments() {
-        expectEqual("", String(format: "", arguments: []))
-        expectEqual(
-            "abc абв \u{0001F60A}",
+    @Test func init_format_arguments() {
+        #expect("" == String(format: "", arguments: []))
+        #expect(
+            "abc абв \u{0001F60A}" ==
             String(format: "abc абв \u{0001F60A}", arguments: []))
 
         let world: NSString = "world"
         let args: [CVarArg] = [ world, 42 ]
-        expectEqual("Hello, world!%42",
+        #expect("Hello, world!%42" ==
                     String(format: "Hello, %@!%%%ld", arguments: args))
     }
 
-    func test_init_format_locale() {
+    @Test func init_format_locale() {
         let world: NSString = "world"
-        expectEqual("Hello, world!%42", String(format: "Hello, %@!%%%ld",
+        #expect("Hello, world!%42" == String(format: "Hello, %@!%%%ld",
                                                locale: nil, world, 42))
     }
 
-    func test_init_format_locale_arguments() {
+    @Test func init_format_locale_arguments() {
         let world: NSString = "world"
         let args: [CVarArg] = [ world, 42 ]
-        expectEqual("Hello, world!%42", String(format: "Hello, %@!%%%ld",
+        #expect("Hello, world!%42" == String(format: "Hello, %@!%%%ld",
                                                locale: nil, arguments: args))
     }
 
-    func test_utf16Count() {
-        expectEqual(1, "a".utf16.count)
-        expectEqual(2, "\u{0001F60A}".utf16.count)
+    @Test func utf16Count() {
+        #expect(1 == "a".utf16.count)
+        #expect(2 == "\u{0001F60A}".utf16.count)
     }
 
-    func test_lengthOfBytesUsingEncoding() {
-        expectEqual(1, "a".lengthOfBytes(using: .utf8))
-        expectEqual(2, "あ".lengthOfBytes(using: .shiftJIS))
+    @Test func lengthOfBytesUsingEncoding() {
+        #expect(1 == "a".lengthOfBytes(using: .utf8))
+        #expect(2 == "あ".lengthOfBytes(using: .shiftJIS))
     }
 
-    func test_lineRangeFor() {
+    @Test func lineRangeFor() {
         let s = "Глокая куздра\nштеко будланула\nбокра и кудрячит\nбокрёнка."
         let r = s.index(s.startIndex, offsetBy: 16)..<s.index(s.startIndex, offsetBy: 35)
         do {
             let result = s.lineRange(for: r)
-            expectEqual("штеко будланула\nбокра и кудрячит\n", s[result])
+            #expect("штеко будланула\nбокра и кудрячит\n" == s[result])
         }
     }
 
-    func test_linguisticTagsIn() {
+    @Test func linguisticTagsIn() {
         let s: String = "Абв. Глокая куздра штеко будланула бокра и кудрячит бокрёнка. Абв."
         let startIndex = s.index(s.startIndex, offsetBy: 5)
         let endIndex = s.index(s.startIndex, offsetBy: 17)
@@ -2178,50 +2142,50 @@ final class StringTestsStdlib: XCTestCase {
                                     scheme: scheme.rawValue,
                                     options: [],
                                     orthography: nil, tokenRanges: &tokenRanges)
-        expectEqual([
+        #expect([
             NSLinguisticTag.word.rawValue,
             NSLinguisticTag.whitespace.rawValue,
             NSLinguisticTag.word.rawValue
-        ], tags)
-        expectEqual(["Глокая", " ", "куздра"],
+        ] == tags)
+        #expect(["Глокая", " ", "куздра"] ==
                     tokenRanges.map { String(s[$0]) } )
     }
 
-    func test_localizedCaseInsensitiveCompare() {
-        expectEqual(ComparisonResult.orderedSame,
+    @Test func localizedCaseInsensitiveCompare() {
+        #expect(ComparisonResult.orderedSame ==
                     "abCD".localizedCaseInsensitiveCompare("AbCd"))
-        expectEqual(ComparisonResult.orderedAscending,
+        #expect(ComparisonResult.orderedAscending ==
                     "abCD".localizedCaseInsensitiveCompare("AbCdE"))
 
-        expectEqual(ComparisonResult.orderedSame,
+        #expect(ComparisonResult.orderedSame ==
                     "абвг".localizedCaseInsensitiveCompare("АбВг"))
-        expectEqual(ComparisonResult.orderedAscending,
+        #expect(ComparisonResult.orderedAscending ==
                     "абВГ".localizedCaseInsensitiveCompare("АбВгД"))
     }
 
-    func test_localizedCompare() {
-        expectEqual(ComparisonResult.orderedAscending,
+    @Test func localizedCompare() {
+        #expect(ComparisonResult.orderedAscending ==
                     "abCD".localizedCompare("AbCd"))
 
-        expectEqual(ComparisonResult.orderedAscending,
+        #expect(ComparisonResult.orderedAscending ==
                     "абвг".localizedCompare("АбВг"))
     }
 
-    func test_localizedStandardCompare() {
-        expectEqual(ComparisonResult.orderedAscending,
+    @Test func localizedStandardCompare() {
+        #expect(ComparisonResult.orderedAscending ==
                     "abCD".localizedStandardCompare("AbCd"))
 
-        expectEqual(ComparisonResult.orderedAscending,
+        #expect(ComparisonResult.orderedAscending ==
                     "абвг".localizedStandardCompare("АбВг"))
     }
 
-    func test_localizedLowercase() {
+    @Test func localizedLowercase() {
         let en = Locale(identifier: "en")
         let ru = Locale(identifier: "ru")
-        expectEqual("abcd", "abCD".lowercased(with: en))
-        expectEqual("абвг", "абВГ".lowercased(with: en))
-        expectEqual("абвг", "абВГ".lowercased(with: ru))
-        expectEqual("たちつてと", "たちつてと".lowercased(with: ru))
+        #expect("abcd" == "abCD".lowercased(with: en))
+        #expect("абвг" == "абВГ".lowercased(with: en))
+        #expect("абвг" == "абВГ".lowercased(with: ru))
+        #expect("たちつてと" == "たちつてと".lowercased(with: ru))
 
         //
         // Special casing.
@@ -2231,28 +2195,28 @@ final class StringTestsStdlib: XCTestCase {
         // to lower case:
         // U+0069 LATIN SMALL LETTER I
         // U+0307 COMBINING DOT ABOVE
-        expectEqual("\u{0069}\u{0307}", "\u{0130}".lowercased(with: Locale(identifier: "en")))
+        #expect("\u{0069}\u{0307}" == "\u{0130}".lowercased(with: Locale(identifier: "en")))
 
         // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE
         // to lower case in Turkish locale:
         // U+0069 LATIN SMALL LETTER I
-        expectEqual("\u{0069}", "\u{0130}".lowercased(with: Locale(identifier: "tr")))
+        #expect("\u{0069}" == "\u{0130}".lowercased(with: Locale(identifier: "tr")))
 
         // U+0049 LATIN CAPITAL LETTER I
         // U+0307 COMBINING DOT ABOVE
         // to lower case:
         // U+0069 LATIN SMALL LETTER I
         // U+0307 COMBINING DOT ABOVE
-        expectEqual("\u{0069}\u{0307}", "\u{0049}\u{0307}".lowercased(with: Locale(identifier: "en")))
+        #expect("\u{0069}\u{0307}" == "\u{0049}\u{0307}".lowercased(with: Locale(identifier: "en")))
 
         // U+0049 LATIN CAPITAL LETTER I
         // U+0307 COMBINING DOT ABOVE
         // to lower case in Turkish locale:
         // U+0069 LATIN SMALL LETTER I
-        expectEqual("\u{0069}", "\u{0049}\u{0307}".lowercased(with: Locale(identifier: "tr")))
+        #expect("\u{0069}" == "\u{0049}\u{0307}".lowercased(with: Locale(identifier: "tr")))
     }
 
-    func test_lowercased() {
+    @Test func lowercased() {
         expectLocalizedEquality("abcd", { loc in "abCD".lowercased(with: loc) }, "en")
 
         expectLocalizedEquality("абвг", { loc in "абВГ".lowercased(with: loc) }, "en")
@@ -2289,139 +2253,136 @@ final class StringTestsStdlib: XCTestCase {
         expectLocalizedEquality("\u{0069}", { loc in "\u{0049}\u{0307}".lowercased(with: loc) }, "tr")
     }
 
-    func test_maximumLengthOfBytesUsingEncoding() {
+    @Test func maximumLengthOfBytesUsingEncoding() {
         do {
             let s = "abc"
-            XCTAssertLessThanOrEqual(s.utf8.count,
-                                     s.maximumLengthOfBytes(using: .utf8))
+            #expect(s.utf8.count <= s.maximumLengthOfBytes(using: .utf8))
         }
         do {
             let s = "abc абв"
-            XCTAssertLessThanOrEqual(s.utf8.count,
-                                     s.maximumLengthOfBytes(using: .utf8))
+            #expect(s.utf8.count <= s.maximumLengthOfBytes(using: .utf8))
         }
         do {
             let s = "\u{1F60A}"
-            XCTAssertLessThanOrEqual(s.utf8.count,
-                                     s.maximumLengthOfBytes(using: .utf8))
+            #expect(s.utf8.count <= s.maximumLengthOfBytes(using: .utf8))
         }
     }
 
-    func test_paragraphRangeFor() {
+    @Test func paragraphRangeFor() {
         let s = "Глокая куздра\nштеко будланула\u{2028}бокра и кудрячит\u{2028}бокрёнка.\n Абв."
         let r = s.index(s.startIndex, offsetBy: 16)..<s.index(s.startIndex, offsetBy: 35)
         do {
             let result = s.paragraphRange(for: r)
-            expectEqual("штеко будланула\u{2028}бокра и кудрячит\u{2028}бокрёнка.\n", s[result])
+            #expect("штеко будланула\u{2028}бокра и кудрячит\u{2028}бокрёнка.\n" == s[result])
         }
     }
 
-    func test_pathComponents() {
-        expectEqual([ "/", "foo", "bar" ] as [NSString], ("/foo/bar" as NSString).pathComponents as [NSString])
-        expectEqual([ "/", "абв", "где" ] as [NSString], ("/абв/где" as NSString).pathComponents as [NSString])
+    @Test func pathComponents() {
+        #expect([ "/", "foo", "bar" ] as [NSString] == ("/foo/bar" as NSString).pathComponents as [NSString])
+        #expect([ "/", "абв", "где" ] as [NSString] == ("/абв/где" as NSString).pathComponents as [NSString])
     }
 
-    func test_precomposedStringWithCanonicalMapping() {
-        expectEqual("abc", "abc".precomposedStringWithCanonicalMapping)
-        expectEqual("だくてん",
+    @Test func precomposedStringWithCanonicalMapping() {
+        #expect("abc" == "abc".precomposedStringWithCanonicalMapping)
+        #expect("だくてん" ==
                     "\u{305f}\u{3099}くてん".precomposedStringWithCanonicalMapping)
-        expectEqual("ﾀﾞｸﾃﾝ",
+        #expect("ﾀﾞｸﾃﾝ" ==
                     "\u{ff80}\u{ff9e}ｸﾃﾝ".precomposedStringWithCanonicalMapping)
-        expectEqual("\u{fb03}", "\u{fb03}".precomposedStringWithCanonicalMapping)
+        #expect("\u{fb03}" == "\u{fb03}".precomposedStringWithCanonicalMapping)
     }
 
-    func test_precomposedStringWithCompatibilityMapping() {
-        expectEqual("abc", "abc".precomposedStringWithCompatibilityMapping)
+    @Test func precomposedStringWithCompatibilityMapping() {
+        #expect("abc" == "abc".precomposedStringWithCompatibilityMapping)
         /*
          Test disabled because of:
          <rdar://problem/17041347> NFKD normalization as implemented by
          'precomposedStringWithCompatibilityMapping:' is not idempotent
 
-         expectEqual("\u{30c0}クテン",
+         #expect("\u{30c0}クテン" ==
          "\u{ff80}\u{ff9e}ｸﾃﾝ".precomposedStringWithCompatibilityMapping)
          */
-        expectEqual("ffi", "\u{fb03}".precomposedStringWithCompatibilityMapping)
+        #expect("ffi" == "\u{fb03}".precomposedStringWithCompatibilityMapping)
     }
 
-    func test_propertyList() {
-        expectEqual(["foo", "bar"],
+    @Test func propertyList() {
+        #expect(["foo", "bar"] ==
                     "(\"foo\", \"bar\")".propertyList() as! [String])
     }
 
-    func test_propertyListFromStringsFileFormat() {
-        expectEqual(["foo": "bar", "baz": "baz"],
+    @Test func propertyListFromStringsFileFormat() {
+        #expect(["foo": "bar", "baz": "baz"] ==
                     "/* comment */\n\"foo\" = \"bar\";\n\"baz\";"
             .propertyListFromStringsFileFormat() as Dictionary<String, String>)
     }
 
-    func test_rangeOfCharacterFrom() {
+    @Test func rangeOfCharacterFrom() {
         do {
             let charset = CharacterSet(charactersIn: "абв")
             do {
                 let s = "Глокая куздра"
                 let r = s.rangeOfCharacter(from: charset)!
-                expectEqual(s.index(s.startIndex, offsetBy: 4), r.lowerBound)
-                expectEqual(s.index(s.startIndex, offsetBy: 5), r.upperBound)
+                #expect(s.index(s.startIndex, offsetBy: 4) == r.lowerBound)
+                #expect(s.index(s.startIndex, offsetBy: 5) == r.upperBound)
             }
             do {
-                XCTAssertNil("клмн".rangeOfCharacter(from: charset))
+                #expect("клмн".rangeOfCharacter(from: charset) == nil)
             }
             do {
                 let s = "абвклмнабвклмн"
                 let r = s.rangeOfCharacter(from: charset,
                                            options: .backwards)!
-                expectEqual(s.index(s.startIndex, offsetBy: 9), r.lowerBound)
-                expectEqual(s.index(s.startIndex, offsetBy: 10), r.upperBound)
+                #expect(s.index(s.startIndex, offsetBy: 9) == r.lowerBound)
+                #expect(s.index(s.startIndex, offsetBy: 10) == r.upperBound)
             }
             do {
                 let s = "абвклмнабв"
                 let r = s.rangeOfCharacter(from: charset,
                                            range: s.index(s.startIndex, offsetBy: 3)..<s.endIndex)!
-                expectEqual(s.index(s.startIndex, offsetBy: 7), r.lowerBound)
-                expectEqual(s.index(s.startIndex, offsetBy: 8), r.upperBound)
+                #expect(s.index(s.startIndex, offsetBy: 7) == r.lowerBound)
+                #expect(s.index(s.startIndex, offsetBy: 8) == r.upperBound)
             }
         }
 
         do {
             let charset = CharacterSet(charactersIn: "\u{305f}\u{3099}")
-            XCTAssertNil("\u{3060}".rangeOfCharacter(from: charset))
+            #expect("\u{3060}".rangeOfCharacter(from: charset) == nil)
         }
         do {
             let charset = CharacterSet(charactersIn: "\u{3060}")
-            XCTAssertNil("\u{305f}\u{3099}".rangeOfCharacter(from: charset))
+            #expect("\u{305f}\u{3099}".rangeOfCharacter(from: charset) == nil)
         }
 
         do {
             let charset = CharacterSet(charactersIn: "\u{1F600}")
             do {
                 let s = "abc\u{1F600}"
-                expectEqual("\u{1F600}",
+                #expect("\u{1F600}" ==
                             s[s.rangeOfCharacter(from: charset)!])
             }
             do {
-                XCTAssertNil("abc\u{1F601}".rangeOfCharacter(from: charset))
+                #expect("abc\u{1F601}".rangeOfCharacter(from: charset) == nil)
             }
         }
     }
 
-    func test_rangeOfComposedCharacterSequence() {
+    @Test func rangeOfComposedCharacterSequence() {
         let s = "\u{1F601}abc \u{305f}\u{3099} def"
-        expectEqual("\u{1F601}", s[s.rangeOfComposedCharacterSequence(
+        #expect("\u{1F601}" == s[s.rangeOfComposedCharacterSequence(
             at: s.startIndex)])
-        expectEqual("a", s[s.rangeOfComposedCharacterSequence(
+        #expect("a" == s[s.rangeOfComposedCharacterSequence(
             at: s.index(s.startIndex, offsetBy: 1))])
-        expectEqual("\u{305f}\u{3099}", s[s.rangeOfComposedCharacterSequence(
+        #expect("\u{305f}\u{3099}" == s[s.rangeOfComposedCharacterSequence(
             at: s.index(s.startIndex, offsetBy: 5))])
-        expectEqual(" ", s[s.rangeOfComposedCharacterSequence(
+        #expect(" " == s[s.rangeOfComposedCharacterSequence(
             at: s.index(s.startIndex, offsetBy: 6))])
     }
 
-    func test_rangeOfComposedCharacterSequences() {
+    @Test func rangeOfComposedCharacterSequences() {
         let s = "\u{1F601}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}"
 
-        expectEqual("\u{1F601}a", s[s.rangeOfComposedCharacterSequences(
+        #expect("\u{1F601}a" == s[s.rangeOfComposedCharacterSequences(
             for: s.startIndex..<s.index(s.startIndex, offsetBy: 2))])
-        expectEqual("せ\u{3099}そ\u{3099}", s[s.rangeOfComposedCharacterSequences(
+        #expect("せ\u{3099}そ\u{3099}" == s[s.rangeOfComposedCharacterSequences(
             for: s.index(s.startIndex, offsetBy: 8)..<s.index(s.startIndex, offsetBy: 10))])
     }
 
@@ -2433,110 +2394,110 @@ final class StringTestsStdlib: XCTestCase {
         return string.distance(from: string.startIndex, to: range.lowerBound) ..< string.distance(from: string.startIndex, to: range.upperBound)
     }
 
-    func test_range() {
+    @Test func range() {
         do {
             let s = ""
-            XCTAssertNil(s.range(of: ""))
-            XCTAssertNil(s.range(of: "abc"))
+            #expect(s.range(of: "") == nil)
+            #expect(s.range(of: "abc") == nil)
         }
         do {
             let s = "abc"
-            XCTAssertNil(s.range(of: ""))
-            XCTAssertNil(s.range(of: "def"))
-            expectEqual(0..<3, toIntRange(s, s.range(of: "abc")))
+            #expect(s.range(of: "") == nil)
+            #expect(s.range(of: "def") == nil)
+            #expect(0..<3 == toIntRange(s, s.range(of: "abc")))
         }
         do {
             let s = "さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}"
-            expectEqual(2..<3, toIntRange(s, s.range(of: "す\u{3099}")))
-            expectEqual(2..<3, toIntRange(s, s.range(of: "\u{305a}")))
+            #expect(2..<3 == toIntRange(s, s.range(of: "す\u{3099}")))
+            #expect(2..<3 == toIntRange(s, s.range(of: "\u{305a}")))
 
-            XCTAssertNil(s.range(of: "\u{3099}す"))
-            XCTAssertNil(s.range(of: "す"))
+            #expect(s.range(of: "\u{3099}す") == nil)
+            #expect(s.range(of: "す") == nil)
 
-            XCTAssertNil(s.range(of: "\u{3099}"))
-            expectEqual("\u{3099}", s[s.range(of: "\u{3099}", options: .literal)!])
+            #expect(s.range(of: "\u{3099}") == nil)
+            #expect("\u{3099}" == s[s.range(of: "\u{3099}", options: .literal)!])
         }
         do {
             let s = "а\u{0301}б\u{0301}в\u{0301}г\u{0301}"
-            expectEqual(0..<1, toIntRange(s, s.range(of: "а\u{0301}")))
-            expectEqual(1..<2, toIntRange(s, s.range(of: "б\u{0301}")))
+            #expect(0..<1 == toIntRange(s, s.range(of: "а\u{0301}")))
+            #expect(1..<2 == toIntRange(s, s.range(of: "б\u{0301}")))
 
-            XCTAssertNil(s.range(of: "б"))
-            XCTAssertNil(s.range(of: "\u{0301}б"))
+            #expect(s.range(of: "б") == nil)
+            #expect(s.range(of: "\u{0301}б") == nil)
 
-            XCTAssertNil(s.range(of: "\u{0301}"))
-            expectEqual("\u{0301}", s[s.range(of: "\u{0301}", options: .literal)!])
+            #expect(s.range(of: "\u{0301}") == nil)
+            #expect("\u{0301}" == s[s.range(of: "\u{0301}", options: .literal)!])
         }
     }
 
-    func test_contains() {
-            expectFalse("".contains(""))
-            expectFalse("".contains("a"))
-            expectFalse("a".contains(""))
-            expectFalse("a".contains("b"))
-            expectTrue("a".contains("a"))
-            expectFalse("a".contains("A"))
-            expectFalse("A".contains("a"))
-            expectFalse("a".contains("a\u{0301}"))
-            expectTrue("a\u{0301}".contains("a\u{0301}"))
-            expectFalse("a\u{0301}".contains("a"))
-            expectFalse("a\u{0301}".contains("\u{0301}")) // Update to match stdlib's `firstRange` and `contains` result
-            expectFalse("a".contains("\u{0301}"))
+    @Test func contains() {
+            #expect(!"".contains(""))
+            #expect(!"".contains("a"))
+            #expect(!"a".contains(""))
+            #expect(!"a".contains("b"))
+            #expect("a".contains("a"))
+            #expect(!"a".contains("A"))
+            #expect(!"A".contains("a"))
+            #expect(!"a".contains("a\u{0301}"))
+            #expect("a\u{0301}".contains("a\u{0301}"))
+            #expect(!"a\u{0301}".contains("a"))
+            #expect(!"a\u{0301}".contains("\u{0301}")) // Update to match stdlib's `firstRange` and `contains` result
+            #expect(!"a".contains("\u{0301}"))
 
-            expectFalse("i".contains("I"))
-            expectFalse("I".contains("i"))
-            expectFalse("\u{0130}".contains("i"))
-            expectFalse("i".contains("\u{0130}"))
-            expectFalse("\u{0130}".contains("ı"))
+            #expect(!"i".contains("I"))
+            #expect(!"I".contains("i"))
+            #expect(!"\u{0130}".contains("i"))
+            #expect(!"i".contains("\u{0130}"))
+            #expect(!"\u{0130}".contains("ı"))
     }
 
-    func test_localizedCaseInsensitiveContains() {
+    @Test func localizedCaseInsensitiveContains() {
         let en = Locale(identifier: "en")
-        expectFalse("".localizedCaseInsensitiveContains("", locale: en))
-        expectFalse("".localizedCaseInsensitiveContains("a", locale: en))
-        expectFalse("a".localizedCaseInsensitiveContains("", locale: en))
-        expectFalse("a".localizedCaseInsensitiveContains("b", locale: en))
-        expectTrue("a".localizedCaseInsensitiveContains("a", locale: en))
-        expectTrue("a".localizedCaseInsensitiveContains("A", locale: en))
-        expectTrue("A".localizedCaseInsensitiveContains("a", locale: en))
-        expectFalse("a".localizedCaseInsensitiveContains("a\u{0301}", locale: en))
-        expectTrue("a\u{0301}".localizedCaseInsensitiveContains("a\u{0301}", locale: en))
-        expectFalse("a\u{0301}".localizedCaseInsensitiveContains("a", locale: en))
-        expectTrue("a\u{0301}".localizedCaseInsensitiveContains("\u{0301}", locale: en))
-        expectFalse("a".localizedCaseInsensitiveContains("\u{0301}", locale: en))
+        #expect(!"".localizedCaseInsensitiveContains("", locale: en))
+        #expect(!"".localizedCaseInsensitiveContains("a", locale: en))
+        #expect(!"a".localizedCaseInsensitiveContains("", locale: en))
+        #expect(!"a".localizedCaseInsensitiveContains("b", locale: en))
+        #expect("a".localizedCaseInsensitiveContains("a", locale: en))
+        #expect("a".localizedCaseInsensitiveContains("A", locale: en))
+        #expect("A".localizedCaseInsensitiveContains("a", locale: en))
+        #expect(!"a".localizedCaseInsensitiveContains("a\u{0301}", locale: en))
+        #expect("a\u{0301}".localizedCaseInsensitiveContains("a\u{0301}", locale: en))
+        #expect(!"a\u{0301}".localizedCaseInsensitiveContains("a", locale: en))
+        #expect("a\u{0301}".localizedCaseInsensitiveContains("\u{0301}", locale: en))
+        #expect(!"a".localizedCaseInsensitiveContains("\u{0301}", locale: en))
 
-        expectTrue("i".localizedCaseInsensitiveContains("I", locale: en))
-        expectTrue("I".localizedCaseInsensitiveContains("i", locale: en))
-        expectFalse("\u{0130}".localizedCaseInsensitiveContains("i", locale: en))
-        expectFalse("i".localizedCaseInsensitiveContains("\u{0130}", locale: en))
+        #expect("i".localizedCaseInsensitiveContains("I", locale: en))
+        #expect("I".localizedCaseInsensitiveContains("i", locale: en))
+        #expect(!"\u{0130}".localizedCaseInsensitiveContains("i", locale: en))
+        #expect(!"i".localizedCaseInsensitiveContains("\u{0130}", locale: en))
 
-        expectFalse("\u{0130}".localizedCaseInsensitiveContains("ı", locale: Locale(identifier: "tr")))
+        #expect(!"\u{0130}".localizedCaseInsensitiveContains("ı", locale: Locale(identifier: "tr")))
     }
 
-    func test_localizedStandardContains() {
+    @Test func localizedStandardContains() {
         let en = Locale(identifier: "en")
-        expectFalse("".localizedStandardContains("", locale: en))
-        expectFalse("".localizedStandardContains("a", locale: en))
-        expectFalse("a".localizedStandardContains("", locale: en))
-        expectFalse("a".localizedStandardContains("b", locale: en))
-        expectTrue("a".localizedStandardContains("a", locale: en))
-        expectTrue("a".localizedStandardContains("A", locale: en))
-        expectTrue("A".localizedStandardContains("a", locale: en))
-        expectTrue("a".localizedStandardContains("a\u{0301}", locale: en))
-        expectTrue("a\u{0301}".localizedStandardContains("a\u{0301}", locale: en))
-        expectTrue("a\u{0301}".localizedStandardContains("a", locale: en))
-        expectTrue("a\u{0301}".localizedStandardContains("\u{0301}", locale: en))
-        expectFalse("a".localizedStandardContains("\u{0301}", locale: en))
+        #expect(!"".localizedStandardContains("", locale: en))
+        #expect(!"".localizedStandardContains("a", locale: en))
+        #expect(!"a".localizedStandardContains("", locale: en))
+        #expect(!"a".localizedStandardContains("b", locale: en))
+        #expect("a".localizedStandardContains("a", locale: en))
+        #expect("a".localizedStandardContains("A", locale: en))
+        #expect("A".localizedStandardContains("a", locale: en))
+        #expect("a".localizedStandardContains("a\u{0301}", locale: en))
+        #expect("a\u{0301}".localizedStandardContains("a\u{0301}", locale: en))
+        #expect("a\u{0301}".localizedStandardContains("a", locale: en))
+        #expect("a\u{0301}".localizedStandardContains("\u{0301}", locale: en))
+        #expect(!"a".localizedStandardContains("\u{0301}", locale: en))
 
-        expectTrue("i".localizedStandardContains("I", locale: en))
-        expectTrue("I".localizedStandardContains("i", locale: en))
-        expectTrue("\u{0130}".localizedStandardContains("i", locale: en))
-        expectTrue("i".localizedStandardContains("\u{0130}", locale: en))
+        #expect("i".localizedStandardContains("I", locale: en))
+        #expect("I".localizedStandardContains("i", locale: en))
+        #expect("\u{0130}".localizedStandardContains("i", locale: en))
+        #expect("i".localizedStandardContains("\u{0130}", locale: en))
 
-        expectTrue("\u{0130}".localizedStandardContains("ı", locale: Locale(identifier: "tr")))
+        #expect("\u{0130}".localizedStandardContains("ı", locale: Locale(identifier: "tr")))
     }
 
-    func test_localizedStandardRange() {
+    @Test func localizedStandardRange() {
         func rangeOf(_ string: String, _ substring: String, locale: Locale) -> Range<Int>? {
             return toIntRange(
                 string, string.localizedStandardRange(of: substring, locale: locale))
@@ -2544,70 +2505,70 @@ final class StringTestsStdlib: XCTestCase {
 
         let en = Locale(identifier: "en")
 
-        XCTAssertNil(rangeOf("", "", locale: en))
-        XCTAssertNil(rangeOf("", "a", locale: en))
-        XCTAssertNil(rangeOf("a", "", locale: en))
-        XCTAssertNil(rangeOf("a", "b", locale: en))
-        expectEqual(0..<1, rangeOf("a", "a", locale: en))
-        expectEqual(0..<1, rangeOf("a", "A", locale: en))
-        expectEqual(0..<1, rangeOf("A", "a", locale: en))
-        expectEqual(0..<1, rangeOf("a", "a\u{0301}", locale: en))
-        expectEqual(0..<1, rangeOf("a\u{0301}", "a\u{0301}", locale: en))
-        expectEqual(0..<1, rangeOf("a\u{0301}", "a", locale: en))
+        #expect(rangeOf("", "", locale: en) == nil)
+        #expect(rangeOf("", "a", locale: en) == nil)
+        #expect(rangeOf("a", "", locale: en) == nil)
+        #expect(rangeOf("a", "b", locale: en) == nil)
+        #expect(0..<1 == rangeOf("a", "a", locale: en))
+        #expect(0..<1 == rangeOf("a", "A", locale: en))
+        #expect(0..<1 == rangeOf("A", "a", locale: en))
+        #expect(0..<1 == rangeOf("a", "a\u{0301}", locale: en))
+        #expect(0..<1 == rangeOf("a\u{0301}", "a\u{0301}", locale: en))
+        #expect(0..<1 == rangeOf("a\u{0301}", "a", locale: en))
         do {
         // FIXME: Indices that don't correspond to grapheme cluster boundaries.
-        let s = "a\u{0301}"
-        expectEqual(
-            "\u{0301}", s[s.localizedStandardRange(of: "\u{0301}", locale: en)!])
+            let s = "a\u{0301}"
+            #expect(
+                "\u{0301}" == s[s.localizedStandardRange(of: "\u{0301}", locale: en)!])
         }
-        XCTAssertNil(rangeOf("a", "\u{0301}", locale: en))
+        #expect(rangeOf("a", "\u{0301}", locale: en) == nil)
 
-        expectEqual(0..<1, rangeOf("i", "I", locale: en))
-        expectEqual(0..<1, rangeOf("I", "i", locale: en))
-        expectEqual(0..<1, rangeOf("\u{0130}", "i", locale: en))
-        expectEqual(0..<1, rangeOf("i", "\u{0130}", locale: en))
+        #expect(0..<1 == rangeOf("i", "I", locale: en))
+        #expect(0..<1 == rangeOf("I", "i", locale: en))
+        #expect(0..<1 == rangeOf("\u{0130}", "i", locale: en))
+        #expect(0..<1 == rangeOf("i", "\u{0130}", locale: en))
 
 
         let tr = Locale(identifier: "tr")
-        expectEqual(0..<1, rangeOf("\u{0130}", "ı", locale: tr))
+        #expect(0..<1 == rangeOf("\u{0130}", "ı", locale: tr))
     }
 
-    func test_smallestEncoding() {
+    @Test func smallestEncoding() {
         let availableEncodings: [String.Encoding] = String.availableStringEncodings
-        expectTrue(availableEncodings.contains("abc".smallestEncoding))
+        #expect(availableEncodings.contains("abc".smallestEncoding))
     }
 
-    func test_addingPercentEncoding() {
-        expectEqual(
-            "abcd1234",
+    @Test func addingPercentEncoding() {
+        #expect(
+            "abcd1234" ==
             "abcd1234".addingPercentEncoding(withAllowedCharacters: .alphanumerics))
-        expectEqual(
-            "abcd%20%D0%B0%D0%B1%D0%B2%D0%B3",
+        #expect(
+            "abcd%20%D0%B0%D0%B1%D0%B2%D0%B3" ==
             "abcd абвг".addingPercentEncoding(withAllowedCharacters: .alphanumerics))
     }
 
-    func test_appendingFormat() {
-        expectEqual("", "".appendingFormat(""))
-        expectEqual("a", "a".appendingFormat(""))
-        expectEqual(
-            "abc абв \u{0001F60A}",
+    @Test func appendingFormat() {
+        #expect("" == "".appendingFormat(""))
+        #expect("a" == "a".appendingFormat(""))
+        #expect(
+            "abc абв \u{0001F60A}" ==
             "abc абв \u{0001F60A}".appendingFormat(""))
 
         let formatArg: NSString = "привет мир \u{0001F60A}"
-        expectEqual(
-            "abc абв \u{0001F60A}def привет мир \u{0001F60A} 42",
+        #expect(
+            "abc абв \u{0001F60A}def привет мир \u{0001F60A} 42" ==
             "abc абв \u{0001F60A}"
                 .appendingFormat("def %@ %ld", formatArg, 42))
     }
 
-    func test_appending() {
-        expectEqual("", "".appending(""))
-        expectEqual("a", "a".appending(""))
-        expectEqual("a", "".appending("a"))
-        expectEqual("さ\u{3099}", "さ".appending("\u{3099}"))
+    @Test func appending() {
+        #expect("" == "".appending(""))
+        #expect("a" == "a".appending(""))
+        #expect("a" == "".appending("a"))
+        #expect("さ\u{3099}" == "さ".appending("\u{3099}"))
     }
 
-    func test_folding() {
+    @Test func folding() {
 
         func fwo(
             _ s: String, _ options: String.CompareOptions
@@ -2634,113 +2595,113 @@ final class StringTestsStdlib: XCTestCase {
             "example123", fwo("ｅｘａｍｐｌｅ１２３", .widthInsensitive), "en")
     }
 
-    func test_padding() {
-        expectEqual(
-            "abc абв \u{0001F60A}",
+    @Test func padding() {
+        #expect(
+            "abc абв \u{0001F60A}" ==
             "abc абв \u{0001F60A}".padding(
                 toLength: 10, withPad: "XYZ", startingAt: 0))
-        expectEqual(
-            "abc абв \u{0001F60A}XYZXY",
+        #expect(
+            "abc абв \u{0001F60A}XYZXY" ==
             "abc абв \u{0001F60A}".padding(
                 toLength: 15, withPad: "XYZ", startingAt: 0))
-        expectEqual(
-            "abc абв \u{0001F60A}YZXYZ",
+        #expect(
+            "abc абв \u{0001F60A}YZXYZ" ==
             "abc абв \u{0001F60A}".padding(
                 toLength: 15, withPad: "XYZ", startingAt: 1))
     }
 
-    func test_replacingCharacters() {
+    @Test func replacingCharacters() {
         do {
             let empty = ""
-            expectEqual("", empty.replacingCharacters(
+            #expect("" == empty.replacingCharacters(
                 in: empty.startIndex..<empty.startIndex, with: ""))
         }
 
         let s = "\u{1F601}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}"
 
-        expectEqual(s, s.replacingCharacters(
+        #expect(s == s.replacingCharacters(
             in: s.startIndex..<s.startIndex, with: ""))
-        expectEqual(s, s.replacingCharacters(
+        #expect(s == s.replacingCharacters(
             in: s.endIndex..<s.endIndex, with: ""))
-        expectEqual("zzz" + s, s.replacingCharacters(
+        #expect("zzz" + s == s.replacingCharacters(
             in: s.startIndex..<s.startIndex, with: "zzz"))
-        expectEqual(s + "zzz", s.replacingCharacters(
+        #expect(s + "zzz" == s.replacingCharacters(
             in: s.endIndex..<s.endIndex, with: "zzz"))
 
-        expectEqual(
-            "す\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "す\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingCharacters(
                 in: s.startIndex..<s.index(s.startIndex, offsetBy: 7), with: ""))
-        expectEqual(
-            "zzzす\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "zzzす\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingCharacters(
                 in: s.startIndex..<s.index(s.startIndex, offsetBy: 7), with: "zzz"))
-        expectEqual(
-            "\u{1F602}す\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F602}す\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingCharacters(
                 in: s.startIndex..<s.index(s.startIndex, offsetBy: 7), with: "\u{1F602}"))
 
-        expectEqual("\u{1F601}", s.replacingCharacters(
+        #expect("\u{1F601}" == s.replacingCharacters(
             in: s.index(after: s.startIndex)..<s.endIndex, with: ""))
-        expectEqual("\u{1F601}zzz", s.replacingCharacters(
+        #expect("\u{1F601}zzz" == s.replacingCharacters(
             in: s.index(after: s.startIndex)..<s.endIndex, with: "zzz"))
-        expectEqual("\u{1F601}\u{1F602}", s.replacingCharacters(
+        #expect("\u{1F601}\u{1F602}" == s.replacingCharacters(
             in: s.index(after: s.startIndex)..<s.endIndex, with: "\u{1F602}"))
 
-        expectEqual(
-            "\u{1F601}aす\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F601}aす\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingCharacters(
                 in: s.index(s.startIndex, offsetBy: 2)..<s.index(s.startIndex, offsetBy: 7), with: ""))
-        expectEqual(
-            "\u{1F601}azzzす\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F601}azzzす\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingCharacters(
                 in: s.index(s.startIndex, offsetBy: 2)..<s.index(s.startIndex, offsetBy: 7), with: "zzz"))
-        expectEqual(
-            "\u{1F601}a\u{1F602}す\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F601}a\u{1F602}す\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingCharacters(
                 in: s.index(s.startIndex, offsetBy: 2)..<s.index(s.startIndex, offsetBy: 7),
                 with: "\u{1F602}"))
     }
 
-    func test_replacingOccurrences() {
+    @Test func replacingOccurrences() {
         do {
             let empty = ""
-            expectEqual("", empty.replacingOccurrences(
+            #expect("" == empty.replacingOccurrences(
                 of: "", with: ""))
-            expectEqual("", empty.replacingOccurrences(
+            #expect("" == empty.replacingOccurrences(
                 of: "", with: "xyz"))
-            expectEqual("", empty.replacingOccurrences(
+            #expect("" == empty.replacingOccurrences(
                 of: "abc", with: "xyz"))
         }
 
         let s = "\u{1F601}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}"
 
-        expectEqual(s, s.replacingOccurrences(of: "", with: "xyz"))
-        expectEqual(s, s.replacingOccurrences(of: "xyz", with: ""))
+        #expect(s == s.replacingOccurrences(of: "", with: "xyz"))
+        #expect(s == s.replacingOccurrences(of: "xyz", with: ""))
 
-        expectEqual("", s.replacingOccurrences(of: s, with: ""))
+        #expect("" == s.replacingOccurrences(of: s, with: ""))
 
-        expectEqual(
-            "\u{1F601}xyzbc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F601}xyzbc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingOccurrences(of: "a", with: "xyz"))
 
-        expectEqual(
-            "\u{1F602}\u{1F603}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F602}\u{1F603}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingOccurrences(
                 of: "\u{1F601}", with: "\u{1F602}\u{1F603}"))
 
-        expectEqual(
-            "\u{1F601}abc さ\u{3099}xyzす\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F601}abc さ\u{3099}xyzす\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingOccurrences(
                 of: "し\u{3099}", with: "xyz"))
 
-        expectEqual(
-            "\u{1F601}abc さ\u{3099}xyzす\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F601}abc さ\u{3099}xyzす\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingOccurrences(
                 of: "し\u{3099}", with: "xyz"))
 
-        expectEqual(
-            "\u{1F601}abc さ\u{3099}xyzす\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F601}abc さ\u{3099}xyzす\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingOccurrences(
                 of: "\u{3058}", with: "xyz"))
 
@@ -2748,13 +2709,13 @@ final class StringTestsStdlib: XCTestCase {
         // Use non-default 'options:'
         //
 
-        expectEqual(
-            "\u{1F602}\u{1F603}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F602}\u{1F603}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingOccurrences(
                 of: "\u{1F601}", with: "\u{1F602}\u{1F603}",
                 options: String.CompareOptions.literal))
 
-        expectEqual(s, s.replacingOccurrences(
+        #expect(s == s.replacingOccurrences(
             of: "\u{3058}", with: "xyz",
             options: String.CompareOptions.literal))
 
@@ -2762,119 +2723,119 @@ final class StringTestsStdlib: XCTestCase {
         // Use non-default 'range:'
         //
 
-        expectEqual(
-            "\u{1F602}\u{1F603}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}",
+        #expect(
+            "\u{1F602}\u{1F603}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}" ==
             s.replacingOccurrences(
                 of: "\u{1F601}", with: "\u{1F602}\u{1F603}",
                 options: String.CompareOptions.literal,
                 range: s.startIndex..<s.index(s.startIndex, offsetBy: 1)))
 
-        expectEqual(s, s.replacingOccurrences(
+        #expect(s == s.replacingOccurrences(
             of: "\u{1F601}", with: "\u{1F602}\u{1F603}",
             options: String.CompareOptions.literal,
             range: s.index(s.startIndex, offsetBy: 1)..<s.index(s.startIndex, offsetBy: 3)))
     }
 
-    func test_removingPercentEncoding() {
-        expectEqual(
-            "abcd абвг",
+    @Test func removingPercentEncoding() {
+        #expect(
+            "abcd абвг" ==
             "abcd абвг".removingPercentEncoding)
 
-        expectEqual(
-            "abcd абвг\u{0000}\u{0001}",
+        #expect(
+            "abcd абвг\u{0000}\u{0001}" ==
             "abcd абвг%00%01".removingPercentEncoding)
 
-        expectEqual(
-            "abcd абвг",
+        #expect(
+            "abcd абвг" ==
             "%61%62%63%64%20%D0%B0%D0%B1%D0%B2%D0%B3".removingPercentEncoding)
 
-        expectEqual(
-            "abcd абвг",
+        #expect(
+            "abcd абвг" ==
             "ab%63d %D0%B0%D0%B1%D0%B2%D0%B3".removingPercentEncoding)
 
-        XCTAssertNil("%ED%B0".removingPercentEncoding)
+        #expect("%ED%B0".removingPercentEncoding == nil)
 
-        XCTAssertNil("%zz".removingPercentEncoding)
+        #expect("%zz".removingPercentEncoding == nil)
 
-        XCTAssertNil("abcd%FF".removingPercentEncoding)
+        #expect("abcd%FF".removingPercentEncoding == nil)
 
-        XCTAssertNil("%".removingPercentEncoding)
+        #expect("%".removingPercentEncoding == nil)
     }
 
-    func test_removingPercentEncoding_() {
-        expectEqual("", "".removingPercentEncoding)
+    @Test func removingPercentEncoding_() {
+        #expect("" == "".removingPercentEncoding)
     }
 
-    func test_trimmingCharacters() {
-        expectEqual("", "".trimmingCharacters(
+    @Test func trimmingCharacters() {
+        #expect("" == "".trimmingCharacters(
             in: CharacterSet.decimalDigits))
 
-        expectEqual("abc", "abc".trimmingCharacters(
+        #expect("abc" == "abc".trimmingCharacters(
             in: CharacterSet.decimalDigits))
 
-        expectEqual("", "123".trimmingCharacters(
+        #expect("" == "123".trimmingCharacters(
             in: CharacterSet.decimalDigits))
 
-        expectEqual("abc", "123abc789".trimmingCharacters(
+        #expect("abc" == "123abc789".trimmingCharacters(
             in: CharacterSet.decimalDigits))
 
         // Performs Unicode scalar comparison.
-        expectEqual(
-            "し\u{3099}abc",
+        #expect(
+            "し\u{3099}abc" ==
             "し\u{3099}abc".trimmingCharacters(
                 in: CharacterSet(charactersIn: "\u{3058}")))
     }
 
-    func test_NSString_stringsByAppendingPaths() {
-        expectEqual([] as [NSString], ("" as NSString).strings(byAppendingPaths: []) as [NSString])
-        expectEqual(
-            [ "/tmp/foo", "/tmp/bar" ] as [NSString],
+    @Test func NSString_stringsByAppendingPaths() {
+        #expect([] as [NSString] == ("" as NSString).strings(byAppendingPaths: []) as [NSString])
+        #expect(
+            [ "/tmp/foo", "/tmp/bar" ] as [NSString] ==
             ("/tmp" as NSString).strings(byAppendingPaths: [ "foo", "bar" ]) as [NSString])
     }
 
     @available(*, deprecated)
-    func test_substring_from() {
+    @Test func substring_from() {
         let s = "\u{1F601}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}"
 
-        expectEqual(s, s.substring(from: s.startIndex))
-        expectEqual("せ\u{3099}そ\u{3099}",
+        #expect(s == s.substring(from: s.startIndex))
+        #expect("せ\u{3099}そ\u{3099}" ==
                     s.substring(from: s.index(s.startIndex, offsetBy: 8)))
-        expectEqual("", s.substring(from: s.index(s.startIndex, offsetBy: 10)))
+        #expect("" == s.substring(from: s.index(s.startIndex, offsetBy: 10)))
     }
 
     @available(*, deprecated)
-    func test_substring_to() {
+    @Test func substring_to() {
         let s = "\u{1F601}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}"
 
-        expectEqual("", s.substring(to: s.startIndex))
-        expectEqual("\u{1F601}abc さ\u{3099}し\u{3099}す\u{3099}",
+        #expect("" == s.substring(to: s.startIndex))
+        #expect("\u{1F601}abc さ\u{3099}し\u{3099}す\u{3099}" ==
                     s.substring(to: s.index(s.startIndex, offsetBy: 8)))
-        expectEqual(s, s.substring(to: s.index(s.startIndex, offsetBy: 10)))
+        #expect(s == s.substring(to: s.index(s.startIndex, offsetBy: 10)))
     }
 
     @available(*, deprecated)
-    func test_substring_with() {
+    @Test func substring_with() {
         let s = "\u{1F601}abc さ\u{3099}し\u{3099}す\u{3099}せ\u{3099}そ\u{3099}"
 
-        expectEqual("", s.substring(with: s.startIndex..<s.startIndex))
-        expectEqual(
-            "",
+        #expect("" == s.substring(with: s.startIndex..<s.startIndex))
+        #expect(
+            "" ==
             s.substring(with: s.index(s.startIndex, offsetBy: 1)..<s.index(s.startIndex, offsetBy: 1)))
-        expectEqual("", s.substring(with: s.endIndex..<s.endIndex))
-        expectEqual(s, s.substring(with: s.startIndex..<s.endIndex))
-        expectEqual(
-            "さ\u{3099}し\u{3099}す\u{3099}",
+        #expect("" == s.substring(with: s.endIndex..<s.endIndex))
+        #expect(s == s.substring(with: s.startIndex..<s.endIndex))
+        #expect(
+            "さ\u{3099}し\u{3099}す\u{3099}" ==
             s.substring(with: s.index(s.startIndex, offsetBy: 5)..<s.index(s.startIndex, offsetBy: 8)))
     }
 
-    func test_localizedUppercase() {
-        expectEqual("ABCD", "abCD".uppercased(with: Locale(identifier: "en")))
+    @Test func localizedUppercase() {
+        #expect("ABCD" == "abCD".uppercased(with: Locale(identifier: "en")))
 
-        expectEqual("АБВГ", "абВГ".uppercased(with: Locale(identifier: "en")))
+        #expect("АБВГ" == "абВГ".uppercased(with: Locale(identifier: "en")))
 
-        expectEqual("АБВГ", "абВГ".uppercased(with: Locale(identifier: "ru")))
+        #expect("АБВГ" == "абВГ".uppercased(with: Locale(identifier: "ru")))
 
-        expectEqual("たちつてと", "たちつてと".uppercased(with: Locale(identifier: "ru")))
+        #expect("たちつてと" == "たちつてと".uppercased(with: Locale(identifier: "ru")))
 
         //
         // Special casing.
@@ -2883,12 +2844,12 @@ final class StringTestsStdlib: XCTestCase {
         // U+0069 LATIN SMALL LETTER I
         // to upper case:
         // U+0049 LATIN CAPITAL LETTER I
-        expectEqual("\u{0049}", "\u{0069}".uppercased(with: Locale(identifier: "en")))
+        #expect("\u{0049}" == "\u{0069}".uppercased(with: Locale(identifier: "en")))
 
         // U+0069 LATIN SMALL LETTER I
         // to upper case in Turkish locale:
         // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE
-        expectEqual("\u{0130}", "\u{0069}".uppercased(with: Locale(identifier: "tr")))
+        #expect("\u{0130}" == "\u{0069}".uppercased(with: Locale(identifier: "tr")))
 
         // U+00DF LATIN SMALL LETTER SHARP S
         // to upper case:
@@ -2896,7 +2857,7 @@ final class StringTestsStdlib: XCTestCase {
         // U+0073 LATIN SMALL LETTER S
         // But because the whole string is converted to uppercase, we just get two
         // U+0053.
-        expectEqual("\u{0053}\u{0053}", "\u{00df}".uppercased(with: Locale(identifier: "en")))
+        #expect("\u{0053}\u{0053}" == "\u{00df}".uppercased(with: Locale(identifier: "en")))
 
         // U+FB01 LATIN SMALL LIGATURE FI
         // to upper case:
@@ -2904,10 +2865,10 @@ final class StringTestsStdlib: XCTestCase {
         // U+0069 LATIN SMALL LETTER I
         // But because the whole string is converted to uppercase, we get U+0049
         // LATIN CAPITAL LETTER I.
-        expectEqual("\u{0046}\u{0049}", "\u{fb01}".uppercased(with: Locale(identifier: "ru")))
+        #expect("\u{0046}\u{0049}" == "\u{fb01}".uppercased(with: Locale(identifier: "ru")))
     }
 
-    func test_uppercased() {
+    @Test func uppercased() {
         expectLocalizedEquality("ABCD", { loc in "abCD".uppercased(with: loc) }, "en")
 
         expectLocalizedEquality("АБВГ", { loc in "абВГ".uppercased(with: loc) }, "en")
@@ -2946,43 +2907,43 @@ final class StringTestsStdlib: XCTestCase {
         expectLocalizedEquality("\u{0046}\u{0049}", { loc in "\u{fb01}".uppercased(with: loc) }, "ru")
     }
 
-    func test_applyingTransform() {
+    @Test func applyingTransform() {
         do {
             let source = "tre\u{300}s k\u{fc}hl"
-            expectEqual(
-                "tres kuhl",
+            #expect(
+                "tres kuhl" ==
                 source.applyingTransform(.stripDiacritics, reverse: false))
         }
         do {
             let source = "hiragana"
-            expectEqual(
-                "ひらがな",
+            #expect(
+                "ひらがな" ==
                 source.applyingTransform(.latinToHiragana, reverse: false))
         }
         do {
             let source = "ひらがな"
-            expectEqual(
-                "hiragana",
+            #expect(
+                "hiragana" ==
                 source.applyingTransform(.latinToHiragana, reverse: true))
         }
     }
 
-    func test_SameTypeComparisons() {
+    @Test func SameTypeComparisons() {
         // U+0323 COMBINING DOT BELOW
         // U+0307 COMBINING DOT ABOVE
         // U+1E63 LATIN SMALL LETTER S WITH DOT BELOW
         let xs = "\u{1e69}"
-        expectTrue(xs == "s\u{323}\u{307}")
-        expectFalse(xs != "s\u{323}\u{307}")
-        expectTrue("s\u{323}\u{307}" == xs)
-        expectFalse("s\u{323}\u{307}" != xs)
-        expectTrue("\u{1e69}" == "s\u{323}\u{307}")
-        expectFalse("\u{1e69}" != "s\u{323}\u{307}")
-        expectTrue(xs == xs)
-        expectFalse(xs != xs)
+        #expect(xs == "s\u{323}\u{307}")
+        #expect(!(xs != "s\u{323}\u{307}"))
+        #expect("s\u{323}\u{307}" == xs)
+        #expect(!("s\u{323}\u{307}" != xs))
+        #expect("\u{1e69}" == "s\u{323}\u{307}")
+        #expect(!("\u{1e69}" != "s\u{323}\u{307}"))
+        #expect(xs == xs)
+        #expect(!(xs != xs))
     }
 
-    func test_MixedTypeComparisons() {
+    @Test func MixedTypeComparisons() {
         // U+0323 COMBINING DOT BELOW
         // U+0307 COMBINING DOT ABOVE
         // U+1E63 LATIN SMALL LETTER S WITH DOT BELOW
@@ -2990,22 +2951,22 @@ final class StringTestsStdlib: XCTestCase {
         // swift but not in Foundation.
         let xs = "\u{1e69}"
         let ys: NSString = "s\u{323}\u{307}"
-        expectFalse(ys == "\u{1e69}")
-        expectTrue(ys != "\u{1e69}")
-        expectFalse("\u{1e69}" == ys)
-        expectTrue("\u{1e69}" != ys)
-        expectFalse(xs as NSString == ys)
-        expectTrue(xs as NSString != ys)
-        expectTrue(ys == ys)
-        expectFalse(ys != ys)
+        #expect(!(ys == "\u{1e69}"))
+        #expect(ys != "\u{1e69}")
+        #expect(!("\u{1e69}" == ys))
+        #expect("\u{1e69}" != ys)
+        #expect(!(xs as NSString == ys))
+        #expect(xs as NSString != ys)
+        #expect(ys == ys)
+        #expect(!(ys != ys))
     }
 
-    func test_copy_construction() {
+    @Test func copy_construction() {
         let expected = "abcd"
         let x = NSString(string: expected as NSString)
-        expectEqual(expected, x as String)
+        #expect(expected == x as String)
         let y = NSMutableString(string: expected as NSString)
-        expectEqual(expected, y as String)
+        #expect(expected == y as String)
     }
 }
 
@@ -3019,117 +2980,117 @@ extension String {
     }
 }
 
-final class StdlibSubstringTests: XCTestCase {
+struct StdlibSubstringTests {
 
-    func test_range_of_NilRange() {
+    @Test func range_of_NilRange() {
         let ss = "aabcdd"[1, -1]
         let range = ss.range(of: "bc")
-        expectEqual("bc", range.map { ss[$0] })
+        #expect("bc" == range.map { ss[$0] })
     }
 
-    func test_range_of_NonNilRange() {
+    @Test func range_of_NonNilRange() {
         let s = "aabcdd"
         let ss = s[1, -1]
         let searchRange = s.range(fromStart: 2, fromEnd: -2)
         let range = ss.range(of: "bc", range: searchRange)
-        expectEqual("bc", range.map { ss[$0] })
+        #expect("bc" == range.map { ss[$0] })
     }
 
-    func test_rangeOfCharacter() {
+    @Test func rangeOfCharacter() {
         let ss = "__hello__"[2, -2]
         let range = ss.rangeOfCharacter(from: CharacterSet.alphanumerics)
-        expectEqual("h", range.map { ss[$0] })
+        #expect("h" == range.map { ss[$0] })
     }
 
-    func test_compare_optionsNilRange() {
+    @Test func compare_optionsNilRange() {
         let needle = "hello"
         let haystack = "__hello__"[2, -2]
-        expectEqual(.orderedSame, haystack.compare(needle))
+        #expect(.orderedSame == haystack.compare(needle))
     }
 
-    func test_compare_optionsNonNilRange() {
+    @Test func compare_optionsNonNilRange() {
         let needle = "hello"
         let haystack = "__hello__"
         let range = haystack.range(fromStart: 2, fromEnd: -2)
-        expectEqual(.orderedSame, haystack[range].compare(needle, range: range))
+        #expect(.orderedSame == haystack[range].compare(needle, range: range))
     }
 
-    func test_replacingCharacters() {
+    @Test func replacingCharacters() {
         let s = "__hello, world"
         let range = s.range(fromStart: 2, fromEnd: -7)
         let expected = "__goodbye, world"
         let replacement = "goodbye"
-        expectEqual(expected,
+        #expect(expected ==
                     s.replacingCharacters(in: range, with: replacement))
-        expectEqual(expected[2, 0],
+        #expect(expected[2, 0] ==
                     s[2, 0].replacingCharacters(in: range, with: replacement))
 
-        expectEqual(replacement,
+        #expect(replacement ==
                     s.replacingCharacters(in: s.startIndex..., with: replacement))
-        expectEqual(replacement,
+        #expect(replacement ==
                     s.replacingCharacters(in: ..<s.endIndex, with: replacement))
-        expectEqual(expected[2, 0],
+        #expect(expected[2, 0] ==
                     s[2, 0].replacingCharacters(in: range, with: replacement[...]))
     }
 
-    func test_replacingOccurrences_NilRange() {
+    @Test func replacingOccurrences_NilRange() {
         let s = "hello"
 
-        expectEqual("he11o", s.replacingOccurrences(of: "l", with: "1"))
-        expectEqual("he11o", s.replacingOccurrences(of: "l"[...], with: "1"))
-        expectEqual("he11o", s.replacingOccurrences(of: "l", with: "1"[...]))
-        expectEqual("he11o", s.replacingOccurrences(of: "l"[...], with: "1"[...]))
+        #expect("he11o" == s.replacingOccurrences(of: "l", with: "1"))
+        #expect("he11o" == s.replacingOccurrences(of: "l"[...], with: "1"))
+        #expect("he11o" == s.replacingOccurrences(of: "l", with: "1"[...]))
+        #expect("he11o" == s.replacingOccurrences(of: "l"[...], with: "1"[...]))
 
-        expectEqual("he11o",
+        #expect("he11o" ==
                     s[...].replacingOccurrences(of: "l", with: "1"))
-        expectEqual("he11o",
+        #expect("he11o" ==
                     s[...].replacingOccurrences(of: "l"[...], with: "1"))
-        expectEqual("he11o",
+        #expect("he11o" ==
                     s[...].replacingOccurrences(of: "l", with: "1"[...]))
-        expectEqual("he11o",
+        #expect("he11o" ==
                     s[...].replacingOccurrences(of: "l"[...], with: "1"[...]))
     }
 
-    func test_replacingOccurrences_NonNilRange() {
+    @Test func replacingOccurrences_NonNilRange() {
         let s = "hello"
         let r = s.range(fromStart: 1, fromEnd: -2)
 
-        expectEqual("he1lo",
+        #expect("he1lo" ==
                     s.replacingOccurrences(of: "l", with: "1", range: r))
-        expectEqual("he1lo",
+        #expect("he1lo" ==
                     s.replacingOccurrences(of: "l"[...], with: "1", range: r))
-        expectEqual("he1lo",
+        #expect("he1lo" ==
                     s.replacingOccurrences(of: "l", with: "1"[...], range: r))
-        expectEqual("he1lo",
+        #expect("he1lo" ==
                     s.replacingOccurrences(of: "l"[...], with: "1"[...], range: r))
 
-        expectEqual("he1lo",
+        #expect("he1lo" ==
                     s[...].replacingOccurrences(of: "l", with: "1", range: r))
-        expectEqual("he1lo",
+        #expect("he1lo" ==
                     s[...].replacingOccurrences(of: "l"[...], with: "1", range: r))
-        expectEqual("he1lo",
+        #expect("he1lo" ==
                     s[...].replacingOccurrences(of: "l", with: "1"[...], range: r))
-        expectEqual("he1lo",
+        #expect("he1lo" ==
                     s[...].replacingOccurrences(of: "l"[...], with: "1"[...], range: r))
 
         let ss = s[1, -1]
-        expectEqual("e1l",
+        #expect("e1l" ==
                     ss.replacingOccurrences(of: "l", with: "1", range: r))
-        expectEqual("e1l",
+        #expect("e1l" ==
                     ss.replacingOccurrences(of: "l"[...], with: "1", range: r))
-        expectEqual("e1l",
+        #expect("e1l" ==
                     ss.replacingOccurrences(of: "l", with: "1"[...], range: r))
-        expectEqual("e1l",
+        #expect("e1l" ==
                     ss.replacingOccurrences(of: "l"[...], with: "1"[...], range: r))
     }
 
     @available(*, deprecated)
-    func test_substring() {
+    @Test func substring() {
         let s = "hello, world"
         let r = s.range(fromStart: 7, fromEnd: 0)
-        expectEqual("world", s.substring(with: r))
-        expectEqual("world", s[...].substring(with: r))
-        expectEqual("world", s[1, 0].substring(with: r))
+        #expect("world" == s.substring(with: r))
+        #expect("world" == s[...].substring(with: r))
+        #expect("world" == s[1, 0].substring(with: r))
     }
 }
 #endif // FOUNDATION_FRAMEWORK


### PR DESCRIPTION
Applies more patches from https://github.com/swiftlang/swift-foundation/pull/908 to bring a handful more FoundationEssentials test suites to swift-testing (adjusting the patches to account for newly added and modified tests)