### PR TITLE
Specify lifetime for protocol requirement

### DIFF
--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2023 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -185,6 +185,8 @@ fileprivate struct URLBufferParseInfo {
 package protocol UIDNAHook {
     static func encode(_ host: some StringProtocol) -> String?
     static func decode(_ host: some StringProtocol) -> String?
+
+    @lifetime(output: copy output)
     static func nameToASCII(
         input: borrowing Span<UTF16.CodeUnit>,
         output: inout OutputSpan<Unicode.ASCII.CodeUnit>


### PR DESCRIPTION
A protocol requirement with a non-escapable parameter should specify that parameter's lifetime.

The existing conformance to this protocol already specifies this lifetime.