### PR TITLE
AttributeScope and AttributedStringKey should conform to SendableMetatype

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -17,7 +17,7 @@
 // }
 // An AttributeScope can contain other scopes as well.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public protocol AttributeScope : DecodingConfigurationProviding, EncodingConfigurationProviding {
+public protocol AttributeScope : DecodingConfigurationProviding, EncodingConfigurationProviding, SendableMetatype {
     static var decodingConfiguration: AttributeScopeCodableConfiguration { get }
     static var encodingConfiguration: AttributeScopeCodableConfiguration { get }
 }

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -95,7 +95,7 @@ extension AttributedString {
 
 // Developers define new attributes by implementing AttributeKey.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public protocol AttributedStringKey {
+public protocol AttributedStringKey : SendableMetatype {
     associatedtype Value : Hashable
     static var name : String { get }
     


### PR DESCRIPTION
Implements the addition proposed by [SF-0029](https://github.com/swiftlang/swift-foundation/blob/main/Proposals/0029-attributedstring-sendable-metatype.md)