### PR TITLE
Guarantee specialization of String decomposition implementation

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -262,7 +262,8 @@ extension UnsafeBufferPointer {
         case illegalScalar
         case decodingError
     }
-    
+
+    @inline(__always) // Trivially forwarding and generic, inlining ensures calls are fully specialized
     fileprivate func _decomposedRebinding<T: UnicodeCodec, InputElement>(_ type: String._NormalizationType, as codec: T.Type, into buffer: UnsafeMutableBufferPointer<InputElement>, nullTerminated: Bool = false) throws -> Int {
         try self.withMemoryRebound(to: T.CodeUnit.self) { reboundSelf in
             try buffer.withMemoryRebound(to: Unicode.UTF8.CodeUnit.self) { reboundBuffer in
@@ -270,7 +271,11 @@ extension UnsafeBufferPointer {
             }
         }
     }
-    
+
+    @specialized(where T == Unicode.UTF8)
+    #if FOUNDATION_FRAMEWORK
+    @specialized(where T == Unicode.UTF16)
+    #endif
     fileprivate func _decomposed<T: UnicodeCodec>(_ type: String._NormalizationType, as codec: T.Type, into buffer: UnsafeMutableBufferPointer<UInt8>, nullTerminated: Bool = false) throws -> Int where Element == T.CodeUnit {
         let scalarSet = BuiltInUnicodeScalarSet(type: type.setType)
         var bufferIdx = 0


### PR DESCRIPTION
Requires the compiler to specialize the core String decomposition implementation used for creating file system representations.

### Motivation:

In many cases the compiler already chooses to specialize this, but it does not always do so. When it does not specialize this code, the unspecialized generics introduce significant overhead to this important funnel point.

### Modifications:

- Use `@specialize` to require that the compiler specialize this for UTF-8 (and UTF-16 in `FOUNDATION_FRAMEWORK` where we may be given a UTF-16 buffer from an `NSString`)
- use `@inline(__always)` to always inline the trivially forwarding generic wrapper around this function to avoid any overhead from that function

### Result:

This function should no longer have any unspecialized generics

### Testing:

Existing unit tests cover usage of this function, and I've manually validated that the compiler emits specialized versions of this function.
