### PR TITLE
Follow up for #1195 for `FOUNDATION_FRAMEWORK`

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2888,13 +2888,6 @@ extension Data {
         /// When a maximum line length is set, specify that the line ending to insert should include a line feed.
         public static let endLineWithLineFeed       = Base64EncodingOptions(rawValue: 1 << 5)
 
-        /// Use the base64url alphabet to encode the data
-        @available(FoundationPreview 6.3, *)
-        public static let base64URLAlphabet = Base64EncodingOptions(rawValue: 1 << 6)
-
-        /// Omit the `=` padding characters in the end of the base64 encoded result
-        @available(FoundationPreview 6.3, *)
-        public static let omitPaddingCharacter = Base64EncodingOptions(rawValue: 1 << 7)
     }
 
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
@@ -2918,6 +2911,15 @@ extension Data {
 }
 #endif //!FOUNDATION_FRAMEWORK
 
+extension Data.Base64EncodingOptions {
+    /// Use the base64url alphabet to encode the data
+    @available(FoundationPreview 6.3, *)
+    public static let base64URLAlphabet = Self(rawValue: 1 << 6)
+
+    /// Omit the `=` padding characters in the end of the base64 encoded result
+    @available(FoundationPreview 6.3, *)
+    public static let omitPaddingCharacter = Self(rawValue: 1 << 7)
+}
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {


### PR DESCRIPTION
Move the new options out of `#if !FOUNDATION_FRAMEWORK` block