### PR TITLE
Support for building with 64-bit time_t/off_t on 32-bit platforms

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -967,6 +967,12 @@ extension _FileManagerImpl {
                 #endif
             }
             
+            #if canImport(Glibc)
+            // support for 64-bit timestamps on 32-bit platforms; unfortunately
+            // suseconds_t is not an alias of the appropriate type, but time_t is
+            typealias suseconds_t = time_t
+            #endif
+
             if let date = attributes[.modificationDate] as? Date {
                 let (isecs, fsecs) = modf(date.timeIntervalSince1970)
                 if let tv_sec = time_t(exactly: isecs),


### PR DESCRIPTION
It is good practice to build with 64-bit `time_t`/`timeval` on 32-bit platforms to avoid the Y2038 issue. This is the default when building on Yocto for armv7, for example. Unfortunately `suseconds_t` is not an alias to a type of the correct width (unlike `time_t`), so for Glibc make it a private alias of `time_t` to fix the build.

It is also possible to build with 64-bit file offsets on 32-bit platforms such as armv7, and indeed this is the default for some build environments such as Yocto. Use `fsblkcnt_t`, which is an alias to a type of the correct width, when computing blockSize.