### PR TITLE
build: Install libraries in an `arch` sub-folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
     endif()
 endif()
 
+option(SwiftFoundation_INSTALL_ARCH_SUBDIR "Install libraries under an architecture subdirectory" NO)
+
 include(GNUInstallDirs)
 include(SwiftFoundationSwiftSupport)
 

--- a/Sources/_FoundationCShims/CMakeLists.txt
+++ b/Sources/_FoundationCShims/CMakeLists.txt
@@ -44,8 +44,8 @@ install(DIRECTORY
 
 if(NOT BUILD_SHARED_LIBS)
     install(TARGETS _FoundationCShims
-        ARCHIVE DESTINATION lib/${install_directory}/${SwiftFoundation_PLATFORM}/${SwiftFoundation_ARCH}
-        LIBRARY DESTINATION lib/${install_directory}/${SwiftFoundation_PLATFORM}/${SwiftFoundation_ARCH}
+        ARCHIVE DESTINATION lib/${install_directory}/${SwiftFoundation_PLATFORM}$<$<BOOL:${SwiftFoundation_INSTALL_ARCH_SUBDIR}>:/${SwiftFoundation_ARCH}>
+        LIBRARY DESTINATION lib/${install_directory}/${SwiftFoundation_PLATFORM}$<$<BOOL:${SwiftFoundation_INSTALL_ARCH_SUBDIR}>:/${SwiftFoundation_ARCH}>
         RUNTIME DESTINATION bin)
 endif()
 

--- a/cmake/modules/SwiftFoundationSwiftSupport.cmake
+++ b/cmake/modules/SwiftFoundationSwiftSupport.cmake
@@ -70,8 +70,8 @@ function(_swift_foundation_install_target module)
   endif()
 
   install(TARGETS ${module}
-    ARCHIVE DESTINATION lib/${swift}/${SwiftFoundation_PLATFORM}/${SwiftFoundation_ARCH}
-    LIBRARY DESTINATION lib/${swift}/${SwiftFoundation_PLATFORM}/${SwiftFoundation_ARCH}
+    ARCHIVE DESTINATION lib/${swift}/${SwiftFoundation_PLATFORM}$<$<BOOL:${SwiftFoundation_INSTALL_ARCH_SUBDIR}>:/${SwiftFoundation_ARCH}>
+    LIBRARY DESTINATION lib/${swift}/${SwiftFoundation_PLATFORM}$<$<BOOL:${SwiftFoundation_INSTALL_ARCH_SUBDIR}>:/${SwiftFoundation_ARCH}>
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   if(type STREQUAL EXECUTABLE)
     return()


### PR DESCRIPTION
This is the proper installation scheme for Swift libraries on Windows and prevents having to manually copy them in `build.ps1`.