### PR TITLE
Add predicate keypath assertion exit tests

### DIFF
--- a/Sources/FoundationEssentials/Predicate/KeyPath+Inspection.swift
+++ b/Sources/FoundationEssentials/Predicate/KeyPath+Inspection.swift
@@ -50,7 +50,7 @@ extension UInt32 {
 extension AnyKeyPath {
     private static var WORD_SIZE: Int { MemoryLayout<Int>.size }
     
-    func _validateForPredicateUsage(restrictArguments: Bool = false) {
+    func _validateForPredicateUsage(restrictArguments: Bool = true) {
         var ptr = unsafeBitCast(self, to: UnsafeRawPointer.self)
         ptr = ptr.advanced(by: Self.WORD_SIZE * 3) // skip isa, type metadata, and KVC string pointers
         let header = ptr.load(as: UInt32.self)


### PR DESCRIPTION
As a followup to https://github.com/swiftlang/swift-foundation/pull/1475, this adds exit tests to validate situations when we _should_ be preventing usage of a particular keypath (specifically, when a keypath is multiple components or when it represents optional chaining or subscripts).

Adding these tests uncovered that the default value of `restrictArguments` in `_validatedForPredicateUsage` was incorrect and that we weren't actually validating that subscripts with arguments can't be used. In addition to adding these tests, this fixes the default value of this argument so that in cases where we don't expect arguments we enforce that they cannot be used.