### PR TITLE
Change return type of gid function from uid_t to gid_t

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -163,7 +163,7 @@ extension Platform {
         }
     }
     
-    static func gid(forName name: String) -> uid_t? {
+    static func gid(forName name: String) -> gid_t? {
         withUserGroupBuffer(name, group(), sizeProperty: Int32(_SC_GETGR_R_SIZE_MAX), operation: getgrnam_r) {
             $0.gr_gid
         }


### PR DESCRIPTION
This seems to be a typo. In practice on macOS at least, they both alias to the same type, but still.