### PR TITLE
Enable exit tests on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,7 +77,7 @@ let wasiLibcCSettings: [CSetting] = [
 
 let testOnlySwiftSettings: [SwiftSetting] = [
     // The latest Windows toolchain does not yet have exit tests in swift-testing
-    .define("FOUNDATION_EXIT_TESTS", .when(platforms: [.macOS, .linux, .openbsd]))
+    .define("FOUNDATION_EXIT_TESTS", .when(platforms: [.macOS, .linux, .openbsd, .windows]))
 ]
 
 let package = Package(


### PR DESCRIPTION
Now that the nightly Windows snapshot toolchain contains support for exit tests (any snapshot from the past few weeks) we can enable exit tests on Windows.