### PR TITLE
Consolidate URL compatibility checks

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Swift.swift
+++ b/Sources/FoundationEssentials/URL/URL_Swift.swift
@@ -864,7 +864,7 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         /// `URL("/").deletingLastPathComponent == URL("/../")`
         /// `URL("/../").standardized == URL("")`
         #if FOUNDATION_FRAMEWORK
-        if URL.compatibility4 && path == "/" {
+        if URL.compatibility1 && path == "/" {
             components.percentEncodedPath = "/../"
         } else {
             components.percentEncodedPath = newPath
@@ -915,7 +915,7 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         /// `URL("/../").standardized == URL("")`
         #if FOUNDATION_FRAMEWORK
         guard isDecomposable else { return nil }
-        let newPath = if URL.compatibility4 && _parseInfo.path == "/../" {
+        let newPath = if URL.compatibility1 && _parseInfo.path == "/../" {
             ""
         } else {
             String(_parseInfo.path).removingDotSegments


### PR DESCRIPTION
`URL.compatibility4` is no longer needed and we can just use `URL.compatibility1` for the `url.deletingPathComponent().standardized` compatibility path instead.