### PR TITLE
Update automerger to merge from 6.3 to main

### DIFF
--- a/.github/workflows/automerge_to_main.yml
+++ b/.github/workflows/automerge_to_main.yml
@@ -13,7 +13,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
     with:
       base_branch: main
-      head_branch: release/6.2
+      head_branch: release/6.3
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/automerge_to_release.yml
+++ b/.github/workflows/automerge_to_release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Create PR to merge main into release branch
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
     with:
-      base_branch: release/6.2
+      base_branch: release/6.3
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Now that we have branched for 6.3, update automerger to merge from 6.3 to main.

While we are not currently running automerger to merge into the release branch, update the version in `automerge_to_release.yml` as well for consistency.

As part of this, we will also disable merge -> future workflow from github action.