### PR TITLE
GetLastError() doesn't return anything if the call succeeds

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -618,7 +618,7 @@ enum _FileOperations {
                     try destination.withNTPathRepresentation { pwszDestination in
                         var faDestinationAttributes: WIN32_FILE_ATTRIBUTE_DATA = .init()
                         if GetFileAttributesExW(pwszDestination, GetFileExInfoStandard, &faDestinationAttributes) {
-                            let error = CocoaError.moveFileError(GetLastError(), src, dst)
+                            let error = CocoaError.moveFileError(ERROR_ALREADY_EXISTS, src, dst)
                             guard fileManager._shouldProceedAfter(error: error, movingItemAtPath: source, to: destination) else {
                                 throw error
                             }


### PR DESCRIPTION
 Changed GetLastError() to ERROR_ALREADY_EXISTS when destination file exists check succeeds.