### PR TITLE
Improve AttributedString.CharacterView to Substring conversion in AttributedStringProtocol.range(of:)

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -63,9 +63,9 @@ let benchmarks = {
     Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .throughput]
     
     let manyAttributesString = createManyAttributesString()
+    let longString = createLongString()
 #if FOUNDATION_FRAMEWORK
     let manyAttributesNS = createManyAttributesNSString()
-    let longString = createLongString()
     let toInsertNS = NSAttributedString(string: String(repeating: "c", count: longString.characters.count))
 #endif
     
@@ -500,6 +500,10 @@ let benchmarks = {
         for (value, range) in longParagraphsString.runs[\.testParagraphConstrained].reversed() {
             blackHole(value)
         }
+    }
+    
+    Benchmark("range(of:)") { benchmark in
+        longString.range(of: "cccc")
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -267,7 +267,7 @@ extension AttributedStringProtocol {
     internal func _range<T: StringProtocol>(of stringToFind: T, options: String.CompareOptions = []) -> Range<AttributedString.Index>? {
 
         // TODO: Implement this on BigString to avoid O(n) iteration
-        let substring = Substring(characters)
+        let substring = Substring(String(_characters: self.characters))
         guard let range = try? substring._range(of: Substring(stringToFind), options: options) else {
             return nil
         }


### PR DESCRIPTION
We don't currently have `range(of:)` implemented natively on `BigString` (or a UTF-8 collection) and instead we must first convert to a `Substring` to perform the searching operation. In the future, we should benchmark and improve this function by writing it natively on the `BigString` storage instead of bridging to `String`. However, today we're taking a very slow, linear path of converting the character view to a `Substring` iterating character by character. Instead, we can take a faster path by using our `CharacterView` to `String` conversion that copies chunk-by-chunk and create a `Substring` from that result. The benchmarks show that this has a significant performance improvement over the existing implementation (with much more room to improve with a native implementation)

## AttributedStringBenchmarks

### range(of:) metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (wall clock) (ns) *         |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |      3745 |      3963 |      4198 |      4321 |      4366 |      4444 |      4613 |       240 |
|                  branch                  |       375 |       403 |       439 |       449 |       458 |       486 |       554 |      2296 |
|                    Δ                     |     -3370 |     -3560 |     -3759 |     -3872 |     -3908 |     -3958 |     -4059 |      2056 |
|              Improvement %               |        90 |        90 |        90 |        90 |        90 |        89 |        88 |      2056 |

<p>
</details>

<details><summary>Time (total CPU): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (total CPU) (ns) *          |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |      3747 |      3965 |      4182 |      4325 |      4362 |      4432 |      4615 |       240 |
|                  branch                  |       376 |       404 |       440 |       450 |       458 |       481 |       534 |      2296 |
|                    Δ                     |     -3371 |     -3561 |     -3742 |     -3875 |     -3904 |     -3951 |     -4081 |      2056 |
|              Improvement %               |        90 |        90 |        89 |        90 |        90 |        89 |        88 |      2056 |

<p>
</details>

<details><summary>Throughput (# / s): results within specified thresholds, fold down for details.</summary>
<p>

|          Throughput (# / s) (K)          |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |       267 |       252 |       238 |       231 |       229 |       225 |       217 |       240 |
|                  branch                  |      2665 |      2481 |      2277 |      2229 |      2185 |      2059 |      1806 |      2296 |
|                    Δ                     |      2398 |      2229 |      2039 |      1998 |      1956 |      1834 |      1589 |      2056 |
|              Improvement %               |       898 |       885 |       857 |       865 |       854 |       815 |       732 |      2056 |

<p>
</details>