### PR TITLE
Mark conformance `FloatingPointRoundingRule: Codable` retroactive.

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -502,7 +502,7 @@ extension FloatingPointRoundingRule {
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-extension FloatingPointRoundingRule : Codable { }
+extension FloatingPointRoundingRule: @retroactive Codable { }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension NumberFormatStyleConfiguration.RoundingIncrement: Codable {


### PR DESCRIPTION
Mostly this is just to quiet some warnings, but it _is_ a retroactive conformance.