### PR TITLE
_amkrtemp error string includes "Optional"

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -173,6 +173,12 @@ private func createTemporaryFile(at destinationPath: String, inPath: PathOrURL, 
         if let sandboxResult {
             return sandboxResult
         }
+        
+        // If we have no result and also no errno, just fail immediately because we failed to produce a file system representation for the path
+        guard let amkrErrno else {
+            throw CocoaError.errorWithFilePath(.fileReadInvalidFileName, inPath.path)
+        }
+        
         // If _amkrtemp failed with EEXIST, just retry
         if amkrErrno == EEXIST {
             continue


### PR DESCRIPTION
Updates error handling logic to avoid printing "Optional" in an error description

### Motivation:

Updates the error message to no longer include the "Optional" string to make it clearer

### Modifications:

Exits earlier if the error code is `nil` indicating we've already hit an error we can't recover from

### Result:

The error message is now only provided when the error code is non-optional (otherwise a better error is thrown)

### Testing:

Validated in the IDE that the interpolated variable is no longer optional (this is nontrivial to add a unit test for because it requires us to be unable to create a file system representation for this specific path)
