### PR TITLE
Update the link for Proposals 0024-CurrentBundle.md

### DIFF
--- a/Proposals/0024-CurrentBundle.md
+++ b/Proposals/0024-CurrentBundle.md
@@ -1,7 +1,7 @@
 # Introduce `#bundle`
 
 
-* Proposal: [SF-0024](0024-filename.md)
+* Proposal: [SF-0024](0024-CurrentBundle.md)
 * Authors:[Matt Seaman](https://github.com/matthewseaman), [Andreas Neusuess](https://github.com/Tantalum73)
 * Review Manager: [Tina L](https://github.com/itingliu)
 * Implementation: https://github.com/swiftlang/swift-foundation/pull/1274


### PR DESCRIPTION
Update the link for Proposals `0024-CurrentBundle.md` . Currently, it displays `404 not found` error.