### PR TITLE
[CI] Enable Wasm SDK build in swift-foundation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,8 @@ jobs:
       enable_macos_checks: false
       macos_xcode_versions: '["16.3"]'
       macos_versions: '["sequoia"]'
+      enable_wasm_sdk_build: true
+      wasm_sdk_versions: '["nightly-main"]'
 
   cmake_build:
     name: Build (CMake)


### PR DESCRIPTION
Now that `swiftlang/github-workflows` supports building with the Swift Wasm SDK in https://github.com/swiftlang/github-workflows/pull/142, we can enable the job in swift-foundation to prevent WASI build regressions.