### PR TITLE
Convert FoundationEssentials formatting tests to swift-testing

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -71,15 +71,6 @@ public struct TimeZone : Hashable, Equatable, Sendable {
         }
     }
 
-    internal init?(name: String) {
-        // Try the cache first
-        if let cached = TimeZoneCache.cache.fixed(name) {
-            _tz = cached
-        } else {
-            return nil
-        }
-    }
-
     /// Returns a time zone identified by a given abbreviation.
     ///
     /// In general, you are discouraged from using abbreviations except for unique instances such as "GMT". Time Zone abbreviations are not standardized and so a given abbreviation may have multiple meanings--for example, "EST" refers to Eastern Time in both the United States and Australia

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ObjC.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ObjC.swift
@@ -23,7 +23,7 @@ extension NSTimeZone {
     static func _timeZoneWith(name: String, data: Data?) -> _NSSwiftTimeZone? {
         if let data {
             // We don't cache data-based TimeZones
-            guard let tz = TimeZone(name: name) else {
+            guard let tz = TimeZone(identifier: name) else {
                 return nil
             }
             return _NSSwiftTimeZone(timeZone: tz, data: data)

--- a/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
@@ -5,17 +5,12 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// RUN: %target-run-simple-swift
-// REQUIRES: executable_test
 
-import XCTest
+import Testing
 
 #if canImport(FoundationEssentials)
 @testable import FoundationEssentials
-#endif
-
-#if FOUNDATION_FRAMEWORK
+#else
 @testable import Foundation
 #endif
 
@@ -27,16 +22,17 @@ import Numberick
 import BigInt
 #endif
 
-final class BinaryIntegerFormatStyleTests: XCTestCase {
+@Suite("BinaryIntegerFormatStyle")
+private struct BinaryIntegerFormatStyleTests {
     // NSR == numericStringRepresentation
-    func checkNSR(value: some BinaryInteger, expected: String) {
-        XCTAssertEqual(String(decoding: value.numericStringRepresentation.utf8, as: Unicode.ASCII.self), expected)
+    func checkNSR(value: some BinaryInteger, expected: String, sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(String(decoding: value.numericStringRepresentation.utf8, as: Unicode.ASCII.self) == expected)
     }
 
-    func testNumericStringRepresentation_builtinIntegersLimits() throws {
-        func check<I: FixedWidthInteger>(type: I.Type = I.self, min: String, max: String) {
-            checkNSR(value: I.min, expected: min)
-            checkNSR(value: I.max, expected: max)
+    @Test func numericStringRepresentation_builtinIntegersLimits() throws {
+        func check<I: FixedWidthInteger>(type: I.Type = I.self, min: String, max: String, sourceLocation: SourceLocation = #_sourceLocation) {
+            checkNSR(value: I.min, expected: min, sourceLocation: sourceLocation)
+            checkNSR(value: I.max, expected: max, sourceLocation: sourceLocation)
         }
 
         check(type: Int8.self, min: "-128", max: "127")
@@ -52,13 +48,13 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
         check(type: UInt128.self, min: "0", max: "340282366920938463463374607431768211455")
     }
 
-    func testNumericStringRepresentation_builtinIntegersAroundDecimalMagnitude() throws {
-        func check<I: FixedWidthInteger>(type: I.Type = I.self, magnitude: String, oneLess: String, oneMore: String) {
+    @Test func numericStringRepresentation_builtinIntegersAroundDecimalMagnitude() throws {
+        func check<I: FixedWidthInteger>(type: I.Type = I.self, magnitude: String, oneLess: String, oneMore: String, sourceLocation: SourceLocation = #_sourceLocation) {
             var mag = I(1); while !mag.multipliedReportingOverflow(by: 10).overflow { mag *= 10 }
             
-            checkNSR(value: mag, expected: magnitude)
-            checkNSR(value: mag - 1, expected: oneLess)
-            checkNSR(value: mag + 1, expected: oneMore)
+            checkNSR(value: mag, expected: magnitude, sourceLocation: sourceLocation)
+            checkNSR(value: mag - 1, expected: oneLess, sourceLocation: sourceLocation)
+            checkNSR(value: mag + 1, expected: oneMore, sourceLocation: sourceLocation)
         }
 
         check(type: Int8.self, magnitude: "100", oneLess: "99", oneMore: "101")
@@ -105,14 +101,14 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
                               String(repeating: "1234567890", count: 10),
                               String(repeating: "1234567890", count: 100)] {
             if let value = initialiser(valueAsString) { // The test cases cover a wide range of values, that don't all fit into every type tested (i.e. the fixed-width types from Numberick).
-                XCTAssertEqual(value.description, valueAsString) // Sanity check that it initialised from the string correctly.
+                #expect(value.description == valueAsString) // Sanity check that it initialised from the string correctly.
                 checkNSR(value: value, expected: valueAsString)
 
                 if I.isSigned {
                     let negativeValueAsString = "-" + valueAsString
                     let negativeValue = initialiser(negativeValueAsString)!
 
-                    XCTAssertEqual(negativeValue.description, negativeValueAsString) // Sanity check that it initialised from the string correctly.
+                    #expect(negativeValue.description == negativeValueAsString) // Sanity check that it initialised from the string correctly.
                     checkNSR(value: negativeValue, expected: negativeValueAsString)
                 }
             }
@@ -120,7 +116,7 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
     }
 
 #if canImport(Numberick)
-    func testNumericStringRepresentation_largeIntegers() throws {
+    @Test func numericStringRepresentation_largeIntegers() throws {
         check(type: Int128.self, initialiser: { Int128($0) })
         check(type: UInt128.self, initialiser: { UInt128($0) })
 
@@ -130,7 +126,7 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
 #endif
 
 #if canImport(BigInt)
-    func testNumericStringRepresentation_arbitraryPrecisionIntegers() throws {
+    @Test func numericStringRepresentation_arbitraryPrecisionIntegers() throws {
         check(type: BigInt.self, initialiser: { BigInt($0)! })
         check(type: BigUInt.self, initialiser: { BigUInt($0)! })
     }
@@ -138,11 +134,11 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
 #endif // canImport(Numberick) || canImport(BigInt)
 }
 
-final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
+struct BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords {
     
     // MARK: Tests
     
-    func testInt32() {
+    @Test func int32() {
         check( Int32(truncatingIfNeeded: 0x00000000 as UInt32), expectation:           "0")
         check( Int32(truncatingIfNeeded: 0x03020100 as UInt32), expectation:    "50462976")
         check( Int32(truncatingIfNeeded: 0x7fffffff as UInt32), expectation:  "2147483647") //  Int32.max
@@ -152,7 +148,7 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
         check( Int32(truncatingIfNeeded: 0xffffffff as UInt32), expectation:          "-1")
     }
     
-    func testUInt32() {
+    @Test func uint32() {
         check(UInt32(truncatingIfNeeded: 0x00000000 as UInt32), expectation:           "0") // UInt32.min
         check(UInt32(truncatingIfNeeded: 0x03020100 as UInt32), expectation:    "50462976")
         check(UInt32(truncatingIfNeeded: 0x7fffffff as UInt32), expectation:  "2147483647")
@@ -162,7 +158,7 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
         check(UInt32(truncatingIfNeeded: 0xffffffff as UInt32), expectation:  "4294967295") // UInt32.max
     }
     
-    func testInt64() {
+    @Test func int64() {
         check( Int64(truncatingIfNeeded: 0x0000000000000000 as UInt64), expectation:                    "0")
         check( Int64(truncatingIfNeeded: 0x0706050403020100 as UInt64), expectation:   "506097522914230528")
         check( Int64(truncatingIfNeeded: 0x7fffffffffffffff as UInt64), expectation:  "9223372036854775807") //  Int64.max
@@ -172,7 +168,7 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
         check( Int64(truncatingIfNeeded: 0xffffffffffffffff as UInt64), expectation:                   "-1")
     }
     
-    func testUInt64() {
+    @Test func uint64() {
         check(UInt64(truncatingIfNeeded: 0x0000000000000000 as UInt64), expectation:                    "0") // UInt64.min
         check(UInt64(truncatingIfNeeded: 0x0706050403020100 as UInt64), expectation:   "506097522914230528")
         check(UInt64(truncatingIfNeeded: 0x7fffffffffffffff as UInt64), expectation:  "9223372036854775807")
@@ -184,7 +180,7 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
     
     // MARK: Tests + Big Integer
     
-    func testInt128() {
+    @Test func int128() {
         check(x64:[0x0000000000000000, 0x0000000000000000] as [UInt64], isSigned: true,  expectation:                                        "0")
         check(x64:[0x0706050403020100, 0x0f0e0d0c0b0a0908] as [UInt64], isSigned: true,  expectation:   "20011376718272490338853433276725592320")
         check(x64:[0xffffffffffffffff, 0x7fffffffffffffff] as [UInt64], isSigned: true,  expectation:  "170141183460469231731687303715884105727") //  Int128.max
@@ -193,7 +189,7 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
         check(x64:[0xffffffffffffffff, 0xffffffffffffffff] as [UInt64], isSigned: true,  expectation:                                       "-1")
     }
     
-    func testUInt128() {
+    @Test func uint128() {
         check(x64:[0x0000000000000000, 0x0000000000000000] as [UInt64], isSigned: false, expectation:                                        "0") // UInt128.min
         check(x64:[0x0706050403020100, 0x0f0e0d0c0b0a0908] as [UInt64], isSigned: false, expectation:   "20011376718272490338853433276725592320")
         check(x64:[0x0000000000000000, 0x8000000000000000] as [UInt64], isSigned: false, expectation:  "170141183460469231731687303715884105728")
@@ -204,12 +200,12 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
     
     // MARK: Tests + Big Integer + Miscellaneous
     
-    func testWordsIsEmptyResultsInZero() {
+    @Test func wordsIsEmptyResultsInZero() {
         check(words:[              ] as [UInt], isSigned: true,  expectation:  "0")
         check(words:[              ] as [UInt], isSigned: false, expectation:  "0")
     }
     
-    func testSignExtendingDoesNotChangeTheResult() {
+    @Test func signExtendingDoesNotChangeTheResult() {
         check(words:[ 0            ] as [UInt], isSigned: true,  expectation:  "0")
         check(words:[ 0,  0        ] as [UInt], isSigned: true,  expectation:  "0")
         check(words:[ 0,  0,  0    ] as [UInt], isSigned: true,  expectation:  "0")
@@ -228,22 +224,22 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
     
     // MARK: Assertions
     
-    func check(_ integer: some BinaryInteger, expectation: String, file: StaticString = #filePath, line: UInt = #line) {
-        XCTAssertEqual(integer.description, expectation, "integer description does not match expectation", file: file, line: line)
-        check(ascii: integer.numericStringRepresentation.utf8, expectation: expectation, file: file, line: line)
-        check(words: Array(integer.words), isSigned: type(of: integer).isSigned, expectation: expectation, file: file, line: line)
+    func check(_ integer: some BinaryInteger, expectation: String, sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(integer.description == expectation, "integer description does not match expectation", sourceLocation: sourceLocation)
+        check(ascii: integer.numericStringRepresentation.utf8, expectation: expectation, sourceLocation: sourceLocation)
+        check(words: Array(integer.words), isSigned: type(of: integer).isSigned, expectation: expectation, sourceLocation: sourceLocation)
     }
     
-    func check(x64: [UInt64], isSigned: Bool, expectation: String, file: StaticString = #filePath, line: UInt = #line) {
-        check(words: x64.flatMap(\.words), isSigned: isSigned, expectation: expectation, file: file, line: line)
+    func check(x64: [UInt64], isSigned: Bool, expectation: String, sourceLocation: SourceLocation = #_sourceLocation) {
+        check(words: x64.flatMap(\.words), isSigned: isSigned, expectation: expectation, sourceLocation: sourceLocation)
     }
     
-    func check(words: [UInt], isSigned: Bool, expectation: String, file: StaticString = #filePath, line: UInt = #line) {
+    func check(words: [UInt], isSigned: Bool, expectation: String, sourceLocation: SourceLocation = #_sourceLocation) {
         let ascii =  numericStringRepresentationForBinaryInteger(words: words, isSigned: isSigned).utf8
-        check(ascii: ascii, expectation: expectation, file: file, line: line)
+        check(ascii: ascii, expectation: expectation, sourceLocation: sourceLocation)
     }
     
-    func check(ascii: some Collection<UInt8>, expectation: String, file: StaticString = #filePath, line: UInt = #line) {
-        XCTAssertEqual(String(decoding: ascii, as: Unicode.ASCII.self), expectation, file: file, line: line)
+    func check(ascii: some Collection<UInt8>, expectation: String, sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(String(decoding: ascii, as: Unicode.ASCII.self) == expectation, sourceLocation: sourceLocation)
     }
 }

--- a/Tests/FoundationEssentialsTests/Formatting/HTTPFormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/HTTPFormatStyleFormattingTests.swift
@@ -10,129 +10,125 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(TestSupport)
-import TestSupport
-#endif
+import Testing
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
+#else
+import Foundation
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@testable import Foundation
-#endif
-
-final class HTTPFormatStyleFormattingTests: XCTestCase {
+@Suite("HTTPFormatStyle Formatting")
+private struct HTTPFormatStyleFormattingTests {
     
-    func test_HTTPFormat() throws {
+    @Test func basics() throws {
         let date = Date.now
         
         let formatted = date.formatted(.http) // e.g.  "Fri, 17 Jan 2025 19:03:05 GMT"
-        let parsed = try? Date(formatted, strategy: .http)
+        let parsed = try Date(formatted, strategy: .http)
         
-        let result = try XCTUnwrap(parsed)
-        XCTAssertEqual(date.timeIntervalSinceReferenceDate, result.timeIntervalSinceReferenceDate, accuracy: 1.0)
+        #expect(abs(date.timeIntervalSinceReferenceDate - parsed.timeIntervalSinceReferenceDate) <= 1.0)
     }
     
-    func test_HTTPFormat_components() throws {
+    @Test func components() throws {
         let date = Date.now
         let formatted = date.formatted(.http) // e.g.  "Fri, 17 Jan 2025 19:03:05 GMT"
         
-        let parsed = try? DateComponents(formatted, strategy: .http)
+        let parsed = try DateComponents(formatted, strategy: .http)
         
-        let result = try XCTUnwrap(parsed)
+        let resultDate = Calendar(identifier: .gregorian).date(from: parsed)
+        let resultDateUnwrapped = try #require(resultDate)
         
-        let resultDate = Calendar(identifier: .gregorian).date(from: result)
-        let resultDateUnwrapped = try XCTUnwrap(resultDate)
-        
-        XCTAssertEqual(date.timeIntervalSinceReferenceDate, resultDateUnwrapped.timeIntervalSinceReferenceDate, accuracy: 1.0)
+        #expect(abs(date.timeIntervalSinceReferenceDate - resultDateUnwrapped.timeIntervalSinceReferenceDate) <= 1.0)
     }
     
-    func test_HTTPFormat_variousInputs() throws {
-        let tests = [
-            "Mon, 20 Jan 2025 01:02:03 GMT",
-            "Tue, 20 Jan 2025 10:02:03 GMT",
-            "Wed, 20 Jan 2025 23:02:03 GMT",
-            "Thu, 20 Jan 2025 01:10:03 GMT",
-            "Fri, 20 Jan 2025 01:50:59 GMT",
-            "Sat, 20 Jan 2025 01:50:60 GMT", // 60 is valid, treated as 0
-            "Sun, 20 Jan 2025 01:03:03 GMT",
-            "20 Jan 2025 01:02:03 GMT", // Missing weekdays is ok
-            "20 Jan 2025 10:02:03 GMT",
-            "20 Jan 2025 23:02:03 GMT",
-            "20 Jan 2025 01:10:03 GMT",
-            "20 Jan 2025 01:50:59 GMT",
-            "20 Jan 2025 01:50:60 GMT",
-            "20 Jan 2025 01:03:03 GMT",
-            "Mon, 20 Jan 2025 01:03:03 GMT",
-            "Mon, 03 Feb 2025 01:03:03 GMT",
-            "Mon, 03 Mar 2025 01:03:03 GMT",
-            "Mon, 14 Apr 2025 01:03:03 GMT",
-            "Mon, 05 May 2025 01:03:03 GMT",
-            "Mon, 21 Jul 2025 01:03:03 GMT",
-            "Mon, 04 Aug 2025 01:03:03 GMT",
-            "Mon, 22 Sep 2025 01:03:03 GMT",
-            "Mon, 30 Oct 2025 01:03:03 GMT",
-            "Mon, 24 Nov 2025 01:03:03 GMT",
-            "Mon, 22 Dec 2025 01:03:03 GMT",
-            "Tue, 29 Feb 2028 01:03:03 GMT", // leap day
-        ]
-        
-        for good in tests {
-            XCTAssertNotNil(try? Date(good, strategy: .http), "Input \(good) was nil")
-            XCTAssertNotNil(try? DateComponents(good, strategy: .http), "Input \(good) was nil")
+    @Test(arguments: [
+        "Mon, 20 Jan 2025 01:02:03 GMT",
+        "Tue, 20 Jan 2025 10:02:03 GMT",
+        "Wed, 20 Jan 2025 23:02:03 GMT",
+        "Thu, 20 Jan 2025 01:10:03 GMT",
+        "Fri, 20 Jan 2025 01:50:59 GMT",
+        "Sat, 20 Jan 2025 01:50:60 GMT", // 60 is valid, treated as 0
+        "Sun, 20 Jan 2025 01:03:03 GMT",
+        "20 Jan 2025 01:02:03 GMT", // Missing weekdays is ok
+        "20 Jan 2025 10:02:03 GMT",
+        "20 Jan 2025 23:02:03 GMT",
+        "20 Jan 2025 01:10:03 GMT",
+        "20 Jan 2025 01:50:59 GMT",
+        "20 Jan 2025 01:50:60 GMT",
+        "20 Jan 2025 01:03:03 GMT",
+        "Mon, 20 Jan 2025 01:03:03 GMT",
+        "Mon, 03 Feb 2025 01:03:03 GMT",
+        "Mon, 03 Mar 2025 01:03:03 GMT",
+        "Mon, 14 Apr 2025 01:03:03 GMT",
+        "Mon, 05 May 2025 01:03:03 GMT",
+        "Mon, 21 Jul 2025 01:03:03 GMT",
+        "Mon, 04 Aug 2025 01:03:03 GMT",
+        "Mon, 22 Sep 2025 01:03:03 GMT",
+        "Mon, 30 Oct 2025 01:03:03 GMT",
+        "Mon, 24 Nov 2025 01:03:03 GMT",
+        "Mon, 22 Dec 2025 01:03:03 GMT",
+        "Tue, 29 Feb 2028 01:03:03 GMT", // leap day
+    ])
+    func variousInputs(good: String) {
+        #expect(throws: Never.self) {
+            try Date(good, strategy: .http)
+        }
+        #expect(throws: Never.self) {
+            try DateComponents(good, strategy: .http)
         }
     }
     
-    func test_HTTPFormat_badInputs() throws {
-        let tests = [
-            "Xri, 17 Jan 2025 19:03:05 GMT",
-            "Fri, 17 Janu 2025 19:03:05 GMT",
-            "Fri, 17Jan 2025 19:03:05 GMT",
-            "Fri, 17 Xrz 2025 19:03:05 GMT",
-            "Fri, 17 Jan 2025 19:03:05", // missing GMT
-            "Fri, 1 Jan 2025 19:03:05 GMT",
-            "Fri, 17 Jan 2025 1:03:05 GMT",
-            "Fri, 17 Jan 2025 19:3:05 GMT",
-            "Fri, 17 Jan 2025 19:03:5 GMT",
-            "Fri, 17 Jan 2025 19:03:05 GmT",
-            "Fri, 17 Jan 20252 19:03:05 GMT",
-            "Fri, 17 Jan 252 19:03:05 GMT",
-            "fri, 17 Jan 2025 19:03:05 GMT", // miscapitalized
-            "Fri, 17 jan 2025 19:03:05 GMT",
-            "Fri, 16 Jan 2025 25:03:05 GMT", // nonsense date
-            "Fri, 30 Feb 2025 25:03:05 GMT", // nonsense date
-        ]
-        
-        for bad in tests {
-            XCTAssertNil(try? Date(bad, strategy: .http), "Input \(bad) was not nil")
-            XCTAssertNil(try? DateComponents(bad, strategy: .http), "Input \(bad) was not nil")
+    @Test(arguments: [
+        "Xri, 17 Jan 2025 19:03:05 GMT",
+        "Fri, 17 Janu 2025 19:03:05 GMT",
+        "Fri, 17Jan 2025 19:03:05 GMT",
+        "Fri, 17 Xrz 2025 19:03:05 GMT",
+        "Fri, 17 Jan 2025 19:03:05", // missing GMT
+        "Fri, 1 Jan 2025 19:03:05 GMT",
+        "Fri, 17 Jan 2025 1:03:05 GMT",
+        "Fri, 17 Jan 2025 19:3:05 GMT",
+        "Fri, 17 Jan 2025 19:03:5 GMT",
+        "Fri, 17 Jan 2025 19:03:05 GmT",
+        "Fri, 17 Jan 20252 19:03:05 GMT",
+        "Fri, 17 Jan 252 19:03:05 GMT",
+        "fri, 17 Jan 2025 19:03:05 GMT", // miscapitalized
+        "Fri, 17 jan 2025 19:03:05 GMT",
+        "Fri, 16 Jan 2025 25:03:05 GMT", // nonsense date
+        "Fri, 30 Feb 2025 25:03:05 GMT", // nonsense date
+    ])
+    func badInputs(bad: String) {
+        #expect(throws: (any Error).self) {
+            try Date(bad, strategy: .http)
+        }
+        #expect(throws: (any Error).self) {
+            try DateComponents(bad, strategy: .http)
         }
     }
     
-    func test_HTTPComponentsFormat() throws {
+    @Test func componentsFormat() throws {
         let input = "Fri, 17 Jan 2025 19:03:05 GMT"
-        let parsed = try? DateComponents(input, strategy: .http)
+        let parsed = try DateComponents(input, strategy: .http)
         
-        XCTAssertEqual(parsed?.weekday, 6)
-        XCTAssertEqual(parsed?.day, 17)
-        XCTAssertEqual(parsed?.month, 1)
-        XCTAssertEqual(parsed?.year, 2025)
-        XCTAssertEqual(parsed?.hour, 19)
-        XCTAssertEqual(parsed?.minute, 3)
-        XCTAssertEqual(parsed?.second, 5)
-        XCTAssertEqual(parsed?.timeZone, TimeZone.gmt)
+        #expect(parsed.weekday == 6)
+        #expect(parsed.day == 17)
+        #expect(parsed.month == 1)
+        #expect(parsed.year == 2025)
+        #expect(parsed.hour == 19)
+        #expect(parsed.minute == 3)
+        #expect(parsed.second == 5)
+        #expect(parsed.timeZone == TimeZone.gmt)
     }
     
-    func test_validatingResultOfParseVsString() throws {
+    @Test func validatingResultOfParseVsString() throws {
         // This date will parse correctly, but of course the value of 99 does not correspond to the actual day.
         let strangeDate = "Mon, 99 Jan 2025 19:03:05 GMT"
-        let date = try XCTUnwrap(Date(strangeDate, strategy: .http))
-        let components = try XCTUnwrap(DateComponents(strangeDate, strategy: .http))
+        let date = try Date(strangeDate, strategy: .http)
+        let components = try DateComponents(strangeDate, strategy: .http)
         
         let actualDay = Calendar(identifier: .gregorian).component(.day, from: date)
-        let componentDay = try XCTUnwrap(components.day)
-        XCTAssertNotEqual(actualDay, componentDay)
+        let componentDay = try #require(components.day)
+        #expect(actualDay != componentDay)
     }
 }
 

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
@@ -10,9 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(TestSupport)
-import TestSupport
-#endif
+import Testing
 
 #if canImport(FoundationEssentials)
 @testable import FoundationEssentials
@@ -22,41 +20,42 @@ import TestSupport
 @testable import Foundation
 #endif
 
-final class ISO8601FormatStyleFormattingTests: XCTestCase {
+@Suite("ISO8601FormatStyle Formatting")
+private struct ISO8601FormatStyleFormattingTests {
 
-    func test_ISO8601Format() throws {
+    @Test func iso8601Format() throws {
         let date = Date(timeIntervalSinceReferenceDate: 665076946.0)
         let fractionalSecondsDate = Date(timeIntervalSinceReferenceDate: 665076946.011)
         let iso8601 = Date.ISO8601FormatStyle()
 
         // Date is: "2022-01-28 15:35:46"
-        XCTAssertEqual(iso8601.format(date), "2022-01-28T15:35:46Z")
+        #expect(iso8601.format(date) == "2022-01-28T15:35:46Z")
 
-        XCTAssertEqual(iso8601.time(includingFractionalSeconds: true).format(fractionalSecondsDate), "15:35:46.011")
+        #expect(iso8601.time(includingFractionalSeconds: true).format(fractionalSecondsDate) == "15:35:46.011")
 
-        XCTAssertEqual(iso8601.year().month().day().time(includingFractionalSeconds: true).format(fractionalSecondsDate), "2022-01-28T15:35:46.011")
+        #expect(iso8601.year().month().day().time(includingFractionalSeconds: true).format(fractionalSecondsDate) == "2022-01-28T15:35:46.011")
 
         // Day-only results: the default time is midnight for parsed date when the time piece is missing
         // Date is: "2022-01-28 00:00:00"
-        XCTAssertEqual(iso8601.year().month().day().dateSeparator(.dash).format(date), "2022-01-28")
+        #expect(iso8601.year().month().day().dateSeparator(.dash).format(date) == "2022-01-28")
         
         // Date is: "2022-01-28 00:00:00"
-        XCTAssertEqual(iso8601.year().month().day().dateSeparator(.omitted).format(date), "20220128")
+        #expect(iso8601.year().month().day().dateSeparator(.omitted).format(date) == "20220128")
 
         // Time-only results: we use the default date of the format style, 1970-01-01, to supplement the parsed date without year, month or day
         // Date is: "1970-01-23 00:00:00"
-        XCTAssertEqual(iso8601.weekOfYear().day().dateSeparator(.dash).format(date), "W04-05")
+        #expect(iso8601.weekOfYear().day().dateSeparator(.dash).format(date) == "W04-05")
 
         // Date is: "1970-01-28 15:35:46"
-        XCTAssertEqual(iso8601.day().time(includingFractionalSeconds: false).timeSeparator(.colon).format(date), "028T15:35:46")
+        #expect(iso8601.day().time(includingFractionalSeconds: false).timeSeparator(.colon).format(date) == "028T15:35:46")
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(iso8601.time(includingFractionalSeconds: false).timeSeparator(.colon).format(date), "15:35:46")
+        #expect(iso8601.time(includingFractionalSeconds: false).timeSeparator(.colon).format(date) == "15:35:46")
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted).format(date), "15:35:46Z")
+        #expect(iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted).format(date) == "15:35:46Z")
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(iso8601.time(includingFractionalSeconds: false).timeZone(separator: .colon).format(date), "15:35:46Z")
+        #expect(iso8601.time(includingFractionalSeconds: false).timeZone(separator: .colon).format(date) == "15:35:46Z")
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(iso8601.timeZone(separator: .colon).time(includingFractionalSeconds: false).timeSeparator(.colon).format(date), "15:35:46Z")
+        #expect(iso8601.timeZone(separator: .colon).time(includingFractionalSeconds: false).timeSeparator(.colon).format(date) == "15:35:46Z")
                 
         // Time zones
         
@@ -67,32 +66,32 @@ final class ISO8601FormatStyleFormattingTests: XCTestCase {
         var iso8601PacificIsh = iso8601
         iso8601PacificIsh.timeZone = TimeZone(secondsFromGMT: -3600 * 8 - 30)!
         
-        XCTAssertEqual(iso8601Pacific.timeSeparator(.omitted).format(date), "2022-01-28T073546-0800")
-        XCTAssertEqual(iso8601Pacific.timeSeparator(.omitted).timeZoneSeparator(.colon).format(date), "2022-01-28T073546-08:00")
+        #expect(iso8601Pacific.timeSeparator(.omitted).format(date) == "2022-01-28T073546-0800")
+        #expect(iso8601Pacific.timeSeparator(.omitted).timeZoneSeparator(.colon).format(date) == "2022-01-28T073546-08:00")
 
-        XCTAssertEqual(iso8601PacificIsh.timeSeparator(.omitted).format(date), "2022-01-28T073516-080030")
-        XCTAssertEqual(iso8601PacificIsh.timeSeparator(.omitted).timeZoneSeparator(.colon).format(date), "2022-01-28T073516-08:00:30")
+        #expect(iso8601PacificIsh.timeSeparator(.omitted).format(date) == "2022-01-28T073516-080030")
+        #expect(iso8601PacificIsh.timeSeparator(.omitted).timeZoneSeparator(.colon).format(date) == "2022-01-28T073516-08:00:30")
         
         var iso8601gmtP1 = iso8601
         iso8601gmtP1.timeZone = TimeZone(secondsFromGMT: 3600)!
-        XCTAssertEqual(iso8601gmtP1.timeSeparator(.omitted).format(date), "2022-01-28T163546+0100")
-        XCTAssertEqual(iso8601gmtP1.timeSeparator(.omitted).timeZoneSeparator(.colon).format(date), "2022-01-28T163546+01:00")
+        #expect(iso8601gmtP1.timeSeparator(.omitted).format(date) == "2022-01-28T163546+0100")
+        #expect(iso8601gmtP1.timeSeparator(.omitted).timeZoneSeparator(.colon).format(date) == "2022-01-28T163546+01:00")
         
     }
 
-    func test_ISO8601ComponentsFormatMissingPieces() throws {
+    @Test func iso8601ComponentsFormatMissingPieces() throws {
         // Example code from the proposal
         let components = DateComponents(year: 1999, month: 12, day: 31)
         let formatted = components.formatted(.iso8601)
-        XCTAssertEqual(formatted, "1999-12-31T00:00:00Z")
+        #expect(formatted == "1999-12-31T00:00:00Z")
 
 
         let emptyComponents = DateComponents()
         let emptyFormatted = emptyComponents.formatted(.iso8601)
-        XCTAssertEqual(emptyFormatted, "1970-01-01T00:00:00Z")
+        #expect(emptyFormatted == "1970-01-01T00:00:00Z")
     }
     
-    func test_ISO8601ComponentsFormat() throws {
+    @Test func iso8601ComponentsFormat() throws {
         let date = Date(timeIntervalSinceReferenceDate: 665076946.0)
         // Be sure to use the ISO8601 calendar here to decompose to the right week of year components (the starting day is not the same as gregorian)
         let componentsInGMT = Calendar(identifier: .iso8601).dateComponents(in: .gmt, from: date)
@@ -101,33 +100,33 @@ final class ISO8601FormatStyleFormattingTests: XCTestCase {
         let iso8601 = DateComponents.ISO8601FormatStyle()
 
         // Date is: "2022-01-28 15:35:46"
-        XCTAssertEqual(iso8601.format(componentsInGMT), "2022-01-28T15:35:46Z")
+        #expect(iso8601.format(componentsInGMT) == "2022-01-28T15:35:46Z")
 
-        XCTAssertEqual(iso8601.time(includingFractionalSeconds: true).format(fractionalSecondsComponents), "15:35:46.011")
+        #expect(iso8601.time(includingFractionalSeconds: true).format(fractionalSecondsComponents) == "15:35:46.011")
 
-        XCTAssertEqual(iso8601.year().month().day().time(includingFractionalSeconds: true).format(fractionalSecondsComponents), "2022-01-28T15:35:46.011")
+        #expect(iso8601.year().month().day().time(includingFractionalSeconds: true).format(fractionalSecondsComponents) == "2022-01-28T15:35:46.011")
 
         // Day-only results: the default time is midnight for parsed date when the time piece is missing
         // Date is: "2022-01-28 00:00:00"
-        XCTAssertEqual(iso8601.year().month().day().dateSeparator(.dash).format(componentsInGMT), "2022-01-28")
+        #expect(iso8601.year().month().day().dateSeparator(.dash).format(componentsInGMT) == "2022-01-28")
         
         // Date is: "2022-01-28 00:00:00"
-        XCTAssertEqual(iso8601.year().month().day().dateSeparator(.omitted).format(componentsInGMT), "20220128")
+        #expect(iso8601.year().month().day().dateSeparator(.omitted).format(componentsInGMT) == "20220128")
 
         // Time-only results: we use the default date of the format style, 1970-01-01, to supplement the parsed date without year, month or day
         // Date is: "1970-01-23 00:00:00"
-        XCTAssertEqual(iso8601.weekOfYear().day().dateSeparator(.dash).format(componentsInGMT), "W04-05")
+        #expect(iso8601.weekOfYear().day().dateSeparator(.dash).format(componentsInGMT) == "W04-05")
 
         // Date is: "1970-01-28 15:35:46"
-        XCTAssertEqual(iso8601.day().time(includingFractionalSeconds: false).timeSeparator(.colon).format(componentsInGMT), "028T15:35:46")
+        #expect(iso8601.day().time(includingFractionalSeconds: false).timeSeparator(.colon).format(componentsInGMT) == "028T15:35:46")
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(iso8601.time(includingFractionalSeconds: false).timeSeparator(.colon).format(componentsInGMT), "15:35:46")
+        #expect(iso8601.time(includingFractionalSeconds: false).timeSeparator(.colon).format(componentsInGMT) == "15:35:46")
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted).format(componentsInGMT), "15:35:46Z")
+        #expect(iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted).format(componentsInGMT) == "15:35:46Z")
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(iso8601.time(includingFractionalSeconds: false).timeZone(separator: .colon).format(componentsInGMT), "15:35:46Z")
+        #expect(iso8601.time(includingFractionalSeconds: false).timeZone(separator: .colon).format(componentsInGMT) == "15:35:46Z")
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(iso8601.timeZone(separator: .colon).time(includingFractionalSeconds: false).timeSeparator(.colon).format(componentsInGMT), "15:35:46Z")
+        #expect(iso8601.timeZone(separator: .colon).time(includingFractionalSeconds: false).timeSeparator(.colon).format(componentsInGMT) == "15:35:46Z")
                 
         // Time zones
         
@@ -136,8 +135,8 @@ final class ISO8601FormatStyleFormattingTests: XCTestCase {
         iso8601Pacific.timeZone = pacificTimeZone
         let componentsInPacific = Calendar(identifier: .iso8601).dateComponents(in: pacificTimeZone, from: date)
 
-        XCTAssertEqual(iso8601Pacific.timeSeparator(.omitted).format(componentsInPacific), "2022-01-28T073546-0800")
-        XCTAssertEqual(iso8601Pacific.timeSeparator(.omitted).timeZoneSeparator(.colon).format(componentsInPacific), "2022-01-28T073546-08:00")
+        #expect(iso8601Pacific.timeSeparator(.omitted).format(componentsInPacific) == "2022-01-28T073546-0800")
+        #expect(iso8601Pacific.timeSeparator(.omitted).timeZoneSeparator(.colon).format(componentsInPacific) == "2022-01-28T073546-08:00")
 
         // Has a seconds component (-28830)
         var iso8601PacificIsh = iso8601
@@ -145,71 +144,72 @@ final class ISO8601FormatStyleFormattingTests: XCTestCase {
         iso8601PacificIsh.timeZone = pacificIshTimeZone
         let componentsInPacificIsh = Calendar(identifier: .iso8601).dateComponents(in: pacificIshTimeZone, from: date)
 
-        XCTAssertEqual(iso8601PacificIsh.timeSeparator(.omitted).format(componentsInPacificIsh), "2022-01-28T073516-080030")
-        XCTAssertEqual(iso8601PacificIsh.timeSeparator(.omitted).timeZoneSeparator(.colon).format(componentsInPacificIsh), "2022-01-28T073516-08:00:30")
+        #expect(iso8601PacificIsh.timeSeparator(.omitted).format(componentsInPacificIsh) == "2022-01-28T073516-080030")
+        #expect(iso8601PacificIsh.timeSeparator(.omitted).timeZoneSeparator(.colon).format(componentsInPacificIsh) == "2022-01-28T073516-08:00:30")
         
         var iso8601gmtP1 = iso8601
         let gmtP1TimeZone = TimeZone(secondsFromGMT: 3600)!
         iso8601gmtP1.timeZone = gmtP1TimeZone
         let componentsInGMTP1 = Calendar(identifier: .iso8601).dateComponents(in: gmtP1TimeZone, from: date)
-        XCTAssertEqual(iso8601gmtP1.timeSeparator(.omitted).format(componentsInGMTP1), "2022-01-28T163546+0100")
-        XCTAssertEqual(iso8601gmtP1.timeSeparator(.omitted).timeZoneSeparator(.colon).format(componentsInGMTP1), "2022-01-28T163546+01:00")
+        #expect(iso8601gmtP1.timeSeparator(.omitted).format(componentsInGMTP1) == "2022-01-28T163546+0100")
+        #expect(iso8601gmtP1.timeSeparator(.omitted).timeZoneSeparator(.colon).format(componentsInGMTP1) == "2022-01-28T163546+01:00")
     }
     
-    func test_codable() {
+    @Test func codable() throws {
         let iso8601Style = Date.ISO8601FormatStyle().year().month().day()
         let encoder = JSONEncoder()
-        let encodedStyle = try! encoder.encode(iso8601Style)
+        let encodedStyle = try encoder.encode(iso8601Style)
         let decoder = JSONDecoder()
-        let decodedStyle = try? decoder.decode(Date.ISO8601FormatStyle.self, from: encodedStyle)
-        XCTAssertNotNil(decodedStyle)
+        #expect(throws: Never.self) {
+            _ = try decoder.decode(Date.ISO8601FormatStyle.self, from: encodedStyle)
+        }
     }
 
-    func testLeadingDotSyntax() {
+    @Test func leadingDotSyntax() {
         let _ = Date().formatted(.iso8601)
     }
 
-    func test_ISO8601FormatWithDate() throws {
+    @Test func iso8601FormatWithDate() throws {
         // dateFormatter.date(from: "2021-07-01 15:56:32")!
         let date = Date(timeIntervalSinceReferenceDate: 646847792.0) // Thursday
-        XCTAssertEqual(date.formatted(.iso8601), "2021-07-01T15:56:32Z")
-        XCTAssertEqual(date.formatted(.iso8601.dateSeparator(.omitted)), "20210701T15:56:32Z")
-        XCTAssertEqual(date.formatted(.iso8601.dateTimeSeparator(.space)), "2021-07-01 15:56:32Z")
-        XCTAssertEqual(date.formatted(.iso8601.timeSeparator(.omitted)), "2021-07-01T155632Z")
-        XCTAssertEqual(date.formatted(.iso8601.dateSeparator(.omitted).timeSeparator(.omitted)), "20210701T155632Z")
-        XCTAssertEqual(date.formatted(.iso8601.year().month().day().time(includingFractionalSeconds: false).timeZone(separator: .omitted)), "2021-07-01T15:56:32Z")
-        XCTAssertEqual(date.formatted(.iso8601.year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .omitted).dateSeparator(.dash).dateTimeSeparator(.standard).timeSeparator(.colon)), "2021-07-01T15:56:32.000Z")
+        #expect(date.formatted(.iso8601) == "2021-07-01T15:56:32Z")
+        #expect(date.formatted(.iso8601.dateSeparator(.omitted)) == "20210701T15:56:32Z")
+        #expect(date.formatted(.iso8601.dateTimeSeparator(.space)) == "2021-07-01 15:56:32Z")
+        #expect(date.formatted(.iso8601.timeSeparator(.omitted)) == "2021-07-01T155632Z")
+        #expect(date.formatted(.iso8601.dateSeparator(.omitted).timeSeparator(.omitted)) == "20210701T155632Z")
+        #expect(date.formatted(.iso8601.year().month().day().time(includingFractionalSeconds: false).timeZone(separator: .omitted)) == "2021-07-01T15:56:32Z")
+        #expect(date.formatted(.iso8601.year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .omitted).dateSeparator(.dash).dateTimeSeparator(.standard).timeSeparator(.colon)) == "2021-07-01T15:56:32.000Z")
 
-        XCTAssertEqual(date.formatted(.iso8601.year()), "2021")
-        XCTAssertEqual(date.formatted(.iso8601.year().month()), "2021-07")
-        XCTAssertEqual(date.formatted(.iso8601.year().month().day()), "2021-07-01")
-        XCTAssertEqual(date.formatted(.iso8601.year().month().day().dateSeparator(.omitted)), "20210701")
+        #expect(date.formatted(.iso8601.year()) == "2021")
+        #expect(date.formatted(.iso8601.year().month()) == "2021-07")
+        #expect(date.formatted(.iso8601.year().month().day()) == "2021-07-01")
+        #expect(date.formatted(.iso8601.year().month().day().dateSeparator(.omitted)) == "20210701")
 
-        XCTAssertEqual(date.formatted(.iso8601.year().weekOfYear()), "2021-W26")
-        XCTAssertEqual(date.formatted(.iso8601.year().weekOfYear().day()), "2021-W26-04") // day() is the weekday number
-        XCTAssertEqual(date.formatted(.iso8601.year().day()), "2021-182") // day() is the ordinal day
+        #expect(date.formatted(.iso8601.year().weekOfYear()) == "2021-W26")
+        #expect(date.formatted(.iso8601.year().weekOfYear().day()) == "2021-W26-04") // day() is the weekday number
+        #expect(date.formatted(.iso8601.year().day()) == "2021-182") // day() is the ordinal day
 
-        XCTAssertEqual(date.formatted(.iso8601.time(includingFractionalSeconds: false)), "15:56:32")
-        XCTAssertEqual(date.formatted(.iso8601.time(includingFractionalSeconds: true)), "15:56:32.000")
-        XCTAssertEqual(date.formatted(.iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted)), "15:56:32Z")
+        #expect(date.formatted(.iso8601.time(includingFractionalSeconds: false)) == "15:56:32")
+        #expect(date.formatted(.iso8601.time(includingFractionalSeconds: true)) == "15:56:32.000")
+        #expect(date.formatted(.iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted)) == "15:56:32Z")
     }
 
-    func test_remoteDate() throws {
+    @Test func remoteDate() throws {
         let date = Date(timeIntervalSince1970: 999999999999.0) // Remote date
-        XCTAssertEqual(date.formatted(.iso8601), "33658-09-27T01:46:39Z")
-        XCTAssertEqual(date.formatted(.iso8601.year().weekOfYear().day()), "33658-W39-05") // day() is the weekday number
+        #expect(date.formatted(.iso8601) == "33658-09-27T01:46:39Z")
+        #expect(date.formatted(.iso8601.year().weekOfYear().day()) == "33658-W39-05") // day() is the weekday number
     }
 
-    func test_internal_formatDateComponents() throws {
+    @Test func internal_formatDateComponents() throws {
         let dc = DateComponents(year: -2025, month: 1, day: 20, hour: 0, minute: 0, second: 0)
         let str = Date.ISO8601FormatStyle().format(dc, appendingTimeZoneOffset: 0)
-        XCTAssertEqual(str, "-2025-01-20T00:00:00Z")
+        #expect(str == "-2025-01-20T00:00:00Z")
     }
     
-    func test_rounding() {
+    @Test func rounding() {
         // Date is: "1970-01-01 15:35:45.9999"
         let date = Date(timeIntervalSinceReferenceDate: -978251054.0 - 0.0001)
         let str = Date.ISO8601FormatStyle().timeZone(separator: .colon).time(includingFractionalSeconds: true).timeSeparator(.colon).format(date)
-        XCTAssertEqual(str, "15:35:45.999Z")
+        #expect(str == "15:35:45.999Z")
     }
 }

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
@@ -6,157 +6,162 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(TestSupport)
-import TestSupport
-#endif
+import Testing
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+import Foundation
 #endif
 
-final class ISO8601FormatStyleParsingTests: XCTestCase {
+@Suite("ISO8601FormatStyle Parsing")
+private struct ISO8601FormatStyleParsingTests {
 
     /// See also the format-only tests in DateISO8601FormatStyleEssentialsTests
-    func test_ISO8601Parse() throws {
+    @Test func iso8601Parse() throws {
         let iso8601 = Date.ISO8601FormatStyle()
 
         // Date is: "2022-01-28 15:35:46"
-        XCTAssertEqual(try? iso8601.parse("2022-01-28T15:35:46Z"), Date(timeIntervalSinceReferenceDate: 665076946.0))
+        #expect(try iso8601.parse("2022-01-28T15:35:46Z") == Date(timeIntervalSinceReferenceDate: 665076946.0))
 
         var iso8601Pacific = iso8601
         iso8601Pacific.timeZone = TimeZone(secondsFromGMT: -3600 * 8)!
-        XCTAssertEqual(try? iso8601Pacific.timeSeparator(.omitted).parse("2022-01-28T073546-0800"), Date(timeIntervalSinceReferenceDate: 665076946.0))
+        #expect(try iso8601Pacific.timeSeparator(.omitted).parse("2022-01-28T073546-0800") == Date(timeIntervalSinceReferenceDate: 665076946.0))
 
         // Day-only results: the default time is midnight for parsed date when the time piece is missing
         // Date is: "2022-01-28 00:00:00"
-        XCTAssertEqual(try? iso8601.year().month().day().dateSeparator(.dash).parse("2022-01-28"), Date(timeIntervalSinceReferenceDate: 665020800.0))
+        #expect(try iso8601.year().month().day().dateSeparator(.dash).parse("2022-01-28") == Date(timeIntervalSinceReferenceDate: 665020800.0))
         // Date is: "2022-01-28 00:00:00"
-        XCTAssertEqual(try? iso8601.year().month().day().dateSeparator(.omitted).parse("20220128"), Date(timeIntervalSinceReferenceDate: 665020800.0))
+        #expect(try iso8601.year().month().day().dateSeparator(.omitted).parse("20220128") == Date(timeIntervalSinceReferenceDate: 665020800.0))
 
         // Time-only results: we use the default date of the format style, 1970-01-01, to supplement the parsed date without year, month or day
         // Date is: "1970-01-23 00:00:00"
-        XCTAssertEqual(try? iso8601.weekOfYear().day().dateSeparator(.dash).parse("W04-05"), Date(timeIntervalSinceReferenceDate: -976406400.0))
+        #expect(try iso8601.weekOfYear().day().dateSeparator(.dash).parse("W04-05") == Date(timeIntervalSinceReferenceDate: -976406400.0))
         // Date is: "1970-01-28 15:35:46"
-        XCTAssertEqual(try? iso8601.day().time(includingFractionalSeconds: false).timeSeparator(.colon).parse("028T15:35:46"), Date(timeIntervalSinceReferenceDate: -975918254.0))
+        #expect(try iso8601.day().time(includingFractionalSeconds: false).timeSeparator(.colon).parse("028T15:35:46") == Date(timeIntervalSinceReferenceDate: -975918254.0))
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(try? iso8601.time(includingFractionalSeconds: false).timeSeparator(.colon).parse("15:35:46"), Date(timeIntervalSinceReferenceDate: -978251054.0))
+        #expect(try iso8601.time(includingFractionalSeconds: false).timeSeparator(.colon).parse("15:35:46") == Date(timeIntervalSinceReferenceDate: -978251054.0))
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(try? iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted).parse("15:35:46Z"), Date(timeIntervalSinceReferenceDate: -978251054.0))
+        #expect(try iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted).parse("15:35:46Z") == Date(timeIntervalSinceReferenceDate: -978251054.0))
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(try? iso8601.time(includingFractionalSeconds: false).timeZone(separator: .colon).parse("15:35:46Z"), Date(timeIntervalSinceReferenceDate: -978251054.0))
+        #expect(try iso8601.time(includingFractionalSeconds: false).timeZone(separator: .colon).parse("15:35:46Z") == Date(timeIntervalSinceReferenceDate: -978251054.0))
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(try? iso8601.timeZone(separator: .colon).time(includingFractionalSeconds: false).timeSeparator(.colon).parse("15:35:46Z"), Date(timeIntervalSinceReferenceDate: -978251054.0))
+        #expect(try iso8601.timeZone(separator: .colon).time(includingFractionalSeconds: false).timeSeparator(.colon).parse("15:35:46Z") == Date(timeIntervalSinceReferenceDate: -978251054.0))
     }
     
-    func test_ISO8601ParseComponents_fromString() throws {
+    @Test func iso8601ParseComponents_fromString() throws {
         let components = try DateComponents.ISO8601FormatStyle().parse("2022-01-28T15:35:46Z")
-        XCTAssertEqual(components, DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, year: 2022, month: 1, day: 28, hour: 15, minute: 35, second: 46))
-        XCTAssertNotNil(components.date)
+        #expect(components == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, year: 2022, month: 1, day: 28, hour: 15, minute: 35, second: 46))
+        #expect(components.date != nil)
     }
     
-    func test_ISO8601ParseComponents_missingComponents() throws {
+    @Test func iso8601ParseComponents_missingComponents() throws {
         // Default style requires time
-        XCTAssertThrowsError(try DateComponents.ISO8601FormatStyle().parse("2022-01-28"))
+        #expect(throws: (any Error).self) {
+            try DateComponents.ISO8601FormatStyle().parse("2022-01-28")
+        }
     }
 
     /// See also the format-only tests in DateISO8601FormatStyleEssentialsTests
-    func test_ISO8601ParseComponents() throws {
+    @Test func iso8601ParseComponents() throws {
         let iso8601 = DateComponents.ISO8601FormatStyle()
 
         // Date is: "2022-01-28 15:35:46"
-        XCTAssertEqual(try? iso8601.parse("2022-01-28T15:35:46Z"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, year: 2022, month: 1, day: 28, hour: 15, minute: 35, second: 46))
+        #expect(try iso8601.parse("2022-01-28T15:35:46Z") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, year: 2022, month: 1, day: 28, hour: 15, minute: 35, second: 46))
 
         var iso8601Pacific = iso8601
         let tz = TimeZone(secondsFromGMT: -3600 * 8)!
         iso8601Pacific.timeZone = tz
-        XCTAssertEqual(try? iso8601Pacific.timeSeparator(.omitted).parse("2022-01-28T073546-0800"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: tz, year: 2022, month: 1, day: 28, hour: 7, minute: 35, second: 46))
+        #expect(try iso8601Pacific.timeSeparator(.omitted).parse("2022-01-28T073546-0800") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: tz, year: 2022, month: 1, day: 28, hour: 7, minute: 35, second: 46))
 
         // Day-only results: the default time is midnight for parsed date when the time piece is missing
         // Date is: "2022-01-28 00:00:00"
-        XCTAssertEqual(try? iso8601.year().month().day().dateSeparator(.dash).parse("2022-01-28"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, year: 2022, month: 1, day: 28))
+        #expect(try iso8601.year().month().day().dateSeparator(.dash).parse("2022-01-28") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, year: 2022, month: 1, day: 28))
         // Date is: "2022-01-28 00:00:00"
-        XCTAssertEqual(try? iso8601.year().month().day().dateSeparator(.omitted).parse("20220128"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, year: 2022, month: 1, day: 28))
+        #expect(try iso8601.year().month().day().dateSeparator(.omitted).parse("20220128") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, year: 2022, month: 1, day: 28))
 
         // Time-only results: we use the default date of the format style, 1970-01-01, to supplement the parsed date without year, month or day
         // Date is: "1970-01-23 00:00:00"
         // note: weekday as understood by Calendar is not the same integer value as the one in the ISO8601 format
-        XCTAssertEqual(try? iso8601.weekOfYear().day().dateSeparator(.dash).parse("W04-05"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, weekday: 6, weekOfYear: 4))
+        #expect(try iso8601.weekOfYear().day().dateSeparator(.dash).parse("W04-05") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, weekday: 6, weekOfYear: 4))
         // Date is: "1970-01-28 15:35:46"
         var expectedWithDayOfYear = DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46)
         expectedWithDayOfYear.dayOfYear = 28
-        XCTAssertEqual(try? iso8601.day().time(includingFractionalSeconds: false).timeSeparator(.colon).parse("028T15:35:46"), expectedWithDayOfYear)
+        #expect(try iso8601.day().time(includingFractionalSeconds: false).timeSeparator(.colon).parse("028T15:35:46") == expectedWithDayOfYear)
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(try? iso8601.time(includingFractionalSeconds: false).timeSeparator(.colon).parse("15:35:46"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46))
+        #expect(try iso8601.time(includingFractionalSeconds: false).timeSeparator(.colon).parse("15:35:46") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46))
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(try? iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted).parse("15:35:46Z"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46))
+        #expect(try iso8601.time(includingFractionalSeconds: false).timeZone(separator: .omitted).parse("15:35:46Z") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46))
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(try? iso8601.time(includingFractionalSeconds: false).timeZone(separator: .colon).parse("15:35:46Z"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46))
+        #expect(try iso8601.time(includingFractionalSeconds: false).timeZone(separator: .colon).parse("15:35:46Z") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46))
         // Date is: "1970-01-01 15:35:46"
-        XCTAssertEqual(try? iso8601.timeZone(separator: .colon).time(includingFractionalSeconds: false).timeSeparator(.colon).parse("15:35:46Z"), DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46))
+        #expect(try iso8601.timeZone(separator: .colon).time(includingFractionalSeconds: false).timeSeparator(.colon).parse("15:35:46Z") == DateComponents(calendar: Calendar(identifier: .iso8601), timeZone: .gmt, hour: 15, minute: 35, second: 46))
     }
         
-    func test_ISO8601FractionalSecondsAreOptional() {
+    @Test func iso8601FractionalSecondsAreOptional() {
         let iso8601 = Date.ISO8601FormatStyle()
         let iso8601WithFraction = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
         
         let str = "2022-01-28T15:35:46Z"
         let strWithFraction = "2022-01-28T15:35:46.123Z"
         
-        XCTAssertNotNil(try? iso8601.parse(str))
-        XCTAssertNotNil(try? iso8601.parse(strWithFraction))
+        #expect(throws: Never.self) {
+            try iso8601.parse(str)
+        }
+        #expect(throws: Never.self) {
+            try iso8601.parse(strWithFraction)
+        }
 
-        XCTAssertNotNil(try? iso8601WithFraction.parse(str))
-        XCTAssertNotNil(try? iso8601WithFraction.parse(strWithFraction))
-    }
-    
-    func test_weekOfYear() throws {
-        let iso8601 = Date.ISO8601FormatStyle()
-
-        // Test some dates around the 2019 - 2020 end of year, and 2026 which has W53
-        let dates = [
-            ("2019-W52-07", "2019-12-29"),
-            ("2020-W01-01", "2019-12-30"),
-            ("2020-W01-02", "2019-12-31"),
-            ("2020-W01-03", "2020-01-01"),
-            ("2026-W53-01", "2026-12-28"),
-            ("2026-W53-02", "2026-12-29"),
-            ("2026-W53-03", "2026-12-30"),
-            ("2026-W53-04", "2026-12-31"),
-            ("2026-W53-05", "2027-01-01"),
-            ("2026-W53-06", "2027-01-02"),
-            ("2026-W53-07", "2027-01-03"),
-            ("2027-W01-01", "2027-01-04"),
-            ("2027-W01-02", "2027-01-05")
-        ]
-
-        for d in dates {
-            let parsedWoY = try iso8601.year().weekOfYear().day().parse(d.0)
-            let parsedY = try iso8601.year().month().day().parse(d.1)
-            XCTAssertEqual(parsedWoY, parsedY)
+        #expect(throws: Never.self) {
+            try iso8601WithFraction.parse(str)
+        }
+        #expect(throws: Never.self) {
+            try iso8601WithFraction.parse(strWithFraction)
         }
     }
     
-    func test_zeroLeadingDigits() {
+    @Test(arguments: [
+        ("2019-W52-07", "2019-12-29"),
+        ("2020-W01-01", "2019-12-30"),
+        ("2020-W01-02", "2019-12-31"),
+        ("2020-W01-03", "2020-01-01"),
+        ("2026-W53-01", "2026-12-28"),
+        ("2026-W53-02", "2026-12-29"),
+        ("2026-W53-03", "2026-12-30"),
+        ("2026-W53-04", "2026-12-31"),
+        ("2026-W53-05", "2027-01-01"),
+        ("2026-W53-06", "2027-01-02"),
+        ("2026-W53-07", "2027-01-03"),
+        ("2027-W01-01", "2027-01-04"),
+        ("2027-W01-02", "2027-01-05")
+    ])
+    func weekOfYear(date: (String, String)) throws {
+        let iso8601 = Date.ISO8601FormatStyle()
+
+        let parsedWoY = try iso8601.year().weekOfYear().day().parse(date.0)
+        let parsedY = try iso8601.year().month().day().parse(date.1)
+        #expect(parsedWoY == parsedY)
+    }
+    
+    @Test func zeroLeadingDigits() throws {
         // The parser allows for an arbitrary number of 0 pads in digits, including none.
         let iso8601 = Date.ISO8601FormatStyle()
 
         // Date is: "2022-01-28 15:35:46"
-        XCTAssertEqual(try? iso8601.parse("2022-01-28T15:35:46Z"), Date(timeIntervalSinceReferenceDate: 665076946.0))
-        XCTAssertEqual(try? iso8601.parse("002022-01-28T15:35:46Z"), Date(timeIntervalSinceReferenceDate: 665076946.0))
-        XCTAssertEqual(try? iso8601.parse("2022-0001-28T15:35:46Z"), Date(timeIntervalSinceReferenceDate: 665076946.0))
-        XCTAssertEqual(try? iso8601.parse("2022-01-0028T15:35:46Z"), Date(timeIntervalSinceReferenceDate: 665076946.0))
-        XCTAssertEqual(try? iso8601.parse("2022-1-28T15:35:46Z"), Date(timeIntervalSinceReferenceDate: 665076946.0))
-        XCTAssertEqual(try? iso8601.parse("2022-01-28T15:35:06Z"), Date(timeIntervalSinceReferenceDate: 665076906.0))
-        XCTAssertEqual(try? iso8601.parse("2022-01-28T15:35:6Z"), Date(timeIntervalSinceReferenceDate: 665076906.0))
-        XCTAssertEqual(try? iso8601.parse("2022-01-28T15:05:46Z"), Date(timeIntervalSinceReferenceDate: 665075146.0))
-        XCTAssertEqual(try? iso8601.parse("2022-01-28T15:5:46Z"), Date(timeIntervalSinceReferenceDate: 665075146.0))
+        #expect(try iso8601.parse("2022-01-28T15:35:46Z") == Date(timeIntervalSinceReferenceDate: 665076946.0))
+        #expect(try iso8601.parse("002022-01-28T15:35:46Z") == Date(timeIntervalSinceReferenceDate: 665076946.0))
+        #expect(try iso8601.parse("2022-0001-28T15:35:46Z") == Date(timeIntervalSinceReferenceDate: 665076946.0))
+        #expect(try iso8601.parse("2022-01-0028T15:35:46Z") == Date(timeIntervalSinceReferenceDate: 665076946.0))
+        #expect(try iso8601.parse("2022-1-28T15:35:46Z") == Date(timeIntervalSinceReferenceDate: 665076946.0))
+        #expect(try iso8601.parse("2022-01-28T15:35:06Z") == Date(timeIntervalSinceReferenceDate: 665076906.0))
+        #expect(try iso8601.parse("2022-01-28T15:35:6Z") == Date(timeIntervalSinceReferenceDate: 665076906.0))
+        #expect(try iso8601.parse("2022-01-28T15:05:46Z") == Date(timeIntervalSinceReferenceDate: 665075146.0))
+        #expect(try iso8601.parse("2022-01-28T15:5:46Z") == Date(timeIntervalSinceReferenceDate: 665075146.0))
     }
     
-    func test_timeZones() {
+    @Test func timeZones() throws {
         let iso8601 = Date.ISO8601FormatStyle()
         let date = Date(timeIntervalSinceReferenceDate: 665076946.0)
         
@@ -167,49 +172,49 @@ final class ISO8601FormatStyleParsingTests: XCTestCase {
         var iso8601PacificIsh = iso8601
         iso8601PacificIsh.timeZone = TimeZone(secondsFromGMT: -3600 * 8 - 30)!
         
-        XCTAssertEqual(try? iso8601Pacific.timeSeparator(.omitted).parse("2022-01-28T073546-0800"), date)
-        XCTAssertEqual(try? iso8601Pacific.timeSeparator(.omitted).timeZoneSeparator(.colon).parse("2022-01-28T073546-08:00"), date)
+        #expect(try iso8601Pacific.timeSeparator(.omitted).parse("2022-01-28T073546-0800") == date)
+        #expect(try iso8601Pacific.timeSeparator(.omitted).timeZoneSeparator(.colon).parse("2022-01-28T073546-08:00") == date)
 
-        XCTAssertEqual(try? iso8601PacificIsh.timeSeparator(.omitted).parse("2022-01-28T073516-080030"), date)
-        XCTAssertEqual(try? iso8601PacificIsh.timeSeparator(.omitted).timeZoneSeparator(.colon).parse("2022-01-28T073516-08:00:30"), date)
+        #expect(try iso8601PacificIsh.timeSeparator(.omitted).parse("2022-01-28T073516-080030") == date)
+        #expect(try iso8601PacificIsh.timeSeparator(.omitted).timeZoneSeparator(.colon).parse("2022-01-28T073516-08:00:30") == date)
         
         var iso8601gmtP1 = iso8601
         iso8601gmtP1.timeZone = TimeZone(secondsFromGMT: 3600)!
-        XCTAssertEqual(try? iso8601gmtP1.timeSeparator(.omitted).parse("2022-01-28T163546+0100"), date)
-        XCTAssertEqual(try? iso8601gmtP1.timeSeparator(.omitted).parse("2022-01-28T163546+010000"), date)
-        XCTAssertEqual(try? iso8601gmtP1.timeSeparator(.omitted).timeZoneSeparator(.colon).parse("2022-01-28T163546+01:00"), date)
-        XCTAssertEqual(try? iso8601gmtP1.timeSeparator(.omitted).timeZoneSeparator(.colon).parse("2022-01-28T163546+01:00:00"), date)
+        #expect(try iso8601gmtP1.timeSeparator(.omitted).parse("2022-01-28T163546+0100") == date)
+        #expect(try iso8601gmtP1.timeSeparator(.omitted).parse("2022-01-28T163546+010000") == date)
+        #expect(try iso8601gmtP1.timeSeparator(.omitted).timeZoneSeparator(.colon).parse("2022-01-28T163546+01:00") == date)
+        #expect(try iso8601gmtP1.timeSeparator(.omitted).timeZoneSeparator(.colon).parse("2022-01-28T163546+01:00:00") == date)
 
         // Due to a quirk of the original implementation, colons are allowed to be present in the time zone even if the time zone separator is omitted
-        XCTAssertEqual(try? iso8601gmtP1.timeSeparator(.omitted).parse("2022-01-28T163546+01:00"), date)
-        XCTAssertEqual(try? iso8601gmtP1.timeSeparator(.omitted).parse("2022-01-28T163546+01:00:00"), date)
+        #expect(try iso8601gmtP1.timeSeparator(.omitted).parse("2022-01-28T163546+01:00") == date)
+        #expect(try iso8601gmtP1.timeSeparator(.omitted).parse("2022-01-28T163546+01:00:00") == date)
     }
     
-    func test_fractionalSeconds() throws {
+    @Test func fractionalSeconds() throws {
         let expectedDate = Date(timeIntervalSinceReferenceDate: 646876592.34567)
         var iso8601 = Date.ISO8601FormatStyle().year().month().day().time(includingFractionalSeconds: true)
         iso8601.timeZone = .gmt
 
-        let parsedWithFraction = try XCTUnwrap(try iso8601.parse("2021-07-01T23:56:32.34567"))
-        let parsedWithoutFraction = try XCTUnwrap(try iso8601.parse("2021-07-01T23:56:32"))
+        let parsedWithFraction = try iso8601.parse("2021-07-01T23:56:32.34567")
+        let parsedWithoutFraction = try iso8601.parse("2021-07-01T23:56:32")
         
-        let parsedWithFraction1 = try XCTUnwrap(try iso8601.parse("2021-07-01T23:56:32.3"))
-        let parsedWithFraction2 = try XCTUnwrap(try iso8601.parse("2021-07-01T23:56:32.34"))
-        let parsedWithFraction3 = try XCTUnwrap(try iso8601.parse("2021-07-01T23:56:32.345"))
-        let parsedWithFraction4 = try XCTUnwrap(try iso8601.parse("2021-07-01T23:56:32.3456"))
+        let parsedWithFraction1 = try iso8601.parse("2021-07-01T23:56:32.3")
+        let parsedWithFraction2 = try iso8601.parse("2021-07-01T23:56:32.34")
+        let parsedWithFraction3 = try iso8601.parse("2021-07-01T23:56:32.345")
+        let parsedWithFraction4 = try iso8601.parse("2021-07-01T23:56:32.3456")
 
-        XCTAssertEqual(parsedWithoutFraction.timeIntervalSinceReferenceDate, expectedDate.timeIntervalSinceReferenceDate, accuracy: 1.0)
+        #expect(abs(parsedWithoutFraction.timeIntervalSinceReferenceDate - expectedDate.timeIntervalSinceReferenceDate) <= 1.0)
 
         // More accurate due to inclusion of fraction
-        XCTAssertEqual(parsedWithFraction.timeIntervalSinceReferenceDate, expectedDate.timeIntervalSinceReferenceDate, accuracy: 0.01)
-        XCTAssertEqual(parsedWithFraction1.timeIntervalSinceReferenceDate, expectedDate.timeIntervalSinceReferenceDate, accuracy: 0.1)
-        XCTAssertEqual(parsedWithFraction2.timeIntervalSinceReferenceDate, expectedDate.timeIntervalSinceReferenceDate, accuracy: 0.1)
-        XCTAssertEqual(parsedWithFraction3.timeIntervalSinceReferenceDate, expectedDate.timeIntervalSinceReferenceDate, accuracy: 0.1)
-        XCTAssertEqual(parsedWithFraction4.timeIntervalSinceReferenceDate, expectedDate.timeIntervalSinceReferenceDate, accuracy: 0.1)
+        #expect(abs(parsedWithFraction.timeIntervalSinceReferenceDate - expectedDate.timeIntervalSinceReferenceDate) <= 0.01)
+        #expect(abs(parsedWithFraction1.timeIntervalSinceReferenceDate - expectedDate.timeIntervalSinceReferenceDate) <= 0.1)
+        #expect(abs(parsedWithFraction2.timeIntervalSinceReferenceDate - expectedDate.timeIntervalSinceReferenceDate) <= 0.1)
+        #expect(abs(parsedWithFraction3.timeIntervalSinceReferenceDate - expectedDate.timeIntervalSinceReferenceDate) <= 0.1)
+        #expect(abs(parsedWithFraction4.timeIntervalSinceReferenceDate - expectedDate.timeIntervalSinceReferenceDate) <= 0.1)
     }
     
-    func test_specialTimeZonesAndSpaces() {
-        let reference = try! Date("2020-03-05T12:00:00+00:00", strategy: .iso8601)
+    @Test func specialTimeZonesAndSpaces() throws {
+        let reference = try Date("2020-03-05T12:00:00+00:00", strategy: .iso8601)
 
         let tests : [(String, Date.ISO8601FormatStyle)] = [
             ("2020-03-05T12:00:00+00:00", Date.ISO8601FormatStyle()),
@@ -242,7 +247,7 @@ final class ISO8601FormatStyleParsingTests: XCTestCase {
 
         for (parseMe, style) in tests {
             let parsed = try? style.parse(parseMe)
-            XCTAssertEqual(parsed, reference, """
+            #expect(parsed == reference, """
 
 parsing : \(parseMe)
 expected: \(reference) \(reference.timeIntervalSinceReferenceDate)
@@ -250,29 +255,20 @@ result  : \(parsed != nil ? parsed!.debugDescription : "nil") \(parsed != nil ? 
 """)
         }
     }
-        
-#if canImport(FoundationInternationalization) || FOUNDATION_FRAMEWORK
-    func test_chileTimeZone() {
-        var iso8601Chile = Date.ISO8601FormatStyle().year().month().day()
-        iso8601Chile.timeZone = TimeZone(name: "America/Santiago")!
-        
-        let date = try? iso8601Chile.parse("2023-09-03")
-        XCTAssertNotNil(date)
-    }
-#endif
 }
 
-final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
+@Suite("Date ISO8601FormatStyle Pattern Matching")
+private struct DateISO8601FormatStylePatternMatchingTests {
 
-    func _matchFullRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {
-        _matchRange(str, formatStyle: formatStyle, range: nil, expectedUpperBound: expectedUpperBound, expectedDate: expectedDate, file: file, line: line)
+    func _matchFullRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, expectedUpperBound: String.Index?, expectedDate: Date?, sourceLocation: SourceLocation = #_sourceLocation) {
+        _matchRange(str, formatStyle: formatStyle, range: nil, expectedUpperBound: expectedUpperBound, expectedDate: expectedDate, sourceLocation: sourceLocation)
     }
 
-    func _matchFullRange(_ str: String, formatStyle: DateComponents.ISO8601FormatStyle, expectedUpperBound: String.Index?, expectedDateComponents: DateComponents?, file: StaticString = #filePath, line: UInt = #line) {
-        _matchRange(str, formatStyle: formatStyle, range: nil, expectedUpperBound: expectedUpperBound, expectedDateComponents: expectedDateComponents, file: file, line: line)
+    func _matchFullRange(_ str: String, formatStyle: DateComponents.ISO8601FormatStyle, expectedUpperBound: String.Index?, expectedDateComponents: DateComponents?, sourceLocation: SourceLocation = #_sourceLocation) {
+        _matchRange(str, formatStyle: formatStyle, range: nil, expectedUpperBound: expectedUpperBound, expectedDateComponents: expectedDateComponents, sourceLocation: sourceLocation)
     }
 
-    func _matchRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, range: Range<String.Index>?, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {
+    func _matchRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, range: Range<String.Index>?, expectedUpperBound: String.Index?, expectedDate: Date?, sourceLocation: SourceLocation = #_sourceLocation) {
         // FIXME: Need tests that starts from somewhere else
         let m = try? formatStyle.consuming(str, startingAt: str.startIndex, in: range ?? str.startIndex..<str.endIndex)
         let upperBound = m?.upperBound
@@ -280,19 +276,16 @@ final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
 
         let upperBoundDescription = upperBound?.utf16Offset(in: str)
         let expectedUpperBoundDescription = expectedUpperBound?.utf16Offset(in: str)
-        XCTAssertEqual(upperBound, expectedUpperBound, "found upperBound: \(String(describing: upperBoundDescription)); expected: \(String(describing: expectedUpperBoundDescription))", file: file, line: line)
+        #expect(upperBound == expectedUpperBound, "found upperBound: \(String(describing: upperBoundDescription)); expected: \(String(describing: expectedUpperBoundDescription))", sourceLocation: sourceLocation)
         if let match, let expectedDate {
-            XCTAssertEqual(
-                match.timeIntervalSinceReferenceDate,
-                expectedDate.timeIntervalSinceReferenceDate,
-                accuracy: 0.001,
-                file: file,
-                line: line
+            #expect(
+                abs(match.timeIntervalSinceReferenceDate - expectedDate.timeIntervalSinceReferenceDate) <= 0.001,
+                sourceLocation: sourceLocation
             )
         }
     }
 
-    func _matchRange(_ str: String, formatStyle: DateComponents.ISO8601FormatStyle, range: Range<String.Index>?, expectedUpperBound: String.Index?, expectedDateComponents: DateComponents?, file: StaticString = #filePath, line: UInt = #line) {
+    func _matchRange(_ str: String, formatStyle: DateComponents.ISO8601FormatStyle, range: Range<String.Index>?, expectedUpperBound: String.Index?, expectedDateComponents: DateComponents?, sourceLocation: SourceLocation = #_sourceLocation) {
         // FIXME: Need tests that starts from somewhere else
         let m = try? formatStyle.consuming(str, startingAt: str.startIndex, in: range ?? str.startIndex..<str.endIndex)
         let upperBound = m?.upperBound
@@ -300,39 +293,37 @@ final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
 
         let upperBoundDescription = upperBound?.utf16Offset(in: str)
         let expectedUpperBoundDescription = expectedUpperBound?.utf16Offset(in: str)
-        XCTAssertEqual(upperBound, expectedUpperBound, "found upperBound: \(String(describing: upperBoundDescription)); expected: \(String(describing: expectedUpperBoundDescription))", file: file, line: line)
+        #expect(upperBound == expectedUpperBound, "found upperBound: \(String(describing: upperBoundDescription)); expected: \(String(describing: expectedUpperBoundDescription))", sourceLocation: sourceLocation)
         if let match, let expectedDateComponents {
             // Only verify the components that are set in the expected. Skip them if they are nil. We don't provide a way to verify the output is nil in this function.
             let comps : [Calendar.Component] = [.era, .year, .month, .day, .hour, .minute, .second, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .nanosecond, .dayOfYear]
             for c in comps {
                 if let expected = expectedDateComponents.value(for: c) {
-                    XCTAssertEqual(
-                        match.value(for: c),
-                        expected,
-                        file: file,
-                        line: line)
+                    #expect(
+                        match.value(for: c) == expected,
+                        sourceLocation: sourceLocation)
                 }
             }
             
             if let tz = expectedDateComponents.timeZone {
-                XCTAssertEqual(match.timeZone, tz, file: file, line: line)
+                #expect(match.timeZone == tz, sourceLocation: sourceLocation)
             }
         }
         
         if match != nil, expectedDateComponents == nil {
-            XCTFail("Expected no result, but got one anyway", file: file, line: line)
+            Issue.record("Expected no result, but got one anyway", sourceLocation: sourceLocation)
         }
     }
 
-    func testMatchDefaultISO8601Style() throws {
-        func verify(_ str: String, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {
+    @Test func matchDefaultISO8601Style() throws {
+        func verify(_ str: String, expectedUpperBound: String.Index?, expectedDate: Date?, sourceLocation: SourceLocation = #_sourceLocation) {
             let iso8601FormatStyle = Date.ISO8601FormatStyle()
-            _matchFullRange(str, formatStyle: iso8601FormatStyle, expectedUpperBound: expectedUpperBound, expectedDate: expectedDate, file: file, line: line)
+            _matchFullRange(str, formatStyle: iso8601FormatStyle, expectedUpperBound: expectedUpperBound, expectedDate: expectedDate, sourceLocation: sourceLocation)
         }
         
-        func verify(_ str: String, expectedUpperBound: String.Index?, expectedDateComponents: DateComponents?, file: StaticString = #filePath, line: UInt = #line) {
+        func verify(_ str: String, expectedUpperBound: String.Index?, expectedDateComponents: DateComponents?, sourceLocation: SourceLocation = #_sourceLocation) {
             let iso8601ComponentsFormatStyle = DateComponents.ISO8601FormatStyle()
-            _matchFullRange(str, formatStyle: iso8601ComponentsFormatStyle, expectedUpperBound: expectedUpperBound, expectedDateComponents: expectedDateComponents, file: file, line: line)
+            _matchFullRange(str, formatStyle: iso8601ComponentsFormatStyle, expectedUpperBound: expectedUpperBound, expectedDateComponents: expectedDateComponents, sourceLocation: sourceLocation)
         }
 
         // dateFormatter.date(from: "2021-07-01 15:56:32")!
@@ -351,15 +342,15 @@ final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
         verify("9999-37-40T35:70:99Z", expectedUpperBound: nil, expectedDateComponents: nil) // This is not a valid date
     }
 
-    func testPartialMatchISO8601() throws {
-        func verify(_ str: String, _ style: Date.ISO8601FormatStyle, expectedDate: Date?, expectedLength: Int?, file: StaticString = #filePath, line: UInt = #line) {
+    @Test func partialMatchISO8601() throws {
+        func verify(_ str: String, _ style: Date.ISO8601FormatStyle, expectedDate: Date?, expectedLength: Int?, sourceLocation: SourceLocation = #_sourceLocation) {
             let expectedUpperBoundStrIndx = (expectedLength != nil) ? str.index(str.startIndex, offsetBy: expectedLength!) : nil
-            _matchFullRange(str, formatStyle: style, expectedUpperBound: expectedUpperBoundStrIndx, expectedDate: expectedDate, file: file, line: line)
+            _matchFullRange(str, formatStyle: style, expectedUpperBound: expectedUpperBoundStrIndx, expectedDate: expectedDate, sourceLocation: sourceLocation)
         }
 
-        func verify(_ str: String, _ style: DateComponents.ISO8601FormatStyle, expectedDateComponents: DateComponents?, expectedLength: Int?, file: StaticString = #filePath, line: UInt = #line) {
+        func verify(_ str: String, _ style: DateComponents.ISO8601FormatStyle, expectedDateComponents: DateComponents?, expectedLength: Int?, sourceLocation: SourceLocation = #_sourceLocation) {
             let expectedUpperBoundStrIndx = (expectedLength != nil) ? str.index(str.startIndex, offsetBy: expectedLength!) : nil
-            _matchFullRange(str, formatStyle: style, expectedUpperBound: expectedUpperBoundStrIndx, expectedDateComponents: expectedDateComponents, file: file, line: line)
+            _matchFullRange(str, formatStyle: style, expectedUpperBound: expectedUpperBoundStrIndx, expectedDateComponents: expectedDateComponents, sourceLocation: sourceLocation)
         }
 
         let gmt = TimeZone(secondsFromGMT: 0)!
@@ -458,14 +449,14 @@ final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
         }
     }
 
-    func testFullMatch() {
+    @Test func fullMatch() {
 
-        func verify(_ str: String, _ style: Date.ISO8601FormatStyle, expectedDate: Date, file: StaticString = #filePath, line: UInt = #line) {
-            _matchFullRange(str, formatStyle: style, expectedUpperBound: str.endIndex, expectedDate: expectedDate, file: file, line: line)
+        func verify(_ str: String, _ style: Date.ISO8601FormatStyle, expectedDate: Date, sourceLocation: SourceLocation = #_sourceLocation) {
+            _matchFullRange(str, formatStyle: style, expectedUpperBound: str.endIndex, expectedDate: expectedDate, sourceLocation: sourceLocation)
         }
 
-        func verify(_ str: String, _ style: DateComponents.ISO8601FormatStyle, expectedDateComponents: DateComponents, file: StaticString = #filePath, line: UInt = #line) {
-            _matchFullRange(str, formatStyle: style, expectedUpperBound: str.endIndex, expectedDateComponents: expectedDateComponents, file: file, line: line)
+        func verify(_ str: String, _ style: DateComponents.ISO8601FormatStyle, expectedDateComponents: DateComponents, sourceLocation: SourceLocation = #_sourceLocation) {
+            _matchFullRange(str, formatStyle: style, expectedUpperBound: str.endIndex, expectedDateComponents: expectedDateComponents, sourceLocation: sourceLocation)
         }
 
         do {

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -732,7 +732,7 @@ final class CalendarTests : XCTestCase {
         let startDate = Date(timeIntervalSinceReferenceDate: 689292158.712307) // 2022-11-04 22:02:38 UTC
         let endDate = startDate + (86400 * 3) + (3600 * 2) // 3 days + 2 hours later - cross a DST boundary which adds a day with an additional hour in it
         var cal = Calendar(identifier: .gregorian)
-        let tz = TimeZone(name: "America/Los_Angeles")!
+        let tz = TimeZone(identifier: "America/Los_Angeles")!
         cal.timeZone = tz
         
         // Purpose of this test is not to test the addition itself (we have others for that), but to smoke test the wrapping API

--- a/Tests/FoundationInternationalizationTests/Formatting/ISO8601FormatStyleInternationalizationParsingTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ISO8601FormatStyleInternationalizationParsingTests.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+#if canImport(FoundationInternationalization)
+import FoundationEssentials
+import FoundationInternationalization
+#else
+import Foundation
+#endif
+
+@Suite("ISO8601FormatStyle Parsing (Internationalization)")
+private struct ISO8601FormatStyleInternationalizationParsingTests {
+    @Test func chileTimeZone() throws {
+        var iso8601Chile = Date.ISO8601FormatStyle().year().month().day()
+        iso8601Chile.timeZone = try #require(TimeZone(identifier: "America/Santiago"))
+        
+        #expect(throws: Never.self) {
+            try iso8601Chile.parse("2023-09-03")
+        }
+    }
+}


### PR DESCRIPTION
This converts the newer Formatting tests for FoundationEssentials to swift-testing. It also moves one test to the internationalization test module since it requires ICU information, and removes an extraneous `internal` `TimeZone` initializer in favor of using the API initializer and removing the `@testable` import.