### PR TITLE
TimeZone, Calendar, and Locale disagree on how `.current` is serialized

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale_Preferences.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Preferences.swift
@@ -453,13 +453,9 @@ extension LocalePreferences: Codable {
             }
             return result as CFDictionary
         }
-        var icuSymbolsAndStrings = try container.decodeIfPresent(ICUSymbolsAndStrings.self, forKey: .icuSymbolsAndStrings)
-        if (icuDateFormats != nil || icuNumberSymbols != nil) && icuSymbolsAndStrings == nil {
-            // Ensure that we have a value to store these in even if the archive didn't contain any serialized info
-            icuSymbolsAndStrings = ICUSymbolsAndStrings()
-        }
-        icuSymbolsAndStrings?.icuDateFormatStrings = icuDateFormats
-        icuSymbolsAndStrings?.icuNumberSymbols = icuNumberSymbols
+        var icuSymbolsAndStrings = try container.decodeIfPresent(ICUSymbolsAndStrings.self, forKey: .icuSymbolsAndStrings) ?? ICUSymbolsAndStrings()
+        icuSymbolsAndStrings.icuDateFormatStrings = icuDateFormats
+        icuSymbolsAndStrings.icuNumberSymbols = icuNumberSymbols
         
         self.init(
             metricUnits: metricUnits,
@@ -475,7 +471,7 @@ extension LocalePreferences: Codable {
             force12Hour: force12Hour,
             numberSymbols: numberSymbols,
             dateFormats: dateFormats,
-            icuSymbolsAndStrings: icuSymbolsAndStrings ?? .init()
+            icuSymbolsAndStrings: icuSymbolsAndStrings
         )
         #else
         self.init(

--- a/Sources/FoundationEssentials/Locale/Locale_Preferences.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Preferences.swift
@@ -17,7 +17,7 @@ internal import _ForSwiftFoundation
 
 /// Holds user preferences about `Locale`, retrieved from user defaults. It is only used when creating the `current` Locale. Fixed-identifier locales never have preferences.
 package struct LocalePreferences: Hashable, Sendable {
-    package enum MeasurementUnit {
+    package enum MeasurementUnit: Int, Codable {
         case centimeters
         case inches
 
@@ -38,7 +38,7 @@ package struct LocalePreferences: Hashable, Sendable {
         }
     }
 
-    package enum TemperatureUnit {
+    package enum TemperatureUnit: Int, Codable {
         case fahrenheit
         case celsius
 
@@ -66,7 +66,7 @@ package struct LocalePreferences: Hashable, Sendable {
     package var firstWeekday: [Calendar.Identifier : Int]?
     package var minDaysInFirstWeek: [Calendar.Identifier : Int]?
 #if FOUNDATION_FRAMEWORK
-    struct ICUSymbolsAndStrings : Hashable, @unchecked Sendable {
+    package struct ICUSymbolsAndStrings : Hashable, @unchecked Sendable {
         // The following `CFDictionary` ivars are used directly by `CFDateFormatter`. Keep them as `CFDictionary` to avoid bridging them into and out of Swift. We don't need to access them from Swift at all.
         
         package var icuDateTimeSymbols: CFDictionary?
@@ -91,6 +91,8 @@ package struct LocalePreferences: Hashable, Sendable {
     package var temperatureUnit: TemperatureUnit?
     package var force24Hour: Bool?
     package var force12Hour: Bool?
+    
+    // Note: When adding new preferences, be sure to include them in the serialized format via the Codable conformance below
 
     package init() { }
     
@@ -108,7 +110,8 @@ package struct LocalePreferences: Hashable, Sendable {
          force24Hour: Bool? = nil,
          force12Hour: Bool? = nil,
          numberSymbols: [UInt32 : String]? = nil,
-         dateFormats: [Date.FormatStyle.DateStyle: String]? = nil) {
+         dateFormats: [Date.FormatStyle.DateStyle: String]? = nil,
+         icuSymbolsAndStrings: ICUSymbolsAndStrings = ICUSymbolsAndStrings()) {
 
         self.metricUnits = metricUnits
         self.languages = languages
@@ -123,6 +126,7 @@ package struct LocalePreferences: Hashable, Sendable {
         self.force12Hour = force12Hour
         self.numberSymbols = numberSymbols
         self.dateFormats = dateFormats
+        self.icuSymbolsAndStrings = icuSymbolsAndStrings
     }
 #else
     package init(metricUnits: Bool? = nil,
@@ -331,3 +335,196 @@ package struct LocalePreferences: Hashable, Sendable {
         }
     }
 }
+
+extension LocalePreferences: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case metricUnits = "metric"
+        case languages = "langs"
+        case locale
+        case collationOrder = "coll"
+        case firstWeekday = "weekFirst"
+        case minDaysInFirstWeek = "weekMin"
+        case icuSymbolsAndStrings = "icu"
+        case dateFormats = "dates"
+        case numberSymbols = "nums"
+        case country
+        case measurementUnits = "meas"
+        case temperatureUnit = "temp"
+        case force24Hour = "24h"
+        case force12Hour = "12h"
+    }
+    
+    package func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(metricUnits, forKey: .metricUnits)
+        try container.encodeIfPresent(languages, forKey: .languages)
+        try container.encodeIfPresent(locale, forKey: .locale)
+        try container.encodeIfPresent(collationOrder, forKey: .collationOrder)
+        let firstWeekdayMapped = self.firstWeekday.map {
+            var result = [String : Int]()
+            for (identifier, day) in $0 {
+                result[identifier.cfCalendarIdentifier] = day
+            }
+            return result
+        }
+        try container.encodeIfPresent(firstWeekdayMapped, forKey: .firstWeekday)
+        let minDaysInFirstWeekMapped = self.minDaysInFirstWeek.map {
+            var result = [String : Int]()
+            for (identifier, days) in $0 {
+                result[identifier.cldrIdentifier] = days
+            }
+            return result
+        }
+        try container.encodeIfPresent(minDaysInFirstWeekMapped, forKey: .minDaysInFirstWeek)
+#if FOUNDATION_FRAMEWORK
+        if icuSymbolsAndStrings.containsValuesToSerialize {
+            try container.encodeIfPresent(icuSymbolsAndStrings, forKey: .icuSymbolsAndStrings)
+        }
+#if !NO_FORMATTERS
+        try container.encodeIfPresent(dateFormats.map {
+            var result = [UInt : String]()
+            for (format, value) in $0 {
+                result[format.rawValue] = value
+            }
+            return result
+        }, forKey: .dateFormats)
+#endif
+#endif
+        try container.encodeIfPresent(numberSymbols, forKey: .numberSymbols)
+        try container.encodeIfPresent(country, forKey: .country)
+        try container.encodeIfPresent(measurementUnits, forKey: .measurementUnits)
+        try container.encodeIfPresent(temperatureUnit, forKey: .temperatureUnit)
+        try container.encodeIfPresent(force24Hour, forKey: .force24Hour)
+        try container.encodeIfPresent(force12Hour, forKey: .force12Hour)
+    }
+    
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let metricUnits = try container.decodeIfPresent(Bool.self, forKey: .metricUnits)
+        let languages = try container.decodeIfPresent([String].self, forKey: .languages)
+        let locale = try container.decodeIfPresent(String.self, forKey: .locale)
+        let collationOrder = try container.decodeIfPresent(String.self, forKey: .collationOrder)
+        let firstWeekday = try container.decodeIfPresent([String : Int].self, forKey: .firstWeekday).map {
+            var result = [Calendar.Identifier : Int]()
+            for (stringIdentifier, day) in $0 {
+                guard let identifier = Calendar.Identifier(identifierString: stringIdentifier) else {
+                    throw DecodingError.dataCorruptedError(forKey: .firstWeekday, in: container, debugDescription: "Unknown calendar identifier '\(stringIdentifier)'")
+                }
+                result[identifier] = day
+            }
+            return result
+        }
+        let minDaysInFirstWeek = try container.decodeIfPresent([String : Int].self, forKey: .minDaysInFirstWeek).map {
+            var result = [Calendar.Identifier : Int]()
+            for (stringIdentifier, days) in $0 {
+                guard let identifier = Calendar.Identifier(identifierString: stringIdentifier) else {
+                    throw DecodingError.dataCorruptedError(forKey: .minDaysInFirstWeek, in: container, debugDescription: "Unknown calendar identifier '\(stringIdentifier)'")
+                }
+                result[identifier] = days
+            }
+            return result
+        }
+        let country = try container.decodeIfPresent(String.self, forKey: .country)
+        let measurementUnits = try container.decodeIfPresent(MeasurementUnit.self, forKey: .measurementUnits)
+        let temperatureUnit = try container.decodeIfPresent(TemperatureUnit.self, forKey: .temperatureUnit)
+        let force24Hour = try container.decodeIfPresent(Bool.self, forKey: .force24Hour)
+        let force12Hour = try container.decodeIfPresent(Bool.self, forKey: .force12Hour)
+        let numberSymbols = try container.decodeIfPresent([UInt32 : String].self, forKey: .numberSymbols)
+        
+        #if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
+        let dateFormats = try container.decodeIfPresent([UInt: String].self, forKey: .dateFormats).map {
+            var result = [Date.FormatStyle.DateStyle : String]()
+            for (rawValue, format) in $0 {
+                result[Date.FormatStyle.DateStyle(rawValue: rawValue)] = format
+            }
+            return result
+        }
+        let icuDateFormats = dateFormats.map {
+            var cfResult = [String : String]()
+            for (style, format) in $0 {
+                cfResult["\(style.rawValue)"] = format
+            }
+            return cfResult as CFDictionary
+        }
+        let icuNumberSymbols = numberSymbols.map {
+            var result = [String : String]()
+            for (rawValue, symbol) in $0 {
+                result["\(rawValue)"] = symbol
+            }
+            return result as CFDictionary
+        }
+        var icuSymbolsAndStrings = try container.decodeIfPresent(ICUSymbolsAndStrings.self, forKey: .icuSymbolsAndStrings)
+        if (icuDateFormats != nil || icuNumberSymbols != nil) && icuSymbolsAndStrings == nil {
+            // Ensure that we have a value to store these in even if the archive didn't contain any serialized info
+            icuSymbolsAndStrings = ICUSymbolsAndStrings()
+        }
+        icuSymbolsAndStrings?.icuDateFormatStrings = icuDateFormats
+        icuSymbolsAndStrings?.icuNumberSymbols = icuNumberSymbols
+        
+        self.init(
+            metricUnits: metricUnits,
+            languages: languages,
+            locale: locale,
+            collationOrder: collationOrder,
+            firstWeekday: firstWeekday,
+            minDaysInFirstWeek: minDaysInFirstWeek,
+            country: country,
+            measurementUnits: measurementUnits,
+            temperatureUnit: temperatureUnit,
+            force24Hour: force24Hour,
+            force12Hour: force12Hour,
+            numberSymbols: numberSymbols,
+            dateFormats: dateFormats,
+            icuSymbolsAndStrings: icuSymbolsAndStrings ?? .init()
+        )
+        #else
+        self.init(
+            metricUnits: metricUnits,
+            languages: languages,
+            locale: locale,
+            collationOrder: collationOrder,
+            firstWeekday: firstWeekday,
+            minDaysInFirstWeek: minDaysInFirstWeek,
+            country: country,
+            measurementUnits: measurementUnits,
+            temperatureUnit: temperatureUnit,
+            force24Hour: force24Hour,
+            force12Hour: force12Hour,
+            numberSymbols: numberSymbols
+        )
+        #endif
+    }
+}
+
+#if FOUNDATION_FRAMEWORK
+extension LocalePreferences.ICUSymbolsAndStrings: Codable {
+    var containsValuesToSerialize: Bool {
+        icuDateTimeSymbols != nil || icuTimeFormatStrings != nil || icuNumberFormatStrings != nil
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case icuDateTimeSymbols = "dtSym"
+        case icuTimeFormatStrings = "times"
+        case icuNumberFormatStrings = "nums"
+    }
+    
+    package func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(icuDateTimeSymbols.map { $0 as? [String : [String]] }, forKey: .icuDateTimeSymbols)
+        try container.encodeIfPresent(icuTimeFormatStrings.map { $0 as? [String : String] }, forKey: .icuTimeFormatStrings)
+        try container.encodeIfPresent(icuNumberFormatStrings.map { $0 as? [String : String] }, forKey: .icuNumberFormatStrings)
+    }
+    
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.icuDateTimeSymbols = try container.decodeIfPresent([String : [String]].self, forKey: .icuDateTimeSymbols).map { $0 as CFDictionary }
+        self.icuTimeFormatStrings = try container.decodeIfPresent([String : String].self, forKey: .icuTimeFormatStrings).map { $0 as CFDictionary }
+        self.icuNumberFormatStrings = try container.decodeIfPresent([String : String].self, forKey: .icuNumberFormatStrings).map { $0 as CFDictionary }
+        
+        // Will be filled in by LocalePreferences serialized value
+        self.icuDateFormatStrings = nil
+        self.icuNumberSymbols = nil
+    }
+}
+#endif

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -335,6 +335,9 @@ extension TimeZone : Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         // Even if we are autoupdatingCurrent, encode the identifier for backward compatibility
         try container.encode(self.identifier, forKey: .identifier)
+        
+        // Autoupdating current timezones are treated as sentinel values, but the current TimeZone is encoded as a fixed TimeZone
+        // This is the same behavior as Locale/Calendar except it did not previously encode as a sentinel value before FoundationPreview 6.3, so no extra key is encoded for the current time zone
         if _tz.isAutoupdating {
             try container.encode(true, forKey: .autoupdating)
         }

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -100,6 +100,13 @@ struct TimeZoneCache : Sendable, ~Copyable {
 #endif
             return oldTimeZone
         }
+        
+        mutating func resetCurrent(to newValue: TimeZone) {
+            currentTimeZone = newValue
+#if FOUNDATION_FRAMEWORK
+            bridgedCurrentTimeZone = nil
+#endif
+        }
 
         /// Reads from environment variables `TZFILE`, `TZ` and finally the symlink pointed at by the C macro `TZDEFAULT` to figure out what the current (aka "system") time zone is.
         mutating func findCurrentTimeZone() -> TimeZone {
@@ -397,6 +404,10 @@ struct TimeZoneCache : Sendable, ~Copyable {
 
     func reset() -> TimeZone? {
         return lock.withLock { $0.reset() }
+    }
+    
+    func resetCurrent(to newValue: TimeZone) {
+        return lock.withLock { $0.resetCurrent(to: newValue) }
     }
 
     var current: TimeZone {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -26,6 +26,42 @@ private struct GregorianCalendarRecurrenceRuleTests {
         gregorian.timeZone = .gmt
         return gregorian
     }()
+  
+    @Test func roundtripEncoding() throws {
+        // These are not necessarily valid recurrence rule, they are constructed
+        // in a way to test all encoding paths
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = .init(identifier: "en_001")
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        
+        var recurrenceRule1 = Calendar.RecurrenceRule(calendar: calendar, frequency: .daily)
+        recurrenceRule1.interval = 2
+        recurrenceRule1.months = [1, 2, Calendar.RecurrenceRule.Month(4, isLeap: true)]
+        recurrenceRule1.weeks = [2, 3]
+        recurrenceRule1.weekdays = [.every(.monday), .nth(1, .wednesday)]
+        recurrenceRule1.end = .afterOccurrences(5)
+        
+        var recurrenceRule2 = Calendar.RecurrenceRule(calendar: calendar, frequency: .daily)
+        recurrenceRule2.months = [2, 10]
+        recurrenceRule2.weeks = [1, -1]
+        recurrenceRule2.setPositions = [1]
+        recurrenceRule2.hours = [14]
+        recurrenceRule2.minutes = [30]
+        recurrenceRule2.seconds = [0]
+        recurrenceRule2.daysOfTheYear = [1]
+        recurrenceRule2.daysOfTheMonth = [4]
+        recurrenceRule2.weekdays = [.every(.monday), .nth(1, .wednesday)]
+        recurrenceRule2.end = .afterDate(.distantFuture)
+        
+        let recurrenceRule1JSON = try JSONEncoder().encode(recurrenceRule1)
+        let recurrenceRule2JSON = try JSONEncoder().encode(recurrenceRule2)
+        let decoded1 = try JSONDecoder().decode(Calendar.RecurrenceRule.self, from: recurrenceRule1JSON)
+        let decoded2 = try JSONDecoder().decode(Calendar.RecurrenceRule.self, from: recurrenceRule2JSON)
+        
+        #expect(recurrenceRule1 == decoded1)
+        #expect(recurrenceRule2 == decoded2)
+        #expect(recurrenceRule1 != recurrenceRule2)
+    }
     
     @Test func simpleDailyRecurrence() {
         let start = Date(timeIntervalSince1970: 1285027200.0) // 2010-09-21T00:00:00-0000

--- a/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
@@ -28,47 +28,6 @@ private struct CalendarRecurrenceRuleTests {
         return gregorian
     }()
     
-    @Test func roundtripEncoding() async throws {
-        // This test does not directly use the current Calendar, however encoding any Calendar will check if it is equivalent to the current Calendar
-        // If equivalent, it will serialize a sentinel value and deserialize as the current Calendar regardless of the actual serialized identifier
-        // This test will fail if calendar == Calendar.current at encode time and the current calendar changes to a different value before decode time (making the encoded calendar and the decoded calendar not equivalent
-        try await usingCurrentInternationalizationPreferences {
-            // These are not necessarily valid recurrence rule, they are constructed
-            // in a way to test all encoding paths
-            var calendar = Calendar(identifier: .gregorian)
-            calendar.locale = .init(identifier: "en_001")
-            calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
-            
-            var recurrenceRule1 = Calendar.RecurrenceRule(calendar: calendar, frequency: .daily)
-            recurrenceRule1.interval = 2
-            recurrenceRule1.months = [1, 2, Calendar.RecurrenceRule.Month(4, isLeap: true)]
-            recurrenceRule1.weeks = [2, 3]
-            recurrenceRule1.weekdays = [.every(.monday), .nth(1, .wednesday)]
-            recurrenceRule1.end = .afterOccurrences(5)
-            
-            var recurrenceRule2 = Calendar.RecurrenceRule(calendar: calendar, frequency: .daily)
-            recurrenceRule2.months = [2, 10]
-            recurrenceRule2.weeks = [1, -1]
-            recurrenceRule2.setPositions = [1]
-            recurrenceRule2.hours = [14]
-            recurrenceRule2.minutes = [30]
-            recurrenceRule2.seconds = [0]
-            recurrenceRule2.daysOfTheYear = [1]
-            recurrenceRule2.daysOfTheMonth = [4]
-            recurrenceRule2.weekdays = [.every(.monday), .nth(1, .wednesday)]
-            recurrenceRule2.end = .afterDate(.distantFuture)
-            
-            let recurrenceRule1JSON = try JSONEncoder().encode(recurrenceRule1)
-            let recurrenceRule2JSON = try JSONEncoder().encode(recurrenceRule2)
-            let decoded1 = try JSONDecoder().decode(Calendar.RecurrenceRule.self, from: recurrenceRule1JSON)
-            let decoded2 = try JSONDecoder().decode(Calendar.RecurrenceRule.self, from: recurrenceRule2JSON)
-            
-            #expect(recurrenceRule1 == decoded1)
-            #expect(recurrenceRule2 == decoded2)
-            #expect(recurrenceRule1 != recurrenceRule2)
-        }
-    }
-    
     @Test func yearlyRecurrenceInLunarCalendar() {
         // Find the first day of the lunar new year
         let start = Date(timeIntervalSince1970: 1726876800.0) // 2024-09-21T00:00:00-0000

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -230,6 +230,34 @@ private struct CalendarTests {
             let decodedModified = try decodeHelper(modified)
             #expect(decodedModified != autoupdatingCurrent)
             #expect(modified == decodedModified)
+            
+            do {
+                // Calendar does not decode the current as a sentinel value
+                var prefs = LocalePreferences()
+                prefs.languages = ["en-US"]
+                prefs.locale = "en_US"
+                prefs.minDaysInFirstWeek = [.gregorian : 5]
+                LocaleCache.cache.resetCurrent(to: prefs)
+                CalendarCache.cache.reset()
+                
+                let encodedCurrent = try JSONEncoder().encode(Calendar.current)
+                let encodedAutoupdatingCurrent = try JSONEncoder().encode(Calendar.autoupdatingCurrent)
+                
+                prefs = LocalePreferences()
+                prefs.languages = ["es-ES"]
+                prefs.locale = "es_ES"
+                prefs.minDaysInFirstWeek = [.gregorian : 3]
+                LocaleCache.cache.resetCurrent(to: prefs)
+                CalendarCache.cache.reset()
+                
+                let decodedCurrent = try JSONDecoder().decode(Calendar.self, from: encodedCurrent)
+                let decodedAutoupdatingCurrent = try JSONDecoder().decode(Calendar.self, from: encodedAutoupdatingCurrent)
+                
+                #expect(decodedCurrent.minimumDaysInFirstWeek == 5)
+                #expect(decodedCurrent.locale?.identifier == "en_US")
+                #expect(decodedAutoupdatingCurrent.minimumDaysInFirstWeek == 3)
+                #expect(decodedAutoupdatingCurrent.locale?.identifier == "es_ES")
+            }
         }
     }
 

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -116,6 +116,34 @@ private struct LocaleTests {
             #expect(current != autoupdatingCurrent)
             #expect(decodedCurrent != autoupdatingCurrent)
             #expect(current != decodedAutoupdatingCurrent)
+            
+            do {
+                // Locale does not decode the current as a sentinel value
+                var prefs = LocalePreferences()
+                prefs.languages = ["en-US"]
+                prefs.locale = "en_US"
+                prefs.minDaysInFirstWeek = [.gregorian : 5]
+                LocaleCache.cache.resetCurrent(to: prefs)
+                CalendarCache.cache.reset()
+                
+                let encodedCurrent = try JSONEncoder().encode(Locale.current)
+                let encodedAutoupdatingCurrent = try JSONEncoder().encode(Locale.autoupdatingCurrent)
+                
+                prefs = LocalePreferences()
+                prefs.languages = ["es-ES"]
+                prefs.locale = "es_ES"
+                prefs.minDaysInFirstWeek = [.gregorian : 3]
+                LocaleCache.cache.resetCurrent(to: prefs)
+                CalendarCache.cache.reset()
+                
+                let decodedCurrent = try JSONDecoder().decode(Locale.self, from: encodedCurrent)
+                let decodedAutoupdatingCurrent = try JSONDecoder().decode(Locale.self, from: encodedAutoupdatingCurrent)
+                
+                #expect(decodedCurrent.identifier == "en_US")
+                #expect(decodedCurrent.prefs?.minDaysInFirstWeek?[.gregorian] == 5)
+                #expect(decodedAutoupdatingCurrent.identifier == "es_ES")
+                #expect(decodedAutoupdatingCurrent.prefs?.minDaysInFirstWeek?[.gregorian] == 3)
+            }
         }
     }
 

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -159,6 +159,22 @@ private struct TimeZoneTests {
             #expect(current != autoupdatingCurrent)
             #expect(decodedCurrent != autoupdatingCurrent)
             #expect(current != decodedAutoupdatingCurrent)
+            
+            do {
+                // TimeZone does not decode the current as a sentinel value
+                TimeZoneCache.cache.resetCurrent(to: .gmt)
+                
+                let encodedCurrent = try JSONEncoder().encode(TimeZone.current)
+                let encodedAutoupdatingCurrent = try JSONEncoder().encode(TimeZone.autoupdatingCurrent)
+                
+                TimeZoneCache.cache.resetCurrent(to: TimeZone(identifier: "America/Los_Angeles")!)
+                
+                let decodedCurrent = try JSONDecoder().decode(TimeZone.self, from: encodedCurrent)
+                let decodedAutoupdatingCurrent = try JSONDecoder().decode(TimeZone.self, from: encodedAutoupdatingCurrent)
+                
+                #expect(decodedCurrent.identifier == "GMT")
+                #expect(decodedAutoupdatingCurrent.identifier == "America/Los_Angeles")
+            }
         }
     }
 }


### PR DESCRIPTION
There's been a handful of changes over the years in this area, but the situation we have today is that `TimeZone`, `Calendar`, and `Locale` all have different behaviors for how they encode `.current`. All 3 mostly agree that `.autoupdatingCurrent` is always encoded as as sentinel value becoming the `.autoupdatingCurrent` at decode time, and that fixed values are decoded simply as fixed values (Calendar doesn't do the latter sometimes). However:

- `TimeZone` always encodes `.current` as a fixed value. When decoded it is the same time zone that was encoded regardless of `.current` at decode time
- `Locale` always encodes `.current` as a sentinel value. When decoded, it takes the value of whatever `.current` is at decode time regardless of the locale that was encoded
- `Calendar` encodes a sentinel current value if the calendar to be encoded is equivalent to the current locale (i.e. if it has the same identifier/properties). This means that `.current` is always encoded as a sentinel value like `Locale`, but some fixed values are also encoded as a `.current` sentinel

The desired behavior is what `TimeZone` does today - `.current` represents a snapshot in time and we should encode that fixed snapshot unless `.autoupdatingCurrent` is used (in which case it should update at decode time). This is trickier for `Locale` because `Locale` contains extra user preferences that are persisted neither in the identifier nor other archive keys (which is why it is not its behavior today). This means encoding `Locale.current` as a fixed locale with just an identifier results in lost information due to lost preferences.

To fix this we do two things:
- `Locale` now persists preferences in the archive (when present) alongside the identifier (to prevent data loss) and `.current` is no longer decoded as a sentinel to match `TimeZone`
- `Calendar` no longer decodes `.current` as a sentinel value to match `TimeZone` (and now `Locale`)

With this change, we always decode a `Calendar` that was encoded as `.current` as a fixed Calendar based on the encoded values. We still encode the `.current` key to preserve the preexisting behavior when decoding on an older runtime, but newer runtimes will ignore the `.current` sentinel and decode the various keys.

This also adds unit tests to each type that validates consistent behavior for all 3 types.