### PR TITLE
Remove Identifiable overloads and base Message protocol from NotificationCenter API proposal

### DIFF
--- a/Proposals/0011-concurrency-safe-notifications.md
+++ b/Proposals/0011-concurrency-safe-notifications.md
@@ -3,7 +3,7 @@
 * Proposal: SF-0011
 * Author(s): [Philippe Hausler](https://github.com/phausler), [Christopher Thielen](https://github.com/cthielen)
 * Review Manager: [Charles Hu](https://github.com/iCharlesHu)
-* Status: **2nd Review** May. 15, 2025 ... May. 22, 2025
+* Status: **Accepted**
 
 ## Revision history
 

--- a/Proposals/0011-concurrency-safe-notifications.md
+++ b/Proposals/0011-concurrency-safe-notifications.md
@@ -11,6 +11,7 @@
 * **v2** Remove `static` from `NotificationCenter.Message.isolation` to better support actor instances
 * **v3** Remove generic isolation pattern in favor of dedicated `MainActorMessage` and `AsyncMessage` types. Apply SE-0299-style static member lookups for `addObserver()`. Provide default value for `Message.name`.
 * **v4** Add `AsyncSequence` APIs for observing. Expand `Message.Subject` conformance to take either `AnyObject` or `Identifiable` where `Identifiable.ID == ObjectIdentifier`. Document `ObservationToken` automatic de-registration behavior. Drop `with` label on `post()` methods in favor of `subject` for clarity.
+* **v5** Remove `Message` base protocol. Remove the `Identifiable`-based overloads.
 
 ## Introduction
 
@@ -35,7 +36,7 @@ Well-written Swift code strongly prefers being explicit about concurrency isolat
 
 ## Proposed solution
 
-We propose a new base protocol, `NotificationCenter.Message`, with specializations `NotificationCenter.MainActorMessage` and `NotificationCenter.AsyncMessage`, which allow the creation of strong types that can be posted and observed using `NotificationCenter`, and an optional protocol, `NotificationCenter.MessageIdentifier`, which provides a typed, ergonomic experience when registering observers.
+We propose two new protocols, `NotificationCenter.MainActorMessage` and `NotificationCenter.AsyncMessage`, which allow the creation of strong types that can be posted and observed using `NotificationCenter`, and an optional protocol, `NotificationCenter.MessageIdentifier`, which provides a typed, ergonomic experience when registering observers.
 
 These protocols can be used on top of existing `Notification` declarations, enabling quick adoption.
 
@@ -71,11 +72,11 @@ extension NotificationCenter.MessageIdentifier
 
 Messages conforming to `MainActorMessage` will bind observers to `MainActor` and deliver messages synchronously from `MainActor`-bound contexts, while messages conforming to `AsyncMessage` are `Sendable`, run observers in an asynchronous context, and are delivered asynchronously.
 
-The optional lookup type, `NotificationCenter.MessageIdentifier`, provides an [SE-0299](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0299-extend-generic-static-member-lookup.md)-style ergonomic experience for finding notification types when registering observers. The use of a separate `MessageIdentifier` type and `BaseMessageIdentifier` type ensures this lookup functionality does not impact implementations of `Message`-conforming types, and prevents `Message` types from needing to be initialized and discarded for the sole purpose of observer registration.
+The optional lookup type, `NotificationCenter.MessageIdentifier`, provides an [SE-0299](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0299-extend-generic-static-member-lookup.md)-style ergonomic experience for finding notification types when registering observers.
 
 The first parameter of `addObserver(of:for:)` accepts both metatypes and instance types. Registering with a metatype enables an observer to receive all messages for the given identifier (equivalent to `object = nil` in the current `NotificationCenter`), while registering with an instance will only deliver messages related to that instance.
 
-`NotificationCenter.Message` provides optional bi-directional interoperability with the existing `Notification` type by using the `Notification.Name` property and two optional methods, `makeMessage(:Notification)` and `makeNotification(:Self)`:
+Optional bi-directional interoperability with the existing `Notification` type is available by using the `Notification.Name` property and two optional methods, `makeMessage(:Notification)` and `makeNotification(:Self)`:
 
 ```swift
 // Framework-side
@@ -107,11 +108,11 @@ extension NSWorkspace {
 }
 ```
 
-Using these methods, posters and observers of both the `Notification` and `Message` type have full, bi-directional interoperability.
+Using these methods, posters and observers of both the `Notification` and `Message`-style type have full, bi-directional interoperability.
 
 ## Example usage
 
-This example adapts the existing [NSWorkspace.willLaunchApplicationNotification](https://developer.apple.com/documentation/appkit/nsworkspace/1528611-willlaunchapplicationnotificatio) `Notification` to use `NotificationCenter.Message`. It defines the optional `MessageIdentifier` to make registering observers easier, and it defines `makeMessage(:Notification)` and `makeNotification(:Self)` for bi-directional interoperability with existing NotificationCenter posters and observers.
+This example adapts the existing [NSWorkspace.willLaunchApplicationNotification](https://developer.apple.com/documentation/appkit/nsworkspace/1528611-willlaunchapplicationnotificatio) `Notification` to use `NotificationCenter.MainActorMessage`. It defines the optional `MessageIdentifier` to make registering observers easier, and it defines `makeMessage(:Notification)` and `makeNotification(:Self)` for bi-directional interoperability with existing NotificationCenter posters and observers.
 
 Existing code which vends notifications do not need to alter existing `Notification` declarations, observers, or posts to adopt to this proposal.
 
@@ -169,39 +170,44 @@ NotificationCenter.default.post(
 
 ## Detailed design
 
-### `NotificationCenter.Message`, `NotificationCenter.MainActorMessage`, and `NotificationCenter.AsyncMessage`
+### `NotificationCenter.MainActorMessage` and `NotificationCenter.AsyncMessage`
 
-The `NotificationCenter.Message` protocol acts as a base for `NotificationCenter.MainActorMessage` and `NotificationCenter.AsyncMessage`, helping the two share functionality:
+`NotificationCenter.MainActorMessage` and `NotificationCenter.AsyncMessage` contain similar functionality:
 
 ```swift
 @available(FoundationPreview 0.5, *)
 extension NotificationCenter {
-    public protocol Message {
+    public protocol MainActorMessage: SendableMetatype {
         associatedtype Subject
+        
+        static var name: Notification.Name { get }
+        
+        @MainActor static func makeMessage(_ notification: Notification) -> Self?
+        @MainActor static func makeNotification(_ message: Self) -> Notification
+    }
+
+    public protocol AsyncMessage: Sendable {
+        associatedtype Subject
+        
         static var name: Notification.Name { get }
         
         static func makeMessage(_ notification: Notification) -> Self?
         static func makeNotification(_ message: Self) -> Notification
     }
-    
-    public protocol MainActorMessage: Message {}
-    public protocol AsyncMessage: Message, Sendable {}
 }
 ```
 
-`NotificationCenter.Message` is designed to interoperate with existing uses of `Notification` by sharing `Notification.Name` identifiers. This means an observer expecting `NotificationCenter.Message` will be called when a `Notification` is posted if the `Notification.Name` identifier matches, and vice versa.
+These two protocols are designed to interoperate with existing uses of `Notification` by sharing `Notification.Name` identifiers. This means an observer expecting a type conforming to either of these protocols will be called when a `Notification` is posted if the `Notification.Name` identifier matches, and vice versa.
 
-The protocol specifies `makeMessage(:Notification)` and `makeNotification(:Self)` to transform the payload between posters and observers of both the `NotificationCenter.Message` and `Notification` types. These methods have default implementations in cases where interoperability with `Notification` is not necessary.
+The protocol specifies `makeMessage(:Notification)` and `makeNotification(:Self)` to transform the payload between posters and observers of both the `Message`-style and `Notification` types. These methods have default implementations in cases where interoperability with `Notification` is not necessary.
 
-For `Message` types that do not need to interoperate with existing `Notification` uses, the `name` property does not need to be specified, and will default to the fully qualified name of the `Message` type, e.g. `MyModule.MyMessage`. Note that when using this default, renaming the type or relocating it to another module has a similar effect as changing ABI, as any code that was compiled separately will not be aware of the name change until recompiled. Developers can control this effect by explicitly setting the `name` property if needed.
+For `Message`-style types that do not need to interoperate with existing `Notification` uses, the `name` property does not need to be specified, and will default to the fully qualified name of the `Message`-style type, e.g. `MyModule.MyMessage`. Note that when using this default, renaming the type or relocating it to another module has a similar effect as changing ABI for any code that relies on a particular spelling. Developers can control this effect by explicitly setting the `name` property if needed.
 
-Each `Message` specifies a specific *subject* variable or metatype to observe, similar to the existing `Notification.object`, e.g. an `NSWindow` instance or the `NSWindow.self` metatype. `Message.Subject` has no conformance requirements in its protocol, but `addObserver()` and `post()` both refine `Message.Subject` to either conform to `AnyObject` or confirm to `Identifiable` where `Identifiable.ID == ObjectIdentifier`.
+Each `Message`-style type specifies a specific *subject* variable or metatype to observe, similar to the existing `Notification.object`, e.g. an `NSWindow` instance or the `NSWindow.self` metatype. `Subject` has no conformance requirements in the protocols, but `addObserver()` and `post()` both refine `Subject` to conform to `AnyObject`. This allows for the posting and observing of either objects or metatypes.
 
 ### Observing messages
 
 Observing messages can be done with new overloads to `addObserver`. Clients do not need to know whether a message conforms to `MainActorMessage` or `AsyncMessage`.
-
-Overloads are provided both for `Message.Subject: AnyObject` and `Message.Subject: Identifiable where ID == ObjectIdentifier`. This allows the observation of both reference types and value types which can provide an `ObjectIdentifier`.
 
 For `MainActorMessage`:
 
@@ -215,12 +221,6 @@ extension NotificationCenter {
         using observer: @escaping @MainActor (Message) -> Void
     ) -> ObservationToken where Identifier.MessageType == Message, Message.Subject: AnyObject
     
-    public func addObserver<Identifier: MessageIdentifier, Message: MainActorMessage>(
-        of subject: Message.Subject,
-        for identifier: Identifier,
-        using observer: @escaping @MainActor (Message) -> Void
-    ) -> ObservationToken where Identifier.MessageType == Message, Message.Subject: Identifiable, Message.Subject.ID == ObjectIdentifier
-
     // e.g. addObserver(of: NSWorkspace.self, for: .willLaunchApplication) { message in ... }
     public func addObserver<Identifier: MessageIdentifier, Message: MainActorMessage>(
         of subject: Message.Subject.Type,
@@ -234,12 +234,6 @@ extension NotificationCenter {
         for messageType: Message.Type,
         using observer: @escaping @MainActor (Message) -> Void
     ) -> ObservationToken where Message.Subject: AnyObject
-
-    public func addObserver<Message: MainActorMessage>(
-        of subject: Message.Subject? = nil,
-        for messageType: Message.Type,
-        using observer: @escaping @MainActor (Message) -> Void
-    ) -> ObservationToken where Message.Subject: Identifiable, Message.Subject.ID == ObjectIdentifier
 }
 ```
 
@@ -255,12 +249,6 @@ extension NotificationCenter {
     ) -> ObservationToken where Identifier.MessageType == Message, Message.Subject: AnyObject
 
     public func addObserver<Identifier: MessageIdentifier, Message: AsyncMessage>(
-        of subject: Message.Subject,
-        for identifier: Identifier,
-        using observer: @escaping @Sendable (Message) async -> Void
-    ) -> ObservationToken where Identifier.MessageType == Message, Message.Subject: Identifiable, Message.Subject.ID == ObjectIdentifier
-
-    public func addObserver<Identifier: MessageIdentifier, Message: AsyncMessage>(
         of subject: Message.Subject.Type,
         for identifier: Identifier,
         using observer: @escaping @Sendable (Message) async -> Void
@@ -271,16 +259,10 @@ extension NotificationCenter {
         for messageType: Message.Type,
         using observer: @escaping @Sendable (Message) async -> Void
     ) -> ObservationToken where Message.Subject: AnyObject
-    
-    public func addObserver<Message: AsyncMessage>(
-        of subject: Message.Subject? = nil,
-        for messageType: Message.Type,
-        using observer: @escaping @Sendable (Message) async -> Void
-    ) -> ObservationToken where Message.Subject: Identifiable, Message.Subject.ID == ObjectIdentifier
 }
 ```
 
-Observer closures take a single `Message` parameter and do not receive the `subject` parameter passed to `addObserver()` nor `post()`. Not all messages use instances for their subjects, and not all subject instances are `Sendable` though their messages may be. If a `Message` author needs the `subject` to be delivered to the observer closure, they can do so by making it a property on their `Message` type.
+Observer closures take a single `Message`-style parameter and do not receive the `subject` parameter passed to `addObserver()` nor `post()`. Not all messages use instances for their subjects, and not all subject instances are `Sendable` though their messages may be. If a `Message`-style type needs the `subject` to be delivered to the observer, it can be added as a property on the message type.
 
 These `addObserver()` methods return a new `ObservationToken`, which can be used with a new `removeObserver()` method for faster de-registration of observers:
 
@@ -307,12 +289,6 @@ extension NotificationCenter {
 	) -> some AsyncSequence<Message, Never> where Identifier.MessageType == Message, Message.Subject: AnyObject
 	
 	public func messages<Identifier: MessageIdentifier, Message: AsyncMessage>(
-		of subject: Message.Subject,
-		for identifier: Identifier,
-		bufferSize limit: Int = 10
-	) -> some AsyncSequence<Message, Never> where Identifier.MessageType == Message, Message.Subject: Identifiable, Message.Subject.ID == ObjectIdentifier {}
-	
-	public func messages<Identifier: MessageIdentifier, Message: AsyncMessage>(
 		of subject: Message.Subject.Type,
 		for identifier: Identifier,
 		bufferSize limit: Int = 10
@@ -323,12 +299,6 @@ extension NotificationCenter {
 		for messageType: Message.Type,
 		bufferSize limit: Int = 10
 	) -> some AsyncSequence<Message, Never> where Message.Subject: AnyObject
-	
-	public func messages<Message: AsyncMessage>(
-		of subject: Message.Subject? = nil,
-		for messageType: Message.Type,
-		bufferSize limit: Int = 10
-	) -> some AsyncSequence<Message, Never> where Message.Subject: Identifiable, Message.Subject.ID == ObjectIdentifier
 }
 ```
 
@@ -346,7 +316,7 @@ for await message in center.messages(for: AnAsyncMessage.self) {
 // etc.
 ```
 
-The `messages()` sequence uses a reasonably-sized buffer to reduce the likelihood of dropped messages caused by the interaction of synchronous and asynchronous code. When a `Message` is dropped, the implementation will log to aid in debugging. Message frequency in practice is typically 0-2x / second / message type and therefore unlikely to result in dropped messages. Certain UI-related messages can post in practice as often as 40 - 50x / second / message, but these are typically `MainActorMessage` and would not be subject to dropping nor available for use with `messages()`.
+If the sequence buffer limit is exceeded, the implementation will log to aid in debugging.
 
 ### Posting messages
 
@@ -363,10 +333,6 @@ extension NotificationCenter {
         where Message.Subject: AnyObject
     
     @MainActor
-    public func post<Message: MainActorMessage>(_ message: Message, subject: Message.Subject)
-        where Message.Subject: Identifiable, Message.Subject.ID == ObjectIdentifier
-
-    @MainActor
     public func post<Message: MainActorMessage>(_ message: Message, subject: Message.Subject.Type = Message.Subject.self)
 
     // AsyncMessage post()
@@ -374,9 +340,6 @@ extension NotificationCenter {
     public func post<Message: AsyncMessage>(_ message: Message, subject: Message.Subject)
         where Message.Subject: AnyObject
     
-    public func post<Message: AsyncMessage>(_ message: Message, subject: Message.Subject)
-        where Message.Subject: Identifiable, Message.Subject.ID == ObjectIdentifier
-
     public func post<Message: AsyncMessage>(_ message: Message, subject: Message.Subject.Type = Message.Subject.self)
 }
 ```
@@ -387,10 +350,10 @@ While both `post()` methods are called synchronously, only the `MainActorMessage
 
 ### Interoperability with `Notification`
 
-Clients can migrate information to and from existing `Notification` types using `NotificationCenter.Message.makeMessage(:Notification)` and `NotificationCenter.Message.makeNotification(:Self)`. Implementing these enables the mixing of posters and observers between the `Notification` and `NotificationCenter.Message` types:
+Clients can migrate information to and from existing `Notification` types using `makeMessage(:Notification)` and `makeNotification(:Self)`. Implementing these enables the mixing of posters and observers between the `Notification` and `Message`-style types:
 
 ```swift
-struct EventDidOccur: NotificationCenter.Message {
+struct EventDidOccur: NotificationCenter.MainActorMessage {
     var foo: Foo
     ...
 
@@ -400,12 +363,12 @@ struct EventDidOccur: NotificationCenter.Message {
     }
     
     static func makeNotification(_ message: Self) -> Notification {
-        return Notification(name: Self.name, object: object, userInfo: ["foo": self.foo])
+        return Notification(name: Self.name, userInfo: ["foo": self.foo])
     }
 }
 ```
 
-These methods do not need to be implemented if all posters and observers are using `NotificationCenter.Message`.
+These methods do not need to be implemented if all posters and observers are using `Message`-style types.
 
 See the table below for the effects of implementing `makeMessage(:Notification)` / `makeNotification(:Self)`:
 
@@ -418,15 +381,15 @@ See the table below for the effects of implementing `makeMessage(:Notification)`
 
 Observers called via the existing, pre-Swift Concurrency `.post()` methods are either called on the same thread as the poster, or called in an explicitly passed `OperationQueue`.
 
-However, users can still adopt `NotificationCenter.Message` with pre-Swift Concurrency `.post()` calls by providing a `NotificationCenter.Message` with the proper `Notification.Name` value and picking the correct type between `MainActorMessage` and `AsyncMessage`.
+However, users can still adopt `Message`-style types with pre-Swift Concurrency `.post()` calls by providing a `Message`-style type with the proper `Notification.Name` value and picking the correct type between `MainActorMessage` and `AsyncMessage`.
 
 For example, if an Objective-C method calls the `post(name:object:userInfo:)` method on the main thread, `NotificationCenter.MainActorMessage` can be used to define a message with the same `Notification.Name`, enabling clients observing the message to access the `object` and `userInfo` parameters of the original `Notification` in a safe manner through `makeMessage(:Notification)`.
 
 ## Impact on existing code
 
-These changes are entirely additive but could impact existing code due to the ability to interoperate between `NotificationCenter.Message` and `Notification`.
+These changes are entirely additive but could impact existing code due to the ability to interoperate between `Message`-style types and `Notification`.
 
-If an observer for `NotificationCenter.Message` receives a message posted as a `Notification` which violates the isolation contract specified in `NotificationCenter.MainActorMessage` / `NotificationCenter.AsyncMessage`, the correct fix may be to modify the existing `Notification` `.post()` call to uphold that contract.
+If an observer receives a message posted as a `Notification` which violates the isolation contract specified in `NotificationCenter.MainActorMessage` / `NotificationCenter.AsyncMessage`, the correct fix may be to modify the existing `Notification` `.post()` call to uphold that contract.
 
 ## Future directions
 
@@ -435,7 +398,7 @@ None at this time.
 ## Alternatives considered
 
 ### Use generic isolation to support actor instances and other global actors
-A previous iteration of this proposal stored an `Actor`-conforming type on the `Message` protocol, enabling `addObserver()` and `post()` to declare `isolated` parameters conforming to the given type. This enabled a flexible form of generic isolation, enabling the use of arbitrary global actors, as well as isolating to instances of an actor:
+A previous iteration of this proposal stored an `Actor`-conforming type on a `Message` protocol, enabling `addObserver()` and `post()` to declare `isolated` parameters conforming to the given type. This enabled a flexible form of generic isolation, enabling the use of arbitrary global actors, as well as isolating to instances of an actor:
 
 ```swift
 public func addObserver<MessageType: NotificationCenter.Message>(
@@ -452,7 +415,7 @@ Unfortunately, the design required careful handling to use correctly and had som
  * The `isolated` parameter value should really have a default value of `message.isolation` but it is not possible to cross-referencing parameter values this way in Swift today.
  * The use of `isolated` in the observer closure requires passing in an `Actor` type that the client likely does not need.
 
-### Use `Message` directly for static member lookup
+### Use `MainActorMessage`/`AsyncMessage` directly for static member lookup
 The `addObserver()` static member lookup experience requires there be a type initialized as the value of the given static member:
 
 ```swift
@@ -465,12 +428,12 @@ extension NotificationCenter.MessageIdentifier
 }
 ```
 
-Alternatively, we could extend `Message` directly, and have the static variable return a specific `Message` type, removing the need for the `MessageIdentifier` protocol and `BaseMessageIdentifier` struct.
+Alternatively, we could extend the `Message`-style protocols directly, and have the static variable return a specific `Message`-style type, removing the need for the `MessageIdentifier` protocol and `BaseMessageIdentifier` struct.
 
-However, this puts initializer requirements on the `Message`-conforming type for the purposes of an optional lookup API, which could encourage developers to declare properties of their `Message` types as `Optional` when they shouldn't be. It also requires initializing and discarding a `Message` variable, which may or may not be large depending on future `Message` adoption, while the `MessageIdentifier` type is unlikely to grow.
+However, this puts initializer requirements on the `Message`-style type for the purposes of an optional lookup API, which could encourage developers to declare properties of their `Message` types as `Optional` when they shouldn't be. It also requires initializing and discarding a `Message` variable, which may be needless.
 
 ### Deliver `subject` as a separate parameter to observers
-The current proposal splits out the subject of a `Message` in the `addObserver()` overload but does not split it out in the observer closure nor the `post()` method:
+The current proposal splits out the subject of a message in the `addObserver()` overload but does not split it out in the observer closure nor the `post()` method:
 
 ```swift
 // Subject is a separate parameter for addObserver() call, but not closure ...
@@ -494,4 +457,4 @@ However, not all messages have subject instances (e.g. `addObserver(of: NSWindow
 
 Further, even messages with subjects do not necessarily need their observers to access the subject instance.
 
-Finally, developers always have the choice of including the subject in the design of their `Message` types if they'd like. For these reasons, we've opted not to ferry `subject` through the API.
+Finally, developers always have the choice of including the subject in the design of their `Message`-style types if they'd like. For these reasons, we've opted not to ferry `subject` through the API.


### PR DESCRIPTION
This PR updates the Concurrency-Safe Notifications proposal to include changes requested during the second review.