### PR TITLE
[FileManager] Fix off by one error when checking error from read in FileManager+Basics

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -277,7 +277,7 @@ internal struct _FileManagerImpl {
                                     return false
                                 }
                             }
-                            if readBytes < -1 { return false }
+                            if readBytes == -1 { return false }
                             return true
                         }
                     }


### PR DESCRIPTION
Check for readBytes being equal to -1, not less than -1.

It returns -1 when there's an error.