### PR TITLE
Update stringshims to always use clocale

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -1081,7 +1081,7 @@ extension JSON5Scanner {
             jsonBytes.formIndex(after: &index)
         }
 
-        let cmp = jsonBytes[index..<endIndex].prefix(2).withUnsafePointer({ _stringshims_strncasecmp_l($0, "0x", $1, nil) })
+        let cmp = jsonBytes[index..<endIndex].prefix(2).withUnsafePointer({ _stringshims_strncasecmp_clocale($0, "0x", $1) })
         if cmp == 0 {
             jsonBytes.formIndex(&index, offsetBy: 2)
 

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -1179,7 +1179,7 @@ extension Double : PrevalidatedJSONNumberBufferConvertible {
     init?(prevalidatedBuffer buffer: BufferView<UInt8>) {
         let decodedValue = buffer.withUnsafePointer { nptr, count -> Double? in
             var endPtr: UnsafeMutablePointer<CChar>? = nil
-            let decodedValue = _stringshims_strtod_l(nptr, &endPtr, nil)
+            let decodedValue = _stringshims_strtod_clocale(nptr, &endPtr)
             if let endPtr, nptr.advanced(by: count) == endPtr {
                 return decodedValue
             } else {
@@ -1195,7 +1195,7 @@ extension Float : PrevalidatedJSONNumberBufferConvertible {
     init?(prevalidatedBuffer buffer: BufferView<UInt8>) {
         let decodedValue = buffer.withUnsafePointer { nptr, count -> Float? in
             var endPtr: UnsafeMutablePointer<CChar>? = nil
-            let decodedValue = _stringshims_strtof_l(nptr, &endPtr, nil)
+            let decodedValue = _stringshims_strtof_clocale(nptr, &endPtr)
             if let endPtr, nptr.advanced(by: count) == endPtr {
                 return decodedValue
             } else {

--- a/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
@@ -231,7 +231,7 @@ open class PropertyListDecoder {
         }
         
         return try buffer[unchecked: baseIdx..<idx].withUnsafePointer { ptr, encodingLength in
-            if encodingLength == 5, _stringshims_strncasecmp_l(ptr, "utf-8", 5, nil) == 0 {
+            if encodingLength == 5, _stringshims_strncasecmp_clocale(ptr, "utf-8", 5) == 0 {
                 return .utf8
             }
             

--- a/Sources/FoundationEssentials/PropertyList/XMLPlistScanner.swift
+++ b/Sources/FoundationEssentials/PropertyList/XMLPlistScanner.swift
@@ -645,7 +645,7 @@ extension XMLPlistMap.Value {
                     return .nan
                 }
             case (UInt8(ascii: "+"), 9):
-                if _stringshims_strncasecmp_l(buf.baseAddress, "+infinity", 9, nil) == 0 {
+                if _stringshims_strncasecmp_clocale(buf.baseAddress, "+infinity", 9) == 0 {
                     return .infinity
                 }
             case (UInt8(ascii: "+"), 4):
@@ -655,7 +655,7 @@ extension XMLPlistMap.Value {
                     return .infinity
                 }
             case (UInt8(ascii: "-"), 9):
-                if _stringshims_strncasecmp_l(buf.baseAddress, "-infinity", 9, nil) == 0 {
+                if _stringshims_strncasecmp_clocale(buf.baseAddress, "-infinity", 9) == 0 {
                     return .infinity * -1
                 }
             case (UInt8(ascii: "-"), 4):
@@ -665,7 +665,7 @@ extension XMLPlistMap.Value {
                     return .infinity * -1
                 }
             case (UInt8(ascii: "i"), 8), (UInt8(ascii: "I"), 8):
-                if _stringshims_strncasecmp_l(buf.baseAddress, "infinity", 8, nil) == 0 {
+                if _stringshims_strncasecmp_clocale(buf.baseAddress, "infinity", 8) == 0 {
                     return .infinity
                 }
             case (.none, 0):
@@ -728,9 +728,9 @@ extension XMLPlistMap.Value {
                 var parseEndPtr : UnsafeMutablePointer<CChar>?
                 let res : T
                 if MemoryLayout<T>.size == MemoryLayout<Float>.size {
-                    res = T(_stringshims_strtof_l(ptr, &parseEndPtr, nil))
+                    res = T(_stringshims_strtof_clocale(ptr, &parseEndPtr))
                 } else if MemoryLayout<T>.size == MemoryLayout<Double>.size {
-                    res = T(_stringshims_strtod_l(ptr, &parseEndPtr, nil))
+                    res = T(_stringshims_strtod_clocale(ptr, &parseEndPtr))
                 } else {
                     preconditionFailure("Only Float and Double are currently supported by PropertyListDecoder, not \(type))")
                 }

--- a/Sources/_FoundationCShims/include/string_shims.h
+++ b/Sources/_FoundationCShims/include/string_shims.h
@@ -37,11 +37,11 @@ extern "C" {
 #define locale_t void *
 #endif
 
-INTERNAL int _stringshims_strncasecmp_l(const char * _Nullable s1, const char * _Nullable s2, size_t n, locale_t _Nullable loc);
+INTERNAL int _stringshims_strncasecmp_clocale(const char * _Nullable s1, const char * _Nullable s2, size_t n);
 
-INTERNAL double _stringshims_strtod_l(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr, locale_t _Nullable loc);
+INTERNAL double _stringshims_strtod_clocale(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr);
 
-INTERNAL float _stringshims_strtof_l(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr, locale_t _Nullable loc);
+INTERNAL float _stringshims_strtof_clocale(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr);
 
 #define _STRINGSHIMS_MACROMAN_MAP_SIZE 129
 INTERNAL const uint8_t _stringshims_macroman_mapping[_STRINGSHIMS_MACROMAN_MAP_SIZE][3];


### PR DESCRIPTION
When updating the JSON encoder tests to swift-testing, we noticed that on Windows the test that calls `setlocale` (which now runs in parallel to other tests) was interfering with other JSON tests causing rare crashes. This updates our string shims to explicitly use the c locale rather than relying on a `NULL` value (which on Windows used the global current locale)