### PR TITLE
Revert "Use updated spelling for lifetime annotations. (#1584)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -147,7 +147,7 @@ let package = Package(
           ] + wasiLibcCSettings,
           swiftSettings: [
             .enableExperimentalFeature("VariadicGenerics"),
-            .enableExperimentalFeature("Lifetimes"),
+            .enableExperimentalFeature("LifetimeDependence"),
             .enableExperimentalFeature("AddressableTypes"),
             .enableExperimentalFeature("AllowUnsafeAttribute"),
             .enableExperimentalFeature("BuiltinModule"),

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 
 target_compile_options(FoundationEssentials PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend VariadicGenerics>"
-    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend Lifetimes>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend LifetimeDependence>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AddressableTypes>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend BuiltinModule>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2212,7 +2212,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var bytes: RawSpan {
-        @_lifetime(borrow self)
+        @lifetime(borrow self)
         borrowing get {
             let buffer: UnsafeRawBufferPointer
             switch _representation {
@@ -2240,7 +2240,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var span: Span<UInt8> {
-        @_lifetime(borrow self)
+        @lifetime(borrow self)
         borrowing get {
             let span = unsafe bytes._unsafeView(as: UInt8.self)
             return _overrideLifetime(span, borrowing: self)
@@ -2250,7 +2250,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var mutableBytes: MutableRawSpan {
-        @_lifetime(&self)
+        @lifetime(&self)
         mutating get {
             let buffer: UnsafeMutableRawBufferPointer
             switch _representation {
@@ -2286,7 +2286,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var mutableSpan: MutableSpan<UInt8> {
-        @_lifetime(&self)
+        @lifetime(&self)
         mutating get {
 #if false // see https://github.com/swiftlang/swift/issues/81218
             var bytes = mutableBytes


### PR DESCRIPTION
This reverts commit 709808e15435036c64bb9535c061a041916e90cd.

Reverting due to a compiler issue that produces an incorrect swiftinterface file.