### PR TITLE
String.pathExtension should allow "..name" file names but not ".."

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -224,14 +224,19 @@ extension String {
     }
 
     internal var pathExtension: String {
-        let lastComponent = lastPathComponent.utf8
-        guard lastComponent.last != ._dot,
-              !lastComponent.starts(with: [._dot, ._dot]),
-              let lastDot = lastComponent.lastIndex(of: ._dot),
-              lastDot != lastComponent.startIndex else {
+        let utf8Component = lastPathComponent.utf8
+        guard utf8Component.last != ._dot,
+              let lastDot = utf8Component.lastIndex(of: ._dot),
+              // Don't treat a hidden file name as an extension
+              lastDot != utf8Component.startIndex else {
             return ""
         }
-        let result = String(lastPathComponent[lastComponent.index(after: lastDot)...])
+        let utf8FileName = utf8Component[..<lastDot]
+        // Guard against "." and ".." file names
+        if (utf8FileName.count == 1 || utf8FileName.count == 2) && utf8FileName.allSatisfy({ $0 == ._dot }) {
+            return ""
+        }
+        let result = String(lastPathComponent[utf8Component.index(after: lastDot)...])
         guard validatePathExtension(result) else {
             return ""
         }

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -854,15 +854,28 @@ private struct StringTests {
         #expect("/foo/bar/.zip".deletingPathExtension() == "/foo/bar/.zip")
         #expect("..".deletingPathExtension() == "..")
         #expect("..zip".deletingPathExtension() == "..zip")
+        #expect("/..".deletingPathExtension() == "/..")
+        #expect("/..zip".deletingPathExtension() == "/..zip")
         #expect("/foo/bar/..zip".deletingPathExtension() == "/foo/bar/..zip")
         #expect("/foo/bar/baz..zip".deletingPathExtension() == "/foo/bar/baz.")
         #expect("...".deletingPathExtension() == "...")
         #expect("...zip".deletingPathExtension() == "...zip")
+        #expect("/...".deletingPathExtension() == "/...")
+        #expect("/...zip".deletingPathExtension() == "/...zip")
         #expect("/foo/bar/...zip".deletingPathExtension() == "/foo/bar/...zip")
         #expect("/foo/bar/baz...zip".deletingPathExtension() == "/foo/bar/baz..")
         #expect("/foo.bar/bar.baz/baz.zip".deletingPathExtension() == "/foo.bar/bar.baz/baz")
         #expect("/.././.././a.zip".deletingPathExtension() == "/.././.././a")
         #expect("/.././.././.".deletingPathExtension() == "/.././.././.")
+
+        // File names starting with "." or ".." are OK
+        // as long as they aren't exactly "." or ".."
+        #expect("..name.txt".deletingPathExtension() == "..name")
+        #expect("/..name.txt".deletingPathExtension() == "/..name")
+        #expect("....txt".deletingPathExtension() == "...")
+        #expect("/....txt".deletingPathExtension() == "/...")
+        #expect(".name.txt".deletingPathExtension() == ".name")
+        #expect("/.name.txt".deletingPathExtension() == "/.name")
 
         #expect("path.foo".deletingPathExtension() == "path")
         #expect("path.foo.zip".deletingPathExtension() == "path.foo")


### PR DESCRIPTION
Minor fix for `String.pathExtension` found when comparing the old `NSString` behavior. `String.pathExtension` returns "" for path extensions appended to "." and ".." file names. This behavior is in part to prevent `.deletingPathExtension()` from returning a path referencing the current or parent directory.

However, `String.pathExtension` currently returns "" for all file names that start with "..", so some valid file paths like "..name.txt" aren't receiving the correct behavior.

This PR makes it so we only disallow extensions that would leave "." and ".." file names when removed. I also renamed a variable to make it more clear we're working with the `UTF8View`.