### PR TITLE
Fix resolution for fragment-only relative NSURLs

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Resolution.swift
+++ b/Sources/FoundationEssentials/URL/URL_Resolution.swift
@@ -333,12 +333,14 @@ internal func resolveURLBuffers<
             writeIndex = absoluteBuffer[writeIndex...].initialize(
                 fromSpan: relativeSpan.extracting(relativePathRange.endIndex...)
             )
-        } else if baseHeader.hasQuery {
-            // No relative query, copy the base query including the leading "?"
-            let baseQueryRange = baseHeader.queryRange
-            writeIndex = absoluteBuffer[writeIndex...].initialize(
-                fromSpan: baseSpan.extracting((baseQueryRange.startIndex - 1)..<baseQueryRange.endIndex)
-            )
+        } else {
+            if baseHeader.hasQuery {
+                // No relative query, copy the base query including the leading "?"
+                let baseQueryRange = baseHeader.queryRange
+                writeIndex = absoluteBuffer[writeIndex...].initialize(
+                    fromSpan: baseSpan.extracting((baseQueryRange.startIndex - 1)..<baseQueryRange.endIndex)
+                )
+            }
             // Copy the relative fragment, if present
             writeIndex = absoluteBuffer[writeIndex...].initialize(
                 fromSpan: relativeSpan.extracting(relativePathRange.endIndex...)


### PR DESCRIPTION
Fix absolute URL resolution for fragment-only relative NS/CFURLs when their Swift implementation is enabled.

### Motivation:

Bug fix to preserve the fragment from fragment-only URLs like `#fragment` when resolving against a base URL.

### Modifications:

Ensure that we always copy the relative fragment; this logic was missing in the case where the relative URL is only a fragment and the base URL does not have a query.

### Result:

A relative URL like `#fragment` will resolve correctly agains a URL like `https://example.com/path` to create an absolute URL `https://example.com/path#fragment`.

### Testing:

Internal unit tests added for `NSURL` and `CFURL` when their Swift implementation is enabled.
