### PR TITLE
Swift NSURL should reject colons in first path segment for compatibility

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Parsing.swift
+++ b/Sources/FoundationEssentials/URL/URL_Parsing.swift
@@ -630,6 +630,18 @@ internal func parse<T: _URLEncoding, Impl: _URLParseable>(
     // Path always exists
     if !validate(span: span.extracting(impl.pointee.pathRange), component: .path) {
         guard allowEncoding else { return false }
+        if flags.isDisjoint(with: [.hasScheme, .hasHost]) {
+            // A relative-ref must not contain a ":" before the first "/"
+            let path = span.extracting(impl.pointee.pathRange)
+            for i in path.indices {
+                let v = path[i]
+                if v == UInt8(ascii: "/") {
+                    break
+                } else if v == UInt8(ascii: ":") {
+                    return false
+                }
+            }
+        }
         flags.insert(.shouldEncodePath)
         shouldEncode = true
     }


### PR DESCRIPTION
URL strings such as `"not a url:"` should continue to return `nil` since a colon cannot exist in the first path segment of a relative-ref.

### Motivation:

Many modern parsers reject strings like `"not a url:"` because a relative-ref (relative path with no scheme or host) cannot contain a `":"` before the first `"/"`, or else it might be mistaken for the scheme. These parsers, and the Swift parser for `NSURL`, treat the string as a relative-ref once we see a non-scheme character, so we must check that the path does not contain a `":"` before the first `"/"` in this case.

The encoded `"not%20a%20url:"` is not necessarily ambiguous since a parser with a different approach would still reject `"not%20a%20url"` as an invalid scheme; however, there's likely unit tests or other code that checks this behavior, so we should continue to return `nil` here.

### Modifications:

For URLs with no scheme or host and invalid characters in the path, return `nil` if `":"` appears before `"/"` in the path.

### Result:

NSURLs initialized with strings such as `"not a url:"` or `"😎:colon/slash"` will continue to return `nil` when the Swift implementation is enabled.

### Testing:

Unit tests for `NSURL`.