### PR TITLE
Fix BufferReader.lineNumber to correctly count newlines

### DIFF
--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -599,7 +599,7 @@ struct BufferReader {
                 if nextIndex < readIndex && fullBuffer[unchecked: nextIndex] == ._newline {
                     p = nextIndex
                 }
-            } else if fullBuffer[offset: 1] == ._newline {
+            } else if fullBuffer[unchecked: p] == ._newline {
                 count += 1
             }
             fullBuffer.formIndex(&p, offsetBy: 1)


### PR DESCRIPTION
The `BufferReader.lineNumber` property had a bug where it used `fullBuffer[offset: 1]` to check for newline characters. Since `offset:` is relative to the start of the buffer, this always checked the same byte (the second byte) regardless of the current cursor position `p`.

This caused incorrect line counting:
- If the second byte happened to be `\n`, it would increment the count on every iteration, overcounting lines
- If the second byte was not `\n`, standalone newlines (without preceding `\r`) would never be counted, undercounting lines.