### PR TITLE
Pin GitHub actions workflows to v0.0.2

### DIFF
--- a/.github/workflows/automerge_to_future.yml
+++ b/.github/workflows/automerge_to_future.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main branch into future branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.2
     with:
       base_branch: future
       head_branch: main

--- a/.github/workflows/automerge_to_main.yml
+++ b/.github/workflows/automerge_to_main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge release branch into main branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.2
     with:
       base_branch: main
       head_branch: release/6.3

--- a/.github/workflows/automerge_to_release.yml
+++ b/.github/workflows/automerge_to_release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main into release branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.2
     with:
       base_branch: release/6.3
     permissions:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: Test (SwiftPM)
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
     with:
       linux_swift_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
@@ -44,7 +44,7 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.2
     with:
       license_header_check_project_name: "Swift.org"
       license_header_check_enabled: false


### PR DESCRIPTION
Pins the version of swiftlang GitHub Actions workflows to v0.0.2 of the repo.

### Motivation:

A recent change to the GitHub workflows have broken the actions in this repo. This pins the workflows to v0.0.2 (like other repos have done) to use a stable version of workflows and avoid these breaking changes.

### Modifications:

Updates the version number in relevant workflow YAML files

### Result:

Workflows should use the v0.0.2 version rather than the version on `main` which may be unstable.

### Testing:

CI testing will confirm that actions now pass.
