### PR TITLE
__DataInvokeDeallocatorUnmap should always call unmap

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -88,8 +88,6 @@ import func WinSDK.UnmapViewOfFile
 internal func __DataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) {
 #if os(Windows)
     _ = UnmapViewOfFile(mem)
-#elseif canImport(C)
-    free(mem)
 #else
     munmap(mem, length)
 #endif


### PR DESCRIPTION
Not sure if this is a typo, nor could I see any rationale for this being free.