### PR TITLE
Create a C callable _NSCurrentDirectoryPath function

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -510,3 +510,27 @@ extension _FileManagerImpl {
 #endif
     }
 }
+
+@_cdecl("_NSCurrentDirectoryPath")
+internal func _NSCurrentDirectoryPath(_ buffer: UnsafeMutablePointer<CChar>?, _ size: Int) -> Bool {
+    guard let buffer = buffer, size > 0 else {
+        return false // Invalid parameters
+    }
+    
+    let currentPath = FileManager.default.currentDirectoryPath
+    
+    // Convert to C string representation
+    let cString = currentPath.utf8CString
+    let requiredSize = cString.count // includes null terminator
+    
+    if requiredSize > size {
+        return false // Buffer too small
+    }
+    
+    // Copy the string to the buffer
+    cString.withUnsafeBufferPointer { sourceBuffer in
+        buffer.initialize(from: sourceBuffer.baseAddress!, count: requiredSize)
+    }
+    
+    return true // Success
+}


### PR DESCRIPTION
In order to remove the libc getcwd dependency and move it to the the foundation FileManager.currentDirectoryPath API we needed a C callable method that the swift-corelib-foundation could use in its NSURL implementation.

This will allow any platform specifics in the
FileManager.currentDirectoryPath implementation (like prefix striping on Windows) to be handled in a single location.