### PR TITLE
FileManager.defaultManager is a Sendable violation

### DIFF
--- a/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
@@ -180,7 +180,7 @@ open class FileManager : @unchecked Sendable {
     // Sendable note: _impl may only be mutated in `init`
     private var _impl: _FileManagerImpl
     private let _lock = LockedState<State>(initialState: .init(delegate: nil))
-    private let isDefault: Bool = false
+    private let isDefault: Bool
     
     private static let _default = FileManager(default: true)
     open class var `default`: FileManager {
@@ -202,14 +202,15 @@ open class FileManager : @unchecked Sendable {
     }
     
     public init() {
+        isDefault = false
         _impl = _FileManagerImpl()
         _impl._manager = self
     }
     
     private init(default: Bool) {
+        isDefault = `default`
         _impl = _FileManagerImpl()
         _impl._manager = self
-        self.isDefault = `default`
     }
 
     open func setAttributes(_ attributes: [FileAttributeKey : Any], ofItemAtPath path: String) throws {


### PR DESCRIPTION
Updates the behavior of `FileManager.default.delegate` to ensure it cannot be set to avoid a `Sendable` violation

### Motivation:

`FileManager` is not `Sendable` for two main reasons:
- It potentially stores a reference to a delegate which may not be `Sendable`
- There are many subclasses, not all of which must be `Sendable`
- 
This makes `FileManager.default` a `Sendable` violation: it provides global access to a single, non-`Sendable` value from any isolation. However, only the first reason actually applies to the default manager since we guarantee that `FileManager.default` is always a `FileManager` and not a subclass.

### Modifications:

To resolve this `Sendable` violation, we add a new runtime-enforced constraint that the default manager cannot have a delegate set, ensuring it cannot be used to ferry non-`Sendable` state across isolation boundaries. It's never a good idea to set the delegate on the default manager since it's global state, so this pushes developers in the correct direction of creating a local `FileManager` if you need a delegate.

### Result:

You can no longer ferry non-`Sendable` state across `FileManager.default.delegate`

### Testing:

Existing runtime testing will confirm nothing does this in practice.
