### PR TITLE
[6.2] swift-testing test fixes

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -1081,7 +1081,7 @@ extension JSON5Scanner {
             jsonBytes.formIndex(after: &index)
         }
 
-        let cmp = jsonBytes[index..<endIndex].prefix(2).withUnsafePointer({ _stringshims_strncasecmp_l($0, "0x", $1, nil) })
+        let cmp = jsonBytes[index..<endIndex].prefix(2).withUnsafePointer({ _stringshims_strncasecmp_clocale($0, "0x", $1) })
         if cmp == 0 {
             jsonBytes.formIndex(&index, offsetBy: 2)
 

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -1179,7 +1179,7 @@ extension Double : PrevalidatedJSONNumberBufferConvertible {
     init?(prevalidatedBuffer buffer: BufferView<UInt8>) {
         let decodedValue = buffer.withUnsafePointer { nptr, count -> Double? in
             var endPtr: UnsafeMutablePointer<CChar>? = nil
-            let decodedValue = _stringshims_strtod_l(nptr, &endPtr, nil)
+            let decodedValue = _stringshims_strtod_clocale(nptr, &endPtr)
             if let endPtr, nptr.advanced(by: count) == endPtr {
                 return decodedValue
             } else {
@@ -1195,7 +1195,7 @@ extension Float : PrevalidatedJSONNumberBufferConvertible {
     init?(prevalidatedBuffer buffer: BufferView<UInt8>) {
         let decodedValue = buffer.withUnsafePointer { nptr, count -> Float? in
             var endPtr: UnsafeMutablePointer<CChar>? = nil
-            let decodedValue = _stringshims_strtof_l(nptr, &endPtr, nil)
+            let decodedValue = _stringshims_strtof_clocale(nptr, &endPtr)
             if let endPtr, nptr.advanced(by: count) == endPtr {
                 return decodedValue
             } else {

--- a/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
@@ -231,7 +231,7 @@ open class PropertyListDecoder {
         }
         
         return try buffer[unchecked: baseIdx..<idx].withUnsafePointer { ptr, encodingLength in
-            if encodingLength == 5, _stringshims_strncasecmp_l(ptr, "utf-8", 5, nil) == 0 {
+            if encodingLength == 5, _stringshims_strncasecmp_clocale(ptr, "utf-8", 5) == 0 {
                 return .utf8
             }
             

--- a/Sources/FoundationEssentials/PropertyList/XMLPlistScanner.swift
+++ b/Sources/FoundationEssentials/PropertyList/XMLPlistScanner.swift
@@ -645,7 +645,7 @@ extension XMLPlistMap.Value {
                     return .nan
                 }
             case (UInt8(ascii: "+"), 9):
-                if _stringshims_strncasecmp_l(buf.baseAddress, "+infinity", 9, nil) == 0 {
+                if _stringshims_strncasecmp_clocale(buf.baseAddress, "+infinity", 9) == 0 {
                     return .infinity
                 }
             case (UInt8(ascii: "+"), 4):
@@ -655,7 +655,7 @@ extension XMLPlistMap.Value {
                     return .infinity
                 }
             case (UInt8(ascii: "-"), 9):
-                if _stringshims_strncasecmp_l(buf.baseAddress, "-infinity", 9, nil) == 0 {
+                if _stringshims_strncasecmp_clocale(buf.baseAddress, "-infinity", 9) == 0 {
                     return .infinity * -1
                 }
             case (UInt8(ascii: "-"), 4):
@@ -665,7 +665,7 @@ extension XMLPlistMap.Value {
                     return .infinity * -1
                 }
             case (UInt8(ascii: "i"), 8), (UInt8(ascii: "I"), 8):
-                if _stringshims_strncasecmp_l(buf.baseAddress, "infinity", 8, nil) == 0 {
+                if _stringshims_strncasecmp_clocale(buf.baseAddress, "infinity", 8) == 0 {
                     return .infinity
                 }
             case (.none, 0):
@@ -728,9 +728,9 @@ extension XMLPlistMap.Value {
                 var parseEndPtr : UnsafeMutablePointer<CChar>?
                 let res : T
                 if MemoryLayout<T>.size == MemoryLayout<Float>.size {
-                    res = T(_stringshims_strtof_l(ptr, &parseEndPtr, nil))
+                    res = T(_stringshims_strtof_clocale(ptr, &parseEndPtr))
                 } else if MemoryLayout<T>.size == MemoryLayout<Double>.size {
-                    res = T(_stringshims_strtod_l(ptr, &parseEndPtr, nil))
+                    res = T(_stringshims_strtod_clocale(ptr, &parseEndPtr))
                 } else {
                     preconditionFailure("Only Float and Double are currently supported by PropertyListDecoder, not \(type))")
                 }

--- a/Sources/_FoundationCShims/include/string_shims.h
+++ b/Sources/_FoundationCShims/include/string_shims.h
@@ -37,11 +37,11 @@ extern "C" {
 #define locale_t void *
 #endif
 
-INTERNAL int _stringshims_strncasecmp_l(const char * _Nullable s1, const char * _Nullable s2, size_t n, locale_t _Nullable loc);
+INTERNAL int _stringshims_strncasecmp_clocale(const char * _Nullable s1, const char * _Nullable s2, size_t n);
 
-INTERNAL double _stringshims_strtod_l(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr, locale_t _Nullable loc);
+INTERNAL double _stringshims_strtod_clocale(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr);
 
-INTERNAL float _stringshims_strtof_l(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr, locale_t _Nullable loc);
+INTERNAL float _stringshims_strtof_clocale(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr);
 
 #define _STRINGSHIMS_MACROMAN_MAP_SIZE 129
 INTERNAL const uint8_t _stringshims_macroman_mapping[_STRINGSHIMS_MACROMAN_MAP_SIZE][3];

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -430,24 +430,21 @@ private struct NumberExtensionParseStrategyTests {
     }
 
     @Test func decimal_withFormat_localeDependent() throws {
-        guard Locale.autoupdatingCurrent.identifier == "en_US" else {
-            print("Your current locale is \(Locale.autoupdatingCurrent). Set it to en_US to run this test")
-            return
-        }
-        #expect(try Decimal("-3,000.14159", format: .number) == Decimal(-3000.14159))
-        #expect(try Decimal("-3.14159", format: .number) == Decimal(-3.14159))
-        #expect(try Decimal("12,345.678", format: .number) == Decimal(12345.678))
-        #expect(try Decimal("0.00", format: .number) == 0)
+        let locale = Locale(identifier: "en_US")
+        #expect(try Decimal("-3,000.14159", format: .number.locale(locale)) == Decimal(-3000.14159))
+        #expect(try Decimal("-3.14159", format: .number.locale(locale)) == Decimal(-3.14159))
+        #expect(try Decimal("12,345.678", format: .number.locale(locale)) == Decimal(12345.678))
+        #expect(try Decimal("0.00", format: .number.locale(locale)) == 0)
 
-        #expect(try Decimal("-3,000.14159%", format: .percent) == Decimal(-30.0014159))
-        #expect(try Decimal("-314.159%", format: .percent) == Decimal(-3.14159))
-        #expect(try Decimal("12,345.678%", format: .percent) == Decimal(123.45678))
-        #expect(try Decimal("0.00%", format: .percent) == 0)
+        #expect(try Decimal("-3,000.14159%", format: .percent.locale(locale)) == Decimal(-30.0014159))
+        #expect(try Decimal("-314.159%", format: .percent.locale(locale)) == Decimal(-3.14159))
+        #expect(try Decimal("12,345.678%", format: .percent.locale(locale)) == Decimal(123.45678))
+        #expect(try Decimal("0.00%", format: .percent.locale(locale)) == 0)
 
-        #expect(try Decimal("$12,345.00", format: .currency(code: "USD")) == Decimal(12345))
-        #expect(try Decimal("$12345.68", format: .currency(code: "USD")) == Decimal(12345.68))
-        #expect(try Decimal("$0.00", format: .currency(code: "USD")) == Decimal(0))
-        #expect(try Decimal("-$3000.0000014", format: .currency(code: "USD")) == Decimal(string: "-3000.0000014")!)
+        #expect(try Decimal("$12,345.00", format: .currency(code: "USD").locale(locale)) == Decimal(12345))
+        #expect(try Decimal("$12345.68", format: .currency(code: "USD").locale(locale)) == Decimal(12345.68))
+        #expect(try Decimal("$0.00", format: .currency(code: "USD").locale(locale)) == Decimal(0))
+        #expect(try Decimal("-$3000.0000014", format: .currency(code: "USD").locale(locale)) == Decimal(string: "-3000.0000014")!)
     }
 }
 


### PR DESCRIPTION
- **Explanation**: Cherry-picks two fixes made to account for issues introduced by swift-testing's parallelism back to 6.2
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Mostly impacts unit test code only, with a small impact to JSON/PropertyList decoding when parsing numbers
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Original PRs**: https://github.com/swiftlang/swift-foundation/pull/1428, https://github.com/swiftlang/swift-foundation/pull/1427
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low - mostly impacts unit tests and non-unit test impact has good coverage with extensive local testing
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: We've seen this failures stop appearing in mainline CI now that they've landed there for a few days, and we've done extensive local testing with these changes to ensure that the nondeterministic failures are eliminated
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @kperryua @itingliu 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
