### PR TITLE
Support for building with 64-bit time_t/off_t on 32-bit platforms

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -727,7 +727,11 @@ extension _FileManagerImpl {
             let blockSize = UInt64(result.f_bsize)
             #else
             let fsNumber = result.f_fsid
+            #if canImport(Glibc)
+            let blockSize = fsblkcnt_t(result.f_frsize) // support 64-bit block sizes on 32-bit platforms
+            #else
             let blockSize = UInt(result.f_frsize)
+            #endif
             #endif
             var totalSizeBytes = result.f_blocks * blockSize
             var availSizeBytes = result.f_bavail * blockSize

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -951,6 +951,12 @@ extension _FileManagerImpl {
                 #endif
             }
             
+            #if canImport(Glibc)
+            // support for 64-bit timestamps on 32-bit platforms; unfortunately
+            // suseconds_t is not an alias of the appropriate type, but time_t is
+            typealias suseconds_t = time_t
+            #endif
+
             if let date = attributes[.modificationDate] as? Date {
                 let (isecs, fsecs) = modf(date.timeIntervalSince1970)
                 if let tv_sec = time_t(exactly: isecs),


### PR DESCRIPTION
Patch is against release/6.1 but it will apply against main.