### PR TITLE
attributed string fast path equality performance improvements

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -423,12 +423,20 @@ let benchmarks = {
     let manyAttributesSubstring = manyAttributesString[manyAttributesStringRange]
     let manyAttributes2Substring = manyAttributesString2[manyAttributesStringRange]
 
+    Benchmark("equalityShared") { benchmark in
+        blackHole(manyAttributesString == manyAttributesString)
+    }
+
     Benchmark("equality") { benchmark in
         blackHole(manyAttributesString == manyAttributesString2)
     }
-    
+
     Benchmark("equalityDifferingCharacters") { benchmark in
         blackHole(manyAttributesString == manyAttributesString3)
+    }
+
+    Benchmark("substringEqualityShared") { benchmark in
+        blackHole(manyAttributesSubstring == manyAttributesSubstring)
     }
     
     Benchmark("substringEquality") { benchmark in

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -150,7 +150,10 @@ extension AttributedString {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString { // Equatable
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        AttributedString.Guts.characterwiseIsEqual(lhs._guts, to: rhs._guts)
+        if lhs._guts === rhs._guts {
+            return true
+        }
+        return AttributedString.Guts.characterwiseIsEqual(lhs._guts, to: rhs._guts)
     }
 }
 


### PR DESCRIPTION
Here is a small performance improvement to value-equality checking in `AttributedString`.

When two `AttributedString` instances are identical we can return `true` in constant-time: we do not need to check through all N characters.

Currently the check for identity equality lives inside `Guts`.[^1][^2][^3] This is still constant-time… but we have the potential to move this check up sooner: directly in the `==` operator on `AttributedString`. This will look similar to what we already have in place for `AttributedSubstring`.[^4]

Benchmarks show improvements close to one order of magnitude increased throughput when our `AttributedString` instances are identical.

## Control

## AttributedStringBenchmarks

### equalityShared

| Metric                    |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:--------------------------|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
| Throughput (# / s) (M)    |       421 |       381 |       381 |       375 |       369 |       296 |        12 |     10000 |
| Time (total CPU) (ns) *   |         3 |         3 |         3 |         3 |         3 |         4 |        83 |     10000 |
| Time (wall clock) (ns) *  |         2 |         3 |         3 |         3 |         3 |         3 |        81 |     10000 |

## Test

## Baseline 'Current_run'

## AttributedStringBenchmarks

### equalityShared

| Metric                    |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:--------------------------|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
| Throughput (# / s) (G)    |        24 |        24 |        24 |        24 |        24 |        12 |         0 |      9634 |
| Time (total CPU) (ns) *   |         1 |         1 |         1 |         1 |         1 |         1 |        14 |     10000 |
| Time (wall clock) (ns) *  |         0 |         0 |         0 |         0 |         0 |         0 |         5 |      9634 |

[^1]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedString%2BGuts.swift#L77
[^2]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedString%2BGuts.swift#L84-L86
[^3]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedString%2BGuts.swift#L105
[^4]: https://github.com/swiftlang/swift-foundation/blob/swift-6.1.2-RELEASE/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift#L79-L81
