### PR TITLE
Configure automergers for 6.3 release

### DIFF
--- a/.github/workflows/automerge_to_main.yml
+++ b/.github/workflows/automerge_to_main.yml
@@ -13,7 +13,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
     with:
       base_branch: main
-      head_branch: release/6.2
+      head_branch: release/6.3
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/automerge_to_release.yml
+++ b/.github/workflows/automerge_to_release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Create PR to merge main into release branch
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
     with:
-      base_branch: release/6.2
+      base_branch: release/6.3
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Now that we have branched for 6.3, this updates the auto mergers to operate on `release/6.3` instead of `release/6.2`. This means that we will now be merging `release/6.3` --> `main` instead of `release/6.2`, and any changes targeting `release/6.2` (there should be very few) will require cherry picking just like the individual `release/6.2.x` branches.