### PR TITLE
Cleanup FoundationMacros availability checks

### DIFF
--- a/Tests/FoundationMacrosTests/MacroTestUtilities.swift
+++ b/Tests/FoundationMacrosTests/MacroTestUtilities.swift
@@ -47,9 +47,9 @@ struct DiagnosticTest : ExpressibleByStringLiteral, Hashable, CustomStringConver
     
     var mappedToExpression: Self {
         DiagnosticTest(
-            message._replacing("Predicate", with: "Expression")._replacing("predicate", with: "expression"),
+            message.replacing("Predicate", with: "Expression").replacing("predicate", with: "expression"),
             fixIts: fixIts.map {
-                FixItTest($0.message, result: $0.result._replacing("#Predicate", with: "#Expression"))
+                FixItTest($0.message, result: $0.result.replacing("#Predicate", with: "#Expression"))
             }
         )
     }
@@ -100,7 +100,7 @@ extension Diagnostic {
         } else {
             var result = "Message: \(debugDescription)\nFix-Its:\n"
             for fixIt in fixIts {
-                result += "\t\(fixIt.message.message)\n\t\(fixIt.changes.first!._result._replacing("\n", with: "\n\t"))"
+                result += "\t\(fixIt.message.message)\n\t\(fixIt.changes.first!._result.replacing("\n", with: "\n\t"))"
             }
             return result
         }
@@ -114,7 +114,7 @@ extension DiagnosticTest {
         } else {
             var result = "Message: \(message)\nFix-Its:\n"
             for fixIt in fixIts {
-                result += "\t\(fixIt.message)\n\t\(fixIt.result._replacing("\n", with: "\n\t"))"
+                result += "\t\(fixIt.message)\n\t\(fixIt.result.replacing("\n", with: "\n\t"))"
             }
             return result
         }
@@ -164,21 +164,9 @@ func AssertPredicateExpansion(_ source: String, _ result: String = "", diagnosti
     )
     AssertMacroExpansion(
         macros: ["Expression" : FoundationMacros.ExpressionMacro.self],
-        source._replacing("#Predicate", with: "#Expression"),
-        result._replacing(".Predicate", with: ".Expression"),
+        source.replacing("#Predicate", with: "#Expression"),
+        result.replacing(".Predicate", with: ".Expression"),
         diagnostics: Set(diagnostics.map(\.mappedToExpression)),
         sourceLocation: sourceLocation
     )
-}
-
-extension String {
-    func _replacing(_ text: String, with other: String) -> Self {
-        if #available(macOS 13.0, *) {
-            // Use the stdlib API if available
-            self.replacing(text, with: other)
-        } else {
-            // Use the Foundation API on older OSes
-            self.replacingOccurrences(of: text, with: other, options: [.literal])
-        }
-    }
 }

--- a/Tests/FoundationMacrosTests/PredicateMacroUsageTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroUsageTests.swift
@@ -21,14 +21,12 @@ import Foundation
 fileprivate func _blackHole<T>(_ t: T) {}
 
 @inline(never)
-@available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 fileprivate func _blackHoleExplicitInput(_ predicate: Predicate<Int>) {}
 
 // MARK: - Tests
 
 @Suite("#Predicate Macro Usage")
 private struct PredicateMacroUsageTests {
-    @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
     @Test func usage() {
         _blackHole(#Predicate<Bool> {
             return $0


### PR DESCRIPTION
We no longer have any scenarios where we need to build the macro for a host older than macOS 14 so we can cleanup some of the availability checks in the macros target to assume a macOS 14 deployment target