### PR TITLE
[RFC][DNM] Add isIdentical Methods for Quick Comparisons to AttributedString and AttributedSubstring

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -431,6 +431,10 @@ let benchmarks = {
         blackHole(manyAttributesString == manyAttributesString2)
     }
 
+    Benchmark("isIdentical") { benchmark in
+        blackHole(manyAttributesString.isIdentical(to: manyAttributesString))
+    }
+
     Benchmark("equalityDifferingCharacters") { benchmark in
         blackHole(manyAttributesString == manyAttributesString3)
     }
@@ -442,7 +446,11 @@ let benchmarks = {
     Benchmark("substringEquality") { benchmark in
         blackHole(manyAttributesSubstring == manyAttributes2Substring)
     }
-    
+
+    Benchmark("substringIsIdentical") { benchmark in
+        blackHole(manyAttributesSubstring.isIdentical(to: manyAttributesSubstring))
+    }
+
     Benchmark("hashAttributedString") { benchmark in
         var hasher = Hasher()
         manyAttributesString.hash(into: &hasher)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -403,3 +403,22 @@ extension Range where Bound == BigString.Index {
         Range<AttributedString.Index>(uncheckedBounds: (AttributedString.Index(lowerBound, version: version), AttributedString.Index(upperBound, version: version)))
     }
 }
+
+extension AttributedString {
+  /// Returns a boolean value indicating whether this string is identical to
+  /// `other`.
+  ///
+  /// Two string values are identical if there is no way to distinguish between
+  /// them.
+  ///
+  /// Comparing strings this way includes comparing (normally) hidden
+  /// implementation details such as the memory location of any underlying
+  /// string storage object. Therefore, identical strings are guaranteed to
+  /// compare equal with `==`, but not all equal strings are considered
+  /// identical.
+  ///
+  /// - Performance: O(1)
+  public func isIdentical(to other: Self) -> Bool {
+    self._guts === other._guts
+  }
+}

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -205,3 +205,23 @@ extension AttributedSubstring {
         }
     }
 }
+
+extension AttributedSubstring {
+  /// Returns a boolean value indicating whether this substring is identical to
+  /// `other`.
+  ///
+  /// Two substring values are identical if there is no way to distinguish
+  /// between them.
+  ///
+  /// Comparing substrings this way includes comparing (normally) hidden
+  /// implementation details such as the memory location of any underlying
+  /// substring storage object. Therefore, identical substrings are guaranteed
+  /// to compare equal with `==`, but not all equal substrings are considered
+  /// identical.
+  ///
+  /// - Performance: O(1)
+  public func isIdentical(to other: Self) -> Bool {
+    self._guts === other._guts &&
+    self._range == other._range
+  }
+}

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -33,6 +33,14 @@ import AppKit
 #endif
 #endif
 
+func createManyAttributesString() -> AttributedString {
+    var str = AttributedString("a")
+    for i in 0..<10000 {
+        str += AttributedString("a", attributes: AttributeContainer().testInt(i))
+    }
+    return str
+}
+
 /// Regression and coverage tests for `AttributedString` and its associated objects
 @Suite("AttributedString")
 private struct  AttributedStringTests {
@@ -360,6 +368,15 @@ private struct  AttributedStringTests {
         #expect(a2.characters.elementsEqual(a3.characters))
     }
 
+    @Test func attributedStringIdentical() {
+        let manyAttributesString = createManyAttributesString()
+        let manyAttributesString2 = createManyAttributesString()
+        #expect(manyAttributesString.isIdentical(to: manyAttributesString))
+        #expect(manyAttributesString2.isIdentical(to: manyAttributesString2))
+        #expect(!(manyAttributesString.isIdentical(to: manyAttributesString2)))
+        #expect(!(manyAttributesString2.isIdentical(to: manyAttributesString)))
+    }
+
     @Test func attributedSubstringEquality() {
         let emptyStr = AttributedString("01234567890123456789")
 
@@ -389,7 +406,19 @@ private struct  AttributedStringTests {
 
         #expect(emptyStr[index0 ..< index5] == AttributedString("01234"))
     }
-    
+
+    @Test func attributedSubstringIdentical() {
+        let manyAttributesString = createManyAttributesString()
+        let manyAttributesString2 = createManyAttributesString()
+        let manyAttributesStringRange = manyAttributesString.characters.index(manyAttributesString.startIndex, offsetBy: manyAttributesString.characters.count / 2)...
+        let manyAttributesSubstring = manyAttributesString[manyAttributesStringRange]
+        let manyAttributes2Substring = manyAttributesString2[manyAttributesStringRange]
+        #expect(manyAttributesSubstring.isIdentical(to: manyAttributesSubstring))
+        #expect(manyAttributes2Substring.isIdentical(to: manyAttributes2Substring))
+        #expect(!(manyAttributesSubstring.isIdentical(to: manyAttributes2Substring)))
+        #expect(!(manyAttributes2Substring.isIdentical(to: manyAttributesSubstring)))
+    }
+
     @Test func runEquality() {
         var attrStr = AttributedString("Hello", attributes: AttributeContainer().testInt(1))
         attrStr += AttributedString(" ")


### PR DESCRIPTION
## Background

https://github.com/swiftlang/swift-foundation/pull/1383

We propose new `isIdentical` instance methods to the following concrete types for determining in constant-time if two instances must be equal by-value:
* AttributedString
* AttributedSubstring
* Data

Instead of “one big diff”… we can try and keep the diffs grouped together by similar functionality:

* AttributedString, AttributedSubstring
* Data

## Changes

### AttributedString

We can look for some clues in the existing `==` operator on `AttributedString`.[^1] This forwards to methods on `Guts`.[^2][^3][^4] A simpler approach for our diff would be to just check directly over `guts` without an extra transformation:

```swift
extension AttributedString {
  public func isIdentical(to other: Self) -> Bool {
    self._guts === other._guts
  }
}
```

An orthogonal diff could also choose to check over `guts` as a fast-path in our `==` operator.

Because `_guts` is defined as `internal` without `usableFromInline` we do not have an easy way to make `isIdentical` back deploy with `@_alwaysEmitIntoClient`. I am open to discussing what our options might be at this point might be to back deploy and what we choose for availability before shipping. It looks like we do have the option to add `usableFromInline` to our `internal` variable declarations without breaking ABI.[^5] The tradeoff is we then ship `guts` as ABI from now on.

### AttributedSubstring

We already have a fast path in the existing `==` operator on `AttributedSubstring`.[^6] We can implement a similar logic for `isIdentical`:

```swift
extension AttributedSubstring {
  public func isIdentical(to other: Self) -> Bool {
    self._guts === other._guts &&
    self._range == other._range
  }
}
```

We can have a similar conversation at this point about what our options for back deployment look like.

## Test Plan

New tests were added for `AttributedString` and `AttributedSubstring`.

## Benchmarks

New benchmarks were added for `AttributedString` and `AttributedSubstring`.

[^1]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedString.swift#L153
[^2]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedString%2BGuts.swift#L77
[^3]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedString%2BGuts.swift#L84-L86
[^4]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedString%2BGuts.swift#L105
[^5]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0193-cross-module-inlining-and-specialization.md
[^6]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift#L79-L81
