### PR TITLE
Fix visionOS availability of `Span`

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2203,7 +2203,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         return try _representation.withUnsafeBytes(body)
     }
 
-    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1, *)
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var bytes: RawSpan {
         @lifetime(borrow self)
@@ -2231,7 +2231,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
     }
 
-    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1, *)
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var span: Span<UInt8> {
         @lifetime(borrow self)
@@ -2241,7 +2241,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
     }
 
-    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1, *)
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var mutableBytes: MutableRawSpan {
         @lifetime(&self)
@@ -2269,7 +2269,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
     }
 
-    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1, *)
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var mutableSpan: MutableSpan<UInt8> {
         @lifetime(&self)


### PR DESCRIPTION
It is available from visionOS 1.0, as fixed in
https://github.com/swiftlang/swift/pull/82850

This requires swift-DEVELOPMENT-SNAPSHOT-2025-07-17-a or swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-09-a.

Addresses https://github.com/swiftlang/swift-foundation/issues/1419