### PR TITLE
Update package dependencies to release/6.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
     message(STATUS "_SwiftFoundationICU_SourceDIR not provided, checking out local copy of swift-foundation-icu")
     FetchContent_Declare(SwiftFoundationICU
         GIT_REPOSITORY https://github.com/apple/swift-foundation-icu.git
-        GIT_TAG main)
+        GIT_TAG release/6.2)
 endif()
 
 if (_SwiftCollections_SourceDIR)

--- a/Package.swift
+++ b/Package.swift
@@ -60,10 +60,10 @@ var dependencies: [Package.Dependency] {
                 from: "1.1.0"),
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
-                branch: "main"),
+                branch: "release/6.2"),
             .package(
                 url: "https://github.com/swiftlang/swift-syntax",
-                branch: "main")
+                branch: "release/6.2")
         ]
     }
 }

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT SwiftSyntax_FOUND)
     # If building at desk, check out and link against the SwiftSyntax repo's targets
     FetchContent_Declare(SwiftSyntax
         GIT_REPOSITORY https://github.com/swiftlang/swift-syntax.git
-        GIT_TAG main)
+        GIT_TAG release/6.2)
     FetchContent_MakeAvailable(SwiftSyntax)
 else()
   message(STATUS "SwiftSyntax_DIR provided, using swift-syntax from ${SwiftSyntax_DIR}")


### PR DESCRIPTION
The `release/6.2` branch of this repo requires the `release/6.2` branch of its dependencies (it is not compatible with the `main` branch of swift-foundation-icu). This updates the dependencies used for local builds and this repo's CI to the appropriate branches for this release branch