### PR TITLE
Prevent encodingDateFormatted() from using the current internationalization preferences

### DIFF
--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -2896,6 +2896,11 @@ extension JSONEncoderTests {
         let formatter = DateFormatter()
         formatter.dateStyle = .full
         formatter.timeStyle = .full
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .gmt
+        formatter.calendar = cal
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.timeZone = .gmt
 
         let timestamp = Date(timeIntervalSince1970: 1000)
         let expectedJSON = "\"\(formatter.string(from: timestamp))\"".data(using: .utf8)!


### PR DESCRIPTION
This test may run at the same time as other tests that change the current locale/calendar/timezone. To ensure that doesn't interfere with this test, we should explicitly set the locale/calendar/timezone of the date formatter in use.