### PR TITLE
Disable `nsICUNumberFormatterCache` test

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -56,7 +56,9 @@ private struct NumberFormatStyleTests {
         #expect(formatter_long.format(42 as Double) == "0,000,000,000,000,000,000,000,000,000,000,000,000,042")
     }
 
-#if !os(watchOS) // 99504292
+#if !os(watchOS) && FOUNDATION_FRAMEWORK // 99504292 && 155484008
+    // This test would fail if the cache is cleared while running the test
+    // But we still enable it for FOUNDATION_FRAMEWORK because it somehow still passes there
     @Test func nsICUNumberFormatterCache() throws {
 
         let intStyle = IntegerFormatStyle<Int64>(locale: Locale(identifier: "en_US"))


### PR DESCRIPTION
This test would fail if the cache is cleared while running the test. It could happen if the number of objects exceeds the internal limit.

For some reason we have not seen test failures when building for FOUNDATION_FRAMEWORK, so still leave it enabled there.

We should come back to re-write the test to be more reliable for all platforms regardless.
