### PR TITLE
Fix Platform.getFullExecutablePath for platforms with no file system

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -365,11 +365,13 @@ extension Platform {
             }
             return String(decodingCString: lpBuffer.baseAddress!, as: UTF16.self)
         }
-#else
+#elseif !NO_FILESYSTEM
         guard let processPath = CommandLine.arguments.first else {
             return nil
         }
         return processPath.lastPathComponent
+#else
+        return nil
 #endif
     }
 }


### PR DESCRIPTION
`CommandLine` is not available on platforms with no file system. Return `nil` in these cases

Resolves: rdar://156436329