### PR TITLE
Remove unknown context from PredicateTests.Object type name

### DIFF
--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -22,23 +22,27 @@ import Foundation
 import RegexBuilder
 #endif
 
+// These types are non-private and in the global scope to ensure a consistent string type name for the debugDescription() test
+struct PredicateTestObject {
+    var a: Int
+    var b: String
+    var c: Double
+    var d: Int
+    var e: Character
+    var f: Bool
+    var g: [Int]
+    var h: Date = .now
+    var i: Any = 3
+}
+
+struct PredicateTestObject2 {
+    var a: Bool
+}
+
 @Suite("Predicate")
 private struct PredicateTests {
-    struct Object {
-        var a: Int
-        var b: String
-        var c: Double
-        var d: Int
-        var e: Character
-        var f: Bool
-        var g: [Int]
-        var h: Date = .now
-        var i: Any = 3
-    }
-    
-    struct Object2 {
-        var a: Bool
-    }
+    typealias Object = PredicateTestObject
+    typealias Object2 = PredicateTestObject2
     
     @Test func basic() throws {
         let compareTo = 2
@@ -375,7 +379,7 @@ private struct PredicateTests {
         let predicateName = _typeName(Predicate<Object>.self)
         #expect(
             debugDescription ==
-            "\(predicateName)(variable: (Variable(#)), expression: NilCoalesce(lhs: OptionalFlatMap(wrapped: ConditionalCast(input: KeyPath(root: Variable(#), keyPath: \\Object.i), desiredType: Swift.Int), variable: Variable(#), transform: Equal(lhs: Variable(#), rhs: Value<Swift.Int>(3))), rhs: Equal(lhs: KeyPath(root: Variable(#), keyPath: \\Object.h), rhs: Value<\(dateName)>(\(date.debugDescription)))))"
+            "\(predicateName)(variable: (Variable(#)), expression: NilCoalesce(lhs: OptionalFlatMap(wrapped: ConditionalCast(input: KeyPath(root: Variable(#), keyPath: \\PredicateTestObject.i), desiredType: Swift.Int), variable: Variable(#), transform: Equal(lhs: Variable(#), rhs: Value<Swift.Int>(3))), rhs: Equal(lhs: KeyPath(root: Variable(#), keyPath: \\PredicateTestObject.h), rhs: Value<\(dateName)>(\(date.debugDescription)))))"
         )
     }
 


### PR DESCRIPTION
Windows swift-ci is currently failing on the swift repo because the name of `Object` produced by `FoundationEssentials` does not match the name produced by the unit tests (the context of the type is different, in `FoundationEssentials` it's unknown but in the unit test file it's based on the file name). To resolve this, I moved `Object` to the global scope and marked it as `internal` so its name is consistently `FoundationEssentialsTests.PredicateTestObject` instead of including a potentially changing intermediate context scope.