### PR TITLE
Fix leadingDotSyntax test reliance on current internationalization preferences

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -190,6 +190,9 @@ private struct DateFormatStyleTests {
     @Test func leadingDotSyntax() async {
         let date = Date.now
         let locale = Locale(identifier: "es_ES")
+        let timeZone = TimeZone.gmt
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
         await usingCurrentInternationalizationPreferences {
             #expect(date.formatted(date: .long, time: .complete) == date.formatted(Date.FormatStyle(date: .long, time: .complete)))
         }
@@ -200,6 +203,8 @@ private struct DateFormatStyleTests {
                     .month()
                     .year()
                     .locale(locale)
+                    .timeZone(timeZone)
+                    .calendar(calendar)
             ) ==
             date.formatted(
                 Date.FormatStyle()
@@ -207,6 +212,8 @@ private struct DateFormatStyleTests {
                     .month()
                     .year()
                     .locale(locale)
+                    .timeZone(timeZone)
+                    .calendar(calendar)
             )
         )
     }

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -190,32 +190,25 @@ private struct DateFormatStyleTests {
     @Test func leadingDotSyntax() async {
         let date = Date.now
         let locale = Locale(identifier: "es_ES")
-        let timeZone = TimeZone.gmt
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = timeZone
         await usingCurrentInternationalizationPreferences {
             #expect(date.formatted(date: .long, time: .complete) == date.formatted(Date.FormatStyle(date: .long, time: .complete)))
-        }
-        #expect(
-            date.formatted(
-                .dateTime
-                    .day()
-                    .month()
-                    .year()
-                    .locale(locale)
-                    .timeZone(timeZone)
-                    .calendar(calendar)
-            ) ==
-            date.formatted(
-                Date.FormatStyle()
-                    .day()
-                    .month()
-                    .year()
-                    .locale(locale)
-                    .timeZone(timeZone)
-                    .calendar(calendar)
+            #expect(
+                date.formatted(
+                    .dateTime
+                        .day()
+                        .month()
+                        .year()
+                        .locale(locale)
+                ) ==
+                date.formatted(
+                    Date.FormatStyle()
+                        .day()
+                        .month()
+                        .year()
+                        .locale(locale)
+                )
             )
-        )
+        }
     }
 
     @Test func dateFormatStyleIndividualFields() {

--- a/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
@@ -106,9 +106,9 @@ private struct DateIntervalFormatStyleTests {
             // This test assumes both the left side and the right side of the comparison has the same `Locale.autoupdatingCurrent`, which assumes the state of the host machine remains unchanged.
             #expect(range.formatted() == Date.IntervalFormatStyle().format(range))
             #expect(range.formatted(date: .numeric, time: .shortened) == Date.IntervalFormatStyle(date: .numeric, time: .shortened).format(range))
+            #expect(range.formatted(.interval.day().month().year().locale(locale)) == Date.IntervalFormatStyle().day().month().year().locale(locale).format(range))
         }
 
-        #expect(range.formatted(.interval.day().month().year().locale(locale)) == Date.IntervalFormatStyle().day().month().year().locale(locale).format(range))
     }
     
 #if FIXED_ICU_74_DAYPERIOD


### PR DESCRIPTION
We encountered a test failure that surfaced an issue with the `leadingDotSyntax` tests: some of them use the current internationalization preferences without being synchronized. This corrects the two tests that contain issues (other `leadingDotSyntax` tests don't have this issue) by either synchronizing usage of the preferences, or avoiding a reliance on the preferences.

Resolves rdar://161031455