### PR TITLE
conversationalDayPeriodsOverride() fails with ICU 78

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -19,6 +19,7 @@ import Testing
 private struct ICUPatternGeneratorTests {
 
     typealias DateFieldCollection = Date.FormatStyle.DateFieldCollection
+#if FIXED_ICU78
     @Test func conversationalDayPeriodsOverride() {
 
         var locale: Locale
@@ -253,5 +254,5 @@ private struct ICUPatternGeneratorTests {
                  expectedPattern: "h:mm:ss a")
         }
     }
-
+#endif
 }


### PR DESCRIPTION
ICU78's update will cause this test to fail. ICU has merged a follow up fix, which should be available soon. Disable the test for now; will re-enable the test once the fix lands.

166656959