### PR TITLE
Revert "FoundationEssentials,FoundationInternationalization: adjust for aliasing"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,6 @@ let availabilityMacros: [SwiftSetting] = versionNumbers.flatMap { version in
 
 let featureSettings: [SwiftSetting] = [
     .enableExperimentalFeature("StrictConcurrency"),
-    .enableExperimentalFeature("ImportMacroAliases"),
     .enableUpcomingFeature("InferSendableFromCaptures"),
     .enableUpcomingFeature("MemberImportVisibility")
 ]

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -117,7 +117,6 @@ import Darwin
 #elseif canImport(Android)
 @preconcurrency import Android
 import posix_filesystem.dirent
-internal import _FoundationCShims
 #elseif canImport(Glibc)
 @preconcurrency import Glibc
 internal import _FoundationCShims

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -30,7 +30,6 @@ add_subdirectory(TimeZone)
 
 target_compile_options(FoundationInternationalization PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
-    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend ImportMacroAliases>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend MemberImportVisibility>")

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -159,7 +159,7 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
     // MARK: -
 
     class FormatResult {
-        var result: OpaquePointer?
+        var result: OpaquePointer
 
         init(formatter: OpaquePointer, value: Int64) throws {
             var status = U_ZERO_ERROR
@@ -188,9 +188,7 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
             var str = value.description
 #endif // FOUNDATION_FRAMEWORK
             str.withUTF8 {
-                $0.withMemoryRebound(to: CChar.self) {
-                    unumf_formatDecimal(formatter, $0.baseAddress, Int32($0.count), result, &status)
-                }
+                unumf_formatDecimal(formatter, $0.baseAddress, Int32($0.count), result, &status)
             }
             try status.checkSuccess()
         }
@@ -202,9 +200,7 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
             
             var value = value
             value.withUTF8 {
-                $0.withMemoryRebound(to: CChar.self) {
-                    unumf_formatDecimal(formatter, $0.baseAddress, Int32($0.count), result, &status)
-                }
+                unumf_formatDecimal(formatter, $0.baseAddress, Int32($0.count), result, &status)
             }
             
             try status.checkSuccess()

--- a/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
@@ -18,7 +18,7 @@ import FoundationEssentials
 
 extension ICU {
     final class CaseMap : @unchecked Sendable {
-        let casemap: OpaquePointer?
+        let casemap: OpaquePointer
         
         let lock: LockedState<Void>
         

--- a/Sources/FoundationInternationalization/ICU/ICU+FieldPositer.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+FieldPositer.swift
@@ -14,7 +14,7 @@ internal import _FoundationICU
 
 extension ICU {
     final class FieldPositer {
-        let positer: OpaquePointer?
+        let positer: OpaquePointer
 
         internal init() throws {
             var status = U_ZERO_ERROR

--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -29,10 +29,7 @@ internal struct ICUError: Error, CustomDebugStringConvertible {
     }
 
     var debugDescription: String {
-        guard let error = u_errorName(code) else {
-            return "Unknown ICU error \(code.rawValue)"
-        }
-        return String(cString: error)
+        String(validatingUTF8: u_errorName(code)) ?? "Unknown ICU error \(code.rawValue)"
     }
 
 #if canImport(os)

--- a/Sources/FoundationInternationalization/ICU/ICU+StringConverter.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+StringConverter.swift
@@ -75,7 +75,7 @@ extension ICU.StringConverter {
                         converter,
                         dest,
                         capacity,
-                        src.baseAddress?.assumingMemoryBound(to: CChar.self),
+                        src.baseAddress,
                         srcLength,
                         &status
                     )
@@ -85,7 +85,7 @@ extension ICU.StringConverter {
     }
 
     func encode(string: String, allowLossyConversion lossy: Bool) -> Data?  {
-        return self._converter.withLock { (converter) -> Data? in
+        return _converter.withLock { (converter) -> Data? in
             defer {
                 ucnv_resetFromUnicode(converter)
             }
@@ -117,7 +117,7 @@ extension ICU.StringConverter {
 
                 ucnv_setFromUCallBack(
                     converter,
-                    { UCNV_FROM_U_CALLBACK_SUBSTITUTE($0, $1, $2, $3, $4, $5, $6) },
+                    UCNV_FROM_U_CALLBACK_SUBSTITUTE,
                     nil, // newContext
                     nil, // oldAction
                     nil, // oldContext
@@ -127,7 +127,7 @@ extension ICU.StringConverter {
             } else {
                 ucnv_setFromUCallBack(
                     converter,
-                    { UCNV_FROM_U_CALLBACK_STOP($0, $1, $2, $3, $4, $5, $6) },
+                    UCNV_FROM_U_CALLBACK_STOP,
                     nil, // newContext
                     nil, // oldAction
                     nil, // oldContext
@@ -138,7 +138,7 @@ extension ICU.StringConverter {
 
             let actualLength = ucnv_fromUChars(
                 converter,
-                dest.assumingMemoryBound(to: CChar.self),
+                dest,
                 CInt(capacity),
                 uchars.baseAddress,
                 CInt(srcLength),

--- a/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
@@ -216,11 +216,7 @@ extension Locale.Region {
             return nil
         }
 
-        guard let region = uregion_getRegionCode(containingRegion) else {
-            return nil
-        }
-
-        guard let code = String(validatingUTF8: region) else {
+        guard let code = String(validatingUTF8: uregion_getRegionCode(containingRegion)) else {
             return nil
         }
 
@@ -240,11 +236,7 @@ extension Locale.Region {
             return nil
         }
 
-        guard let region = uregion_getRegionCode(containingContinent) else {
-            return nil
-        }
-
-        guard let code = String(validatingUTF8: region) else {
+        guard let code = String(validatingUTF8: uregion_getRegionCode(containingContinent)) else {
             return nil
         }
 
@@ -453,11 +445,7 @@ extension Locale.Region {
             return nil
         }
 
-        guard let region = uregion_getRegionCode(containing) else {
-            return nil
-        }
-
-        guard let code = String(validatingCString: region) else {
+        guard let code = String(validatingCString: uregion_getRegionCode(containing)) else {
             return nil
         }
 
@@ -611,8 +599,8 @@ extension Locale.NumberingSystem {
         var status = U_ZERO_ERROR
         let numberingSystem = unumsys_open(localeIdentifier, &status)
         defer { unumsys_close(numberingSystem) }
-        if let numberingSystem, status.isSuccess, let name = unumsys_getName(numberingSystem) {
-            self.init(String(cString: name))
+        if let numberingSystem, status.isSuccess {
+            self.init(String(cString: unumsys_getName(numberingSystem)))
         } else {
             self = .latn
         }

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1543,8 +1543,7 @@ extension Locale {
         var working = Set<String>()
         let localeCount = uloc_countAvailable()
         for locale in 0..<localeCount {
-            guard let name = uloc_getAvailable(locale) else { continue }
-            let localeID = String(cString: name)
+            let localeID = String(cString: uloc_getAvailable(locale))
             working.insert(localeID)
         }
         return Array(working)


### PR DESCRIPTION
Reverts swiftlang/swift-foundation#1340

This and https://github.com/swiftlang/swift-foundation-icu/pull/63 together seem to cause Windows CI to fail, possibly until a nightly actually contains https://github.com/swiftlang/swift/commit/c08372a91d04b8d0875b1debae9542e69daa01a0