### PR TITLE
Limit the use of concurrent scope in unit tests

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -188,24 +188,27 @@ private struct DateFormatStyleTests {
     }
 
     @Test func leadingDotSyntax() async {
+        let date = Date.now
+        let locale = Locale(identifier: "es_ES")
         await usingCurrentInternationalizationPreferences {
-            let date = Date.now
             #expect(date.formatted(date: .long, time: .complete) == date.formatted(Date.FormatStyle(date: .long, time: .complete)))
-            #expect(
-                date.formatted(
-                    .dateTime
-                        .day()
-                        .month()
-                        .year()
-                ) ==
-                date.formatted(
-                    Date.FormatStyle()
-                        .day()
-                        .month()
-                        .year()
-                )
-            )
         }
+        #expect(
+            date.formatted(
+                .dateTime
+                    .day()
+                    .month()
+                    .year()
+                    .locale(locale)
+            ) ==
+            date.formatted(
+                Date.FormatStyle()
+                    .day()
+                    .month()
+                    .year()
+                    .locale(locale)
+            )
+        )
     }
 
     @Test func dateFormatStyleIndividualFields() {

--- a/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
@@ -100,12 +100,15 @@ private struct DateIntervalFormatStyleTests {
     }
     
     @Test func leadingDotSyntax() async {
+        let locale = Locale(identifier: "en_GB")
+        let range = (Date(timeIntervalSinceReferenceDate: 0) ..< Date(timeIntervalSinceReferenceDate: 0) + (60 * 60))
         await usingCurrentInternationalizationPreferences {
-            let range = (Date(timeIntervalSinceReferenceDate: 0) ..< Date(timeIntervalSinceReferenceDate: 0) + (60 * 60))
+            // This test assumes both the left side and the right side of the comparison has the same `Locale.autoupdatingCurrent`, which assumes the state of the host machine remains unchanged.
             #expect(range.formatted() == Date.IntervalFormatStyle().format(range))
             #expect(range.formatted(date: .numeric, time: .shortened) == Date.IntervalFormatStyle(date: .numeric, time: .shortened).format(range))
-            #expect(range.formatted(.interval.day().month().year()) == Date.IntervalFormatStyle().day().month().year().format(range))
         }
+
+        #expect(range.formatted(.interval.day().month().year().locale(locale)) == Date.IntervalFormatStyle().day().month().year().locale(locale).format(range))
     }
     
 #if FIXED_ICU_74_DAYPERIOD

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -2163,36 +2163,35 @@ extension FormatStylePatternMatchingTests {
 #if FOUNDATION_FRAMEWORK
 extension NumberFormatStyleTests {
     @Test func formattedLeadingDotSyntax() async {
-        await usingCurrentInternationalizationPreferences {
-            let integer = 12345
-            #expect(integer.formatted(.number) == integer.formatted(IntegerFormatStyle.number))
-            #expect(integer.formatted(.percent) == integer.formatted(IntegerFormatStyle.Percent.percent))
-            #expect(integer.formatted(.currency(code: "usd")) == integer.formatted(IntegerFormatStyle.Currency.currency(code: "usd")))
-            
-            let double = 1.2345
-            #expect(double.formatted(.number) == double.formatted(FloatingPointFormatStyle.number))
-            #expect(double.formatted(.percent) == double.formatted(FloatingPointFormatStyle.Percent.percent))
-            #expect(double.formatted(.currency(code: "usd")) == double.formatted(FloatingPointFormatStyle.Currency.currency(code: "usd")))
-            
-            
-            func parseableFunc<Style: ParseableFormatStyle>(_ value: Style.FormatInput, style: Style) -> Style { style }
-            
-            #expect(parseableFunc(UInt8(), style: .number) == parseableFunc(UInt8(), style: IntegerFormatStyle.number))
-            #expect(parseableFunc(Int16(), style: .percent) == parseableFunc(Int16(), style: IntegerFormatStyle.Percent.percent))
-            #expect(parseableFunc(Int(), style: .currency(code: "usd")) == parseableFunc(Int(), style: IntegerFormatStyle.Currency.currency(code: "usd")))
-            
-            #expect(parseableFunc(Float(), style: .number) == parseableFunc(Float(), style: FloatingPointFormatStyle.number))
-            #expect(parseableFunc(Double(), style: .percent) == parseableFunc(Double(), style: FloatingPointFormatStyle.Percent.percent))
-            #expect(parseableFunc(CGFloat(), style: .currency(code: "usd")) == parseableFunc(CGFloat(), style: FloatingPointFormatStyle.Currency.currency(code: "usd")))
-            
-            #expect(parseableFunc(Decimal(), style: .number) == parseableFunc(Decimal(), style: Decimal.FormatStyle.number))
-            #expect(parseableFunc(Decimal(), style: .percent) == parseableFunc(Decimal(), style: Decimal.FormatStyle.Percent.percent))
-            #expect(parseableFunc(Decimal(), style: .currency(code: "usd")) == parseableFunc(Decimal(), style: Decimal.FormatStyle.Currency.currency(code: "usd")))
-            
-            struct GenericWrapper<V> {}
-            func parseableWrapperFunc<Style: ParseableFormatStyle>(_ value: GenericWrapper<Style.FormatInput>, style: Style) -> Style { style }
-            #expect(parseableWrapperFunc(GenericWrapper<Double>(), style: .number) == parseableWrapperFunc(GenericWrapper<Double>(), style: FloatingPointFormatStyle.number))
-        }
+        let locale = Locale(identifier: "ja_JP")
+        let integer = 12345
+        #expect(integer.formatted(.number.locale(locale)) == integer.formatted(IntegerFormatStyle.number.locale(locale)))
+        #expect(integer.formatted(.percent.locale(locale)) == integer.formatted(IntegerFormatStyle.Percent.percent.locale(locale)))
+        #expect(integer.formatted(.currency(code: "usd").locale(locale)) == integer.formatted(IntegerFormatStyle.Currency.currency(code: "usd").locale(locale)))
+
+        let double = 1.2345
+        #expect(double.formatted(.number.locale(locale)) == double.formatted(FloatingPointFormatStyle.number.locale(locale)))
+        #expect(double.formatted(.percent.locale(locale)) == double.formatted(FloatingPointFormatStyle.Percent.percent.locale(locale)))
+        #expect(double.formatted(.currency(code: "usd").locale(locale)) == double.formatted(FloatingPointFormatStyle.Currency.currency(code: "usd").locale(locale)))
+
+
+        func parseableFunc<Style: ParseableFormatStyle>(_ value: Style.FormatInput, style: Style) -> Style { style }
+
+        #expect(parseableFunc(UInt8(), style: .number.locale(locale)) == parseableFunc(UInt8(), style: IntegerFormatStyle.number.locale(locale)))
+        #expect(parseableFunc(Int16(), style: .percent.locale(locale)) == parseableFunc(Int16(), style: IntegerFormatStyle.Percent.percent.locale(locale)))
+        #expect(parseableFunc(Int(), style: .currency(code: "usd").locale(locale)) == parseableFunc(Int(), style: IntegerFormatStyle.Currency.currency(code: "usd").locale(locale)))
+
+        #expect(parseableFunc(Float(), style: .number.locale(locale)) == parseableFunc(Float(), style: FloatingPointFormatStyle.number.locale(locale)))
+        #expect(parseableFunc(Double(), style: .percent.locale(locale)) == parseableFunc(Double(), style: FloatingPointFormatStyle.Percent.percent.locale(locale)))
+        #expect(parseableFunc(CGFloat(), style: .currency(code: "usd").locale(locale)) == parseableFunc(CGFloat(), style: FloatingPointFormatStyle.Currency.currency(code: "usd").locale(locale)))
+
+        #expect(parseableFunc(Decimal(), style: .number.locale(locale)) == parseableFunc(Decimal(), style: Decimal.FormatStyle.number.locale(locale)))
+        #expect(parseableFunc(Decimal(), style: .percent.locale(locale)) == parseableFunc(Decimal(), style: Decimal.FormatStyle.Percent.percent.locale(locale)))
+        #expect(parseableFunc(Decimal(), style: .currency(code: "usd").locale(locale)) == parseableFunc(Decimal(), style: Decimal.FormatStyle.Currency.currency(code: "usd").locale(locale)))
+
+        struct GenericWrapper<V> {}
+        func parseableWrapperFunc<Style: ParseableFormatStyle>(_ value: GenericWrapper<Style.FormatInput>, style: Style) -> Style { style }
+        #expect(parseableWrapperFunc(GenericWrapper<Double>(), style: .number.locale(locale)) == parseableWrapperFunc(GenericWrapper<Double>(), style: FloatingPointFormatStyle.number.locale(locale)))
     }
 }
 #endif


### PR DESCRIPTION
Many tests for the dot syntax assume that the left hand side of the comparison is using the same locale as the right side, in which case is `Locale.autoupdatingCurrent`. Previously we put them inside `usingCurrentInternationalizationPreferences` to ensure that the current locale isn't mutated concurrently while the tests are running. That works but we can also set the locale of both the left and right side to a specific locale so they don't depend on the current status.

Addresses 155437764