### PR TITLE
Ensure that subscripting AttributeSliceX behaves consistently regardless of index location

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -594,9 +594,6 @@ extension AttributedString.Runs {
         // _strBounds.range(containing:) below validates that i._value is within the bounds of this slice
         precondition(!attributeNames.isEmpty)
         let r = _guts.findRun(at: i._value)
-        if r.runIndex.offset == endIndex._runOffset {
-            return (i, r.runIndex)
-        }
         let currentRange = _strBounds.range(containing: i._value).range
         
         guard constraints.count != 1 || constraints.contains(nil) else {

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -1983,6 +1983,34 @@ E {
             }
         }
     }
+    
+    @Test func runSliceSubscripting() {
+        var str = AttributedString("Foo", attributes: .init().testInt(1))
+        str += AttributedString("Bar", attributes: .init().testInt(2))
+        str += AttributedString("Baz", attributes: .init().testInt(3))
+        
+        do {
+            let runsSlice = str.runs[\.testInt]
+            for (value, range) in runsSlice {
+                for idx in str.utf8[range].indices {
+                    let subscriptResult = runsSlice[idx]
+                    #expect(subscriptResult.0 == value, "Subscript index \(idx) did not produce same value as runs slice")
+                    #expect(subscriptResult.1 == range, "Subscript index \(idx) did not produce same range as runs slice")
+                }
+            }
+        }
+        
+        do {
+            let runsSlice = str[str.index(afterCharacter: str.startIndex) ..< str.index(beforeCharacter: str.endIndex)].runs[\.testInt]
+            for (value, range) in runsSlice {
+                for idx in str.utf8[range].indices {
+                    let subscriptResult = runsSlice[idx]
+                    #expect(subscriptResult.0 == value, "Subscript index \(idx) did not produce same value as runs slice")
+                    #expect(subscriptResult.1 == range, "Subscript index \(idx) did not produce same range as runs slice")
+                }
+            }
+        }
+    }
 
     // MARK: - Other Tests
     


### PR DESCRIPTION
The `AttributedString.Runs.AttributesSliceX` types represent a run view that is sliced over a specific set of attributes. Iterating this view provides a coalesced range and the value of each attribute across this range. This view can also be subscripted at any `AttributedString.Index` to find the longest effective range of the specified attributes at a given index. The underlying implementation of this subscript had an early-return condition for when the run containing the index happened to be the final run in the slice, in which case the input index was used as the start of the returned range. This isn't correct - the start of this run is dependent upon where the specified attribute value begins and where the prior run boundary is (if applicable). In most situations you'll never hit this early-exit or it happens to be correct, but if you have an attribute slice over a substring and subscript into the middle of the final run, the returned range will be `inputIndex ..< endOfRun` rather than `startOfRun ..< endOfRun`. The added unit test failed due to the mismatch in ranges but by removing this early-return it now passes.

Resolves rdar://154342005