### PR TITLE
update package deps for custom project root

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,24 +42,33 @@ let featureSettings: [SwiftSetting] = [
     .enableUpcomingFeature("MemberImportVisibility")
 ]
 
-var dependencies: [Package.Dependency] {
-    if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil {
+var dependencies: [Package.Dependency] = []
+
+if let useLocalDepsEnv = Context.environment["SWIFTCI_USE_LOCAL_DEPS"], !useLocalDepsEnv.isEmpty {
+    let root: String
+    if useLocalDepsEnv == "1" {
+        root = ".."
+    } else {
+        root = useLocalDepsEnv
+    }
+    dependencies += 
         [
             .package(
                 name: "swift-collections",
-                path: "../swift-collections"),
+                path: "\(root)/swift-collections"),
             .package(
                 name: "swift-foundation-icu",
-                path: "../swift-foundation-icu"),
+                path: "\(root)/swift-foundation-icu"),
             .package(
                 name: "swift-syntax",
-                path: "../swift-syntax")
+                path: "\(root)/swift-syntax")
         ]
-    } else {
+} else {
+    dependencies += 
         [
             .package(
                 url: "https://github.com/apple/swift-collections",
-                from: "1.1.0"),
+                branch: "main"),
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
                 branch: "main"),
@@ -67,7 +76,6 @@ var dependencies: [Package.Dependency] {
                 url: "https://github.com/swiftlang/swift-syntax",
                 branch: "main")
         ]
-    }
 }
 
 let wasiLibcCSettings: [CSetting] = [

--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,8 @@ if let useLocalDepsEnv = Context.environment["SWIFTCI_USE_LOCAL_DEPS"], !useLoca
                 path: "\(root)/swift-syntax")
         ]
 } else {
+    // These dependencies should match `update-checkout`
+    // See `update-checkout-config.json` for the `main` branch-scheme
     dependencies += 
         [
             .package(

--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,7 @@ if let useLocalDepsEnv = Context.environment["SWIFTCI_USE_LOCAL_DEPS"], !useLoca
         [
             .package(
                 url: "https://github.com/apple/swift-collections",
-                branch: "main"),
+                from: "1.1.0"),
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
                 branch: "main"),


### PR DESCRIPTION
One small improvement to package manifest:
* We follow the pattern from `swift-corelibs-foundation`[^1] to compute the location of dependencies:
  * `SWIFTCI_USE_LOCAL_DEPS=1` moves us up one directory when looking for dependencies.
  * Missing or empty `SWIFTCI_USE_LOCAL_DEPS` pulls dependencies from GitHub.

This also keeps us consistent with how we compute a local path for Benchmarks.[^2]

Tested locally from my machine:

```shell
$ cd ~/Developer/swift-foundation
$ swift build
...
Build complete!

$ SWIFTCI_USE_LOCAL_DEPS=~/Developer swift build
...
Build complete!

$ SWIFTCI_USE_LOCAL_DEPS=~ swift build
...
error: the package at '/Users/rick/swift-collections' cannot be accessed (Error Domain=NSCocoaErrorDomain Code=260 "The folder “swift-collections” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/rick/swift-collections, NSURL=file:///Users/rick/swift-collections, NSUnderlyingError=0x6000020b0e40 {Error Domain=NSOSStatusErrorDomain Code=-43 "fnfErr: File not found"}})
error: ExitCode(rawValue: 1)
```

[^1]: https://github.com/swiftlang/swift-corelibs-foundation/blob/swift-6.1.2-RELEASE/Package.swift#L155-L181
[^2]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Benchmarks/Package.swift#L62
