### PR TITLE
Revert "Adopt utimensat for setting file modification dates (#1324)"

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -966,14 +966,14 @@ extension _FileManagerImpl {
             if let date = attributes[.modificationDate] as? Date {
                 let (isecs, fsecs) = modf(date.timeIntervalSince1970)
                 if let tv_sec = time_t(exactly: isecs),
-                   let tv_nsec = Int(exactly: round(fsecs * 1000000000.0)) {
-                    var timespecs = (timespec(), timespec())
-                    timespecs.0.tv_sec = tv_sec
-                    timespecs.0.tv_nsec = tv_nsec
-                    timespecs.1 = timespecs.0
-                    try withUnsafePointer(to: timespecs) {
-                        try $0.withMemoryRebound(to: timespec.self, capacity: 2) {
-                            if utimensat(AT_FDCWD, fileSystemRepresentation, $0, 0) != 0 {
+                   let tv_usec = suseconds_t(exactly: round(fsecs * 1000000.0)) {
+                    var timevals = (timeval(), timeval())
+                    timevals.0.tv_sec = tv_sec
+                    timevals.0.tv_usec = tv_usec
+                    timevals.1 = timevals.0
+                    try withUnsafePointer(to: timevals) {
+                        try $0.withMemoryRebound(to: timeval.self, capacity: 2) {
+                            if utimes(fileSystemRepresentation, $0) != 0 {
                                 throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
                             }
                         }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -841,21 +841,6 @@ private struct FileManagerTests {
         }
     }
 
-    @Test func roundtripModificationDate() async throws {
-        try await FilePlayground {
-            "foo"
-        }.test {
-            // Precision of modification dates is dependent not only on the platform, but on the file system used
-            // Ensure that roundtripping supports at least millisecond-level precision, but some file systems may support more up to nanosecond precision
-            let date = Date(timeIntervalSince1970: 10.003)
-            try $0.setAttributes([.modificationDate : date], ofItemAtPath: "foo")
-            let readValue = try #require($0.attributesOfItem(atPath: "foo")[.modificationDate], "No value provided for file modification date")
-            let possibleDate = readValue as? Date
-            let readDate = try #require(possibleDate, "File modification date was not a date (found type \(type(of: readValue)))")
-            #expect(abs(readDate.timeIntervalSince1970 - date.timeIntervalSince1970) <= 0.0005, "File modification date (\(readDate.timeIntervalSince1970)) does not match expected modification date (\(date.timeIntervalSince1970))")
-        }
-    }
-
     @Test func implicitlyConvertibleFileAttributes() async throws {
         try await FilePlayground {
             File("foo", attributes: [.posixPermissions : UInt16(0o644)])


### PR DESCRIPTION
While the `utimensat` has the ability to set nanosecond-precision dates on files (when supported by the file system), unfortunately the current call site of it loses precision for some input dates (represented as `Double`s). Unfortunately I haven't found a good way to convert the `Double` date representation to the second and nanosecond components without losing precision, and this precision causes issues with some clients expecting dates to roundtrip with full fidelity (even though values like `Date.now` may only support 1000ns-level precision, the imprecision when calculating nanosecond values can cause round tripping a date to return a different value than the one set).

Resolves rdar://153731450