### PR TITLE
Units.smallestUnit can choose the wrong smallest value

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -97,8 +97,9 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
         public static var `default`: Self { .all }
 
         fileprivate var smallestUnit: Unit {
-            for idx in (Unit.byte.rawValue...Unit.petabyte.rawValue) {
-                if self.contains(.init(rawValue: UInt(idx))) { return Unit(rawValue: idx)! }
+            for idx in Unit.byte.rawValue...Unit.petabyte.rawValue {
+                let mask = UInt(1 << idx)
+                if self.contains(.init(rawValue: mask)) { return Unit(rawValue: idx)! }
             }
             // 84270854: Fall back to petabyte if the unit is larger than petabyte, which is the largest we currently support
             return .petabyte

--- a/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
@@ -187,6 +187,16 @@ private struct ByteCountFormatStyleTests {
     }
 
 #if !_pointerBitWidth(_32)
+    @Test func higherUnitsFallbackToPetabyte() {
+        // Units above petabyte are not yet supported by ICU; they should fallback to PB
+        let value: Int64 = 10_000_000_000_000_000 // 10 PB
+        let locale = Locale(identifier: "en_US")
+
+        #expect(value.formatted(.byteCount(style: .file, allowedUnits: .eb).locale(locale)) == "10 PB")
+        #expect(value.formatted(.byteCount(style: .file, allowedUnits: .zb).locale(locale)) == "10 PB")
+        #expect(value.formatted(.byteCount(style: .file, allowedUnits: .ybOrHigher).locale(locale)) == "10 PB")
+    }
+
     @Test func testEveryAllowedUnit() {
         // 84270854: The largest unit supported currently is pb
         let expectations: [ByteCountFormatStyle.Units: String] = [


### PR DESCRIPTION
Units.smallestUnit was checking rawValue bits incorrectly using rawValue == idx instead of 1 << idx.