### PR TITLE
Fix copy-paste error in string_shim.c

### DIFF
--- a/Sources/_FoundationCShims/string_shims.c
+++ b/Sources/_FoundationCShims/string_shims.c
@@ -91,7 +91,7 @@ float _stringshims_strtof_clocale(const char * _Nullable restrict nptr,
 #else
     // Use the C locale
     locale_t oldLocale = uselocale(FOUNDATION_C_LOCALE);
-    double result = strtof(nptr, endptr);
+    float result = strtof(nptr, endptr);
     // Restore locale
     uselocale(oldLocale);
     return result;


### PR DESCRIPTION
result is a float, not a double, so define it as float.