### PR TITLE
#1724: Convert to UInt64 in attributesOfFileSystem to fix 32-bit Linux platforms

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -741,10 +741,10 @@ extension _FileManagerImpl {
             let blockSize = UInt64(result.f_bsize)
             #else
             let fsNumber = result.f_fsid
-            let blockSize = UInt(result.f_frsize)
+            let blockSize = UInt64(result.f_frsize)
             #endif
-            var totalSizeBytes = result.f_blocks * blockSize
-            var availSizeBytes = result.f_bavail * blockSize
+            var totalSizeBytes = UInt64(result.f_blocks) * blockSize
+            var availSizeBytes = UInt64(result.f_bavail) * blockSize
             var totalFiles = result.f_files
             var availFiles = result.f_ffree
             


### PR DESCRIPTION
Add the proposed fix from #1724 to ensure that filesystem size calculations do not crash on 32-bit platforms for Linux.

### Motivation:

Resolves the issue described in #1724.

### Modifications:

Cast `result.f_frsize`, `result.f_blocks`, and `result.f_bavail` to `UInt64` in `attributesOfFileSystem(forPath: String)` so that filesystem size calculations do not crash on 32-bit Linux platforms.

### Result:

When this method is called on an armv7/armhf platform in Linux, the call no longer crashes with a segfault or illegal instruction.

### Testing:

The entire `FoundationEssentialsTests` suite passes with this change when compiled with `6.3-snapshot-2026-01-29`.