### PR TITLE
Enable exit tests on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,8 +75,7 @@ let wasiLibcCSettings: [CSetting] = [
 ]
 
 let testOnlySwiftSettings: [SwiftSetting] = [
-    // The latest Windows toolchain does not yet have exit tests in swift-testing
-    .define("FOUNDATION_EXIT_TESTS", .when(platforms: [.macOS, .linux, .openbsd]))
+    .define("FOUNDATION_EXIT_TESTS", .when(platforms: [.macOS, .linux, .openbsd, .windows]))
 ]
 
 let package = Package(


### PR DESCRIPTION
Now that the toolchains have been updated, this enables exit tests on Windows