### PR TITLE
Keep executable path

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -366,12 +366,10 @@ extension Platform {
             return String(decodingCString: lpBuffer.baseAddress!, as: UTF16.self)
         }
 #elseif !NO_FILESYSTEM
-        guard let processPath = CommandLine.arguments.first else {
-            return nil
+        if let processPath = CommandLine.arguments.first {
+            return processPath
         }
-        return processPath.lastPathComponent
-#else
-        return nil
 #endif
+    return nil
     }
 }


### PR DESCRIPTION
The Swift driver uses the location of the driver to search for other binaries including the swift-frontend, legacy driver, etc... Dropping the filepath means that we lose this information and search from the current working directory instead of where the driver exists, which then results in the driver failing.

This broke the FreeBSD job: `error: unknown or missing subcommand 'swiftc-legacy-driver'`