### PR TITLE
Lazily calculate needed components in `dateComponents(:from:in:)`

### DIFF
--- a/Benchmarks/Benchmarks/Internationalization/BenchmarkCalendar.swift
+++ b/Benchmarks/Benchmarks/Internationalization/BenchmarkCalendar.swift
@@ -136,6 +136,23 @@ func calendarBenchmarks() {
         }
     }
 
+    let testDates = {
+        let date = Date(timeIntervalSince1970: 0)
+        var dates = [Date]()
+        dates.reserveCapacity(10000)
+        for i in 0...10000 {
+            dates.append(Date(timeInterval: Double(i * 3600), since: date))
+        }
+        return dates
+    }()
+
+    Benchmark("NextDatesMatchingOnHour") { _ in
+        for d in testDates {
+            let t = currentCalendar.nextDate(after: d, matching: DateComponents(minute: 0, second: 0), matchingPolicy: .nextTime)
+            blackHole(t)
+        }
+    }
+
     // MARK: - Allocations
     let reference = Date(timeIntervalSince1970: 1474666555.0) //2016-09-23T14:35:55-0700
     

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -330,6 +330,10 @@ public struct Calendar : Hashable, Equatable, Sendable {
             // The calendar and timeZone properties do not count as a 'highest unit set', since they are not ordered in time like the others are.
             return nil
         }
+
+        var containsOnlyTimeComponents: Bool {
+            !self.contains(.era) && !self.contains(.year) && !self.contains(.dayOfYear) && !self.contains(.quarter) && !self.contains(.month) && !self.contains(.day) && !self.contains(.weekday) && !self.contains(.weekdayOrdinal) && !self.contains(.weekOfMonth) && !self.contains(.weekOfYear) && !self.contains(.yearForWeekOfYear) && !self.contains(.isLeapMonth) && !self.contains(.isRepeatedDay)
+        }
     }
 
     /// An enumeration for the various components of a calendar date.

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -1991,21 +1991,25 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         let dateOffsetInSeconds = localDate.timeIntervalSinceReferenceDate.rounded(.down)
         let date = Date(timeIntervalSinceReferenceDate: dateOffsetInSeconds) // Round down the given date to seconds
 
-        let useJulianRef = useJulianReference(date)
+        let totalSeconds = Int(dateOffsetInSeconds)
+        let secondsInDay = (totalSeconds % 86400 + 86400) % 86400
 
-        var timeInDay = dateOffsetInSeconds.remainder(dividingBy: 86400) // this has precision of one second
-        if (timeInDay < 0) {
-            timeInDay += 86400
-        }
-
-        let hour = Int(timeInDay / 3600) // zero-based
-        timeInDay = timeInDay.truncatingRemainder(dividingBy: 3600.0)
-
-        let minute = Int(timeInDay / 60)
-        timeInDay = timeInDay.truncatingRemainder(dividingBy: 60.0)
-
-        let second = Int(timeInDay)
+        let hour = secondsInDay / 3600
+        let minute = (secondsInDay % 3600) / 60
+        let second = secondsInDay % 60
         let nanosecond = Int((localDate.timeIntervalSinceReferenceDate - dateOffsetInSeconds) * 1_000_000_000)
+
+        if components.containsOnlyTimeComponents {
+            var dcHour: Int?
+            var dcMinute: Int?
+            var dcSecond: Int?
+            var dcNano: Int?
+            if components.contains(.hour) { dcHour = hour }
+            if components.contains(.minute) { dcMinute = minute }
+            if components.contains(.second) { dcSecond = second }
+            if components.contains(.nanosecond) { dcNano = nanosecond }
+            return DateComponents(hour: dcHour, minute: dcMinute, second: dcSecond, nanosecond: dcNano)
+        }
 
         let dayOfYear: Int
         let weekday: Int
@@ -2018,6 +2022,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         var month: Int
         var day: Int
         do {
+            let useJulianRef = useJulianReference(date)
             let julianDay = try date.julianDay()
              (year, month, day) = Self.yearMonthDayFromJulianDay(julianDay, useJulianRef: useJulianRef)
             isLeapYear = gregorianYearIsLeap(year)


### PR DESCRIPTION
We are currently eagerly calculating all components in `_GregorianCalendar.dateComponents(:from:in:)` even if they're not needed. Skip all those if they're not being requested at all.

Also switch from floating point's `remainder(dividingBy:)` and `truncatingRemainder(dividingBy:)` to integer math.

The use case in the original report is essentially the `NextDatesMatchingOnHour` benchmark, where only time components are requested. Here's the result for this one. For other existing benchmarks I'm seeing 1.5-2x of improvement.

```
// NextDatesMatchingOnHour

** BEFORE **

╒═══════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                    │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *          │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      28 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)    │       9 │       9 │       9 │       9 │       9 │       9 │       9 │      28 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (μs) *   │     108 │     109 │     109 │     109 │     109 │     110 │     110 │      28 │
╘═══════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

** AFTER **

╒═══════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                    │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *          │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      97 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)    │      33 │      33 │      32 │      32 │      32 │      31 │      31 │      97 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (μs) *   │      30 │      31 │      31 │      31 │      31 │      31 │      31 │      97 │
╘═══════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

Fixes 165794940