### PR TITLE
benchmarks package manifest fix for local deps directory

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -37,7 +37,7 @@ let usePackage: UsePackage
 
 if let useLocalPackageEnv = Context.environment["SWIFTCI_USE_LOCAL_DEPS"], !useLocalPackageEnv.isEmpty {
     if useLocalPackageEnv == "1" {
-        usePackage = .useLocalPackage("..")
+        usePackage = .useLocalPackage("../..")
     } else {
         usePackage = .useLocalPackage(useLocalPackageEnv)
     }


### PR DESCRIPTION
Attempting to build the Benchmarks package with `SWIFTCI_USE_LOCAL_DEPS=1`:

```shell
$ SWIFTCI_USE_LOCAL_DEPS=1 swift build --package-path Benchmarks
```
fails:

```text
error: the package at '/Users/rick/Developer/swift-foundation/swift-foundation' cannot be accessed (Error Domain=NSCocoaErrorDomain Code=260 "The folder “swift-foundation” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/rick/Developer/swift-foundation/swift-foundation, NSURL=file:///Users/rick/Developer/swift-foundation/swift-foundation, NSUnderlyingError=0x60000283a310 {Error Domain=NSOSStatusErrorDomain Code=-43 "fnfErr: File not found"}})
error: ExitCode(rawValue: 1)
```

The directory we should be looking for is `Developer/swift-foundation`… *not* `Developer/swift-foundation/swift-foundation`.

It looks like we need to move one directory up before looking for `swift-foundation`:

```diff
if let useLocalPackageEnv = Context.environment["SWIFTCI_USE_LOCAL_DEPS"], !useLocalPackageEnv.isEmpty {
    if useLocalPackageEnv == "1" {
-        usePackage = .useLocalPackage("..")
+        usePackage = .useLocalPackage("../..")
```

Attempting to build now sees the correct `swift-foundation` directory.

This change should only affect when engineers build with `SWIFTCI_USE_LOCAL_DEPS=1`. Passing a custom directory here like `SWIFTCI_USE_LOCAL_DEPS=foo` will still work (assuming this is the real project root directory).