### PR TITLE
Ensure there is a null byte at the end of the JSON

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -123,7 +123,14 @@ internal struct JSON5Scanner {
             throw JSONError.unexpectedCharacter(context: "after top-level value", ascii: char, location: reader.sourceLocation)
         }
 
-        return JSONMap(mapBuffer: partialMap.mapData, dataBuffer: self.reader.bytes)
+        let map = JSONMap(mapBuffer: partialMap.mapData, dataBuffer: self.reader.bytes)
+
+        // If the input contains only a number, ensure a trailing NUL byte is available for strtod/strtof parsing.
+        if case .number = map.loadValue(at: 0)! {
+            map.copyInBuffer()
+        }
+
+        return map
     }
 
     // MARK: Generic Value Scanning


### PR DESCRIPTION
In JSON5 mode, a top-level number (e.g. "123") is left without a guaranteed terminator.

Do what JSONScanner does in this case.