### PR TITLE
Use __BundleLookupHelper.self when building mergable library

### DIFF
--- a/Sources/FoundationMacros/BundleMacro.swift
+++ b/Sources/FoundationMacros/BundleMacro.swift
@@ -22,6 +22,8 @@ public struct BundleMacro: SwiftSyntaxMacros.ExpressionMacro, Sendable {
                 return Bundle.module
             #elseif SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE
                 #error("No resource bundle is available for this module. If resources are included elsewhere, specify the bundle manually.")
+            #elseif SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE
+                return Bundle(for: __BundleLookupHelper.self)
             #else
                 return Bundle(_dsoHandle: #dsohandle) ?? .main
             #endif

--- a/Tests/FoundationMacrosTests/BundleMacroTests.swift
+++ b/Tests/FoundationMacrosTests/BundleMacroTests.swift
@@ -28,6 +28,8 @@ private struct BundleMacroTests {
                     return Bundle.module
                 #elseif SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE
                     #error("No resource bundle is available for this module. If resources are included elsewhere, specify the bundle manually.")
+                #elseif SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE
+                    return Bundle(for: __BundleLookupHelper.self)
                 #else
                     return Bundle(_dsoHandle: #dsohandle) ?? .main
                 #endif
@@ -48,6 +50,8 @@ private struct BundleMacroTests {
                     return Bundle.module
                 #elseif SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE
                     #error("No resource bundle is available for this module. If resources are included elsewhere, specify the bundle manually.")
+                #elseif SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE
+                    return Bundle(for: __BundleLookupHelper.self)
                 #else
                     return Bundle(_dsoHandle: #dsohandle) ?? .main
                 #endif


### PR DESCRIPTION
Updating the `#bundle` macro to check whether `SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE` is set. If that is the case, the build system built a mergable library and emitted a class called `__BundleLookupHelper`. 

The linker has a code path that makes `Bundle(forClass: )` work for merged libraries, whereas the DSO-handle is the same for all merged targets.

The build system counterpart has been merged here: https://github.com/swiftlang/swift-build/pull/599