### PR TITLE
[Testing] Don't strip Windows NT prefix from cwd

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -516,7 +516,7 @@ extension _FileManagerImpl {
         // Handle Windows NT object namespace prefix
         // The \\?\ prefix is used by Windows NT for device paths and may appear
         // in current working directory paths. We strip it to return a standard path.
-        return cwd?.removingNTPathPrefix()
+        return cwd
 #else
         withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
             guard getcwd(buffer.baseAddress!, FileManager.MAX_PATH_SIZE) != nil else {


### PR DESCRIPTION
I suspect stripping the NT prefix from `FileManager.currentDirectoryPath` might be causing test failures in swift-corelibs-foundation.

```
TestFoundation/TestURL.swift:512: error: TestURL.test_fileURLWithPath_isDirectory : XCTAssertEqual failed: ("41") is not equal to ("36") - fileSystemRepresentation was too short
```

The file system representation of a file `URL` initialized with `FileManager.default.currentDirectoryPath` appears to be 5 characters too short. Will add better logging to the tests in swift-corelibs-foundation and test with this PR to see if this resolves it and to get more info.