### PR TITLE
Finish FoundationInternationalization swift-testing migration

### DIFF
--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -159,15 +159,15 @@ private struct ProcessInfoTests {
     
     @Test func processName() {
 #if FOUNDATION_FRAMEWORK
-        let targetName = "TestHost"
+        let targetNames = ["TestHost"]
 #elseif os(Linux) || os(Windows) || os(Android) || os(FreeBSD)
-        let targetName = "swift-foundationPackageTests.xctest"
+        let targetNames = ["swift-foundationPackageTests.xctest"]
 #else
-        let targetName = "swiftpm-testing-helper"
+        let targetNames = ["swiftpm-testing-helper", "xctest"]
 #endif
         let processInfo = ProcessInfo.processInfo
         let originalProcessName = processInfo.processName
-        #expect(originalProcessName == targetName)
+        #expect(targetNames.contains(originalProcessName))
         
         // Try assigning a new process name.
         let newProcessName = "TestProcessName"

--- a/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
@@ -5,14 +5,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// RUN: %target-run-simple-swift
-// REQUIRES: executable_test
-// REQUIRES: objc_interop
 
-#if canImport(TestSupport)
-import TestSupport
-#endif
+import Testing
 
 #if canImport(FoundationInternationalization)
 @testable import FoundationEssentials
@@ -23,68 +17,69 @@ import TestSupport
 @testable import Foundation
 #endif
 
-class ListFormatStyleTests : XCTestCase {
-    func test_orList() {
+@Suite("ListFormatStyle")
+private struct ListFormatStyleTests {
+    @Test func orList() {
         var style: ListFormatStyle<StringStyle, [String]> = .list(type: .or, width: .standard)
         style.locale = Locale(identifier: "en_US")
 
-        XCTAssertEqual(["one", "two"].formatted(style), "one or two")
-        XCTAssertEqual(["one", "two", "three"].formatted(style), "one, two, or three")
+        #expect(["one", "two"].formatted(style) == "one or two")
+        #expect(["one", "two", "three"].formatted(style) == "one, two, or three")
     }
 
-    func test_andList() {
+    @Test func andList() {
         var style: ListFormatStyle<StringStyle, [String]> = .list(type: .and, width: .standard)
         style.locale = Locale(identifier: "en_US")
 
-        XCTAssertEqual(["one", "two"].formatted(style), "one and two")
-        XCTAssertEqual(["one", "two", "three"].formatted(style), "one, two, and three")
+        #expect(["one", "two"].formatted(style) == "one and two")
+        #expect(["one", "two", "three"].formatted(style) == "one, two, and three")
     }
 
-    func test_narrowList() {
+    @Test func narrowList() {
         var style: ListFormatStyle<StringStyle, [String]> = .list(type: .and, width: .narrow)
         style.locale = Locale(identifier: "en_US")
 
-        XCTAssertEqual(["one", "two"].formatted(style), "one, two")
-        XCTAssertEqual(["one", "two", "three"].formatted(style), "one, two, three")
+        #expect(["one", "two"].formatted(style) == "one, two")
+        #expect(["one", "two", "three"].formatted(style) == "one, two, three")
     }
 
-    func test_shortList() {
+    @Test func shortList() {
         var style: ListFormatStyle<StringStyle, [String]> = .list(type: .and, width: .short)
         style.locale = Locale(identifier: "en_US")
 
-        XCTAssertEqual(["one", "two"].formatted(style), "one & two")
-        XCTAssertEqual(["one", "two", "three"].formatted(style), "one, two, & three")
+        #expect(["one", "two"].formatted(style) == "one & two")
+        #expect(["one", "two", "three"].formatted(style) == "one, two, & three")
     }
 
-#if FOUNDATION_FRAMEWORK // FIXME: rdar://104091257
-    func test_leadingDotSyntax() {
+    @Test func leadingDotSyntax() {
         let _ = ["one", "two"].formatted(.list(type: .and))
         let _ = ["one", "two"].formatted()
         let _ = [1, 2].formatted(.list(memberStyle: .number, type: .or, width: .standard))
     }
-#endif
     
-    func testAutoupdatingCurrentChangesFormatResults() {
-        let locale = Locale.autoupdatingCurrent
-        let list = ["one", "two", "three", "four"]
-        
-        // Get a formatted result from es-ES
-        var prefs = LocalePreferences()
-        prefs.languages = ["es-ES"]
-        prefs.locale = "es_ES"
-        LocaleCache.cache.resetCurrent(to: prefs)
-        let formattedSpanish = list.formatted(.list(type: .and).locale(locale))
-        
-        // Get a formatted result from en-US
-        prefs.languages = ["en-US"]
-        prefs.locale = "en_US"
-        LocaleCache.cache.resetCurrent(to: prefs)
-        let formattedEnglish = list.formatted(.list(type: .and).locale(locale))
-        
-        // Reset to current preferences before any possibility of failing this test
-        LocaleCache.cache.reset()
-
-        // No matter what 'current' was before this test was run, formattedSpanish and formattedEnglish should be different.
-        XCTAssertNotEqual(formattedSpanish, formattedEnglish)
+    @Test func autoupdatingCurrentChangesFormatResults() async {
+        await usingCurrentInternationalizationPreferences {
+            let locale = Locale.autoupdatingCurrent
+            let list = ["one", "two", "three", "four"]
+            
+            // Get a formatted result from es-ES
+            var prefs = LocalePreferences()
+            prefs.languages = ["es-ES"]
+            prefs.locale = "es_ES"
+            LocaleCache.cache.resetCurrent(to: prefs)
+            let formattedSpanish = list.formatted(.list(type: .and).locale(locale))
+            
+            // Get a formatted result from en-US
+            prefs.languages = ["en-US"]
+            prefs.locale = "en_US"
+            LocaleCache.cache.resetCurrent(to: prefs)
+            let formattedEnglish = list.formatted(.list(type: .and).locale(locale))
+            
+            // Reset to current preferences before any possibility of failing this test
+            LocaleCache.cache.reset()
+            
+            // No matter what 'current' was before this test was run, formattedSpanish and formattedEnglish should be different.
+            #expect(formattedSpanish != formattedEnglish)
+        }
     }
 }

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -5,80 +5,73 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// RUN: %target-run-simple-swift
-// REQUIRES: executable_test
-// REQUIRES: objc_interop
 
-#if canImport(TestSupport)
-import TestSupport
-#endif
+import Testing
 
 #if canImport(FoundationInternationalization)
 @testable import FoundationEssentials
 @testable import FoundationInternationalization
-#endif
-
-#if FOUNDATION_FRAMEWORK
+#elseif FOUNDATION_FRAMEWORK
 @testable import Foundation
 #endif
 
-final class NumberParseStrategyTests : XCTestCase {
-    func testIntStrategy() {
-        let format: IntegerFormatStyle<Int> = .init()
+@Suite("Number ParseStrategy")
+private struct NumberParseStrategyTests {
+    @Test func intStrategy() throws {
+        let format: IntegerFormatStyle<Int> = .init(locale: Locale(identifier: "en_US"))
         let strategy = IntegerParseStrategy(format: format, lenient: true)
-        XCTAssert(try! strategy.parse("123,123") == 123123)
-        XCTAssert(try! strategy.parse(" -123,123 ") == -123123)
-        XCTAssert(try! strategy.parse("+8,765,000") == 8765000)
-        XCTAssert(try! strategy.parse("+87,650,000") == 87650000)
+        #expect(try strategy.parse("123,123") == 123123)
+        #expect(try strategy.parse(" -123,123 ") == -123123)
+        #expect(try strategy.parse("+8,765,000") == 8765000)
+        #expect(try strategy.parse("+87,650,000") == 87650000)
     }
-
-    func testParsingCurrency() throws {
+    
+    @Test func parsingCurrency() throws {
         let currencyStyle: IntegerFormatStyle<Int>.Currency = .init(code: "USD", locale: Locale(identifier: "en_US"))
         let strategy = IntegerParseStrategy(format: currencyStyle, lenient: true)
-        XCTAssertEqual(try! strategy.parse("$1.00"), 1)
-        XCTAssertEqual(try! strategy.parse("1.00 US dollars"), 1)
-        XCTAssertEqual(try! strategy.parse("USD\u{00A0}1.00"), 1)
-
-        XCTAssertEqual(try! strategy.parse("$1,234.56"), 1234)
-        XCTAssertEqual(try! strategy.parse("1,234.56 US dollars"), 1234)
-        XCTAssertEqual(try! strategy.parse("USD\u{00A0}1,234.56"), 1234)
-
-        XCTAssertEqual(try! strategy.parse("-$1,234.56"), -1234)
-        XCTAssertEqual(try! strategy.parse("-1,234.56 US dollars"), -1234)
-        XCTAssertEqual(try! strategy.parse("-USD\u{00A0}1,234.56"), -1234)
-
+        #expect(try strategy.parse("$1.00") == 1)
+        #expect(try strategy.parse("1.00 US dollars") == 1)
+        #expect(try strategy.parse("USD\u{00A0}1.00") == 1)
+        
+        #expect(try strategy.parse("$1,234.56") == 1234)
+        #expect(try strategy.parse("1,234.56 US dollars") == 1234)
+        #expect(try strategy.parse("USD\u{00A0}1,234.56") == 1234)
+        
+        #expect(try strategy.parse("-$1,234.56") == -1234)
+        #expect(try strategy.parse("-1,234.56 US dollars") == -1234)
+        #expect(try strategy.parse("-USD\u{00A0}1,234.56") == -1234)
+        
         let accounting = IntegerParseStrategy(format: currencyStyle.sign(strategy: .accounting), lenient: true)
-        XCTAssertEqual(try! accounting.parse("($1,234.56)"), -1234)
+        #expect(try accounting.parse("($1,234.56)") == -1234)
     }
-
-    func testParsingIntStyle() throws {
-        func _verifyResult(_ testData: [String], _ expected: [Int], _ style: IntegerFormatStyle<Int>, _ testName: String = "") {
+    
+    @Test func parsingIntStyle() throws {
+        func _verifyResult(_ testData: [String], _ expected: [Int], _ style: IntegerFormatStyle<Int>, _ testName: Comment? = nil) throws {
             for i in 0..<testData.count {
-                let parsed = try! Int(testData[i], strategy: style.parseStrategy)
-                XCTAssertEqual(parsed, expected[i], testName)
+                let parsed = try Int(testData[i], strategy: style.parseStrategy)
+                #expect(parsed == expected[i], testName)
             }
         }
-
+        
         let locale = Locale(identifier: "en_US")
         let style: IntegerFormatStyle<Int> = .init(locale: locale)
         let data = [
             87650000, 8765000, 876500, 87650, 8765, 876, 87, 8, 0
         ]
-
-        _verifyResult([ "8.765E7", "8.765E6", "8.765E5", "8.765E4", "8.765E3", "8.76E2", "8.7E1", "8E0", "0E0" ], data, style.notation(.scientific), "int style, notation: scientific")
-        _verifyResult([ "87,650,000.", "8,765,000.", "876,500.", "87,650.", "8,765.", "876.", "87.", "8.", "0." ], data, style.decimalSeparator(strategy: .always), "int style, decimal separator: always")
+        
+        try _verifyResult([ "8.765E7", "8.765E6", "8.765E5", "8.765E4", "8.765E3", "8.76E2", "8.7E1", "8E0", "0E0" ], data, style.notation(.scientific), "int style, notation: scientific")
+        try _verifyResult([ "87,650,000.", "8,765,000.", "876,500.", "87,650.", "8,765.", "876.", "87.", "8.", "0." ], data, style.decimalSeparator(strategy: .always), "int style, decimal separator: always")
     }
-
-    func testRoundtripParsing_percent() {
-        func _verifyRoundtripPercent(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Percent, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) {
+    
+    @Test func roundtripParsing_percent() throws {
+        func _verifyRoundtripPercent(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Percent, _ testName: String = "", sourceLocation: SourceLocation = #_sourceLocation) throws {
             for value in testData {
                 let str = style.format(value)
-                let parsed = try! Int(str, strategy: style.parseStrategy)
-                XCTAssertEqual(value, parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", file: file, line: line)
-
-                let nonLenientParsed = try! Int(str, format: style, lenient: false)
-                XCTAssertEqual(value, nonLenientParsed, file: file, line: line)
+                let parsed = try Int(str, strategy: style.parseStrategy)
+                #expect(value == parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", sourceLocation: sourceLocation)
+                
+                let nonLenientParsed = try Int(str, format: style, lenient: false)
+                #expect(value == nonLenientParsed, sourceLocation: sourceLocation)
             }
         }
         let locale = Locale(identifier: "en_US")
@@ -89,38 +82,38 @@ final class NumberParseStrategyTests : XCTestCase {
         let negativeData: [Int] = [
             -87650000, -8765000, -876500, -87650, -8765, -876, -87, -8
         ]
-        _verifyRoundtripPercent(testData, percentStyle, "percent style")
-        _verifyRoundtripPercent(testData, percentStyle.sign(strategy: .always()), "percent style, sign: always")
-        _verifyRoundtripPercent(testData, percentStyle.grouping(.never), "percent style, grouping: never")
-        _verifyRoundtripPercent(testData, percentStyle.notation(.scientific), "percent style, scientific notation")
-        _verifyRoundtripPercent(testData, percentStyle.decimalSeparator(strategy: .always), "percent style, decimal display: always")
+        try _verifyRoundtripPercent(testData, percentStyle, "percent style")
+        try _verifyRoundtripPercent(testData, percentStyle.sign(strategy: .always()), "percent style, sign: always")
+        try _verifyRoundtripPercent(testData, percentStyle.grouping(.never), "percent style, grouping: never")
+        try _verifyRoundtripPercent(testData, percentStyle.notation(.scientific), "percent style, scientific notation")
+        try _verifyRoundtripPercent(testData, percentStyle.decimalSeparator(strategy: .always), "percent style, decimal display: always")
 
-        _verifyRoundtripPercent(negativeData, percentStyle, "percent style")
-        _verifyRoundtripPercent(negativeData, percentStyle.grouping(.never), "percent style, grouping: never")
-        _verifyRoundtripPercent(negativeData, percentStyle.notation(.scientific), "percent style, scientific notation")
-        _verifyRoundtripPercent(negativeData, percentStyle.decimalSeparator(strategy: .always), "percent style, decimal display: always")
+        try _verifyRoundtripPercent(negativeData, percentStyle, "percent style")
+        try _verifyRoundtripPercent(negativeData, percentStyle.grouping(.never), "percent style, grouping: never")
+        try _verifyRoundtripPercent(negativeData, percentStyle.notation(.scientific), "percent style, scientific notation")
+        try _verifyRoundtripPercent(negativeData, percentStyle.decimalSeparator(strategy: .always), "percent style, decimal display: always")
 
-        func _verifyRoundtripPercent(_ testData: [Double], _ style: FloatingPointFormatStyle<Double>.Percent, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) {
+        func _verifyRoundtripPercent(_ testData: [Double], _ style: FloatingPointFormatStyle<Double>.Percent, _ testName: String = "", sourceLocation: SourceLocation = #_sourceLocation) throws {
             for value in testData {
                 let str = style.format(value)
-                let parsed = try! Double(str, format: style, lenient: true)
-                XCTAssertEqual(value, parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", file: file, line: line)
+                let parsed = try Double(str, format: style, lenient: true)
+                #expect(value == parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", sourceLocation: sourceLocation)
 
-                let nonLenientParsed = try! Double(str, format: style, lenient: false)
-                XCTAssertEqual(value, nonLenientParsed, file: file, line: line)
+                let nonLenientParsed = try Double(str, format: style, lenient: false)
+                #expect(value == nonLenientParsed, sourceLocation: sourceLocation)
             }
         }
 
         let floatData = testData.map { Double($0) }
         let floatStyle: FloatingPointFormatStyle<Double>.Percent = .init(locale: locale)
-        _verifyRoundtripPercent(floatData, floatStyle, "percent style")
-        _verifyRoundtripPercent(floatData, floatStyle.sign(strategy: .always()), "percent style, sign: always")
-        _verifyRoundtripPercent(floatData, floatStyle.grouping(.never), "percent style, grouping: never")
-        _verifyRoundtripPercent(floatData, floatStyle.notation(.scientific), "percent style, scientific notation")
-        _verifyRoundtripPercent(floatData, floatStyle.decimalSeparator(strategy: .always), "percent style, decimal display: always")
+        try _verifyRoundtripPercent(floatData, floatStyle, "percent style")
+        try _verifyRoundtripPercent(floatData, floatStyle.sign(strategy: .always()), "percent style, sign: always")
+        try _verifyRoundtripPercent(floatData, floatStyle.grouping(.never), "percent style, grouping: never")
+        try _verifyRoundtripPercent(floatData, floatStyle.notation(.scientific), "percent style, scientific notation")
+        try _verifyRoundtripPercent(floatData, floatStyle.decimalSeparator(strategy: .always), "percent style, decimal display: always")
     }
 
-    func test_roundtripCurrency() {
+    @Test func roundtripCurrency() {
         let testData: [Int] = [
             87650000, 8765000, 876500, 87650, 8765, 876, 87, 8, 0
         ]
@@ -128,14 +121,14 @@ final class NumberParseStrategyTests : XCTestCase {
             -87650000, -8765000, -876500, -87650, -8765, -876, -87, -8
         ]
 
-        func _verifyRoundtripCurrency(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Currency, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) {
+        func _verifyRoundtripCurrency(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Currency, _ testName: String = "", sourceLocation: SourceLocation = #_sourceLocation) {
             for value in testData {
                 let str = style.format(value)
                 let parsed = try! Int(str, strategy: style.parseStrategy)
-                XCTAssertEqual(value, parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", file: file, line: line)
+                #expect(value == parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", sourceLocation: sourceLocation)
 
                 let nonLenientParsed = try! Int(str, format: style, lenient: false)
-                XCTAssertEqual(value, nonLenientParsed, file: file, line: line)
+                #expect(value == nonLenientParsed, sourceLocation: sourceLocation)
             }
         }
 
@@ -157,31 +150,31 @@ final class NumberParseStrategyTests : XCTestCase {
         _verifyRoundtripCurrency(negativeData, currencyStyle.decimalSeparator(strategy: .always), "currency style, decimal display: always")
     }
 
-    func testParseCurrencyWithDifferentCodes() throws {
+    @Test func parseCurrencyWithDifferentCodes() throws {
         let enUS = Locale(identifier: "en_US")
         // Decimal
         let style = Decimal.FormatStyle.Currency(code: "GBP", locale: enUS).presentation(.isoCode)
-        XCTAssertEqual(style.format(3.14), "GBP 3.14")
+        #expect(style.format(3.14) == "GBP 3.14")
 
         let parsed = try style.parseStrategy.parse("GBP 3.14")
-        XCTAssertEqual(parsed, 3.14)
+        #expect(parsed == 3.14)
 
         // Floating point
         let floatingPointStyle: FloatingPointFormatStyle<Double>.Currency = .init(code: "GBP", locale: enUS).presentation(.isoCode)
-        XCTAssertEqual(floatingPointStyle.format(3.14), "GBP 3.14")
+        #expect(floatingPointStyle.format(3.14) == "GBP 3.14")
 
         let parsedFloatingPoint = try floatingPointStyle.parseStrategy.parse("GBP 3.14")
-        XCTAssertEqual(parsedFloatingPoint, 3.14)
+        #expect(parsedFloatingPoint == 3.14)
 
         // Integer
         let integerStyle: IntegerFormatStyle<Int32>.Currency = .init(code: "GBP", locale: enUS).presentation(.isoCode)
-        XCTAssertEqual(integerStyle.format(32), "GBP 32.00")
+        #expect(integerStyle.format(32) == "GBP 32.00")
 
         let parsedInt = try integerStyle.parseStrategy.parse("GBP 32.00")
-        XCTAssertEqual(parsedInt, 32)
+        #expect(parsedInt == 32)
     }
 
-    func test_roundtripForeignCurrency() throws {
+    @Test func roundtripForeignCurrency() throws {
         let testData: [Int] = [
             87650000, 8765000, 876500, 87650, 8765, 876, 87, 8, 0
         ]
@@ -189,14 +182,14 @@ final class NumberParseStrategyTests : XCTestCase {
             -87650000, -8765000, -876500, -87650, -8765, -876, -87, -8
         ]
 
-        func _verifyRoundtripCurrency(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Currency, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+        func _verifyRoundtripCurrency(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Currency, _ testName: String = "", sourceLocation: SourceLocation = #_sourceLocation) throws {
             for value in testData {
                 let str = style.format(value)
                 let parsed = try Int(str, strategy: style.parseStrategy)
-                XCTAssertEqual(value, parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", file: file, line: line)
+                #expect(value == parsed, "\(testName): formatted string: \(str) parsed: \(parsed)", sourceLocation: sourceLocation)
 
                 let nonLenientParsed = try Int(str, format: style, lenient: false)
-                XCTAssertEqual(value, nonLenientParsed, file: file, line: line)
+                #expect(value == nonLenientParsed, sourceLocation: sourceLocation)
             }
         }
 
@@ -218,7 +211,7 @@ final class NumberParseStrategyTests : XCTestCase {
         try _verifyRoundtripCurrency(negativeData, currencyStyle.decimalSeparator(strategy: .always), "currency style, decimal display: always")
     }
 
-    func test_parseStategyCodable_sameCurrency() throws {
+    @Test func parseStategyCodable_sameCurrency() throws {
         // same currency code
         let fs: IntegerFormatStyle<Int32>.Currency = .init(code: "USD", locale: Locale(identifier:"en_US"))
         let p = IntegerParseStrategy(format: fs)
@@ -227,18 +220,15 @@ final class NumberParseStrategyTests : XCTestCase {
             {"formatStyle":{"locale":{"current":0,"identifier":"en_US"},"collection":{"presentation":{"option":1}},"currencyCode":"USD"},"numberFormatType":{"currency":{"_0":{"presentation":{"option":1}}}},"lenient":true,"locale":{"identifier":"en_US","current":0}}
         """
 
-        guard let existingData = existingSerializedParseStrategy.data(using: String._Encoding.utf8) else {
-            XCTFail("Unable to get data from JSON string")
-            return
-        }
+        let existingData = try #require(existingSerializedParseStrategy.data(using: String.Encoding.utf8))
 
         let decoded: IntegerParseStrategy<IntegerFormatStyle<Int32>.Currency> = try JSONDecoder().decode(IntegerParseStrategy<IntegerFormatStyle<Int32>.Currency>.self, from: existingData)
-        XCTAssertEqual(decoded, p)
-        XCTAssertEqual(decoded.formatStyle, fs)
-        XCTAssertEqual(decoded.formatStyle.currencyCode, "USD")
+        #expect(decoded == p)
+        #expect(decoded.formatStyle == fs)
+        #expect(decoded.formatStyle.currencyCode == "USD")
     }
 
-    func test_parseStategyCodable_differentCurrency() throws {
+    @Test func parseStategyCodable_differentCurrency() throws {
         let fs: IntegerFormatStyle<Int32>.Currency = .init(code: "GBP", locale: Locale(identifier:"en_US"))
         let p = IntegerParseStrategy(format: fs)
         // Valid JSON representation for `p`
@@ -246,164 +236,218 @@ final class NumberParseStrategyTests : XCTestCase {
             {"formatStyle":{"collection":{"presentation":{"option":1}},"locale":{"current":0,"identifier":"en_US"},"currencyCode":"GBP"},"lenient":true,"locale":{"current":0,"identifier":"en_US"},"numberFormatType":{"currency":{"_0":{"presentation":{"option":1}}}}}
         """
 
-        guard let existingData = existingSerializedParseStrategy.data(using: String._Encoding.utf8) else {
-            XCTFail("Unable to get data from JSON string")
-            return
-        }
+        let existingData = try #require(existingSerializedParseStrategy.data(using: String.Encoding.utf8))
         let decoded: IntegerParseStrategy<IntegerFormatStyle<Int32>.Currency> = try JSONDecoder().decode(IntegerParseStrategy<IntegerFormatStyle<Int32>.Currency>.self, from: existingData)
-        XCTAssertEqual(decoded, p)
-        XCTAssertEqual(decoded.formatStyle, fs)
-        XCTAssertEqual(decoded.formatStyle.currencyCode, "GBP")
+        #expect(decoded == p)
+        #expect(decoded.formatStyle == fs)
+        #expect(decoded.formatStyle.currencyCode == "GBP")
     }
 
     let testNegativePositiveDecimalData: [Decimal] = [  Decimal(string:"87650")!, Decimal(string:"8765")!,
         Decimal(string:"876.5")!, Decimal(string:"87.65")!, Decimal(string:"8.765")!, Decimal(string:"0.8765")!, Decimal(string:"0.08765")!, Decimal(string:"0.008765")!, Decimal(string:"0")!, Decimal(string:"-0.008765")!, Decimal(string:"-876.5")!, Decimal(string:"-87650")! ]
 
-    func testDecimalParseStrategy() throws {
-        func _verifyRoundtrip(_ testData: [Decimal], _ style: Decimal.FormatStyle, _ testName: String = "") {
+    @Test func decimalParseStrategy() throws {
+        func _verifyRoundtrip(_ testData: [Decimal], _ style: Decimal.FormatStyle, _ testName: Comment = "") throws {
             for value in testData {
                 let str = style.format(value)
-                let parsed = try! Decimal(str, strategy: Decimal.ParseStrategy(formatStyle: style, lenient: true))
-                XCTAssertEqual(value, parsed, "\(testName): formatted string: \(str) parsed: \(parsed)")
+                let parsed = try Decimal(str, strategy: Decimal.ParseStrategy(formatStyle: style, lenient: true))
+                #expect(value == parsed, "\(testName): formatted string: \(str) parsed: \(parsed)")
             }
         }
 
         let style = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
-        _verifyRoundtrip(testNegativePositiveDecimalData, style)
+        try _verifyRoundtrip(testNegativePositiveDecimalData, style)
     }
 
-    func testDecimalParseStrategy_Currency() throws {
+    @Test func decimalParseStrategy_Currency() throws {
         let currencyStyle = Decimal.FormatStyle.Currency(code: "USD", locale: Locale(identifier: "en_US"))
         let strategy = Decimal.ParseStrategy(formatStyle: currencyStyle, lenient: true)
-        XCTAssertEqual(try! strategy.parse("$1.00"), 1)
-        XCTAssertEqual(try! strategy.parse("1.00 US dollars"), 1)
-        XCTAssertEqual(try! strategy.parse("USD\u{00A0}1.00"), 1)
+        #expect(try strategy.parse("$1.00") == 1)
+        #expect(try strategy.parse("1.00 US dollars") == 1)
+        #expect(try strategy.parse("USD\u{00A0}1.00") == 1)
 
-        XCTAssertEqual(try! strategy.parse("$1,234.56"), Decimal(string: "1234.56")!)
-        XCTAssertEqual(try! strategy.parse("1,234.56 US dollars"), Decimal(string: "1234.56")!)
-        XCTAssertEqual(try! strategy.parse("USD\u{00A0}1,234.56"), Decimal(string: "1234.56")!)
+        #expect(try strategy.parse("$1,234.56") == Decimal(string: "1234.56")!)
+        #expect(try strategy.parse("1,234.56 US dollars") == Decimal(string: "1234.56")!)
+        #expect(try strategy.parse("USD\u{00A0}1,234.56") == Decimal(string: "1234.56")!)
 
-        XCTAssertEqual(try! strategy.parse("-$1,234.56"), Decimal(string: "-1234.56")!)
-        XCTAssertEqual(try! strategy.parse("-1,234.56 US dollars"), Decimal(string: "-1234.56")!)
-        XCTAssertEqual(try! strategy.parse("-USD\u{00A0}1,234.56"), Decimal(string: "-1234.56")!)
+        #expect(try strategy.parse("-$1,234.56") == Decimal(string: "-1234.56")!)
+        #expect(try strategy.parse("-1,234.56 US dollars") == Decimal(string: "-1234.56")!)
+        #expect(try strategy.parse("-USD\u{00A0}1,234.56") == Decimal(string: "-1234.56")!)
     }
 
-    func testNumericBoundsParsing() throws {
+    @Test func numericBoundsParsing() throws {
         let locale = Locale(identifier: "en_US")
         do {
             let format: IntegerFormatStyle<Int8> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
-            XCTAssertEqual(try parseStrategy.parse(Int8.min.formatted(format)), Int8.min)
-            XCTAssertEqual(try parseStrategy.parse(Int8.max.formatted(format)), Int8.max)
-            XCTAssertThrowsError(try parseStrategy.parse("-129"))
-            XCTAssertThrowsError(try parseStrategy.parse("128"))
+            #expect(try parseStrategy.parse(Int8.min.formatted(format)) == Int8.min)
+            #expect(try parseStrategy.parse(Int8.max.formatted(format)) == Int8.max)
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("-129")
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("128")
+            }
         }
         
         do {
             let format: IntegerFormatStyle<Int64> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
-            XCTAssertEqual(try parseStrategy.parse(Int64.min.formatted(format)), Int64.min)
-            XCTAssertEqual(try parseStrategy.parse(Int64.max.formatted(format)), Int64.max)
-            XCTAssertThrowsError(try parseStrategy.parse("-9223372036854775809"))
-            XCTAssertThrowsError(try parseStrategy.parse("9223372036854775808"))
+            #expect(try parseStrategy.parse(Int64.min.formatted(format)) == Int64.min)
+            #expect(try parseStrategy.parse(Int64.max.formatted(format)) == Int64.max)
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("-9223372036854775809")
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("9223372036854775808")
+            }
         }
         
         do {
             let format: IntegerFormatStyle<UInt8> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
-            XCTAssertEqual(try parseStrategy.parse(UInt8.min.formatted(format)), UInt8.min)
-            XCTAssertEqual(try parseStrategy.parse(UInt8.max.formatted(format)), UInt8.max)
-            XCTAssertThrowsError(try parseStrategy.parse("-1"))
-            XCTAssertThrowsError(try parseStrategy.parse("256"))
+            #expect(try parseStrategy.parse(UInt8.min.formatted(format)) == UInt8.min)
+            #expect(try parseStrategy.parse(UInt8.max.formatted(format)) == UInt8.max)
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("-1")
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("256")
+            }
         }
         
         do {
             // TODO: Parse integers greater than Int64
             let format: IntegerFormatStyle<UInt64> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
-            XCTAssertEqual(      try parseStrategy.parse(UInt64.min.formatted(format)), UInt64.min)
-            XCTAssertThrowsError(try parseStrategy.parse(UInt64.max.formatted(format)))
-            XCTAssertThrowsError(try parseStrategy.parse("-1"))
-            XCTAssertThrowsError(try parseStrategy.parse("18446744073709551616"))
+            #expect(try parseStrategy.parse(UInt64.min.formatted(format)) == UInt64.min)
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse(UInt64.max.formatted(format))
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("-1")
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("18446744073709551616")
+            }
             
             // TODO: Parse integers greater than Int64
             let maxInt64 = UInt64(Int64.max)
-            XCTAssertEqual(      try parseStrategy.parse((maxInt64 + 0).formatted(format)), maxInt64) // not a Double
-            XCTAssertThrowsError(try parseStrategy.parse((maxInt64 + 1).formatted(format)))           // exact Double
-            XCTAssertThrowsError(try parseStrategy.parse((maxInt64 + 2).formatted(format)))           // not a Double
-            XCTAssertThrowsError(try parseStrategy.parse((maxInt64 + 3).formatted(format)))           // not a Double
+            #expect(try parseStrategy.parse((maxInt64 + 0).formatted(format)) == maxInt64) // not a Double
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse((maxInt64 + 1).formatted(format))           // exact Doubl
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse((maxInt64 + 2).formatted(format))           // not a Doubl
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse((maxInt64 + 3).formatted(format))           // not a Doubl
+            }
         }
     }
     
-    func testIntegerParseStrategyDoesNotRoundLargeIntegersToNearestDouble() {
-        XCTAssertEqual(Double("9007199254740992"), Double(exactly: UInt64(1) << 53)!) // +2^53 + 0 -> +2^53
-        XCTAssertEqual(Double("9007199254740993"), Double(exactly: UInt64(1) << 53)!) // +2^53 + 1 -> +2^53
-        XCTAssertEqual(Double.significandBitCount, 52, "Double can represent each integer in -2^53 ... 2^53")
+    @Test func integerParseStrategyDoesNotRoundLargeIntegersToNearestDouble() throws {
+        #expect(Double("9007199254740992") == Double(exactly: UInt64(1) << 53)!) // +2^53 + 0 -> +2^53
+        #expect(Double("9007199254740993") == Double(exactly: UInt64(1) << 53)!) // +2^53 + 1 -> +2^53
+        #expect(Double.significandBitCount == 52, "Double can represent each integer in -2^53 ... 2^53")
         let locale = Locale(identifier: "en_US")
 
         do {
             let format: IntegerFormatStyle<Int64> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
-            XCTAssertNotEqual(try? parseStrategy.parse("-9223372036854776832"), -9223372036854775808) // -2^63 - 1024 (Double: -2^63)
-            XCTAssertNil(     try? parseStrategy.parse("-9223372036854776833"))                       // -2^63 - 1025 (Double: -2^63 - 2048)
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("-9223372036854776832") // -2^63 - 1024 (Double: -2^63)
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("-9223372036854776833") // -2^63 - 1025 (Double: -2^63 - 2048)
+            }
         }
         
         do {
             let format: IntegerFormatStyle<UInt64> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
-            XCTAssertNotEqual(try? parseStrategy.parse( "9223372036854776832"),  9223372036854775808) // +2^63 + 1024 (Double: +2^63)
-            XCTAssertNotEqual(try? parseStrategy.parse( "9223372036854776833"),  9223372036854777856) // +2^63 + 1025 (Double: +2^63 + 2048)
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("9223372036854776832") // +2^63 + 1024 (Double: +2^63)
+            }
+            #expect(throws: (any Error).self) {
+                try parseStrategy.parse("9223372036854776833") // +2^63 + 1025 (Double: +2^63 + 2048)
+            }
         }
     }
 }
 
-final class NumberExtensionParseStrategyTests: XCTestCase {
+@Suite("Number Extension ParseStrategy")
+private struct NumberExtensionParseStrategyTests {
     let enUS = Locale(identifier: "en_US")
 
-    func testDecimal_stringLength() throws {
+    @Test func decimal_stringLength() throws {
         let numberStyle = Decimal.FormatStyle(locale: enUS)
-        XCTAssertNotNil(try Decimal("-3,000.14159", format: numberStyle))
-        XCTAssertNotNil(try Decimal("-3.14159", format: numberStyle))
-        XCTAssertNotNil(try Decimal("12,345.678", format: numberStyle))
-        XCTAssertNotNil(try Decimal("0.00", format: numberStyle))
+        #expect(throws: Never.self) {
+            try Decimal("-3,000.14159", format: numberStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("-3.14159", format: numberStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("12,345.678", format: numberStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("0.00", format: numberStyle)
+        }
 
         let percentStyle = Decimal.FormatStyle.Percent(locale: enUS)
-        XCTAssertNotNil(try Decimal("-3,000.14159%", format: percentStyle))
-        XCTAssertNotNil(try Decimal("-3.14159%", format: percentStyle))
-        XCTAssertNotNil(try Decimal("12,345.678%", format: percentStyle))
-        XCTAssertNotNil(try Decimal("0.00%", format: percentStyle))
+        #expect(throws: Never.self) {
+            try Decimal("-3,000.14159%", format: percentStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("-3.14159%", format: percentStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("12,345.678%", format: percentStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("0.00%", format: percentStyle)
+        }
 
         let currencyStyle = Decimal.FormatStyle.Currency(code: "USD", locale: enUS)
-        XCTAssertNotNil(try Decimal("$12,345.00", format: currencyStyle))
-        XCTAssertNotNil(try Decimal("$12345.68", format: currencyStyle))
-        XCTAssertNotNil(try Decimal("$0.00", format: currencyStyle))
-        XCTAssertNotNil(try Decimal("-$3000.0000014", format: currencyStyle))
+        #expect(throws: Never.self) {
+            try Decimal("$12,345.00", format: currencyStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("$12345.68", format: currencyStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("$0.00", format: currencyStyle)
+        }
+        #expect(throws: Never.self) {
+            try Decimal("-$3000.0000014", format: currencyStyle)
+        }
     }
 
-    func testDecimal_withFormat() throws {
-        XCTAssertEqual(try Decimal("+3000", format: .number.locale(enUS).grouping(.never).sign(strategy: .always())), Decimal(3000))
-        XCTAssertEqual(try Decimal("$3000", format: .currency(code: "USD").locale(enUS).grouping(.never)), Decimal(3000))
+    @Test func decimal_withFormat() throws {
+        #expect(try Decimal("+3000", format: .number.locale(enUS).grouping(.never).sign(strategy: .always())) == Decimal(3000))
+        #expect(try Decimal("$3000", format: .currency(code: "USD").locale(enUS).grouping(.never)) == Decimal(3000))
     }
 
-    func testDecimal_withFormat_localeDependent() throws {
+    @Test func decimal_withFormat_localeDependent() throws {
         guard Locale.autoupdatingCurrent.identifier == "en_US" else {
             print("Your current locale is \(Locale.autoupdatingCurrent). Set it to en_US to run this test")
             return
         }
-        XCTAssertEqual(try Decimal("-3,000.14159", format: .number), Decimal(-3000.14159))
-        XCTAssertEqual(try Decimal("-3.14159", format: .number), Decimal(-3.14159))
-        XCTAssertEqual(try Decimal("12,345.678", format: .number), Decimal(12345.678))
-        XCTAssertEqual(try Decimal("0.00", format: .number), 0)
+        #expect(try Decimal("-3,000.14159", format: .number) == Decimal(-3000.14159))
+        #expect(try Decimal("-3.14159", format: .number) == Decimal(-3.14159))
+        #expect(try Decimal("12,345.678", format: .number) == Decimal(12345.678))
+        #expect(try Decimal("0.00", format: .number) == 0)
 
-        XCTAssertEqual(try Decimal("-3,000.14159%", format: .percent), Decimal(-30.0014159))
-        XCTAssertEqual(try Decimal("-314.159%", format: .percent), Decimal(-3.14159))
-        XCTAssertEqual(try Decimal("12,345.678%", format: .percent), Decimal(123.45678))
-        XCTAssertEqual(try Decimal("0.00%", format: .percent), 0)
+        #expect(try Decimal("-3,000.14159%", format: .percent) == Decimal(-30.0014159))
+        #expect(try Decimal("-314.159%", format: .percent) == Decimal(-3.14159))
+        #expect(try Decimal("12,345.678%", format: .percent) == Decimal(123.45678))
+        #expect(try Decimal("0.00%", format: .percent) == 0)
 
-        XCTAssertEqual(try Decimal("$12,345.00", format: .currency(code: "USD")), Decimal(12345))
-        XCTAssertEqual(try Decimal("$12345.68", format: .currency(code: "USD")), Decimal(12345.68))
-        XCTAssertEqual(try Decimal("$0.00", format: .currency(code: "USD")), Decimal(0))
-        XCTAssertEqual(try Decimal("-$3000.0000014", format: .currency(code: "USD")), Decimal(string: "-3000.0000014")!)
+        #expect(try Decimal("$12,345.00", format: .currency(code: "USD")) == Decimal(12345))
+        #expect(try Decimal("$12345.68", format: .currency(code: "USD")) == Decimal(12345.68))
+        #expect(try Decimal("$0.00", format: .currency(code: "USD")) == Decimal(0))
+        #expect(try Decimal("-$3000.0000014", format: .currency(code: "USD")) == Decimal(string: "-3000.0000014")!)
     }
 }
 


### PR DESCRIPTION
This finishes the swift-testing migration for FoundationInternationalization (and the entirety of swift-foundation). I'll followup with one final PR to cleanup out TestSupport module and remove our XCTest workarounds.

This also includes one change to the `ProcessInfo` tests that I noticed failed when run in Xcode but passed when run via the CLI since they use different test runner process names.