### PR TITLE
Fix or disable tests around accessing current locale

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -291,7 +291,7 @@ private struct DateFormatStyleTests {
         #expect(date.formatted(style.locale(Locale.localeAsIfCurrent(name: esES, overrides: .init(force24Hour: true)))) == "16:00:00")
     }
     
-#if !os(watchOS) // 99504292
+#if !os(watchOS) && FOUNDATION_FRAMEWORK // 99504292 && 155484008
     @Test func nsICUDateFormatterCache() async throws {
         await usingCurrentInternationalizationPreferences {
             // This test can only be run with the system set to the en_US language
@@ -405,7 +405,8 @@ private struct DateFormatStyleTests {
         var locale: Locale
         var format: Date.FormatStyle
         func verifyWithFormat(_ date: Date, expected: String, sourceLocation: SourceLocation = #_sourceLocation) {
-            let fmt = format.locale(locale)
+            var fmt = format.locale(locale)
+            fmt.calendar = Calendar(identifier: .gregorian)
             let formatted = fmt.format(date)
             #expect(formatted == expected, sourceLocation: sourceLocation)
         }
@@ -1408,6 +1409,7 @@ private struct TestDateStyleDiscreteConformance {
 
         let now = date("2023-05-15 08:47:20Z")
 
+#if FOUNDATION_FRAMEWORK // 155526268
         assertEvaluation(
             of: .init(date: .complete, time: .complete).secondFraction(.fractional(2)),
             in: (now - 0.1)...(now + 0.1),
@@ -1435,6 +1437,7 @@ private struct TestDateStyleDiscreteConformance {
                 "Monday, May 15, 2023 at 8:47:20.10 AM GMT",
             ])
 
+
         assertEvaluation(
             of: .init(date: .complete, time: .complete),
             in: (now - 3)...(now + 3),
@@ -1447,6 +1450,7 @@ private struct TestDateStyleDiscreteConformance {
                 "Monday, May 15, 2023 at 8:47:22 AM GMT",
                 "Monday, May 15, 2023 at 8:47:23 AM GMT",
             ])
+#endif
 
         assertEvaluation(
             of: .init().hour(.twoDigits(amPM: .abbreviated)).minute(),

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -635,7 +635,7 @@ private struct DateAttributedFormatStyleTests {
     }
     
     @Test func individualFields() throws {
-        let baseStyle = Date.FormatStyle(locale: enUSLocale, timeZone: gmtTimeZone)
+        let baseStyle = Date.FormatStyle(locale: enUSLocale, calendar: Calendar(identifier: .gregorian), timeZone: gmtTimeZone)
         // dateFormatter.date(from: "2021-04-12 15:04:32")!
         let date = Date(timeIntervalSinceReferenceDate: 639932672.0)
         let expectations: [Date.FormatStyle : [Segment]] = [

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -1820,7 +1820,7 @@ private struct FormatStylePatternMatchingTests {
     typealias TestCase = (string: String, style: IntegerFormatStyle<Int>, value: Int?)
 
     @Test func integerFormatStyle_Consumer() {
-        let style: IntegerFormatStyle<Int> = .init()
+        let style: IntegerFormatStyle<Int> = .init(locale: Locale(identifier: "en_US"))
         let string = "42,000,000"
 
         _verifyMatching(string, formatStyle: style, expectedUpperBound: string.endIndex, expectedValue: 42000000)
@@ -1860,7 +1860,7 @@ private struct FormatStylePatternMatchingTests {
     }
 
     @Test func percentFormatStyle_Consumer() {
-        let style = IntegerFormatStyle<Int>.Percent()
+        let style = IntegerFormatStyle<Int>.Percent(locale: Locale(identifier: "en_US"))
         let string = "42%"
 
         _verifyMatching(string, formatStyle: style, expectedUpperBound: string.endIndex, expectedValue: 42)


### PR DESCRIPTION
I believe these tests are failing because some other tests are mutating the global cached current locale or calendar.

We've identified most tests whose test expectations depend on the current locale. We've addressed them by either specifying a fixed locale on the tests, or guard them inside `usingCurrentInternationalizationPreferences`. But even if a test doesn't assert the result based on the value of the current locale, the test might still cause the cache to be populated concurrently at the time of accessing autoupdating and current locale, and subsequently break tests that expect a given value of the current locale.
    
Disable the tests for now while investigating a proper way to update the tests. These tests pass when building as part of the Darwin SDK, so leave them enabled there.
    
155476600