### PR TITLE
Update availability macros for macOS 15 deployment target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,14 +94,11 @@ list(APPEND CMAKE_MODULE_PATH ${SwiftFoundation_SOURCE_DIR}/cmake/modules)
 
 # Availability Macros (only applies to FoundationEssentials and FoundationInternationalization)
 set(_SwiftFoundation_BaseAvailability "macOS 15, iOS 18, tvOS 18, watchOS 11")
+set(_SwiftFoundation_macOS26Availability "macOS 26, iOS 26, tvOS 26, watchOS 26")
 set(_SwiftFoundation_FutureAvailability "macOS 10000, iOS 10000, tvOS 10000, watchOS 10000")
 
 # All versions to define for each availability name
 list(APPEND _SwiftFoundation_versions
-    "0.1"
-    "0.2"
-    "0.3"
-    "0.4"
     "6.0.2"
     "6.1"
     "6.2"
@@ -110,16 +107,12 @@ list(APPEND _SwiftFoundation_versions
 # Each availability name to define
 list(APPEND _SwiftFoundation_availability_names
     "FoundationPreview"
-    "FoundationPredicate"
-    "FoundationPredicateRegex"
     "FoundationSpan")
 
 # The aligned availability for each name (in the same order)
 list(APPEND _SwiftFoundation_availability_releases
     ${_SwiftFoundation_BaseAvailability}
-    ${_SwiftFoundation_BaseAvailability}
-    ${_SwiftFoundation_BaseAvailability}
-    ${_SwiftFoundation_FutureAvailability})
+    ${_SwiftFoundation_macOS26Availability})
 
 foreach(version ${_SwiftFoundation_versions})
     foreach(name release IN ZIP_LISTS _SwiftFoundation_availability_names _SwiftFoundation_availability_releases)

--- a/Package.swift
+++ b/Package.swift
@@ -7,17 +7,16 @@ import CompilerPluginSupport
 // Availability Macros
 
 let availabilityTags: [_Availability] = [
-    _Availability("FoundationPreview"), // Default FoundationPreview availability,
-    _Availability("FoundationPredicate"), // Predicate relies on pack parameter runtime support
-    _Availability("FoundationPredicateRegex"), // Predicate regexes rely on new stdlib APIs
-    _Availability("FoundationSpan", availability: .future), // Availability of Span types
+    _Availability("FoundationPreview"), // Default FoundationPreview availability
+    _Availability("FoundationSpan", availability: .macOS26), // Availability of Span types
 ]
-let versionNumbers = ["0.1", "0.2", "0.3", "0.4", "6.0.2", "6.1", "6.2"]
+let versionNumbers = ["6.0.2", "6.1", "6.2"]
 
 // Availability Macro Utilities
 
 enum _OSAvailability: String {
     case alwaysAvailable = "macOS 15, iOS 18, tvOS 18, watchOS 11" // This should match the package's deployment target
+    case macOS26 = "macOS 26, iOS 26, tvOS 26, watchOS 26"
     // Use 10000 for future availability to avoid compiler magic around the 9999 version number but ensure it is greater than 9999
     case future = "macOS 10000, iOS 10000, tvOS 10000, watchOS 10000"
 }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -123,7 +123,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         return _defaultCount
     }
 
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline
     internal var _count: Int {
         _characters.count
@@ -153,7 +153,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         return _defaultIndex(i, offsetBy: distance)
     }
 
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline
     internal func _index(_ i: AttributedString.Index, offsetBy distance: Int) -> AttributedString.Index {
         precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
@@ -176,7 +176,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         return _defaultIndex(i, offsetBy: distance, limitedBy: limit)
     }
 
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline
     internal func _index(
         _ i: AttributedString.Index,
@@ -207,7 +207,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         return _defaultDistance(from: start, to: end)
     }
 
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline
     internal func _distance(from start: AttributedString.Index, to end: AttributedString.Index) -> Int {
         precondition(start >= startIndex && start <= endIndex, "AttributedString index out of bounds")

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -366,7 +366,7 @@ extension AttributedString.Runs: BidirectionalCollection {
     #endif
     }
 
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline
     internal func _index(_ index: Index, offsetBy distance: Int) -> Index {
         guard _isDiscontiguous else {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -124,7 +124,7 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
         return _defaultCount
     }
 
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline
     internal var _count: Int {
         _unicodeScalars.count
@@ -165,7 +165,7 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
         return _defaultIndex(i, offsetBy: distance, limitedBy: limit)
     }
 
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline
     internal func _index(
         _ i: AttributedString.Index,

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -41,7 +41,7 @@ extension String {
     }
     #endif
 
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline
     internal init(_characters: AttributedString.CharacterView) {
         self.init(_characters._characters)

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -40,13 +40,13 @@ extension AttributeScopes {
         public let writingDirection: WritingDirectionAttribute
 
 #if FOUNDATION_FRAMEWORK
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public let agreementConcept: AgreementConceptAttribute
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public let agreementArgument: AgreementArgumentAttribute
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public let referentConcept: ReferentConceptAttribute
-        @available(FoundationPreview 0.4, *)
+        @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public let localizedNumberFormat: LocalizedNumberFormatAttribute
         
         // TODO: Support AttributedString markdown in FoundationPreview: https://github.com/apple/swift-foundation/issues/44
@@ -119,7 +119,7 @@ extension AttributeScopes.FoundationAttributes {
 #if FOUNDATION_FRAMEWORK
     
     @frozen
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public enum ReferentConceptAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public typealias Value = Int
         public static let name = NSAttributedString.Key.referentConcept.rawValue
@@ -127,7 +127,7 @@ extension AttributeScopes.FoundationAttributes {
     }
 
     @frozen
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public enum AgreementConceptAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public typealias Value = Int
         public static let name = NSAttributedString.Key.agreeWithConcept.rawValue
@@ -135,7 +135,7 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public enum AgreementArgumentAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public typealias Value = Int
         public static let name = NSAttributedString.Key.agreeWithArgument.rawValue
@@ -168,7 +168,7 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @available(FoundationPreview 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public enum LocalizedNumberFormatAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public struct Value: Equatable, Hashable, Codable, Sendable {
             enum Format {
@@ -851,7 +851,7 @@ extension AttributeScopes.FoundationAttributes.PersonNameComponentAttribute : Ob
     public typealias ObjectiveCValue = NSString
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension AttributeScopes.FoundationAttributes.LocalizedNumberFormatAttribute.Value: _ObjectiveCBridgeable {
     public func _bridgeToObjectiveC() -> __NSLocalizedNumberFormatRule {
         switch self.format {

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -323,10 +323,10 @@ public struct Calendar : Hashable, Equatable, Sendable {
         case nanosecond
         case calendar
         case timeZone
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         case isLeapMonth
         
-        @available(FoundationPreview 0.4, *)
+        @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         case dayOfYear
         
         fileprivate var componentSetValue: ComponentSet.RawValue {
@@ -620,7 +620,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - parameter value: The value of the specified component to add or subtract. The default value is `1`. The value can be negative, which causes subtraction.
     /// - parameter wrappingComponents: If `true`, the component should be incremented and wrap around to zero/one on overflow, and should not cause higher components to be incremented. The default value is `false`.
     /// - returns: A `Sequence` of `Date` values, or an empty sequence if no addition could be performed.
-    @available(FoundationPreview 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public func dates(byAdding component: Calendar.Component,
                       value: Int = 1,
                       startingAt start: Date,
@@ -641,7 +641,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - parameter components: The components to add or subtract.
     /// - parameter wrappingComponents: If `true`, the component should be incremented and wrap around to zero/one on overflow, and should not cause higher components to be incremented. The default value is `false`.
     /// - returns: A `Sequence` of `Date` values, or an empty sequence if no addition could be performed.
-    @available(FoundationPreview 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public func dates(byAdding components: DateComponents,
                       startingAt start: Date,
                       in range: Range<Date>? = nil,
@@ -1222,7 +1222,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - parameter matchingPolicy: Determines the behavior of the search algorithm when the input produces an ambiguous result.
     /// - parameter repeatedTimePolicy: Determines the behavior of the search algorithm when the input produces a time that occurs twice on a particular day.
     /// - parameter direction: Which direction in time to search. The default value is `.forward`, which means later in time.
-    @available(FoundationPreview 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public func dates(byMatching components: DateComponents,
                       startingAt start: Date,
                       in range: Range<Date>? = nil,
@@ -1617,7 +1617,7 @@ package struct WeekendRange: Equatable, Hashable {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Calendar.MatchingPolicy: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -1650,7 +1650,7 @@ extension Calendar.MatchingPolicy: Codable {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Calendar.RepeatedTimePolicy: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -1580,7 +1580,7 @@ extension Calendar {
         return result
     }
     
-    @available(FoundationPreview 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     internal func dateAfterMatchingDayOfYear(startingAt: Date, components: DateComponents, direction: SearchDirection) throws -> Date? {
         guard let dayOfYear = components.dayOfYear else {
             // Nothing to do

--- a/Sources/FoundationEssentials/Calendar/DateComponents.swift
+++ b/Sources/FoundationEssentials/Calendar/DateComponents.swift
@@ -271,7 +271,7 @@ public struct DateComponents : Hashable, Equatable, Sendable {
     /// A day of the year.
     /// For example, in the Gregorian calendar, can go from 1 to 365 or 1 to 366 in leap years.
     /// - note: This value is interpreted in the context of the calendar in which it is used.
-    @available(FoundationPreview 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public var dayOfYear: Int? {
         get { _dayOfYear }
         set { _dayOfYear = converted(newValue) }

--- a/Sources/FoundationEssentials/Calendar/RecurrenceRule.swift
+++ b/Sources/FoundationEssentials/Calendar/RecurrenceRule.swift
@@ -12,7 +12,7 @@
 
 extension Calendar {
     /// A rule which specifies how often an event should repeat in the future
-    @available(FoundationPreview 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public struct RecurrenceRule: Sendable, Equatable {
         /// The calendar in which the recurrence occurs
         public var calendar: Calendar
@@ -304,7 +304,7 @@ extension Calendar {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Calendar.RecurrenceRule.End: Codable {
     enum CodingKeys: String, CodingKey {
         case count
@@ -332,7 +332,7 @@ extension Calendar.RecurrenceRule.End: Codable {
         }
     }
 }
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Calendar.RecurrenceRule.Weekday: Codable {
     enum CodingKeys: String, CodingKey {
         case weekday
@@ -359,7 +359,7 @@ extension Calendar.RecurrenceRule.Weekday: Codable {
         }
     }
 }
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Calendar.RecurrenceRule.Month: Codable {
     enum CodingKeys: String, CodingKey {
         case month
@@ -388,7 +388,7 @@ extension Calendar.RecurrenceRule.Month: Codable {
         }
     }
 }
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Calendar.RecurrenceRule: Codable {
     enum CodingKeys: String, CodingKey {
         case calendar

--- a/Sources/FoundationEssentials/ComparisonResult.swift
+++ b/Sources/FoundationEssentials/ComparisonResult.swift
@@ -30,7 +30,7 @@ public enum ComparisonResult : Int, Sendable {
 
 #endif // !FOUNDATION_FRAMEWORK
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension ComparisonResult : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -430,7 +430,7 @@ internal final class __DataStorage : @unchecked Sendable {
     }
 
     #if FOUNDATION_FRAMEWORK
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     #endif
     @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
     func replaceBytes(in range_: Range<Int>, with replacementBytes: UnsafeRawPointer?, length replacementLength: Int) {

--- a/Sources/FoundationEssentials/Formatting/DiscreteFormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/DiscreteFormatStyle.swift
@@ -102,7 +102,7 @@
 /// - the formatted output for `xA` and higher is **most likely** different from `format(y)`
 /// - the  formatted output between `xB` and `zB`, as well as `zA` and `xA` (excluding bounds) cannot
 ///   be predicted
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 public protocol DiscreteFormatStyle<FormatInput, FormatOutput> : FormatStyle {
     /// The next discretization boundary before the given input.
     ///
@@ -191,7 +191,7 @@ public protocol DiscreteFormatStyle<FormatInput, FormatOutput> : FormatStyle {
     func input(after input: FormatInput) -> FormatInput?
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension DiscreteFormatStyle where FormatInput : FloatingPoint {
     public func input(before input: FormatInput) -> FormatInput? {
         guard input > -FormatInput.infinity else {
@@ -210,7 +210,7 @@ extension DiscreteFormatStyle where FormatInput : FloatingPoint {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension DiscreteFormatStyle where FormatInput : FixedWidthInteger {
     public func input(before input: FormatInput) -> FormatInput? {
         guard input > FormatInput.min else {
@@ -229,7 +229,7 @@ extension DiscreteFormatStyle where FormatInput : FixedWidthInteger {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension DiscreteFormatStyle where FormatInput == Date {
     public func input(before input: FormatInput) -> FormatInput? {
         guard input > Date.distantPast else {
@@ -258,7 +258,7 @@ extension Date {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension DiscreteFormatStyle where FormatInput == Duration {
     public func input(before input: FormatInput) -> FormatInput? {
         guard input > .seconds(Int64.min) else {

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -346,14 +346,14 @@ open class JSONDecoder {
         }, from: data)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func decode<T: DecodableWithConfiguration>(_ type: T.Type, from data: Data, configuration: T.DecodingConfiguration) throws -> T {
         try _decode({
             try $0.unwrap($1, as: type, configuration: configuration, for: .root, _CodingKey?.none)
         }, from: data)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func decode<T, C>(_ type: T.Type, from data: Data, configuration: C.Type) throws -> T where T : DecodableWithConfiguration, C : DecodingConfigurationProviding, T.DecodingConfiguration == C.DecodingConfiguration {
         try decode(type, from: data, configuration: C.decodingConfiguration)
     }

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -352,14 +352,14 @@ open class JSONEncoder {
         }, value: value)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func encode<T : EncodableWithConfiguration>(_ value: T, configuration: T.EncodingConfiguration) throws -> Data {
         try _encode({
             try $0.wrapGeneric(value, configuration: configuration)
         }, value: value)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func encode<T, C>(_ value: T, configuration: C.Type) throws -> Data where T : EncodableWithConfiguration, C : EncodingConfigurationProviding, T.EncodingConfiguration == C.EncodingConfiguration {
         try encode(value, configuration: C.encodingConfiguration)
     }

--- a/Sources/FoundationEssentials/Locale/Locale+Components.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Components.swift
@@ -124,31 +124,31 @@ extension Locale {
     }
 }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.LanguageCode : CustomDebugStringConvertible { }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.Script : CustomDebugStringConvertible { }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.Region : CustomDebugStringConvertible { }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.Currency : CustomDebugStringConvertible { }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.Collation : CustomDebugStringConvertible { }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.NumberingSystem : CustomDebugStringConvertible { }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.Subdivision : CustomDebugStringConvertible { }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.Variant : CustomDebugStringConvertible { }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Locale.MeasurementSystem : CustomDebugStringConvertible { }
 
 extension Locale {
@@ -169,7 +169,7 @@ extension Locale {
         package var _identifier: String
         package var _normalizedIdentifier: String
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }
@@ -254,7 +254,7 @@ extension Locale {
             }
         }
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }
@@ -316,7 +316,7 @@ extension Locale {
         package var _identifier: String
         package var _normalizedIdentifier: String
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }
@@ -395,7 +395,7 @@ extension Locale {
             }
         }
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }
@@ -467,7 +467,7 @@ extension Locale {
             }
         }
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }
@@ -533,7 +533,7 @@ extension Locale {
             }
         }
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }
@@ -655,7 +655,7 @@ extension Locale {
             }
         }
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }
@@ -734,7 +734,7 @@ extension Locale {
             }
         }
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }
@@ -806,7 +806,7 @@ extension Locale {
             }
         }
 
-        @available(FoundationPreview 0.1, *)
+        @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public var debugDescription: String {
             _normalizedIdentifier
         }

--- a/Sources/FoundationEssentials/Predicate/Archiving/EncodingContainers+PredicateExpression.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/EncodingContainers+PredicateExpression.swift
@@ -14,7 +14,7 @@
 
 // Initial API constrained to Output == Bool
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension KeyedEncodingContainer {
     public mutating func encodePredicateExpression<T: PredicateExpression & Encodable, each Input>(_ expression: T, forKey key: Self.Key, variable: repeat PredicateExpressions.Variable<each Input>, predicateConfiguration: PredicateCodableConfiguration) throws where T.Output == Bool {
         var container = self.nestedContainer(keyedBy: PredicateExpressionCodingKeys.self, forKey: key)
@@ -33,7 +33,7 @@ extension PredicateExpression {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension KeyedDecodingContainer {
     @_optimize(none) // Work around swift optimizer crash (rdar://124533887)
     public mutating func decodePredicateExpression<each Input>(forKey key: Self.Key, input: repeat (each Input).Type, predicateConfiguration: PredicateCodableConfiguration) throws -> (expression: any PredicateExpression<Bool>, variable: (repeat PredicateExpressions.Variable<each Input>)) {
@@ -48,7 +48,7 @@ extension KeyedDecodingContainer {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension UnkeyedEncodingContainer {
     public mutating func encodePredicateExpression<T: PredicateExpression & Encodable, each Input>(_ expression: T, variable: repeat PredicateExpressions.Variable<each Input>, predicateConfiguration: PredicateCodableConfiguration) throws where T.Output == Bool {
         var container = self.nestedContainer(keyedBy: PredicateExpressionCodingKeys.self)
@@ -64,7 +64,7 @@ extension UnkeyedEncodingContainer {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension UnkeyedDecodingContainer {
     @_optimize(none) // Work around swift optimizer crash (rdar://124533887)
     public mutating func decodePredicateExpression<each Input>(input: repeat (each Input).Type, predicateConfiguration: PredicateCodableConfiguration) throws -> (expression: any PredicateExpression<Bool>, variable: (repeat PredicateExpressions.Variable<each Input>)) {
@@ -87,7 +87,7 @@ extension UnkeyedDecodingContainer {
 
 // Added API without Output Constraint
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension KeyedEncodingContainer {
     @_disfavoredOverload
     public mutating func encodePredicateExpression<T: PredicateExpression & Encodable, each Input>(_ expression: T, forKey key: Self.Key, variable: repeat PredicateExpressions.Variable<each Input>, predicateConfiguration: PredicateCodableConfiguration) throws {
@@ -102,7 +102,7 @@ extension KeyedEncodingContainer {
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension KeyedDecodingContainer {
     public mutating func decodePredicateExpression<each Input, Output>(forKey key: Self.Key, input: repeat (each Input).Type, output: Output.Type, predicateConfiguration: PredicateCodableConfiguration) throws -> (expression: any PredicateExpression<Output>, variable: (repeat PredicateExpressions.Variable<each Input>)) {
         var container = try self.nestedContainer(keyedBy: PredicateExpressionCodingKeys.self, forKey: key)
@@ -115,7 +115,7 @@ extension KeyedDecodingContainer {
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension UnkeyedEncodingContainer {
     @_disfavoredOverload
     public mutating func encodePredicateExpression<T: PredicateExpression & Encodable, each Input>(_ expression: T, variable: repeat PredicateExpressions.Variable<each Input>, predicateConfiguration: PredicateCodableConfiguration) throws {
@@ -133,7 +133,7 @@ extension UnkeyedEncodingContainer {
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension UnkeyedDecodingContainer {
     public mutating func decodePredicateExpression<each Input, Output>(input: repeat (each Input).Type, output: Output.Type, predicateConfiguration: PredicateCodableConfiguration) throws -> (expression: any PredicateExpression<Output>, variable: (repeat PredicateExpressions.Variable<each Input>)) {
         var container = try self.nestedContainer(keyedBy: PredicateExpressionCodingKeys.self)

--- a/Sources/FoundationEssentials/Predicate/Archiving/Predicate+Codable.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/Predicate+Codable.swift
@@ -26,7 +26,7 @@ extension PredicateCodableConfiguration {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Predicate : Codable {
     public func encode(to encoder: Encoder) throws {
         try self.encode(to: encoder, configuration: .default)
@@ -37,7 +37,7 @@ extension Predicate : Codable {
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Expression : Codable {
     public func encode(to encoder: Encoder) throws {
         try self.encode(to: encoder, configuration: .default)
@@ -48,7 +48,7 @@ extension Expression : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Predicate : CodableWithConfiguration {
     public typealias EncodingConfiguration = PredicateCodableConfiguration
     public typealias DecodingConfiguration = PredicateCodableConfiguration
@@ -69,7 +69,7 @@ extension Predicate : CodableWithConfiguration {
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Expression : CodableWithConfiguration {
     public typealias EncodingConfiguration = PredicateCodableConfiguration
     public typealias DecodingConfiguration = PredicateCodableConfiguration

--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -15,13 +15,13 @@
 #if canImport(ReflectionInternal)
 internal import ReflectionInternal
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public protocol PredicateCodableKeyPathProviding {
     @preconcurrency
     static var predicateCodableKeyPaths : [String : PartialKeyPath<Self> & Sendable] { get }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConvertible {
     enum AllowListType : Equatable, Sendable {
         case concrete(Type)
@@ -268,7 +268,7 @@ public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConverti
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateCodableConfiguration {
     func _identifier(for keyPath: AnyKeyPath & Sendable) -> String? {
         let concreteIdentifier = allowedKeyPaths.first {
@@ -342,7 +342,7 @@ extension PredicateCodableConfiguration {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateCodableConfiguration {
     public static let standardConfiguration: Self = {
         var configuration = Self()

--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateExpressionConstruction.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateExpressionConstruction.swift
@@ -14,7 +14,7 @@
 
 internal import ReflectionInternal
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 enum PredicateCodableError : Error, CustomStringConvertible {
     case disallowedType(typeName: String, path: String)
     case disallowedIdentifier(String, path: String)
@@ -38,7 +38,7 @@ enum PredicateCodableError : Error, CustomStringConvertible {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 private struct ExpressionStructure : Codable {
     private enum Argument : Codable {
         case scalar(ExpressionStructure)
@@ -144,7 +144,7 @@ private struct ExpressionStructure : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 class PredicateArchivingState {
     var configuration: PredicateCodableConfiguration
     
@@ -165,7 +165,7 @@ class PredicateArchivingState {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension _ThreadLocal.Key<PredicateArchivingState> {
     static let predicateArchivingState = Self<PredicateArchivingState>()
 }
@@ -176,7 +176,7 @@ enum PredicateExpressionCodingKeys : CodingKey {
     case structure
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 fileprivate extension PredicateCodableConfiguration {
     mutating func allowInputs<each Input>(_ input: repeat (each Input).Type) {
         guard self.shouldAddInputTypes else { return }
@@ -202,7 +202,7 @@ private func _withPredicateArchivingState<R>(_ configuration: PredicateCodableCo
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension KeyedEncodingContainer where Key == PredicateExpressionCodingKeys {
     mutating func _encode<T: PredicateExpression & Encodable, each Input>(_ expression: T, variable: repeat PredicateExpressions.Variable<each Input>, predicateConfiguration: PredicateCodableConfiguration) throws {
         var predicateConfiguration = predicateConfiguration
@@ -217,7 +217,7 @@ extension KeyedEncodingContainer where Key == PredicateExpressionCodingKeys {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension KeyedDecodingContainer where Key == PredicateExpressionCodingKeys {
     mutating func _decode<each Input, Output>(input: repeat (each Input).Type, output: Output.Type, predicateConfiguration: PredicateCodableConfiguration) throws -> (expression: any PredicateExpression<Output>, variable: (repeat PredicateExpressions.Variable<each Input>)) {
         var predicateConfiguration = predicateConfiguration

--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 public struct Expression<each Input, Output> : Sendable {
     public let expression : any StandardPredicateExpression<Output>
     public let variable: (repeat PredicateExpressions.Variable<each Input>)
@@ -29,6 +29,6 @@ public struct Expression<each Input, Output> : Sendable {
 
 #if hasFeature(Macros)
 @freestanding(expression)
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 public macro Expression<each Input, Output>(_ body: (repeat each Input) -> Output) -> Expression<repeat each Input, Output> = #externalMacro(module: "FoundationMacros", type: "ExpressionMacro")
 #endif

--- a/Sources/FoundationEssentials/Predicate/Expressions/Aggregate.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Aggregate.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct SequenceMaximum<
         Elements : PredicateExpression
@@ -36,23 +36,23 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMaximum : StandardPredicateExpression where Elements : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceMaximum : CustomStringConvertible {
     public var description: String {
         "SequenceMaximum(elements: \(elements))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMaximum : Codable where Elements : Codable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMaximum : Sendable where Elements : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct SequenceMinimum<
         Elements : PredicateExpression
@@ -78,18 +78,18 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMinimum : StandardPredicateExpression where Elements : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceMinimum : CustomStringConvertible {
     public var description: String {
         "SequenceMinimum(elements: \(elements))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMinimum : Codable where Elements : Codable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMinimum : Sendable where Elements : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Arithmetic.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Arithmetic.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public enum ArithmeticOperator: Codable, Sendable {
         case add, subtract, multiply
@@ -53,17 +53,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Arithmetic : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Arithmetic : CustomStringConvertible {
     public var description: String {
         "Arithmetic(lhs: \(lhs), operator: \(op), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Arithmetic : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -80,5 +80,5 @@ extension PredicateExpressions.Arithmetic : Codable where LHS : Codable, RHS : C
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Arithmetic : Sendable where LHS : Sendable, RHS : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Collection.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Collection.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct CollectionIndexSubscript<
         Wrapped : PredicateExpression,
@@ -45,17 +45,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionIndexSubscript : Sendable where Wrapped : Sendable, Index : Sendable {}
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.CollectionIndexSubscript : CustomStringConvertible {
     public var description: String {
         "CollectionIndexSubscript(wrapped: \(wrapped), index: \(index))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionIndexSubscript : Codable where Wrapped : Codable, Index : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -70,10 +70,10 @@ extension PredicateExpressions.CollectionIndexSubscript : Codable where Wrapped 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionIndexSubscript : StandardPredicateExpression where Wrapped : StandardPredicateExpression, Index : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct CollectionRangeSubscript<
         Wrapped : PredicateExpression,
@@ -113,17 +113,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.CollectionRangeSubscript : CustomStringConvertible {
     public var description: String {
         "CollectionRangeSubscript(wrapped: \(wrapped), range: \(range))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionRangeSubscript : Sendable where Wrapped : Sendable, Range : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionRangeSubscript : Codable where Wrapped : Codable, Range : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -138,10 +138,10 @@ extension PredicateExpressions.CollectionRangeSubscript : Codable where Wrapped 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionRangeSubscript : StandardPredicateExpression where Wrapped : StandardPredicateExpression, Range : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct CollectionContainsCollection<
         Base : PredicateExpression,
@@ -174,17 +174,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.CollectionContainsCollection : CustomStringConvertible {
     public var description: String {
         "CollectionContainsCollection(base: \(base), other: \(other))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionContainsCollection : Sendable where Base : Sendable, Other : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionContainsCollection : Codable where Base : Codable, Other : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -199,5 +199,5 @@ extension PredicateExpressions.CollectionContainsCollection : Codable where Base
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionContainsCollection : StandardPredicateExpression where Base : StandardPredicateExpression, Other : StandardPredicateExpression {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Comparison.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Comparison.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public enum ComparisonOperator: Codable, Sendable {
         case lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual
@@ -54,17 +54,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Comparison : CustomStringConvertible {
     public var description: String {
         "Comparison(lhs: \(lhs), operator: \(op), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Comparison : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Comparison : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -81,5 +81,5 @@ extension PredicateExpressions.Comparison : Codable where LHS : Codable, RHS : C
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Comparison : Sendable where LHS : Sendable, RHS : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Conditional.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Conditional.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct Conditional<
         Test : PredicateExpression,
@@ -48,17 +48,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Conditional : CustomStringConvertible {
     public var description: String {
         "Conditional(test: \(test), trueBranch: \(trueBranch), falseBranch: \(falseBranch))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Conditional : StandardPredicateExpression where Test : StandardPredicateExpression, If : StandardPredicateExpression, Else : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Conditional : Codable where Test : Codable, If : Codable, Else : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -75,5 +75,5 @@ extension PredicateExpressions.Conditional : Codable where Test : Codable, If : 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Conditional : Sendable where Test : Sendable, If : Sendable, Else : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Conjunction.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Conjunction.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct Conjunction<
         LHS : PredicateExpression,
@@ -40,17 +40,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Conjunction : CustomStringConvertible {
     public var description: String {
         "Conjunction(lhs: \(lhs), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Conjunction : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Conjunction : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -65,5 +65,5 @@ extension PredicateExpressions.Conjunction : Codable where LHS : Codable, RHS : 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Conjunction : Sendable where LHS : Sendable, RHS : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Dictionary.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Dictionary.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct DictionaryKeySubscript<
         Wrapped : PredicateExpression,
@@ -40,17 +40,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.DictionaryKeySubscript : CustomStringConvertible {
     public var description: String {
         "DictionaryKeySubscript(wrapped: \(wrapped), key: \(key))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.DictionaryKeySubscript : Sendable where Wrapped : Sendable, Key : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.DictionaryKeySubscript : Codable where Wrapped : Codable, Key : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -65,10 +65,10 @@ extension PredicateExpressions.DictionaryKeySubscript : Codable where Wrapped : 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.DictionaryKeySubscript : StandardPredicateExpression where Wrapped : StandardPredicateExpression, Key : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct DictionaryKeyDefaultValueSubscript<
         Wrapped : PredicateExpression,
@@ -103,17 +103,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : CustomStringConvertible {
     public var description: String {
         "DictionaryKeyDefaultValueSubscript(wrapped: \(wrapped), key: \(key), defaultValue: \(`default`))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : Sendable where Wrapped : Sendable, Key : Sendable, Default : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : Codable where Wrapped : Codable, Key : Codable, Default : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -130,5 +130,5 @@ extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : Codable wher
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : StandardPredicateExpression where Wrapped : StandardPredicateExpression, Key : StandardPredicateExpression, Default : StandardPredicateExpression {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Disjunction.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Disjunction.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct Disjunction<
         LHS : PredicateExpression,
@@ -40,17 +40,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Disjunction : CustomStringConvertible {
     public var description: String {
         "Disjunction(lhs: \(lhs), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Disjunction : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Disjunction : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -65,5 +65,5 @@ extension PredicateExpressions.Disjunction : Codable where LHS : Codable, RHS : 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Disjunction : Sendable where LHS : Sendable, RHS : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Division.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Division.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct IntDivision<
         LHS : PredicateExpression,
@@ -100,37 +100,37 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.FloatDivision : CustomStringConvertible {
     public var description: String {
         "FloatDivision(lhs: \(lhs), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.IntDivision : CustomStringConvertible {
     public var description: String {
         "IntDivision(lhs: \(lhs), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.IntRemainder : CustomStringConvertible {
     public var description: String {
         "IntRemainder(lhs: \(lhs), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.FloatDivision : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.IntRemainder : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.IntDivision : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.FloatDivision : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -145,7 +145,7 @@ extension PredicateExpressions.FloatDivision : Codable where LHS : Codable, RHS 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.IntRemainder : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -160,7 +160,7 @@ extension PredicateExpressions.IntRemainder : Codable where LHS : Codable, RHS :
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.IntDivision : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -175,11 +175,11 @@ extension PredicateExpressions.IntDivision : Codable where LHS : Codable, RHS : 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.FloatDivision : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.IntRemainder : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.IntDivision : Sendable where LHS : Sendable, RHS : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Equality.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Equality.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct Equal<
         LHS : PredicateExpression,
@@ -40,17 +40,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Equal : CustomStringConvertible {
     public var description: String {
         "Equal(lhs: \(lhs), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Equal : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Equal : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -65,5 +65,5 @@ extension PredicateExpressions.Equal : Codable where LHS : Codable, RHS : Codabl
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Equal : Sendable where LHS : Sendable, RHS : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/ExpressionEvaluation.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/ExpressionEvaluation.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
-    @available(FoundationPredicate 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public struct ExpressionEvaluate<
         Transformation : PredicateExpression,
         each Input : PredicateExpression,
@@ -35,23 +35,23 @@ extension PredicateExpressions {
         }
     }
     
-    @available(FoundationPredicate 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public static func build_evaluate<Transformation, each Input, Output>(_ expression: Transformation, _ input: repeat each Input) -> ExpressionEvaluate<Transformation, repeat each Input, Output> {
         ExpressionEvaluate(expression: expression, input: repeat each input)
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.ExpressionEvaluate : CustomStringConvertible {
     public var description: String {
         "ExpressionEvaluate(expression: \(expression), input: \(input))"
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.ExpressionEvaluate : StandardPredicateExpression where Transformation : StandardPredicateExpression, repeat each Input : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.ExpressionEvaluate : Codable where Transformation : Codable, repeat each Input : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -66,5 +66,5 @@ extension PredicateExpressions.ExpressionEvaluate : Codable where Transformation
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.ExpressionEvaluate : Sendable where Transformation : Sendable, repeat each Input : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Filter.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Filter.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct Filter<
         LHS : PredicateExpression,
@@ -47,17 +47,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Filter : CustomStringConvertible {
     public var description: String {
         "Filter(sequence: \(sequence), variable: \(variable), filter: \(filter))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Filter : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Filter : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -74,5 +74,5 @@ extension PredicateExpressions.Filter : Codable where LHS : Codable, RHS : Codab
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Filter : Sendable where LHS : Sendable, RHS : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Inequality.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Inequality.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct NotEqual<
         LHS : PredicateExpression,
@@ -40,17 +40,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.NotEqual : CustomStringConvertible {
     public var description: String {
         "NotEqual(lhs: \(lhs), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.NotEqual : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.NotEqual : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -65,5 +65,5 @@ extension PredicateExpressions.NotEqual : Codable where LHS : Codable, RHS : Cod
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.NotEqual : Sendable where LHS : Sendable, RHS : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Negation.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Negation.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct Negation<Wrapped: PredicateExpression> : PredicateExpression where Wrapped.Output == Bool {
         public typealias Output = Bool
@@ -31,17 +31,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Negation : CustomStringConvertible {
     public var description: String {
         "Negation(wrapped: \(wrapped))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Negation : StandardPredicateExpression where Wrapped : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Negation : Codable where Wrapped : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -54,5 +54,5 @@ extension PredicateExpressions.Negation : Codable where Wrapped : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Negation : Sendable where Wrapped : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Optional.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Optional.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct OptionalFlatMap<
         LHS : PredicateExpression,
@@ -111,37 +111,37 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.OptionalFlatMap : CustomStringConvertible {
     public var description: String {
         "OptionalFlatMap(wrapped: \(wrapped), variable: \(variable), transform: \(transform))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.NilCoalesce : CustomStringConvertible {
     public var description: String {
         "NilCoalesce(lhs: \(lhs), rhs: \(rhs))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.ForcedUnwrap : CustomStringConvertible {
     public var description: String {
         "ForcedUnwrap(inner: \(inner))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.OptionalFlatMap : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.NilCoalesce : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ForcedUnwrap : StandardPredicateExpression where Inner : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.OptionalFlatMap : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -158,7 +158,7 @@ extension PredicateExpressions.OptionalFlatMap : Codable where LHS : Codable, RH
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.NilCoalesce : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -173,7 +173,7 @@ extension PredicateExpressions.NilCoalesce : Codable where LHS : Codable, RHS : 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ForcedUnwrap : Codable where Inner : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -186,16 +186,16 @@ extension PredicateExpressions.ForcedUnwrap : Codable where Inner : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.OptionalFlatMap : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.NilCoalesce : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ForcedUnwrap : Sendable where Inner : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct NilLiteral<Wrapped> : StandardPredicateExpression, Codable, Sendable {
         public typealias Output = Optional<Wrapped>

--- a/Sources/FoundationEssentials/Predicate/Expressions/PredicateEvaluation.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/PredicateEvaluation.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
-    @available(FoundationPredicate 0.3, *)
+    @available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
     public struct PredicateEvaluate<
         Condition : PredicateExpression,
         each Input : PredicateExpression
@@ -37,23 +37,23 @@ extension PredicateExpressions {
         }
     }
     
-    @available(FoundationPredicate 0.3, *)
+    @available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
     public static func build_evaluate<Condition, each Input>(_ predicate: Condition, _ input: repeat each Input) -> PredicateEvaluate<Condition, repeat each Input> {
         PredicateEvaluate<Condition, repeat each Input>(predicate: predicate, input: repeat each input)
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.PredicateEvaluate : CustomStringConvertible {
     public var description: String {
         "PredicateEvaluate(predicate: \(predicate), input: \(input))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.PredicateEvaluate : StandardPredicateExpression where Condition : StandardPredicateExpression, repeat each Input : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.PredicateEvaluate : Codable where Condition : Codable, repeat each Input : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -68,6 +68,6 @@ extension PredicateExpressions.PredicateEvaluate : Codable where Condition : Cod
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.PredicateEvaluate : Sendable where Condition : Sendable, repeat each Input : Sendable {}
 #endif

--- a/Sources/FoundationEssentials/Predicate/Expressions/Range.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Range.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct Range<
         LHS : PredicateExpression,
@@ -45,17 +45,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Range : CustomStringConvertible {
     public var description: String {
         "Range(lower: \(lower), upper: \(upper))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Range : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Range : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -70,10 +70,10 @@ extension PredicateExpressions.Range : Codable where LHS : Codable, RHS : Codabl
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Range : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct ClosedRange<
         LHS : PredicateExpression,
@@ -105,17 +105,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.ClosedRange : CustomStringConvertible {
     public var description: String {
         "ClosedRange(lower: \(lower), upper: \(upper))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ClosedRange : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ClosedRange : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -130,10 +130,10 @@ extension PredicateExpressions.ClosedRange : Codable where LHS : Codable, RHS : 
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ClosedRange : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct RangeExpressionContains<
         RangeExpression : PredicateExpression,
@@ -162,17 +162,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.RangeExpressionContains : CustomStringConvertible {
     public var description: String {
         "RangeExpressionContains(range: \(range), element: \(element))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.RangeExpressionContains : StandardPredicateExpression where RangeExpression : StandardPredicateExpression, Element : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.RangeExpressionContains : Codable where RangeExpression : Codable, Element : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -187,5 +187,5 @@ extension PredicateExpressions.RangeExpressionContains : Codable where RangeExpr
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.RangeExpressionContains : Sendable where RangeExpression : Sendable, Element : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Regex.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Regex.swift
@@ -12,7 +12,7 @@
 
 #if compiler(>=5.11)
 
-@available(FoundationPredicateRegex 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions {
     public struct StringContainsRegex<
         Subject : PredicateExpression,
@@ -48,7 +48,7 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicateRegex 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions {
     public struct PredicateRegex: Sendable, Codable, RegexComponent, CustomStringConvertible {
         private struct _Storage: @unchecked Sendable {
@@ -90,10 +90,10 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicateRegex 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.StringContainsRegex : Sendable where Subject : Sendable, Regex : Sendable {}
 
-@available(FoundationPredicateRegex 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.StringContainsRegex : Codable where Subject : Codable, Regex : Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -108,7 +108,7 @@ extension PredicateExpressions.StringContainsRegex : Codable where Subject : Cod
     }
 }
 
-@available(FoundationPredicateRegex 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.StringContainsRegex : StandardPredicateExpression where Subject : StandardPredicateExpression, Regex : StandardPredicateExpression {}
 
 #endif

--- a/Sources/FoundationEssentials/Predicate/Expressions/Sequence.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Sequence.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct SequenceContains<
         LHS : PredicateExpression,
@@ -141,40 +141,40 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceContains : CustomStringConvertible {
     public var description: String {
         "SequenceContains(sequence: \(sequence), element: \(element))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceContainsWhere : CustomStringConvertible {
     public var description: String {
         "SequenceContainsWhere(sequence: \(sequence), variable: \(variable), test: \(test))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceAllSatisfy : CustomStringConvertible {
     public var description: String {
         "SequenceAllSatisfy(sequence: \(sequence), variable: \(variable), test: \(test))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceContains : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceContainsWhere : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceAllSatisfy : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceStartsWith : StandardPredicateExpression where Base : StandardPredicateExpression, Prefix : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceContains : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -189,7 +189,7 @@ extension PredicateExpressions.SequenceContains : Codable where LHS : Codable, R
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceContainsWhere : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -206,7 +206,7 @@ extension PredicateExpressions.SequenceContainsWhere : Codable where LHS : Codab
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceAllSatisfy : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -223,7 +223,7 @@ extension PredicateExpressions.SequenceAllSatisfy : Codable where LHS : Codable,
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceStartsWith : Codable where Base : Codable, Prefix : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -238,14 +238,14 @@ extension PredicateExpressions.SequenceStartsWith : Codable where Base : Codable
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceContains : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceContainsWhere : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceAllSatisfy : Sendable where LHS : Sendable, RHS : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceStartsWith : Sendable where Base : Sendable, Prefix : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/StringComparison.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/StringComparison.swift
@@ -12,7 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct StringCaseInsensitiveCompare<
         Root : PredicateExpression,
@@ -41,17 +41,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.StringCaseInsensitiveCompare : CustomStringConvertible {
     public var description: String {
         "StringCaseInsensitiveCompare(root: \(root), other: \(other))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.StringCaseInsensitiveCompare : StandardPredicateExpression where Root : StandardPredicateExpression, Other : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.StringCaseInsensitiveCompare : Codable where Root : Codable, Other : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
@@ -66,7 +66,7 @@ extension PredicateExpressions.StringCaseInsensitiveCompare : Codable where Root
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.StringCaseInsensitiveCompare : Sendable where Root : Sendable, Other : Sendable {}
 
 #endif

--- a/Sources/FoundationEssentials/Predicate/Expressions/Types.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Types.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct ConditionalCast<
         Input : PredicateExpression,
@@ -68,37 +68,37 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.ConditionalCast : CustomStringConvertible {
     public var description: String {
         "ConditionalCast(input: \(input), desiredType: \(_typeName(Desired.self)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.ForceCast : CustomStringConvertible {
     public var description: String {
         "ForceCast(input: \(input), desiredType: \(_typeName(Desired.self)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.TypeCheck : CustomStringConvertible {
     public var description: String {
         "TypeCheck(input: \(input), desiredType: \(_typeName(Desired.self)))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ConditionalCast : StandardPredicateExpression where Input : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ForceCast : StandardPredicateExpression where Input : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.TypeCheck : StandardPredicateExpression where Input : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ConditionalCast : Codable where Input : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -111,7 +111,7 @@ extension PredicateExpressions.ConditionalCast : Codable where Input : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ForceCast : Codable where Input : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -124,7 +124,7 @@ extension PredicateExpressions.ForceCast : Codable where Input : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.TypeCheck : Codable where Input : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -137,11 +137,11 @@ extension PredicateExpressions.TypeCheck : Codable where Input : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ConditionalCast : Sendable where Input : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ForceCast : Sendable where Input : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.TypeCheck : Sendable where Input : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/UnaryMinus.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/UnaryMinus.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct UnaryMinus<Wrapped: PredicateExpression> : PredicateExpression where Wrapped.Output: SignedNumeric {
         public typealias Output = Wrapped.Output
@@ -31,17 +31,17 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.UnaryMinus : CustomStringConvertible {
     public var description: String {
         "UnaryMinus(wrapped: \(wrapped))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.UnaryMinus : StandardPredicateExpression where Wrapped : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.UnaryMinus : Codable where Wrapped : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -54,5 +54,5 @@ extension PredicateExpressions.UnaryMinus : Codable where Wrapped : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.UnaryMinus : Sendable where Wrapped : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -562,7 +562,7 @@ extension OverwritingInitializable {
 extension NSPredicate : OverwritingInitializable {}
 extension NSExpression : OverwritingInitializable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension NSPredicate {
     public convenience init?<Input>(_ predicate: Predicate<Input>) where Input : NSObject {
         let variable = predicate.variable
@@ -574,7 +574,7 @@ extension NSPredicate {
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension NSExpression {
     public convenience init?<Input, Output>(_ expression: Expression<Input, Output>) where Input : NSObject {
         let variable = expression.variable

--- a/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 package struct DebugStringConversionState {
     private var variables: [PredicateExpressions.VariableID : String]
     private var nextVariable = 1
@@ -78,61 +78,61 @@ extension AnyKeyPath {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 package protocol DebugStringConvertiblePredicateExpression : StandardPredicateExpression {
     func debugString(state: inout DebugStringConversionState) -> String
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Variable : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         state[self.key]
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.KeyPath : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         root.debugString(state: &state) + keyPath.debugStringWithoutType
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Value : DebugStringConvertiblePredicateExpression where Self : StandardPredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         state.addCapture(value)
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Conjunction : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lhs.debugString(state: &state)) && \(rhs.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Disjunction : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lhs.debugString(state: &state)) || \(rhs.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Equal : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lhs.debugString(state: &state)) == \(rhs.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.NotEqual : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lhs.debugString(state: &state)) != \(rhs.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Arithmetic : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         let op = switch self.op {
@@ -144,7 +144,7 @@ extension PredicateExpressions.Arithmetic : DebugStringConvertiblePredicateExpre
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Comparison : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         let op = switch self.op {
@@ -157,42 +157,42 @@ extension PredicateExpressions.Comparison : DebugStringConvertiblePredicateExpre
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.UnaryMinus : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "-\(wrapped.debugString(state: &state))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceMinimum : DebugStringConvertiblePredicateExpression where Elements : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(elements.debugString(state: &state)).min()"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceMaximum : DebugStringConvertiblePredicateExpression where Elements : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(elements.debugString(state: &state)).max()"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.ClosedRange : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lower.debugString(state: &state)) ... \(upper.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Range : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lower.debugString(state: &state)) ..< \(upper.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Conditional : DebugStringConvertiblePredicateExpression where Test : DebugStringConvertiblePredicateExpression, If : DebugStringConvertiblePredicateExpression, Else : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         """
@@ -205,56 +205,56 @@ extension PredicateExpressions.Conditional : DebugStringConvertiblePredicateExpr
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.CollectionIndexSubscript : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression, Index : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(wrapped.debugString(state: &state))[\(index.debugString(state: &state))]"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.CollectionRangeSubscript : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression, Range : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(wrapped.debugString(state: &state))[\(range.debugString(state: &state))]"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.CollectionContainsCollection : DebugStringConvertiblePredicateExpression where Base : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(base.debugString(state: &state)).contains(\(other.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.ConditionalCast : DebugStringConvertiblePredicateExpression where Input : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(input.debugString(state: &state)) as? \(_typeName(Desired.self)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.ForceCast : DebugStringConvertiblePredicateExpression where Input : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(input.debugString(state: &state)) as! \(_typeName(Desired.self)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.TypeCheck : DebugStringConvertiblePredicateExpression where Input : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(input.debugString(state: &state)) is \(_typeName(Desired.self)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.ForcedUnwrap : DebugStringConvertiblePredicateExpression where Inner : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(inner.debugString(state: &state))!"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.OptionalFlatMap : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         state.setupVariable(variable.key)
@@ -266,84 +266,84 @@ extension PredicateExpressions.OptionalFlatMap : DebugStringConvertiblePredicate
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.DictionaryKeySubscript : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression, Key : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(wrapped.debugString(state: &state))[\(key.debugString(state: &state))]"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression, Key : DebugStringConvertiblePredicateExpression, Default : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(wrapped.debugString(state: &state))[\(key.debugString(state: &state)), default: \(self.default.debugString(state: &state))]"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.FloatDivision : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lhs.debugString(state: &state)) / \(rhs.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.IntDivision : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lhs.debugString(state: &state)) / \(rhs.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.IntRemainder : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lhs.debugString(state: &state)) % \(rhs.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Negation : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "!\(wrapped.debugString(state: &state))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.NilCoalesce : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS: DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "(\(lhs.debugString(state: &state)) ?? \(rhs.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.NilLiteral : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "nil"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.RangeExpressionContains : DebugStringConvertiblePredicateExpression where RangeExpression : DebugStringConvertiblePredicateExpression, Element : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(range.debugString(state: &state)).contains(\(element.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceContains : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS: DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(sequence.debugString(state: &state)).contains(\(element.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceStartsWith : DebugStringConvertiblePredicateExpression where Base : DebugStringConvertiblePredicateExpression, Prefix : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(base.debugString(state: &state)).starts(with: \(prefix.debugString(state: &state)))"
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceContainsWhere : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         state.setupVariable(variable.key)
@@ -355,7 +355,7 @@ extension PredicateExpressions.SequenceContainsWhere : DebugStringConvertiblePre
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.SequenceAllSatisfy : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         state.setupVariable(variable.key)
@@ -367,7 +367,7 @@ extension PredicateExpressions.SequenceAllSatisfy : DebugStringConvertiblePredic
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Filter : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         state.setupVariable(variable.key)
@@ -380,7 +380,7 @@ extension PredicateExpressions.Filter : DebugStringConvertiblePredicateExpressio
 }
 
 #if compiler(>=5.11)
-@available(FoundationPredicateRegex 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.StringContainsRegex : DebugStringConvertiblePredicateExpression where Subject : DebugStringConvertiblePredicateExpression, Regex : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(subject.debugString(state: &state)).contains(\(subject.debugString(state: &state)))"
@@ -388,7 +388,7 @@ extension PredicateExpressions.StringContainsRegex : DebugStringConvertiblePredi
 }
 #endif
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension PredicateExpressions.ExpressionEvaluate : DebugStringConvertiblePredicateExpression where Transformation : DebugStringConvertiblePredicateExpression, repeat each Input : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         var inputStrings: [String] = []
@@ -399,7 +399,7 @@ extension PredicateExpressions.ExpressionEvaluate : DebugStringConvertiblePredic
 
 #if FOUNDATION_FRAMEWORK
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.PredicateEvaluate : DebugStringConvertiblePredicateExpression where Condition : DebugStringConvertiblePredicateExpression, repeat each Input : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         var inputStrings: [String] = []
@@ -408,7 +408,7 @@ extension PredicateExpressions.PredicateEvaluate : DebugStringConvertiblePredica
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.StringCaseInsensitiveCompare : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(root.debugString(state: &state)).caseInsensitiveCompare(\(other.debugString(state: &state)))"
@@ -417,7 +417,7 @@ extension PredicateExpressions.StringCaseInsensitiveCompare : DebugStringConvert
 
 #endif
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 private func createDescription<each Input, Output>(variable: repeat PredicateExpressions.Variable<each Input>, expression: some StandardPredicateExpression, typeName: String, outputType: Output.Type = Void.self) -> String {
     var variableIDs: [PredicateExpressions.VariableID] = []
     repeat variableIDs.append((each variable).key)
@@ -447,7 +447,7 @@ private func createDescription<each Input, Output>(variable: repeat PredicateExp
     return result
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension Predicate : CustomStringConvertible {
     @_optimize(none) // Work around swift optimizer crash (rdar://124533887)
     public var description: String {
@@ -455,14 +455,14 @@ extension Predicate : CustomStringConvertible {
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Expression : CustomStringConvertible {
     public var description: String {
         createDescription(variable: repeat each variable, expression: expression, typeName: "Expression", outputType: Output.self)
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension Predicate : CustomDebugStringConvertible {
     public var debugDescription: String {
         var variableDesc: [String] = []
@@ -471,7 +471,7 @@ extension Predicate : CustomDebugStringConvertible {
     }
 }
 
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Expression : CustomDebugStringConvertible {
     public var debugDescription: String {
         var variableDesc: [String] = []

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public struct Predicate<each Input> : Sendable {
     public let expression : any StandardPredicateExpression<Bool>
     public let variable: (repeat PredicateExpressions.Variable<each Input>)
@@ -29,11 +29,11 @@ public struct Predicate<each Input> : Sendable {
 
 #if hasFeature(Macros)
 @freestanding(expression)
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public macro Predicate<each Input>(_ body: (repeat each Input) -> Bool) -> Predicate<repeat each Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
 #endif
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Predicate {
     private init(value: Bool) {
         self.variable = (repeat PredicateExpressions.Variable<each Input>())
@@ -51,7 +51,7 @@ extension Predicate {
 
 
 // Namespace for operator expressions
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 @frozen public enum PredicateExpressions {}
 
 @available(macOS, unavailable, introduced: 14.0)
@@ -61,7 +61,7 @@ extension Predicate {
 @available(*, unavailable)
 extension PredicateExpressions : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Sequence {
     public func filter(_ predicate: Predicate<Element>) throws -> [Element] {
         try self.filter {

--- a/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public struct PredicateBindings {
     // Store as a values as an array instead of a dictionary (since it is almost always very few elements, this reduces heap allocation and hashing overhead)
     private var storage: [(id: PredicateExpressions.VariableID, value: Any)]

--- a/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
@@ -14,7 +14,7 @@
 internal import Synchronization
 #endif
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public protocol PredicateExpression<Output> {
     associatedtype Output
     
@@ -22,10 +22,10 @@ public protocol PredicateExpression<Output> {
 }
 
 // Only Foundation should add conformances to this protocol
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public protocol StandardPredicateExpression<Output> : PredicateExpression, Codable, Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
     internal enum _Error: Hashable, Sendable {
         case undefinedVariable
@@ -81,7 +81,7 @@ public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
     public static let invalidInput = Self(.invalidInput(nil))
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     public struct VariableID: Hashable, Codable, Sendable {
         let id: UInt
@@ -203,7 +203,7 @@ extension AnyKeyPath {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.KeyPath : Codable where Root : Codable {
     private enum CodingKeys : CodingKey {
         case root
@@ -240,20 +240,20 @@ extension PredicateExpressions.KeyPath : Codable where Root : Codable {
 #endif // FOUNDATION_FRAMEWORK
     }
 }
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.KeyPath : Sendable where Root : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.KeyPath : StandardPredicateExpression where Root : StandardPredicateExpression {}
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.KeyPath : CustomStringConvertible {
     public var description: String {
         "KeyPath(root: \(root), keyPath: \(keyPath.debugDescription))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Value : Codable where Output : Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -266,13 +266,13 @@ extension PredicateExpressions.Value : Codable where Output : Codable {
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Value : Sendable where Output : Sendable {}
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Value : StandardPredicateExpression where Output : Codable /*, Output : Sendable*/ {}
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Value : CustomStringConvertible {
     public var description: String {
         var result = "Value<\(_typeName(Output.self))>("
@@ -281,14 +281,14 @@ extension PredicateExpressions.Value : CustomStringConvertible {
     }
 }
 
-@available(FoundationPredicate 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.Variable : CustomStringConvertible {
     public var description: String {
         "Variable(\(key.id))"
     }
 }
 
-@available(FoundationPredicate 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.KeyPath {
     public enum CommonKeyPathKind : Hashable, Sendable {
         case collectionCount

--- a/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
@@ -103,23 +103,23 @@ open class PropertyListDecoder {
         }, from: data, format: &format)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func decode<T : DecodableWithConfiguration>(_ type: T.Type, from data: Data, configuration: T.DecodingConfiguration) throws -> T {
         var format: PropertyListDecoder.PropertyListFormat = .binary
         return try decode(type, from: data, format: &format, configuration: configuration)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func decode<T, C>(_ type: T.Type, from data: Data, configuration: C.Type) throws -> T where T : DecodableWithConfiguration, C : DecodingConfigurationProviding, T.DecodingConfiguration == C.DecodingConfiguration {
         try decode(type, from: data, configuration: C.decodingConfiguration)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func decode<T, C>(_ type: T.Type, from data: Data, format: inout PropertyListDecoder.PropertyListFormat, configuration: C.Type) throws -> T where T : DecodableWithConfiguration, C: DecodingConfigurationProviding, T.DecodingConfiguration == C.DecodingConfiguration {
         try decode(type, from: data, format: &format, configuration: C.decodingConfiguration)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func decode<T : DecodableWithConfiguration>(_ type: T.Type, from data: Data, format: inout PropertyListDecoder.PropertyListFormat, configuration: T.DecodingConfiguration) throws -> T {
         try _decode({
             try $0.decode(type, configuration: configuration)

--- a/Sources/FoundationEssentials/PropertyList/PlistEncoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistEncoder.swift
@@ -168,7 +168,7 @@ open class PropertyListEncoder {
         return try writer.serializePlist(topLevel)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func encode<T : EncodableWithConfiguration>(_ value: T, configuration: T.EncodingConfiguration) throws -> Data {
         let format = self.outputFormat
         do {
@@ -202,7 +202,7 @@ open class PropertyListEncoder {
         return try writer.serializePlist(topLevel)
     }
     
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     open func encode<T, C>(_ value: T, configuration: C.Type) throws -> Data where T : EncodableWithConfiguration, C : EncodingConfigurationProviding, T.EncodingConfiguration == C.EncodingConfiguration {
         try encode(value, configuration: C.encodingConfiguration)
     }

--- a/Sources/FoundationEssentials/SortComparator.swift
+++ b/Sources/FoundationEssentials/SortComparator.swift
@@ -143,7 +143,7 @@ public struct ComparableComparator<Compared: Comparable>: SortComparator, Sendab
     public var order: SortOrder
     
 #if FOUNDATION_FRAMEWORK
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(order: SortOrder = .forward) {
         self.order = order
     }

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -98,7 +98,7 @@ dynamic package func _icuStringEncodingConvert(string: String, using encoding: S
 }
 #endif
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension String {
     public func data(using encoding: String.Encoding, allowLossyConversion: Bool = false) -> Data? {
         // allowLossyConversion is a no-op for UTF8 and UTF16. For UTF32, we fall back to NSString when lossy conversion is requested on Darwin platforms.

--- a/Sources/FoundationEssentials/UUID.swift
+++ b/Sources/FoundationEssentials/UUID.swift
@@ -125,9 +125,9 @@ extension UUID : Codable {
     }
 }
 
-@available(FoundationPreview 0.1, *)
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension UUID : Comparable {
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public static func < (lhs: UUID, rhs: UUID) -> Bool {
         var leftUUID = lhs.uuid
         var rightUUID = rhs.uuid

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+AnchoredRelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+AnchoredRelativeFormatStyle.swift
@@ -18,7 +18,7 @@ internal import _FoundationICU
 
 // MARK: Date.AnchoredRelativeFormatStyle
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date {
     /// A relative format style that is detached from the system time, and instead
     /// formats an anchor date relative to the format input.
@@ -114,7 +114,7 @@ extension Date {
 
 // MARK: DiscreteFormatStyle Conformance
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.AnchoredRelativeFormatStyle : DiscreteFormatStyle {
     public func discreteInput(before input: Date) -> Date? {
         guard let (bound, isIncluded) = bound(for: input, relativeTo: anchor, movingDown: true, countingTowardZero: input > anchor) else {

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
@@ -22,7 +22,7 @@ extension Date {
 
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public struct RelativeFormatStyle : Codable, Hashable, Sendable {
-        @available(FoundationPreview 0.4, *)
+        @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public typealias Field = Date.ComponentsFormatStyle.Field
 
         public struct UnitsStyle : Codable, Hashable, Sendable {
@@ -95,7 +95,7 @@ extension Date {
         public var calendar: Calendar
 
         /// The fields that can be used in the formatted output.
-        @available(FoundationPreview 0.4, *)
+        @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public var allowedFields: Set<Field> {
             get {
                 _allowedFields
@@ -125,7 +125,7 @@ extension Date {
             self._allowedFields = Set(Date.ComponentsFormatStyle.Field.Option.allCases.map { .init(option: $0) })
         }
 
-        @available(FoundationPreview 0.4, *)
+        @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public init(allowedFields: Set<Field>, presentation: Presentation = .numeric, unitsStyle: UnitsStyle = .wide, locale: Locale = .autoupdatingCurrent, calendar: Calendar = .autoupdatingCurrent, capitalizationContext: FormatStyleCapitalizationContext = .unknown) {
             self.presentation = presentation
             self.unitsStyle = unitsStyle

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+VerbatimFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+VerbatimFormatStyle.swift
@@ -78,7 +78,7 @@ extension Date.VerbatimFormatStyle: ParseableFormatStyle {
 
 // MARK: Typed Attributed Style
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.VerbatimFormatStyle {
     /// The type preserving attributed variant of this style.
     ///
@@ -139,7 +139,7 @@ extension Date.VerbatimFormatStyle : CustomConsumingRegexComponent {
 
 // MARK: DiscreteFormatStyle Conformance
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.VerbatimFormatStyle : DiscreteFormatStyle {
     public func discreteInput(before input: Date) -> Date? {
         guard let (bound, isIncluded) = bound(for: input, isLower: true) else {
@@ -176,7 +176,7 @@ extension Date.VerbatimFormatStyle : DiscreteFormatStyle {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.VerbatimFormatStyle.Attributed : DiscreteFormatStyle {
     public func discreteInput(before input: Date) -> Date? {
         base.discreteInput(before: input)

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
@@ -999,97 +999,97 @@ public extension Date.FormatStyle.Symbol.TimeZone {
 
 // MARK: Omitted Symbol Options
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Era {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Year {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.YearForWeekOfYear {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.CyclicYear {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Quarter {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Month {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Week {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Day {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.DayOfYear {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Weekday {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.DayPeriod {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Hour {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Minute {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.Second {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.SecondFraction {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Symbol.TimeZone {
     /// The option for not including the symbol in the formatted output.
     public static let omitted: Self = .init(option: nil)

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -346,7 +346,7 @@ extension Date.AttributedStyle : FormatStyle {}
 
 // MARK: Typed Attributed Style
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle {
     /// The type preserving attributed variant of this style.
     ///
@@ -557,7 +557,7 @@ extension Date.FormatStyle {
 
 // MARK: Symbol Modifiers Attributed Style
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Attributed {
     /// Change the representation of the era in the format.
     ///
@@ -817,7 +817,7 @@ public extension ParseStrategy where Self == Date.FormatStyle {
 
 // MARK: DiscreteFormatStyle Conformance
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle : DiscreteFormatStyle {
     public func discreteInput(before input: Date) -> Date? {
         guard let (bound, isIncluded) = bound(for: input, isLower: true) else {
@@ -854,7 +854,7 @@ extension Date.FormatStyle : DiscreteFormatStyle {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Date.FormatStyle.Attributed : DiscreteFormatStyle {
     public func discreteInput(before input: Date) -> Date? {
         base.discreteInput(before: input)

--- a/Sources/FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift
@@ -423,7 +423,7 @@ extension Duration.TimeFormatStyle {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Duration.TimeFormatStyle {
     /// Returns a modified style that applies the given `grouping` rule to the highest field in the
     /// pattern.
@@ -440,7 +440,7 @@ extension Duration.TimeFormatStyle {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Duration.TimeFormatStyle.Attributed {
     /// Returns a modified style that applies the given `grouping` rule to the highest field in the
     /// pattern.
@@ -453,7 +453,7 @@ extension Duration.TimeFormatStyle.Attributed {
 
 // MARK: Dynamic Member Lookup
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Duration.TimeFormatStyle.Attributed {
     private var innerStyle: Duration.TimeFormatStyle {
         get {
@@ -480,7 +480,7 @@ extension Duration.TimeFormatStyle.Attributed {
 
 // MARK: DiscreteFormatStyle Conformance
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Duration.TimeFormatStyle.Attributed : DiscreteFormatStyle {
     public func discreteInput(before input: Duration) -> Duration? {
         Duration.TimeFormatStyle(pattern: pattern, locale: locale).discreteInput(before: input)
@@ -491,7 +491,7 @@ extension Duration.TimeFormatStyle.Attributed : DiscreteFormatStyle {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Duration.TimeFormatStyle : DiscreteFormatStyle {
     public func discreteInput(before input: Duration) -> Duration? {
         let (bound, isIncluded) = Duration.bound(for: input, in: interval(for: input), countingDown: true, roundingRule: self.pattern.roundingRule)

--- a/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
@@ -632,7 +632,7 @@ extension Duration.UnitsFormatStyle {
 
 // MARK: Dynamic Member Lookup
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Duration.UnitsFormatStyle.Attributed {
     public subscript<T>(dynamicMember key: KeyPath<Duration.UnitsFormatStyle, T>) -> T {
         innerStyle[keyPath: key]
@@ -650,7 +650,7 @@ extension Duration.UnitsFormatStyle.Attributed {
 
 // MARK: DiscreteFormatStyle Conformance
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Duration.UnitsFormatStyle.Attributed : DiscreteFormatStyle {
     public func discreteInput(before input: Duration) -> Duration? {
         self.innerStyle.discreteInput(before: input)
@@ -661,7 +661,7 @@ extension Duration.UnitsFormatStyle.Attributed : DiscreteFormatStyle {
     }
 }
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 extension Duration.UnitsFormatStyle : DiscreteFormatStyle {
     public func discreteInput(before input: Duration) -> Duration? {
         let (bound, isIncluded) = self.bound(for: input, countingDown: true)

--- a/Sources/FoundationInternationalization/Formatting/Number/Decimal+FormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/Decimal+FormatStyle.swift
@@ -239,7 +239,7 @@ extension Decimal.FormatStyle {
         ///
         /// - Parameter notation: The notation to apply to the format style.
         /// - Returns: A decimal currency format style modified to use the specified notation.
-        @available(FoundationPreview 0.4, *)
+        @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public func notation(_ notation: Configuration.Notation) -> Self {
             var new = self
             new.collection.notation = notation

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
@@ -206,7 +206,7 @@ extension FloatingPointFormatStyle {
         ///
         /// - Parameter notation: The notation to apply to the format style.
         /// - Returns: A floating-point currency format style modified to use the specified notation.
-        @available(FoundationPreview 0.4, *)
+        @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public func notation(_ notation: Configuration.Notation) -> Self {
             var new = self
             new.collection.notation = notation

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
@@ -206,7 +206,7 @@ extension IntegerFormatStyle {
         ///
         /// - Parameter notation: The notation to apply to the format style.
         /// - Returns: An integer currency format style modified to use the specified notation.
-        @available(FoundationPreview 0.4, *)
+        @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public func notation(_ notation: Configuration.Notation) -> Self {
             var new = self
             new.collection.notation = notation

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -318,7 +318,7 @@ public enum CurrencyFormatStyleConfiguration {
     public typealias DecimalSeparatorDisplayStrategy = NumberFormatStyleConfiguration.DecimalSeparatorDisplayStrategy
     public typealias RoundingRule = NumberFormatStyleConfiguration.RoundingRule
     /// The type used to configure notation for currency format styles.
-    @available(FoundationPreview 0.4, *)
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
     public typealias Notation = NumberFormatStyleConfiguration.Notation
 
     internal typealias RoundingIncrement = NumberFormatStyleConfiguration.RoundingIncrement

--- a/Sources/FoundationInternationalization/Predicate/LocalizedString.swift
+++ b/Sources/FoundationInternationalization/Predicate/LocalizedString.swift
@@ -41,14 +41,14 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPreview 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.StringLocalizedStandardContains : CustomStringConvertible {
     public var description: String {
         "StringLocalizedStandardContains(root: \(root), other: \(other))"
     }
 }
 
-@available(FoundationPreview 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.StringLocalizedStandardContains : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(root.debugString(state: &state)).localizedStandardContains(\(other.debugString(state: &state)))"
@@ -105,14 +105,14 @@ extension PredicateExpressions {
     }
 }
 
-@available(FoundationPreview 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.StringLocalizedCompare : CustomStringConvertible {
     public var description: String {
         "StringLocalizedCompare(root: \(root), other: \(other))"
     }
 }
 
-@available(FoundationPreview 0.3, *)
+@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)
 extension PredicateExpressions.StringLocalizedCompare : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
         "\(root.debugString(state: &state)).localizedCompare(\(other.debugString(state: &state)))"

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -182,7 +182,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// The key path to the field for comparison.
     ///
     /// This value is `nil` when `Compared` is not an NSObject
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public var keyPath: PartialKeyPath<Compared>? {
         switch comparison {
         case .comparable(_, let keyPath):
@@ -202,7 +202,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///
     /// This property is non-`nil` when the `SortDescriptor` value is created
     /// with one.
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public var stringComparator: String.StandardComparator? {
         var result: String.StandardComparator?
         switch comparison {
@@ -237,38 +237,38 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     // A temporary workaround to a compiler bug that changes the ABI when adding the & Sendable constraint
     // Should be removed and the related functions should be made public when rdar://131764614 is resolved
     @_alwaysEmitIntoClient
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init<Value>(_ keyPath: KeyPath<Compared, Value> & Sendable, order: SortOrder = .forward) where Value: Comparable {
         self.init(keyPath as KeyPath<Compared, Value>, order: order)
     }
     
     @_alwaysEmitIntoClient
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init<Value>(_ keyPath: KeyPath<Compared, Value?> & Sendable, order: SortOrder = .forward) where Value: Comparable {
         self.init(keyPath as KeyPath<Compared, Value?>, order: order)
     }
     
     #if FOUNDATION_FRAMEWORK
     @_alwaysEmitIntoClient
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
         self.init(keyPath as KeyPath<Compared, String>, comparator: comparator)
     }
     
     @_alwaysEmitIntoClient
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
         self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator)
     }
     
     @_alwaysEmitIntoClient
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.init(keyPath as KeyPath<Compared, String>, comparator: comparator, order: order)
     }
     
     @_alwaysEmitIntoClient
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator, order: order)
     }
@@ -454,7 +454,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     /*public*/ @usableFromInline init<Value>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) where Value: Comparable {
         self.order = order
         self.keyString = nil
@@ -476,7 +476,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     /*public*/ @usableFromInline init<Value>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) where Value: Comparable {
         self.order = order
         self.keyString = nil
@@ -505,7 +505,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) {
         self.order = comparator.order
         self.keyString = nil
@@ -524,7 +524,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) {
         self.order = comparator.order
         self.keyString = nil
@@ -544,7 +544,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.order = order
         self.keyString = nil
@@ -566,7 +566,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    @available(FoundationPreview 0.1, *)
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.order = order
         self.keyString = nil

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -52,7 +52,7 @@ public typealias CurrencyFormatStyleConfiguration = Foundation.CurrencyFormatSty
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public typealias IntegerParseStrategy = Foundation.IntegerParseStrategy
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 public typealias DiscreteFormatStyle = Foundation.DiscreteFormatStyle
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -110,7 +110,7 @@ public typealias StandardPredicateExpression = Foundation.StandardPredicateExpre
 public typealias PredicateError = Foundation.PredicateError
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public typealias PredicateCodableConfiguration = Foundation.PredicateCodableConfiguration
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 public typealias Expression = Foundation.Expression
 #else
 
@@ -152,7 +152,7 @@ public typealias CurrencyFormatStyleConfiguration = FoundationInternationalizati
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public typealias IntegerParseStrategy = FoundationInternationalization.IntegerParseStrategy
 
-@available(FoundationPreview 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 public typealias DiscreteFormatStyle = FoundationEssentials.DiscreteFormatStyle
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -213,7 +213,7 @@ public typealias PredicateExpressions = FoundationEssentials.PredicateExpression
 public typealias StandardPredicateExpression = FoundationEssentials.StandardPredicateExpression
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public typealias PredicateError = FoundationEssentials.PredicateError
-@available(FoundationPredicate 0.4, *)
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
 public typealias Expression = FoundationEssentials.Expression
 
 public typealias SortDescriptor = FoundationInternationalization.SortDescriptor

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -312,7 +312,6 @@ private struct PredicateTests {
     }
 
     @Test
-    @available(FoundationPredicateRegex 0.4, *)
     func regex() throws {
         let literalRegex = #/[AB0-9]\/?[^\n]+/#
         var predicate = #Predicate<Object> {
@@ -329,7 +328,6 @@ private struct PredicateTests {
     
     #if canImport(RegexBuilder)
     @Test
-    @available(FoundationPredicateRegex 0.4, *)
     func regex_RegexBuilder() throws {
         let builtRegex = Regex {
             ChoiceOf {
@@ -349,7 +347,6 @@ private struct PredicateTests {
     #endif
     
     @Test
-    @available(FoundationPredicate 0.3, *)
     func debugDescription() throws {
         let date = Date.now
         let predicate = #Predicate<Object> {
@@ -385,7 +382,6 @@ private struct PredicateTests {
 
     #if FOUNDATION_FRAMEWORK
     @Test
-    @available(FoundationPredicate 0.3, *)
     func nested() throws {
         let predicateA = #Predicate<Object> {
             $0.a == 3
@@ -404,7 +400,6 @@ private struct PredicateTests {
     #endif
     
     @Test
-    @available(FoundationPredicate 0.4, *)
     func expression() throws {
         let expression = #Expression<Int, Int> {
             $0 + 1

--- a/Tests/FoundationEssentialsTests/UUIDTests.swift
+++ b/Tests/FoundationEssentialsTests/UUIDTests.swift
@@ -99,7 +99,6 @@ private struct UUIDTests {
         #expect(String(reflecting: uuid) == "89E90DC6-5EBA-41A8-A64D-81D3576EE46E")
     }
 
-    @available(FoundationPreview 0.1, *)
     @Test func comparable() throws {
         var uuid1 = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
         var uuid2 = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002"))


### PR DESCRIPTION
This PR does the following:

- Removes all `FoundationPredicate`/`FoundationPredicateRegex` availability: since these are always available in the package there is no longer a distinction between these and `FoundationPreview` so they are no longer needed
- Replace all `FoundationPreview 0.x` availability with the "real" availability: all of these versions match OS versions lower than the deployment target of the package (macOS 15) so it does not have any impact on the availability of things within the package
- Update `FoundationSpan` to list macOS 26-aligned availability instead of future availability to match the availability of `Span` types in the standard library