### PR TITLE
Bug fix for wrong _CalendarGregorian.date(from:) calculation when pass negative .month (end of February)

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -1698,7 +1698,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         } else if month < 1 {
             let (q, r) = month.quotientAndRemainder(dividingBy: 12)
             month = r + 12
-            year = year - q - 1
+            year = year + q - 1
         }
         switch month {
         case 1, 3, 5, 7, 8, 10, 12:

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -35,6 +35,7 @@ private struct GregorianCalendarTests {
         #expect(gregorianCalendar.numberOfDaysInMonth(14, year: 2024) == 28) //  equivalent to month: 2, year: 2025, not leap
 
         #expect(gregorianCalendar.numberOfDaysInMonth(50, year: 2024) == 29) //  equivalent to month: 2, year: 2028, leap
+        #expect(gregorianCalendar.numberOfDaysInMonth(-22, year: 2026) == 29) //  equivalent to month: 2, year: 2024, leap
     }
 
     @Test func testRemoteJulianDayCrash() {


### PR DESCRIPTION
The sign for **q** (quotient) in year calculation in **_CalendarGregorian.numberOfDaysInMonth(_:year:)** method was changed from "-" to "+"  for negative month values. (minus to minus gives a plus, therefore sign "+" should be used for subtraction)

### Motivation:

There are some rare cases when Gregorian _Calendar.date(byAdding:value:to:)_ incorrectly calculates the date. For example, when we want to get the date from January 30, 2026 minus 47 months:

`let date = Calendar.current.date(byAdding: .month, value: -47, to: Date(timeIntervalSince1970: 1769774400)`

it should be February 28, 2022. It can't be February 30 because February has 28 days in usual years and 29 days in leap years. That's why the method should return the last day of February. But for some years it returns March 1 (2022, 2018, 2014 ...). And another issue that the method doesn't return 29 February for leap years, it returns 28 February instead. This happens only if the passed date "from" has some specific years and days of month should be >29.

### Modifications:

_Calendar.date(byAdding:value:to)_ calls **_CalendarGregorian.numberOfDaysInMonth(_:year:)** inside it. **_CalendarGregorian** is internal class but the issue is inside it. 
The issue is that quotient in year calculation in **_CalendarGregorian.numberOfDaysInMonth(_:year:)** (line 1701) incorrectly calculates the modified year. Month is negative in this case and quotient is negative as well. That's why the quotient should be subtracted with a sign "+", not "-". Because minus and minus is plus. That's why modified year is incorrect and when _gregorianYearIsLeap(_)_ method is called we can get incorrect results in cases listed above. But in some cases it works because modified year can be leap when the difference in years is 2. Because it doesn't matter if we add or subtract 2 years, the result of _gregorianYearIsLeap()_ will be the same.

Moreover there's a very similar logic for year calculation in the same file (**Calendar_Gregorian.swift**) in _static func carryOver(rawYear:rawMonth:)_ in line 109:

`year = rawYear + q - 1`

And the **q** (quotient) for negative months has sign "+" because q is negative in this case. And if q should be subtracted and it's negative we need to add a sign "+". Here's a correct logic, therefore we need to use the same logic in _numberOfDaysInMonth(_:year:)_

### Result:

When the year in **_CalendarGregorian.numberOfDaysInMonth(_:year:)** is calculated correctly, the method return the correct number of days and therefore we get the correct date.

### Testing:

Test added for this specific case
