### PR TITLE
CMakeLists.txt: fix status message for `swift-collections`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
 endif()
 
 if (_SwiftCollections_SourceDIR)
-    message(STATUS "_SwiftCollections_SourceDIR provided, using swift-foundation-icu checkout at ${_SwiftCollections_SourceDIR}")
+    message(STATUS "_SwiftCollections_SourceDIR provided, using swift-collections checkout at ${_SwiftCollections_SourceDIR}")
     FetchContent_Declare(SwiftCollections
         SOURCE_DIR ${_SwiftCollections_SourceDIR})
 else()


### PR DESCRIPTION
The current configuration status message is quite confusing:
```
-- _SwiftCollections_SourceDIR provided, using swift-foundation-icu checkout at 
```
which clearly should be
```
-- _SwiftCollections_SourceDIR provided, using swift-collections checkout at 
```