### PR TITLE
Guard against integer overflow

### DIFF
--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -583,6 +583,19 @@ private struct GregorianCalendarTests {
             testAdding(.init(month: 2), to: date2, wrap: false, expected: Date(timeIntervalSince1970: 983404800)) // 2001-03-01 00:00:00 UTC, 2001-02-28 16:00:00 PT
         }
     }
+#if _pointerBitWidth(_64)
+    @Test func testAddLargeValue() throws {
+
+        let date = Date(timeIntervalSinceReferenceDate: 656157793.922098)
+        let calendar = Calendar(identifier: .gregorian)
+        let value = 578721382704613386
+
+        let allComponents: Set<Calendar.Component> = [.era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear]
+        for component in allComponents {
+            _ = calendar.date(byAdding: component, value: value, to: date)
+        }
+    }
+#endif
 
     // MARK: - Ordinality
 


### PR DESCRIPTION
In a recent change we changed to use integer math for better performance. However, this approach doesn't work if the date offset of the input Date cannot be represented by a Int, which would trigger a swift runtime error.

### Modifications:

Fix this by checking if the offset is representable as an Int, and fallback to the previous implementation with floating point math if it isn't.

### Testing:

Added a test that would trigger a runtime error before the fix, but passes after the fix.

168600685
