### PR TITLE
Add 6.3 as an allowed availability version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ list(APPEND _SwiftFoundation_versions
     "6.0.2"
     "6.1"
     "6.2"
+    "6.3"
     )
 
 # Each availability name to define

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import CompilerPluginSupport
 let availabilityTags: [_Availability] = [
     _Availability("FoundationPreview"), // Default FoundationPreview availability
 ]
-let versionNumbers = ["6.0.2", "6.1", "6.2"]
+let versionNumbers = ["6.0.2", "6.1", "6.2", "6.3"]
 
 // Availability Macro Utilities
 


### PR DESCRIPTION
Now that we're focusing main branch development on the next release, this adds the ability to write `FoundationPreview 6.3` in code for declarations targeting the next swift release