### PR TITLE
[CI] Enable Android SDK build in swift-foundation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,8 @@ jobs:
       macos_versions: '["sequoia"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-main"]'
+      enable_android_sdk_build: true
+      android_sdk_versions: '["nightly-main"]'
 
   cmake_build:
     name: Build (CMake)


### PR DESCRIPTION
Now that swiftlang/github-workflows supports building with the Swift SDK for Android in https://github.com/swiftlang/github-workflows/pull/172, we can enable the job in swift-foundation to prevent Android build regressions.

Other projects have recently added Android CI at https://github.com/swiftlang/swift-testing/pull/1382, https://github.com/swiftlang/swift-subprocess/pull/202, and https://github.com/swiftlang/swift-toolchain-sqlite/pull/23.

This follows the precedent set by https://github.com/swiftlang/swift-foundation/pull/1461 for adding Wasm to the CI for swift-foundation. You can see a successful run of this CI at https://github.com/swift-android-sdk/swift-foundation/actions/runs/18980991140/job/54213198187

CC: @finagolfin, @shahmishal 