### PR TITLE
Staging for new default AttributeScope lookup approach

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -123,6 +123,16 @@ fileprivate struct LoadedScopeCache : Sendable {
 
 fileprivate let _loadedScopeCache = LockedState(initialState: LoadedScopeCache())
 
+extension AttributeScopes {
+    @_spi(AttributedStringDefaultScopes)
+    @objc
+    open class _DefaultScopeRegistration: NSObject, @unchecked Sendable {
+        open class func _attributeScopeType() -> any AttributeScope.Type {
+            fatalError("Class \(Self.self) does not implement _attributeScopeType()")
+        }
+    }
+}
+
 internal func _loadDefaultAttributes() -> [String : any AttributedStringKey.Type] {
     // On native macOS, the UI framework that gets loaded is AppKit. On
     // macCatalyst however, we load a version of UIKit.


### PR DESCRIPTION
Stages new declarations to improve the default `AttributeScope` lookup performance

### Motivation:

Looking up the default attribute scope currently goes through `dlopen` to find all necessary higher level frameworks. `dlopen` is much more expensive than `objc_getClass`, so this stages in a class that higher level frameworks can subclass which we can lookup by name to find scopes that need to be included rather than using `dlopen`

### Modifications:

Add a new class for higher level frameworks to subclass that Foundation will lookup by name (the latter half will come in a later change)

### Result:

The new class is available for subclassing

### Testing:

This does not enable the new behavior yet, so there is no change to validate via testing (aside from ensuring this still builds)
