### PR TITLE
Use _TimeZoneGMTICU instead of using _TimeZoneICU for timezones such as "GMT+8" for bridged timezone

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -353,15 +353,35 @@ struct TimeZoneCache : Sendable, ~Copyable {
                 bridgedFixedTimeZones[identifier] = bridged
                 return bridged
             }
-#if canImport(_FoundationICU)
-            if let innerTz = _TimeZoneICU(identifier: identifier) {
-                // In this case, the identifier is unique and we need to cache it (in two places)
-                fixedTimeZones[identifier] = innerTz
-                let bridgedTz = _NSSwiftTimeZone(timeZone: TimeZone(inner: innerTz))
-                bridgedFixedTimeZones[identifier] = bridgedTz
-                return bridgedTz
+
+            if identifier == "GMT" {
+                return bridgedOffsetFixed(0)
             }
+
+            let bridgedTZ: _NSSwiftTimeZone?
+            if let innerTZ = _TimeZoneGMT(identifier: identifier) {
+                // Identifier takes a form of GMT offset such as "GMT+8"
+                fixedTimeZones[identifier] = innerTZ
+                bridgedTZ = _NSSwiftTimeZone(timeZone: TimeZone(inner: innerTZ))
+            } else {
+#if canImport(_FoundationICU)
+                if let innerTz = _TimeZoneICU(identifier: identifier) {
+                    fixedTimeZones[identifier] = innerTz
+                    bridgedTZ = _NSSwiftTimeZone(timeZone: TimeZone(inner: innerTz))
+                } else {
+                    bridgedTZ = nil
+                }
+#else
+                bridgedTZ = nil
 #endif
+            }
+
+            if let bridgedTZ {
+                // In this case, the identifier is unique and we need to cache it, both in `fixedTimeZones` and `bridgedFixedTimeZones`
+                bridgedFixedTimeZones[identifier] = bridgedTZ
+                return bridgedTZ
+            }
+
             return nil
         }
 


### PR DESCRIPTION
This is a follow up for #1657. In that change, we switched to use `_TimeZoneGMTICU` instead of `_TimeZoneICU` for timezones whose identifier is a fixed offset, e.g. "GMT+8". This applies the same logic to bridged timezone.

I did not add new tests because we have plenty of tests for `NSTimeZone` and `CFTimeZone` in Objective-c that covers this code path.

167791762