### PR TITLE
Improve performance of JSONDecoder and JSONEncoder for large apps

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -1857,8 +1857,8 @@ extension EncodingError {
      }
  }
 
-extension JSONDecoder.KeyDecodingStrategy {
-    fileprivate var isDefault: Bool {
+fileprivate extension JSONDecoder.KeyDecodingStrategy {
+    var isDefault: Bool {
         switch self {
         case .useDefaultKeys: true
         default: false

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -1503,7 +1503,7 @@ extension Array : _JSONDirectArrayEncodable where Element: _JSONSimpleValueArray
     }
 }
 
-private extension JSONEncoder.KeyEncodingStrategy {
+fileprivate extension JSONEncoder.KeyEncodingStrategy {
     var isDefault: Bool {
         switch self {
         case .useDefaultKeys:


### PR DESCRIPTION
In short: `T.self is _JSONStringDictionaryDecodableMarker.Type`, `value as? _JSONStringDictionaryEncodableMarker` and `value as? _JSONDirectArrayEncodable` are really slow operations. And the bigger binary gets the slower this check works for the first time for each pair of `class/struct/enum` and protocol.

But checking whether current type conforms to `_JSONStringDictionaryDecodableMarker` and `_JSONStringDictionaryEncodableMarker` is needed only when we use custom keyDecoding/EncodingStrategy. Comments in code confirm this:

```swift
/// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
/// containing `Decodable` values (in which case it should be exempt from key conversion strategies).
///
/// The marker protocol also provides access to the type of the `Decodable` values,
/// which is needed for the implementation of the key conversion strategy exemption.
private protocol _JSONStringDictionaryDecodableMarker {
    static var elementType: Decodable.Type { get }
}
```

```swift
/// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
/// containing `Encodable` values (in which case it should be exempt from key conversion strategies).
private protocol _JSONStringDictionaryEncodableMarker { }
```

So we can easily skip this checks when default keyDecoding/EncodingStrategy is used.

For details: see this issue: https://github.com/swiftlang/swift-foundation/issues/1480