### PR TITLE
Disable large data tests on watchOS

### DIFF
--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -215,7 +215,6 @@ private final class DataIOTests {
 
 extension LargeDataTests {
     // This test is placed in the LargeDataTests suite since it allocates an extremely large amount of memory for some devices
-#if !os(watchOS)
     @Test func readLargeFile() throws {
         let url = URL.temporaryDirectory.appendingPathComponent("testfile-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: url) }
@@ -236,6 +235,5 @@ extension LargeDataTests {
         #expect(data.count == readNS.count)
 #endif
     }
-#endif
 }
 

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2547,7 +2547,16 @@ extension DataTests {
 #endif
 
 // These tests require allocating an extremely large amount of data and are serialized to prevent the test runner from using all available memory at once
-@Suite("Large Data Tests", .serialized)
+@Suite("Large Data Tests",
+       .serialized, // Tests are serialized to avoid allocating large amounts of data concurrently
+       .disabled(if: {
+           #if os(watchOS) // Disable these tests on watchOS since the test runner will likely be terminated for consuming too much memory
+           true
+           #else
+           false
+           #endif
+       }(), "Allocating large amounts of data is not supported on this platform")
+)
 struct LargeDataTests {
 #if _pointerBitWidth(_64)
     let largeCount = Int(Int32.max)


### PR DESCRIPTION
Disables the `LargeDataTests` suite on watchOS

### Motivation:

These tests are isolated because they allocate very large amounts of memory to test `Data`'s large slice paths (~2GB of memory). In environments like watchOS, this can cause the test runner to be terminated due to memory growth.

### Modifications:

On watchOS, these tests are marked as disabled so that they will be skipped to avoid terminating the test runner.

### Result:

The large data tests are skipped on watchOS but continue running on all platforms

### Testing:

This is a unit-test only change
