### PR TITLE
Julian year 4713 BC is -4712, because year 0 = 1 BC

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -389,7 +389,7 @@ extension Date : _CustomPlaygroundQuickLookable {
 #endif // FOUNDATION_FRAMEWORK
 
 extension Date {
-    // Julian day 0 (-4713-01-01 12:00:00 +0000) in CFAbsoluteTime to 506713-02-07 00:00:00 +0000, smaller than the max time ICU supported.
+    // Julian day 0 (-4712-01-01 12:00:00 +0000) in CFAbsoluteTime to 506713-02-07 00:00:00 +0000, smaller than the max time ICU supported.
     package static let validCalendarRange = Date(timeIntervalSinceReferenceDate: TimeInterval(-211845067200.0))...Date(timeIntervalSinceReferenceDate: TimeInterval(15927175497600.0))
 
     // aka __CFCalendarValidateAndCapTimeRange


### PR DESCRIPTION
Companion PR to (currently unmerged) https://github.com/swiftlang/swift-corelibs-foundation/pull/5274

This is a minor comment-only fix. The minimum of the range (`-211845067200.0`) does indeed represent Julian day 0 (proleptic Gregorian `-4713-11-24 12:00:00 +0000` = November 24, 4714 BC), but it is documented incorrectly as proleptic Julian `-4713-01-01 12:00:00 +0000` which is 4714 BC instead of the correct year -4712 = 4713 BC