### PR TITLE
CMake: modulemap override in build interface

### DIFF
--- a/Sources/_FoundationCShims/CMakeLists.txt
+++ b/Sources/_FoundationCShims/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(_FoundationCShims STATIC
 target_include_directories(_FoundationCShims PUBLIC include)
 
 target_compile_options(_FoundationCShims INTERFACE
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap>")
+  "$<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap>>")
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS _FoundationCShims)
 


### PR DESCRIPTION
The modulemap override should only be added in the build interface, where we don't copy the modulemap and header files. The install interface installs the modulemap and header files to a location where the compiler will see it, so passing the override results in the compiler seeing both modulemaps defining the same module and then failing. This moves the override to only be part of the build interface.