### PR TITLE
Only rename __DataStorage.replaceBytes symbol on FOUNDATION_FRAMEWORK

### DIFF
--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -342,8 +342,8 @@ internal final class __DataStorage : @unchecked Sendable {
         self.replaceBytes(in: (range_.lowerBound, range_.upperBound &- range_.lowerBound), with: replacementBytes, length: replacementLength)
     }
     
-    // This ABI entrypoint was original written using NSRange instead of Range<Int>. The ABI contract of this function must continue to accept NSRange values from code inlined into callers
-    // To avoid using the real NSRange type at the source level, we use a tuple that is layout-compatible with NSRange instead and use @_silgen_name to preserve the original symbol name that includes "NSRange"
+    // This utility function was originally written in terms of NSRange instead of Range<Int>. On Darwin platforms, it is also an ABI entry point so we need to continue accepting NSRange values from code that has been inlined into callers.
+    // To avoid requiring the use of NSRange in source, we instead use a tuple that is layout-compatible with NSRange. On Darwin platforms, we can use `@_silgen_name to preserve the original symbol name that refers to NSRange.
     @usableFromInline
     #if FOUNDATION_FRAMEWORK
     @_silgen_name("$s10Foundation13__DataStorageC12replaceBytes2in4with6lengthySo8_NSRangeV_SVSgSitF")


### PR DESCRIPTION
We use `@_silgen_name` here to rename this symbol to use `NSRange` instead of `(Int, Int)` because the symbol was originally introduced with `NSRange` instead but we want to use `(Int, Int)` in source to avoid a dependency on `NSRange`. However, this current `@_silgen_name` causes issues when building the package in some environments because it uses "Foundation" as the module name (instead of "FoundationEssentials"). Since the package (and non-`FOUNDATION_FRAMEWORK` platforms) are not ABI stable and don't need to preserve the historic symbol name, we can just only apply `@_silgen_name` when building with `FOUNDATION_FRAMEWORK` to avoid conflicting definitions when ABI preservation is not required (while still preserving the ABI where it matters).