### PR TITLE
Ignore EOPNOTSUPP error when copying directory xattrs

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -1017,7 +1017,10 @@ enum _FileOperations {
                                 valueSize = fgetxattr(srcFD, current, valueBuffer.baseAddress!, valueSize)
                                 if valueSize >= 0 {
                                     if fsetxattr(dstFD, current, valueBuffer.baseAddress!, valueSize, 0) != 0 {
-                                        try delegate.throwIfNecessary(errno, srcPath(), dstPath())
+                                        // Ignore the error if setting this xattr is not supported (ex. SELinux security xattrs)
+                                        if errno != EOPNOTSUPP {
+                                            try delegate.throwIfNecessary(errno, srcPath(), dstPath())
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Avoids throwing an error when copying directories that contain xattrs that the system does not support copying to the destination directory.

### Motivation:

When SELinux security xattrs are applied to a directory, they cannot be copied to the destination directory when copying (and `cp` does not copy them either). Instead of throwing an error when encountering these attributes, we should ignore them.

Resolves https://github.com/swiftlang/swift-foundation/issues/1676

### Modifications:

Avoids throwing an error when setting xattrs when the error code is `EOPNOTSUPP`

### Result:

Directories with xattrs that cannot be copied will still be copied successfully

### Testing:

I was unable to add a unit test since it is not possible for us to set an SELinux attribute on this file in a unit test (doing so requires calling a function like `setfilecon` which requires the host build machine to have the selinux dev package installed which is not guaranteed), but we can validate this by building a toolchain and ensuring the reported issue is resolved
