### PR TITLE
Fix-prevented "?" from being added in case query is empty

### DIFF
--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -480,7 +480,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             } else {
                 result += percentEncodedPath
             }
-            if let percentEncodedQuery {
+            if let percentEncodedQuery, !percentEncodedQuery.isEmpty {
                 result += "?\(percentEncodedQuery)"
             }
             if let percentEncodedFragment {
@@ -526,9 +526,9 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             } else {
                 result += percentEncodedPath
             }
-            if componentsToDecode.contains(.query), let query {
+            if componentsToDecode.contains(.query), let query, !query.isEmpty {
                 result += "?\(query)"
-            } else if let percentEncodedQuery {
+            } else if let percentEncodedQuery, !percentEncodedQuery.isEmpty {
                 result += "?\(percentEncodedQuery)"
             }
             if componentsToDecode.contains(.fragment), let fragment {

--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -711,7 +711,7 @@ internal struct RFC3986Parser {
             finalURLString += path
         }
 
-        if let query = parseInfo.query {
+        if let query = parseInfo.query, !query.isEmpty {
             if invalidComponents.contains(.query) {
                 finalURLString += "?\(percentEncode(query, component: .query)!)"
             } else {
@@ -1322,7 +1322,7 @@ extension RFC3986Parser {
             finalURLString += path
         }
 
-        if let query = parseInfo.query {
+        if let query = parseInfo.query, !query.isEmpty {
             if invalidComponents.contains(.query) {
                 finalURLString += "?\(percentEncode(query, component: .query, skipAlreadyEncoded: true)!)"
             } else {

--- a/Sources/FoundationEssentials/URL/URL_ObjC.swift
+++ b/Sources/FoundationEssentials/URL/URL_ObjC.swift
@@ -486,7 +486,7 @@ extension _NSSwiftURL {
             return String(relativeString[start...])
         }
         var result: String?
-        if let query = url._parseInfo.query {
+        if let query = url._parseInfo.query, !query.isEmpty {
             result = "?\(query)"
         }
         if let fragment = url._parseInfo.fragment {

--- a/Sources/FoundationEssentials/URL/URL_Swift.swift
+++ b/Sources/FoundationEssentials/URL/URL_Swift.swift
@@ -1115,7 +1115,7 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
                 result += ":\(portString)"
             }
             result += path
-            if let query {
+            if let query, !query.isEmpty {
                 result += "?\(query)"
             }
             if let fragment {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -666,6 +666,12 @@ private struct URLTests {
         )
 
         // Append queryItems
+        let emptyQueryItems = [URLQueryItem]()
+        #expect(
+            base.appending(queryItems: emptyQueryItems).absoluteString ==
+            "https://www.example.com"
+        )
+
         let queryItems = [
             URLQueryItem(name: "id", value: "42"),
             URLQueryItem(name: "color", value: "blue")


### PR DESCRIPTION
_Prevent appending `?` to URL when query items array is empty_

### Motivation:

When calling `URL.appending(queryItems:)` with an empty array, the current implementation appends a trailing `?` to the URL (e.g., `"www.google.com"` becomes `"www.google.com?"`). This produces potentially invalid URLs and forces users to add defensive checks before calling the method.

Related to this issue #1548

### Modifications:

Added an extra check before adding `"?\(query)"` to prevent "?" from being added in case of an empty query.

### Result:

Calling `url.appending(queryItems: [])` now returns the original URL without any modifications, allowing developers to chain URL construction methods without defensive empty-array checks:
```swift
// Before: "www.google.com?"
// After:  "www.google.com"
let url = URL(string: "www.google.com")!.appending(queryItems: [])
```

### Testing:

- Added a test case verifying that appending an empty query items array returns the original URL unchanged
- Verified existing tests pass to ensure no regression in behavior when non-empty query items are provided