### PR TITLE
Minor Data updates

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -608,7 +608,7 @@ extension Base64 {
 
         let outputLength = ((inBuffer.count + 3) / 4) * 3
 
-        let pointer = malloc(outputLength)
+        let pointer = __DataStorage.allocate(outputLength, false)
         let other = pointer?.bindMemory(to: UInt8.self, capacity: outputLength)
         let target = UnsafeMutableBufferPointer(start: other, count: outputLength)
         var length = outputLength

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -48,7 +48,9 @@
 @usableFromInline let memcmp = WASILibc.memcmp
 #endif
 
+#if !NO_CSHIMS
 internal import _FoundationCShims
+#endif
 import Builtin
 
 #if canImport(Darwin)

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -45,7 +45,6 @@ fileprivate let _pageSize: Int = Int(getpagesize())
 internal import CoreFoundation_Private
 #endif
 
-
 package struct Platform {
     static var pageSize: Int {
         _pageSize


### PR DESCRIPTION
Makes a few very minor tweaks to data for consistency

### Motivation:

Ensures we are consistent and keeps `Data` building in all environments

### Modifications:

Continue calling typed allocators when necessary and guards the CShim import statement with a conditional for configurations where it should be excluded

### Result:

Typed allocators are used when returning base64 data

### Testing:

No testing needed, existing test coverage includes these code paths
