### PR TITLE
Fix crash when creating predicate with generic root type

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -310,7 +310,7 @@ extension PredicateCodableConfiguration {
             guard root == rootReflectionType.partial, let constructed = constructor(rootReflectionType.genericArguments) else {
                 return nil
             }
-            constructed._validateForPredicateUsage(restrictArguments: false)
+            constructed._validateForPredicateUsage()
             return constructed
         }
     }

--- a/Sources/FoundationEssentials/Predicate/KeyPath+Inspection.swift
+++ b/Sources/FoundationEssentials/Predicate/KeyPath+Inspection.swift
@@ -50,7 +50,7 @@ extension UInt32 {
 extension AnyKeyPath {
     private static var WORD_SIZE: Int { MemoryLayout<Int>.size }
     
-    func _validateForPredicateUsage(restrictArguments: Bool = true) {
+    func _validateForPredicateUsage() {
         var ptr = unsafeBitCast(self, to: UnsafeRawPointer.self)
         ptr = ptr.advanced(by: Self.WORD_SIZE * 3) // skip isa, type metadata, and KVC string pointers
         let header = ptr.load(as: UInt32.self)
@@ -72,9 +72,7 @@ extension AnyKeyPath {
                 componentWords += 1
             }
             if firstComponentHeader._keyPathComponentHeader_computedHasArguments {
-                if restrictArguments {
-                    fatalError("Predicate does not support keypaths with arguments")
-                }
+                // TODO: Ensure KeyPath only contains generic arguments and not subscript arguments (https://github.com/swiftlang/swift-foundation/issues/1482)
                 let capturesSize = ptr.advanced(by: Self.WORD_SIZE * componentWords).load(as: UInt.self)
                 componentWords += 2 + (Int(capturesSize) / Self.WORD_SIZE)
             }


### PR DESCRIPTION
`KeyPath`s used in predicates with a computed component can contain two types of arguments:

1. Concrete values passed as parameters to subscripts
2. Generic arguments used to satisfy generic constraints of a property

`Predicate` can support generic arguments, but not concrete values passed to subscripts (the subscript predicate expression should be used instead). When originally writing this code, I had conflated the two concepts as one and introduced the `restrictArguments` flag to work around cases where code accidentally asserted eagerly for only generic arguments. However, I also accidentally defaulted the argument to `false` so the assertion never ran. As part of https://github.com/swiftlang/swift-foundation/pull/1476 I set the default value to `true` correcting this mistake. Unfortunately, since the assertion conflates the two types of arguments, the assertion trips incorrectly in some existing client code (`Predicate`s created where the root type is generic and therefore property access provides a generic argument in the key path). For now, to fix this regression, this removes the `restrictArguments` parameter and removes the assertion altogether. In the long term, we should followup with a fix that adds this assertion back with improved validation logic not based on a `restrictArguments` parameter but rather based on other contents in the keypath to distinguish between the two types of arguments (tracked by https://github.com/swiftlang/swift-foundation/issues/1482 - I think this is something we should do as a followup since its implementation requires more testing and either requires a new C shim or some even more hacky workarounds).