### PR TITLE
Typo fix: check for intValue should be &&, not ||

### DIFF
--- a/Sources/FoundationEssentials/String/String+Comparison.swift
+++ b/Sources/FoundationEssentials/String/String+Comparison.swift
@@ -425,7 +425,7 @@ extension Unicode.UTF8.CodeUnit : _StringCompareOptionsConvertible {
     }
 
     var intValue: Int? {
-        return (self >= 48 || self <= 57) ? Int(self - 48) : nil
+        return (self >= 48 && self <= 57) ? Int(self - 48) : nil
     }
 
     var isExtendCharacter: Bool {


### PR DESCRIPTION
We are checking between 48 and 57 inclusive, so it should be &&.