### PR TITLE
Avoid race condition in default AttributeScope loading

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -93,14 +93,19 @@ fileprivate struct LoadedScopeCache : Sendable {
             }
         }
         
-        guard let handle = dlopen(path, RTLD_NOLOAD),
+        guard let handle = dlopen(path, RTLD_NOLOAD | RTLD_FIRST),
              let symbol = dlsym(handle, name) else {
             scopeMangledNames[name] = .notLoaded
             return nil
         }
         
         guard let type = unsafeBitCast(symbol, to: Any.Type.self) as? any AttributeScope.Type else {
-            fatalError("Symbol \(name) is not an AttributeScope type")
+            // RTLD_NOLOAD means that dlopen will check the image list without taking the dlopen() lock
+            // This means that it is possible the image is currently added to the image list (and a handle is returned), but static initializers have not finished and the image is not fully "loaded"
+            // In these scenarios, the scope symbol may exist, but its AttributeScope conformance may not yet be available to the dynamic cast machinery
+            // Return nil for now to indicate that the scope is not yet loaded, but avoid cacheing the value so that we try again next time after loading may have successfully finished
+            dlclose(handle)
+            return nil
         }
         scopeMangledNames[name] = .loaded(type)
         return type


### PR DESCRIPTION
Update default attribute scope loading to avoid a race with other calls to `dlopen`

### Motivation:

In certain conditions, there is a race condition that exists between AttributedString looking up UI-level frameworks via `dlopen(RTLD_NOLOAD)` and something else in the process asking that the framework be loaded (ex. via another `dlopen` call). In this race condition, AttributedString can get a handle to the framework and find an attribute scope symbol in it before its `AttributeScope` conformance is accessible to swift dynamic casts because the framework is not fully initialized.

Previously I added a `fatalError` here to quickly find cases where we used the wrong symbol name for a given framework. However, this situation presents itself in the wild under these conditions and results in a crash.

### Modifications:

 To avoid the crash, instead I simply updated it to close the handle and return a `nil` result (as if the scope wasn't loaded) but not cache the result so that we try again on the next lookup in case the framework has finished initializing by time we lookup the scope again (we cannot rely on our existing cache invalidating mechanism when new images are loaded because that triggers at the same time that `dlopen` starts finding the image, not when the image is fully initialized).

### Result:

Now this code path will not crash and will instead behave as if the framework were not loaded. Subsequent calls will check if the framework has finished initializing.

### Testing:

There is not a way to add a unit test for this as it is a very rare race condition under specific circumstances, however existing unit tests that validate the correct path still pass.
