### PR TITLE
Fix crash when using keypaths on final classes in Predicates

### DIFF
--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -310,6 +310,13 @@ private struct PredicateTests {
             $0.a == $0.c && $0.b == now
         }
     }
+    
+    @Test func finalKeyPaths() {
+        final class Foo {
+            var id: Int = 1
+        }
+        _ = #Predicate<Foo> { $0.id == 2 }
+    }
 
     @Test
     func regex() throws {


### PR DESCRIPTION
This predicate code validates that the provided `KeyPath` only contains a single component. Originally, for stored property components, this code checked the payload value to see if it was an inline offset or the out-of-line sentinel defined by the [KeyPath ABI documentation](https://github.com/swiftlang/swift/blob/main/docs/ABI/KeyPaths.md) to determine if the buffer size matches the expected single component buffer size. However, this document was determined to be incorrect and there are actually  [multiple sentinel values](https://github.com/swiftlang/swift/blob/d837d6052cf5403644e14956ee4376454ad633bd/stdlib/public/SwiftShims/swift/shims/KeyPath.h#L70-L77) defined. https://github.com/swiftlang/swift-foundation/pull/216 attempted to correct this by switching to `MemoryLayout.offset(of:)` to check for a single stored property component. However, `MemoryLayout.offset(of:)` is also not an appropriate way to check for a single stored property component as not all single stored components have offsets (for example, a property in a final class).

This changes the implementation back to the original style of check before https://github.com/swiftlang/swift-foundation/pull/216 but with a corrected check for whether the offset is stored inline (based on the existence of multiple sentinel values and the max inline offset defined [here](https://github.com/swiftlang/swift/blob/d837d6052cf5403644e14956ee4376454ad633bd/stdlib/public/SwiftShims/swift/shims/KeyPath.h#L67-L68)). This fixes the regression caused for final class properties while still ensuring that we respect other sentinel values as well.

Resolves https://github.com/swiftlang/swift-foundation/issues/1173