### PR TITLE
Add a UTF8Span FileSystemRepresentation helper

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -413,7 +413,7 @@ extension UTF8Span {
         var seenNullIdx: Int? = nil
         var iterator = self.makeUnicodeScalarIterator()
         
-        guard span.capacity > 0 else {
+        guard !span.isFull else {
             if !nullTerminated && iterator.next() == nil {
                 // No bytes to write, so an empty buffer is OK
                 return


### PR DESCRIPTION
Add an internal extension to `UTF8Span` to emit its file system representation into an `OutputBuffer`.

### Motivation:

This part of #1714 which will let us provide more flexible types for file system representations, including noncopyable types. This improves performance when dealing with file paths. 

### Modifications:

Adds the internal extension, but does not use it from anywhere in actual code just yet.

### Testing:

For now, internal only with no additional testing.