### PR TITLE
localizedName_103036605() fails when the current date is around DST change

### DIFF
--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -82,7 +82,7 @@ private struct TimeZoneTests {
 
         test("America/Los_Angeles", "zh_TW", .shortStandard, "PST", "PST")
         test("Europe/Paris",       "zh_TW", .shortStandard, "GMT+1", "GMT+2")
-        test("Antarctica/Vostok",   "zh_TW", .shortStandard, "GMT+6", "GMT+6")
+        test("Antarctica/Davis",   "zh_TW", .shortStandard, "GMT+7", "GMT+7")
         test("Asia/Chongqing",      "zh_TW", .shortStandard, "GMT+8", "GMT+8")
         test("America/Sao_Paulo",   "zh_TW", .shortStandard, "GMT-3", "GMT-3")
 


### PR DESCRIPTION
We saw a test failure in this CI job: https://ci.swift.org/job/oss-swift-6.2-bootstrap-ubuntu-24_04-x86_64/318

```
[2025-10-26T00:58:39.054Z] ✘ Test localizedName_103036605() recorded an issue at TimeZoneTests.swift:74:13: Expectation failed: (tz?.localizedName(for: .generic, locale: locale) → "Central European Time (Germany)") == (expected → "Central European Time")
```

The cause of this test failure is that this `TimeZone` API uses the current time as reference, and depending on `style` it may include the time zone city to disambiguate that from the [golden zone](https://www.unicode.org/reports/tr35/tr35-dates.html#Using_Time_Zone_Names) if the current time is close to a DST transition.

Update the test to use the golden zone to opt out of this unexpected behavior since that is not what this test was meant to test.

Also while we're here, update the test to respect the `style` argument.
