### PR TITLE
Locale.Region subregion API is misspelled

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
@@ -417,7 +417,11 @@ extension Locale.Region {
 
     /// An array of the sub-regions, matching the specified category of the region.
     @available(FoundationPreview 6.2, *)
-    public func subRegions(ofCategoy category: Category) -> [Locale.Region] {
+#if FOUNDATION_FRAMEWORK
+    // Renamed in 6.2.1
+    @abi(func subRegions(ofCategoy category: Category) -> [Locale.Region])
+#endif
+    public func subRegions(ofCategory category: Category) -> [Locale.Region] {
         var status = U_ZERO_ERROR
         let icuRegion = uregion_getRegionFromCode(identifier, &status)
         guard let icuRegion, status.isSuccess else {

--- a/Tests/FoundationInternationalizationTests/LocaleRegionTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleRegionTests.swift
@@ -43,14 +43,14 @@ struct LocaleRegionTests {
     }
 
     @Test func subRegionOfCategory() async throws {
-        #expect(Locale.Region.unknown.subRegions(ofCategoy: .world) == [])
-        #expect(Locale.Region.unknown.subRegions(ofCategoy: .territory) == [])
+        #expect(Locale.Region.unknown.subRegions(ofCategory: .world) == [])
+        #expect(Locale.Region.unknown.subRegions(ofCategory: .territory) == [])
 
-        #expect(Set(Locale.Region.world.subRegions(ofCategoy: .continent)) == Set(Locale.Region.isoRegions(ofCategory: .continent)))
+        #expect(Set(Locale.Region.world.subRegions(ofCategory: .continent)) == Set(Locale.Region.isoRegions(ofCategory: .continent)))
 
-        #expect(Locale.Region.argentina.subRegions(ofCategoy: .continent) == [])
-        #expect(Locale.Region.argentina.subRegions(ofCategoy: .territory) == Locale.Region.argentina.subRegions)
+        #expect(Locale.Region.argentina.subRegions(ofCategory: .continent) == [])
+        #expect(Locale.Region.argentina.subRegions(ofCategory: .territory) == Locale.Region.argentina.subRegions)
 
-        #expect(Locale.Region("not a region").subRegions(ofCategoy: .territory) == [])
+        #expect(Locale.Region("not a region").subRegions(ofCategory: .territory) == [])
     }
 }


### PR DESCRIPTION
With @abi we can make an ABI compatible change so existing clients can continue to work on user's 6.2 devices even after they adopt the correct name on 6.2.1 and above.

But only use @abi for FOUNDATION_FRAMEWORK since ABI compatibility isn't a concern in other scenarios.