### PR TITLE
Resolve a few Data warnings

### DIFF
--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -239,7 +239,9 @@ extension Data : MutableDataProtocol {
     public var regions: CollectionOfOne<Data> {
         return CollectionOfOne(self)
     }
-    
+}
+
+extension Data {
     /// Copy the contents of the data to a pointer.
     ///
     /// - parameter pointer: A pointer to the buffer you wish to copy the bytes into.

--- a/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
@@ -159,7 +159,6 @@ extension Data {
         @inlinable // This is @inlinable as reasonably small.
         mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
             ensureUniqueReference()
-            let upperbound = storage.length + storage._offset
             storage.replaceBytes(
                 in: (
                     location: range.upperBound,


### PR DESCRIPTION
Resolve a few warnings in Data code that snuck in recently.

1. The removed property is now unused and can be deleted
2. There are a few functions that I moved into the `Data: MutableDataProtocol` extension - these functions don't actually provide witnesses for `MutableDataProtocol` requirements but are close and thus produce compiler warnings about the slight mismatch. I split them out into a new extension to silence the warnings (but kept them in the same place organizationally)