### PR TITLE
Use hash(into) instead of hashValue

### DIFF
--- a/Sources/FoundationEssentials/Error/CocoaError.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError.swift
@@ -27,8 +27,8 @@ public struct CocoaError : _BridgedStoredNSError {
     
     public static var errorDomain: String { return NSCocoaErrorDomain }
     
-    public var hashValue: Int {
-        return _nsError.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_nsError)
     }
 }
 

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -38,8 +38,8 @@ public struct POSIXError : _BridgedStoredNSError {
 
     public static var errorDomain: String { return NSPOSIXErrorDomain }
 
-    public var hashValue: Int {
-        return _nsError.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_nsError)
     }
 
     public typealias Code = POSIXErrorCode


### PR DESCRIPTION
hashValue is deprecated.