### PR TITLE
Fix `afterOccurrences` to be calculated from startDate in RecurrenceRule

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -373,6 +373,11 @@ extension Calendar {
                     // If a range has been specified, we should skip a few extra 
                     // occurrences until we reach the start date
                     if let baseRecurrenceLowerBound, nextDate < baseRecurrenceLowerBound {
+                        resultsFound += 1
+                        if let limit = recurrence.end.occurrences, resultsFound >= limit {
+                            finished = true
+                            return
+                        }
                         continue
                     }
                     anchor = nextDate

--- a/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
@@ -134,4 +134,42 @@ private struct CalendarRecurrenceRuleTests {
         ]
         #expect(results == expectedResults)
     }
+
+    @Test func afterOccurrenceMatchingDays() {
+        let recurrenceRule = Calendar.RecurrenceRule.init(
+            calendar: gregorian,
+            frequency: .daily,
+            end: .afterOccurrences(3)
+        )
+
+        let startDate = Date(timeIntervalSince1970: 1764576000.0) // 2025-12-01T00:00:00-0800
+
+        let rangeStartDate = Date(timeIntervalSince1970: 1765353600.0) // 2025-12-10T00:00:00-0800
+        let rangeEndDate = Date(timeIntervalSince1970: 1766217600.0) // 2025-12-20T00:00:00-0800
+
+        let result = Array(recurrenceRule.recurrences(of: startDate, in: rangeStartDate..<rangeEndDate))
+
+        #expect(result.isEmpty)
+    }
+
+    @Test func afterOccurrencesReturnsInRangeOccurrences() {
+        let recurrenceRule = Calendar.RecurrenceRule.init(
+            calendar: gregorian,
+            frequency: .daily,
+            end: .afterOccurrences(4)
+        )
+
+        let startDate = Date(timeIntervalSince1970: 1765094400.0) // 2025-12-07T00:00:00-0800
+
+        let rangeStartDate = Date(timeIntervalSince1970: 1765267200.0) // 2025-12-09T00:00:00-0800
+        let rangeEndDate = Date(timeIntervalSince1970: 1765440000.0) // 2025-12-11T00:00:00-0800
+
+        let result = Array(recurrenceRule.recurrences(of: startDate, in: rangeStartDate..<rangeEndDate))
+        let expectedResults = [
+            Date(timeIntervalSince1970: 1765267200.0), // 2025-12-09T00:00:00-0800
+            Date(timeIntervalSince1970: 1765353600.0), // 2025-12-10T00:00:00-0800
+        ]
+
+        #expect(result == expectedResults)
+    }
 }


### PR DESCRIPTION
Fix `Calendar.RecurrenceRule.afterOccurrences` to be calculated from `startDate` in `recurrences(of:in:)`

### Motivation:

When using `Calendar.RecurrenceRule.End.afterOccurrences` with
`recurrences(of:in:)`, the occurrence count is currently applied relative to
the start of the queried range, rather than the original `startDate` of the
recurrence.

This leads to unexpected results when the query range begins after all
occurrences allowed by `afterOccurrences` have already been exhausted, causing
occurrences to be returned even though the recurrence should have ended.

Fixes: #1633 

### Modifications:

- Updated the recurrence enumeration logic so that the `afterOccurrences` limit
is applied globally from the startDate passed to `recurrences(of:in:)`,
rather than being reset relative to the query range.
- Ensured that occurrences falling before the queried range still contribute
to the total occurrence count.
- Added new tests to validate the corrected behavior and prevent regressions.

### Result:

After this change, `recurrences(of:in:)` no longer returns occurrences when the
query range starts after all occurrences permitted by `afterOccurrences` have
been reached.

### Testing:

- Added new tests covering `afterOccurrences` behavior when the query range
  starts after all allowed occurrences, as well as when the range intersects
  partially with the allowed occurrence set.
