### PR TITLE
Use the canonicalized name to create ICU timezone object

### DIFF
--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -108,7 +108,8 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
 
         var status = U_ZERO_ERROR
-        let timeZone : UnsafeMutablePointer<UTimeZone?>? = Array(identifier.utf16).withUnsafeBufferPointer {
+        // Use the already canonicalized `name` instead of `identifier` to initiate ICU time zone
+        let timeZone : UnsafeMutablePointer<UTimeZone?>? = Array(name.utf16).withUnsafeBufferPointer {
             let uatimezone = uatimezone_open($0.baseAddress, Int32($0.count), &status)
             guard status.isSuccess else {
                 return nil

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -1436,6 +1436,18 @@ private struct CalendarTests {
         try test(Date(timeIntervalSinceReferenceDate: 731154876), Date(timeIntervalSinceReferenceDate: 731842476))
     }
 
+    @Test func testDateComponentsTimeZone() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+
+        var components = DateComponents(year:2021, month: 6, day: 10, hour: 23, minute: 59, second: 59)
+        let tz = try #require(TimeZone(identifier: "UTC+9"))
+        components.timeZone = tz
+
+        let date = try #require(calendar.date(from: components))
+        #expect(date.timeIntervalSinceReferenceDate == 645029999)
+    }
+
 #if _pointerBitWidth(_64) // These tests assumes Int is Int64
     @Test func dateFromComponentsOverflow() {
         let calendar = Calendar(identifier: .gregorian)


### PR DESCRIPTION
ICU expects time zone identifiers to be IANA identifiers, such as "America/Los_Angeles". Hence names such as "UTC+9" aren't officially supported.

There is a canonicalization function available, but I did not remember to use it when switching to the new ICU `uatimezone` SPI.

Fix this by always using the canonicalized version to initiate an ICU timezone object.

164490980