### PR TITLE
Remove ~<user> expansion from `URL` file path initializers

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1434,8 +1434,9 @@ extension URL {
             return isAbsolute
         }
         #if !NO_FILESYSTEM
-        // Expand the tilde if present
-        if filePath.utf8.first == UInt8(ascii: "~") {
+        // Expand the tilde, but only for "~/" (no user)
+        // Treat a lone "~" as a potential file name and don't expand it
+        if filePath.utf8.starts(with: [UInt8(ascii: "~"), UInt8(ascii: "/")]) {
             filePath = filePath.expandingTildeInPath
         }
         #endif


### PR DESCRIPTION

Remove tilde expansion for `~<user>` paths from `URL` file path initializers, keeping only the expansion of `~/` prefixed paths.

### Motivation:

`URL(fileURLWithPath:)` unexpectedly resolves `~AnyText` to an iOS app's container directory.

Tilde expansion was originally added to the `URL` file path initializers to prevent confusion surrounding "Why doesn't `URL(fileURLWithPath: "~/Desktop/myFile.txt")` work?" and to avoid the `(path as NSString).expandingTildeInPath` dance required before passing the string to `URL`, which is unfortunate and often missed.

My original thought was that some `~FileName` is very unlikely to conflict with a valid system username and therefore attempting to expand the tilde would fail and return the original path. However, it turns out that for containerized iOS apps, `"~AnyText".expandingTildeInPath` universally resolves to the app's container directory via the check for `CFFIXED_USER_HOME`, leading to unexpected behavior when passing file names that start with `~` to the `URL` file path initializers.

### Modifications:

In `URL` file path initializers, only expand the tilde if the path explicitly starts with `~/`, which is by far the most commonly useful case. Allow `~` as a file name if desired.

### Result:

`URL(filePath: "~/Desktop")`, `URL(filePath: "~/Downloads")`, etc. will expand to their absolute home directory path, while URLs such as `URL(filePath: "~")`, `URL(filePath: "~mobile")`, `URL(filePath: "~MyFile.txt")` will all be considered relative paths with their `.baseURL` as the current working directory.

### Testing:

Added unit tests.