### PR TITLE
Simplify #bundle expansion with build configuration

### DIFF
--- a/Tests/FoundationMacrosTests/BundleMacroTests.swift
+++ b/Tests/FoundationMacrosTests/BundleMacroTests.swift
@@ -12,51 +12,92 @@
 
 import Testing
 import FoundationMacros
+import SwiftIfConfig
 
 @Suite("#bundle Macro")
 private struct BundleMacroTests {
 
-    @Test func testSimple() {
+    func buildConditions(_ conditions: Set<String>) -> StaticBuildConfiguration {
+        StaticBuildConfiguration(customConditions: conditions, languageVersion: VersionTuple(components: [6, 0]), compilerVersion: VersionTuple(components: [6, 2]))
+    }
+
+    @Test func noBuildConfig() {
+        AssertMacroExpansion(
+            macros: ["bundle": BundleMacro.self],
+            """
+            #bundle
+            """,
+            diagnostics: ["1:1: #bundle was not provided a build configuration."]
+        )
+    }
+
+    @Test func simple() {
         AssertMacroExpansion(
             macros: ["bundle": BundleMacro.self],
             """
             #bundle
             """,
             """
-            {
-                #if SWIFT_MODULE_RESOURCE_BUNDLE_AVAILABLE
-                    return Bundle.module
-                #elseif SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE
-                    #error("No resource bundle is available for this module. If resources are included elsewhere, specify the bundle manually.")
-                #elseif SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE
-                    return Bundle(for: __BundleLookupHelper.self)
-                #else
-                    return unsafe Bundle(_dsoHandle: #dsohandle) ?? .main
-                #endif
-            }()
-            """
+            unsafe Bundle(_dsoHandle: #dsohandle) ?? .main
+            """,
+            buildConfiguration: buildConditions([])
         )
     }
 
-    @Test func testUsingParenthesis() {
+    @Test func simpleUsingParenthesis() {
         AssertMacroExpansion(
             macros: ["bundle": BundleMacro.self],
             """
             #bundle()
             """,
             """
-            {
-                #if SWIFT_MODULE_RESOURCE_BUNDLE_AVAILABLE
-                    return Bundle.module
-                #elseif SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE
-                    #error("No resource bundle is available for this module. If resources are included elsewhere, specify the bundle manually.")
-                #elseif SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE
-                    return Bundle(for: __BundleLookupHelper.self)
-                #else
-                    return unsafe Bundle(_dsoHandle: #dsohandle) ?? .main
-                #endif
-            }()
+            unsafe Bundle(_dsoHandle: #dsohandle) ?? .main
+            """,
+            buildConfiguration: buildConditions([])
+        )
+    }
+
+    @Test func moduleResourceBundle() {
+        AssertMacroExpansion(
+            macros: ["bundle": BundleMacro.self],
             """
+            #bundle
+            """,
+            """
+            Bundle.module
+            """,
+            buildConfiguration: buildConditions(["SWIFT_MODULE_RESOURCE_BUNDLE_AVAILABLE"])
+        )
+
+        AssertMacroExpansion(
+            macros: ["bundle": BundleMacro.self],
+            """
+            #bundle
+            """,
+            diagnostics: ["1:1: No resource bundle is available for this module. If resources are included elsewhere, specify the bundle manually."],
+            buildConfiguration: buildConditions(["SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE"])
+        )
+
+        AssertMacroExpansion(
+            macros: ["bundle": BundleMacro.self],
+            """
+            #bundle
+            """,
+            diagnostics: ["1:1: Both SWIFT_MODULE_RESOURCE_BUNDLE_AVAILABLE and SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE cannot be set when using #bundle."],
+            buildConfiguration: buildConditions(["SWIFT_MODULE_RESOURCE_BUNDLE_AVAILABLE", "SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE"])
+        )
+    }
+
+    @Test func lookupHelper() {
+        AssertMacroExpansion(
+            macros: ["bundle": BundleMacro.self],
+            """
+            #bundle
+            """,
+            """
+            Bundle(for: __BundleLookupHelper.self)
+            """,
+            buildConfiguration: buildConditions(["SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE"])
         )
     }
 }

--- a/Tests/FoundationMacrosTests/MacroTestUtilities.swift
+++ b/Tests/FoundationMacrosTests/MacroTestUtilities.swift
@@ -19,6 +19,7 @@ import SwiftParser
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntaxMacroExpansion
+import SwiftIfConfig
 
 #if FOUNDATION_FRAMEWORK
 let foundationModuleName = "Foundation"
@@ -121,13 +122,13 @@ extension DiagnosticTest {
     }
 }
 
-func AssertMacroExpansion(macros: [String : Macro.Type], testModuleName: String = "TestModule", testFileName: String = "test.swift", _ source: String, _ result: String = "", diagnostics: Set<DiagnosticTest> = [], sourceLocation: Testing.SourceLocation = #_sourceLocation) {
+func AssertMacroExpansion(macros: [String : Macro.Type], testModuleName: String = "TestModule", testFileName: String = "test.swift", _ source: String, _ result: String = "", diagnostics: Set<DiagnosticTest> = [], buildConfiguration: (any BuildConfiguration)? = nil, sourceLocation: Testing.SourceLocation = #_sourceLocation) {
     let origSourceFile = Parser.parse(source: source)
     let expandedSourceFile: Syntax
     let context: BasicMacroExpansionContext
     do {
         let foldedSourceFile = try OperatorTable.standardOperators.foldAll(origSourceFile).cast(SourceFileSyntax.self)
-        context = BasicMacroExpansionContext(sourceFiles: [foldedSourceFile : .init(moduleName: testModuleName, fullFilePath: testFileName)])
+        context = BasicMacroExpansionContext(sourceFiles: [foldedSourceFile : .init(moduleName: testModuleName, fullFilePath: testFileName)], buildConfiguration: buildConfiguration)
         expandedSourceFile = foldedSourceFile.expand(macros: macros) {
             BasicMacroExpansionContext(sharingWith: context, lexicalContext: [$0])
         }


### PR DESCRIPTION
Uses the new build configuration information provided to the macro during expansion to conditionalize the output of the `#bundle` macro.

### Motivation:

Today, `#bundle` expands to a series of `#if`/`#elseif`/`#else` directives to adjust expansion depending on the build configuration at the invocation site. Now, swift-syntax provides the macro expansion with the list of defined build conditions at the location of expansion. We can use this to have `#bundle` expand to just the appropriate initializer rather than the `#if` directives. This makes the expanded form of `#bundle` more readable, provides better diagnostics, and should reduce post-expansion parse time.

### Modifications:

Updates `#bundle` to only emit the appropriate code evaluating the build conditions during expansion

### Result:

Now `#bundle` expands to a single expression (i.e. `Bundle.module` or `Bundle(_dsoHandle: #dsoHandle)`) depending on the build configuration rather than expanding to a conditional.

### Testing:

Macro unit tests are updated to validate the new expansion across a variety of build configurations (and to validate the diagnostic behavior on the failure paths).
