### PR TITLE
GetUserNameExW returns 0 on error, non-zero on success

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -229,7 +229,7 @@ final class _ProcessInfo: Sendable {
         _ = GetUserNameExW(NameDisplay, nil, &ulLength)
 
         return withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(ulLength)) { wszBuffer in
-            guard GetUserNameExW(NameDisplay, wszBuffer.baseAddress!, &ulLength) == 0 else {
+            guard GetUserNameExW(NameDisplay, wszBuffer.baseAddress!, &ulLength) != 0 else {
                 return ""
             }
             return String(decoding: wszBuffer.prefix(Int(ulLength)), as: UTF16.self)

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -147,7 +147,7 @@ private struct ProcessInfoTests {
         "ProcessInfo thinks we are on System 70")
     }
 
-#if os(macOS)
+#if canImport(Darwin) || os(Windows)
     @Test func userName() {
         #expect(!ProcessInfo.processInfo.userName.isEmpty)
     }


### PR DESCRIPTION
I know Microsoft is not consistent on this, but GetUserNameExW returns 0 on error.