### PR TITLE
Replace GetProcessId(GetCurrentProcess()) with GetCurrentProcessId()

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -156,7 +156,7 @@ final class _ProcessInfo: Sendable {
 
     var processIdentifier: Int32 {
 #if os(Windows)
-        return Int32(bitPattern: UInt32(GetProcessId(GetCurrentProcess())))
+        return Int32(bitPattern: UInt32(GetCurrentProcessId()))
 #else
         return Int32(getpid())
 #endif


### PR DESCRIPTION
GetCurrentProcessId() is more direct and cleaner.
