### PR TITLE
Fix FileManager's extended attribute symlink handling

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -193,15 +193,15 @@ extension _FileManagerImpl {
             #else
             var result: Int32
             if followSymLinks {
-                result = lsetxattr(path, key, buffer.baseAddress!, buffer.count, 0)
-            } else {
                 result = setxattr(path, key, buffer.baseAddress!, buffer.count, 0)
+            } else {
+                result = lsetxattr(path, key, buffer.baseAddress!, buffer.count, 0)
             }
             #endif
 
             #if os(macOS) && FOUNDATION_FRAMEWORK
-            // if setxaddr failed and its a permission error for a sandbox app trying to set quaratine attribute, ignore it since its not
-            // permitted, the attribute will be put on the file by the quaratine MAC hook
+            // if setxattr failed and its a permission error for a sandbox app trying to set quarantine attribute, ignore it since its not
+            // permitted, the attribute will be put on the file by the quarantine MAC hook
             if result == -1 && errno == EPERM && _xpc_runtime_is_app_sandboxed() && strcmp(key, "com.apple.quarantine") == 0 {
                 return
             }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1046,6 +1046,60 @@ private struct FileManagerTests {
         }
     }
 
+    // Extended attributes are not supported on all platforms
+    #if !os(Windows) && !os(WASI) && !os(OpenBSD) && !canImport(Android)
+    @Test func extendedAttributesOnSymlinks() async throws {
+        let xattrKey = FileAttributeKey("NSFileExtendedAttributes")
+        #if os(Linux)
+        // Linux requires the user.* namespace prefix for regular files
+        let attrName = "user.swift.foundation.symlinktest"
+        #else
+        let attrName = "org.swift.foundation.symlinktest"
+        #endif
+        let attrValue = Data([0xAA, 0xBB, 0xCC])
+        let attrValue2 = Data([0xDD, 0xEE, 0xFF])
+
+        try await FilePlayground {
+            File("target", contents: Data("payload".utf8))
+            SymbolicLink("link", destination: "target")
+        }.test { fileManager in
+            // First, validate that reading the attribute from the link does not read the value from the target
+            do {
+                try fileManager.setAttributes([xattrKey: [attrName: attrValue]], ofItemAtPath: "target")
+                let targetAttrs = try fileManager.attributesOfItem(atPath: "target")
+                let targetXAttrs = targetAttrs[xattrKey] as? [String: Data]
+                #expect(targetXAttrs?[attrName] == attrValue)
+                
+                let linkAttrs = try fileManager.attributesOfItem(atPath: "link")
+                let linkXAttrs = linkAttrs[xattrKey] as? [String: Data]
+                #expect(linkXAttrs?[attrName] == nil)
+            }
+
+            // Attempt to set xattrs on the symlink
+            #if os(Linux)
+            // On Linux, user xattrs cannot be set on symlinks
+            #expect(throws: CocoaError.self) {
+                try fileManager.setAttributes([xattrKey: [attrName: attrValue2]], ofItemAtPath: "link")
+            }
+            let expectedValue: Data? = nil
+            #else
+            try fileManager.setAttributes([xattrKey: [attrName: attrValue2]], ofItemAtPath: "link")
+            let expectedValue: Data? = attrValue2
+            #endif
+            
+            // Ensure that reading back the xattr of the link produces the expected value
+            let linkAttrs = try fileManager.attributesOfItem(atPath: "link")
+            let linkXAttrs = linkAttrs[xattrKey] as? [String: Data]
+            #expect(linkXAttrs?[attrName] == expectedValue)
+            
+            // Ensure that setting the xattr on the link did not set the xattr on the target
+            let targetAttrs = try fileManager.attributesOfItem(atPath: "target")
+            let targetXAttrs = targetAttrs[xattrKey] as? [String: Data]
+            #expect(targetXAttrs?[attrName] == attrValue)
+        }
+    }
+    #endif
+
     #if !canImport(Darwin) || os(macOS)
     @Test func currentUserHomeDirectory() async throws {
         let userName = ProcessInfo.processInfo.userName


### PR DESCRIPTION
The if statement appears inverted:  setxattr follows simlinks: lsetxattr does not.

Additionally, _extendedAttributes was ignoring simlinks entirely.

Both of these issues have been addressed.