### PR TITLE
Fallback to `argv[0]` for `ProcessInfo.processName` on platforms without specific APIs.

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -366,8 +366,10 @@ extension Platform {
             return String(decodingCString: lpBuffer.baseAddress!, as: UTF16.self)
         }
 #else
-        // TODO: Implement for other platforms
-        return nil
+        guard let processPath = CommandLine.arguments.first else {
+            return nil
+        }
+        return processPath.lastPathComponent
 #endif
     }
 }


### PR DESCRIPTION
WASI does not provide a specific API to retrieve the process name, so we used `CommandLine.arguments.first` for `ProcessInfo.processName`. After #1411, `CommandLine.arguments.first` started using platform-specific APIs to retrieve the process name, but the fallback path with `argv[0]` was removed. This commit restores that fallback for platforms like WASI.