### PR TITLE
[DRAFT] Migrate to UTF8Span

### DIFF
--- a/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
@@ -407,7 +407,7 @@ extension DateComponents.ISO8601FormatStyle {
         var components: DateComponents
     }
     
-    private func components(from inputString: String, fillMissingUnits: Bool, defaultTimeZone: TimeZone, in view: borrowing BufferView<UInt8>) throws -> ComponentsParseResult {
+    private func components(fillMissingUnits: Bool, defaultTimeZone: TimeZone, in view: borrowing BufferView<UInt8>) throws -> ComponentsParseResult {
         let fields = formatFields
         
         var it = view.makeIterator()
@@ -429,7 +429,7 @@ extension DateComponents.ISO8601FormatStyle {
 
         if fields.contains(.year) {
             let max = dateSeparator == .omitted ? 4 : nil
-            let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+            let value = try it.digits(maxDigits: max, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             if fields.contains(.weekOfYear) {
                 yearForWeekOfYear = value
             } else {
@@ -444,30 +444,30 @@ extension DateComponents.ISO8601FormatStyle {
         
         if fields.contains(.month) {
             if needsSeparator && dateSeparator == .dash {
-                try it.expectCharacter(UInt8(ascii: "-"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                try it.expectCharacter(UInt8(ascii: "-"), input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             }
             
             // parse month digits
             let max = dateSeparator == .omitted ? 2 : nil
-            let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+            let value = try it.digits(maxDigits: max, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             guard _calendar.maximumRange(of: .month)!.contains(value) else {
-                throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
+                throw parseError(view, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
             }
             month = value
 
             needsSeparator = true
         } else if fields.contains(.weekOfYear) {
             if needsSeparator && dateSeparator == .dash {
-                try it.expectCharacter(UInt8(ascii: "-"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                try it.expectCharacter(UInt8(ascii: "-"), input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             }
             // parse W
-            try it.expectCharacter(UInt8(ascii: "W"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+            try it.expectCharacter(UInt8(ascii: "W"), input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
 
             // parse week of year digits
             let max = dateSeparator == .omitted ? 2 : nil
-            let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+            let value = try it.digits(maxDigits: max, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             guard _calendar.maximumRange(of: .weekOfYear)!.contains(value) else {
-                throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
+                throw parseError(view, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
             }
             weekOfYear = value
             
@@ -479,26 +479,26 @@ extension DateComponents.ISO8601FormatStyle {
         
         if fields.contains(.day) {
             if needsSeparator && dateSeparator == .dash {
-                try it.expectCharacter(UInt8(ascii: "-"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                try it.expectCharacter(UInt8(ascii: "-"), input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             }
             
             if fields.contains(.weekOfYear) {
                 // parse day of week ('ee')
                 // ISO8601 "1" is Monday. For our date components, 2 is Monday. Add 1 to account for difference.
                 let max = dateSeparator == .omitted ? 2 : nil
-                let value = (try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now)) % 7) + 1
-                
+                let value = (try it.digits(maxDigits: max, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now)) % 7) + 1
+
                 guard _calendar.maximumRange(of: .weekday)!.contains(value) else {
-                    throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
+                    throw parseError(view, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
                 }
                 weekday = value
                 
             } else if fields.contains(.month) {
                 // parse day of month ('dd')
                 let max = dateSeparator == .omitted ? 2 : nil
-                let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                let value = try it.digits(maxDigits: max, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                 guard _calendar.maximumRange(of: .day)!.contains(value) else {
-                    throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
+                    throw parseError(view, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
                 }
 
                 day = value
@@ -506,9 +506,9 @@ extension DateComponents.ISO8601FormatStyle {
             } else {
                 // parse 3 digit day of year ('DDD')
                 let max = dateSeparator == .omitted ? 3 : nil
-                let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                let value = try it.digits(maxDigits: max, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                 guard _calendar.maximumRange(of: .dayOfYear)!.contains(value) else {
-                    throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
+                    throw parseError(view, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
                 }
 
                 dayOfYear = value
@@ -522,24 +522,24 @@ extension DateComponents.ISO8601FormatStyle {
                 switch dateTimeSeparator {
                 case .standard:
                     // parse T
-                    try it.expectCharacter(UInt8(ascii: "T"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                    try it.expectCharacter(UInt8(ascii: "T"), input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                 case .space:
                     // parse any number of spaces
-                    try it.expectOneOrMoreCharacters(UInt8(ascii: " "), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                    try it.expectOneOrMoreCharacters(UInt8(ascii: " "), input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                 }
             }
             
             switch timeSeparator {
             case .colon:
-                hour = try it.digits(input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                minute = try it.digits(input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                second = try it.digits(input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                hour = try it.digits(input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                try it.expectCharacter(UInt8(ascii: ":"), input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                minute = try it.digits(input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                try it.expectCharacter(UInt8(ascii: ":"), input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                second = try it.digits(input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             case .omitted:
-                hour = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                minute = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                second = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                hour = try it.digits(maxDigits: 2, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                minute = try it.digits(maxDigits: 2, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                second = try it.digits(maxDigits: 2, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             }
             
             // When parsing, fractional seconds are always optional (as of Swift 6.2).
@@ -547,7 +547,7 @@ extension DateComponents.ISO8601FormatStyle {
             if let next = it.peek(), next == UInt8(ascii: ".") {
                 // Looks like a fractional seconds
                 let _ = it.next() // consume the period
-                let fractionalSeconds = try it.digits(nanoseconds: true, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                let fractionalSeconds = try it.digits(nanoseconds: true, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                 nanosecond = fractionalSeconds
             }
             
@@ -562,7 +562,7 @@ extension DateComponents.ISO8601FormatStyle {
             
             guard let plusOrMinusOrZ = it.next() else {
                 // Expected time zone
-                throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
+                throw parseError(view, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
             }
 
 
@@ -606,7 +606,7 @@ extension DateComponents.ISO8601FormatStyle {
                     positive = false
                 } else {
                     // Expected time zone, found garbage
-                    throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
+                    throw parseError(view, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
                 }
     
                 if !skipDigits {
@@ -614,8 +614,8 @@ extension DateComponents.ISO8601FormatStyle {
 
                     // parse Time Zone: ISO8601 extended hms?, with Z
                     // examples: -08:00, -07:52:58, Z
-                    let hours = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                    
+                    let hours = try it.digits(maxDigits: 2, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+
                     // Expect a colon, or a minutes value, or the end.
                     let expectMinutes: Bool
                     if let next = it.peek() {
@@ -641,8 +641,8 @@ extension DateComponents.ISO8601FormatStyle {
                         tzOffset = hours * 3600
                     } else {
                         // Continue on
-                        let minutes = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                        
+                        let minutes = try it.digits(maxDigits: 2, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+
                         if let maybeColon = it.peek(), maybeColon == UInt8(ascii: ":") {
                             // Throw it away
                             it.advance()
@@ -650,7 +650,7 @@ extension DateComponents.ISO8601FormatStyle {
 
                         if let secondsTens = it.peek(), isASCIIDigit(secondsTens) {
                             // We have seconds
-                            let seconds = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                            let seconds = try it.digits(maxDigits: 2, input: view, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                             tzOffset = (hours * 3600) + (minutes * 60) + seconds
                         } else {
                             // If the next character is missing, that's allowed - the time can be something like just -0852 and then the string can end
@@ -664,7 +664,7 @@ extension DateComponents.ISO8601FormatStyle {
                 } else {
                     guard let parsedTimeZone = TimeZone(secondsFromGMT: positive ? tzOffset : -tzOffset) else {
                         // Out of range time zone
-                        throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
+                        throw parseError(view, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
                     }
                     
                     timeZone = parsedTimeZone
@@ -740,7 +740,7 @@ extension DateComponents.ISO8601FormatStyle : ParseStrategy {
         let result = v.withUTF8 { buffer -> (Int, DateComponents)? in
             let view = BufferView(unsafeBufferPointer: buffer)!
 
-            guard let comps = try? components(from: value, fillMissingUnits: fillMissingUnits, defaultTimeZone: timeZone, in: view) else {
+            guard let comps = try? components(fillMissingUnits: fillMissingUnits, defaultTimeZone: timeZone, in: view) else {
                 return nil
             }
             

--- a/Sources/FoundationEssentials/Formatting/FormatParsingUtilities.swift
+++ b/Sources/FoundationEssentials/Formatting/FormatParsingUtilities.swift
@@ -10,6 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+internal // NOTE: internal because BufferView is internal, `parseError` below is `package`
+func parseError(
+    _ value: BufferView<UInt8>, exampleFormattedString: String?, extendedDescription: String? = nil
+) -> CocoaError {
+    // TODO: change to UTF8Span, and prototype string append and interpolation taking UTF8Span
+    parseError(String(decoding: value, as: UTF8.self), exampleFormattedString: exampleFormattedString, extendedDescription: extendedDescription)
+}
+
 package func parseError(_ value: String, exampleFormattedString: String?, extendedDescription: String? = nil) -> CocoaError {
     let errorStr: String
     if let exampleFormattedString = exampleFormattedString {
@@ -25,13 +33,13 @@ func isASCIIDigit(_ x: UInt8) -> Bool {
 }
 
 extension BufferViewIterator<UInt8> {
-    mutating func expectCharacter(_ expected: UInt8, input: String, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws {
+    mutating func expectCharacter(_ expected: UInt8, input: BufferView<UInt8>, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws {
         guard let parsed = next(), parsed == expected else {
             throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
         }
     }
     
-    mutating func expectOneOrMoreCharacters(_ expected: UInt8, input: String, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws {
+    mutating func expectOneOrMoreCharacters(_ expected: UInt8, input: BufferView<UInt8>, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws {
         guard let parsed = next(), parsed == expected else {
             throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
         }
@@ -47,7 +55,7 @@ extension BufferViewIterator<UInt8> {
         }
     }
             
-    mutating func digits(minDigits: Int? = nil, maxDigits: Int? = nil, nanoseconds: Bool = false, input: String, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws -> Int {
+    mutating func digits(minDigits: Int? = nil, maxDigits: Int? = nil, nanoseconds: Bool = false, input: BufferView<UInt8>, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws -> Int {
         // Consume all leading zeros, parse until we no longer see a digit
         var result = 0
         var count = 0

--- a/Sources/FoundationEssentials/JSON/BufferViewIterator.swift
+++ b/Sources/FoundationEssentials/JSON/BufferViewIterator.swift
@@ -49,4 +49,9 @@ extension BufferViewIterator: IteratorProtocol {
         guard curPointer < endPointer else { return }
         curPointer = curPointer.advanced(by: MemoryLayout<Element>.stride)
     }
+
+    mutating func _uncheckedAdvance() {
+        assert(curPointer < endPointer)
+        curPointer = curPointer.advanced(by: MemoryLayout<Element>.stride)
+    }
 }


### PR DESCRIPTION
This might be better understood by looking at the 3 commits individually (otherwise it's a big diff).

First commit gets us out of passing down the original `String` value all the way through for the purposes of diagnostics.

Second commit untangles all diagnostic code from the low-level scanner/lexer style code, while keeping the behavior and basic code structure unchanged. This shows us the basic patterns that we could surface as API on our Span-like types and should spark some interesting designs and discussions.

Third commit just migrates over to `UTF8Span`, albeit via a `guard #available else { fatalError() } ` pattern. Not sure if that's the way we want to go.

Note that I haven't tested this fully yet.