### PR TITLE
Remove unsafe span API

### DIFF
--- a/Sources/FoundationEssentials/PropertyList/BPlistDecodingFormat.swift
+++ b/Sources/FoundationEssentials/PropertyList/BPlistDecodingFormat.swift
@@ -73,15 +73,6 @@ struct _BPlistDecodingFormat : PlistDecodingFormat {
         return result
     }
     
-    @_lifetime(borrow map)
-    static func stringSpan(from mapValue: BPlistMap.Value, isAscii outIsAscii: inout Bool, in map: BPlistMap, for codingPathNode: _CodingPathNode, _ additionalKey: (some CodingKey)?) throws -> Span<UInt8> {
-        guard case let .string(region, isAscii) = mapValue else {
-            throw DecodingError._typeMismatch(at: codingPathNode.path(byAppending: additionalKey), expectation: String.self, reality: mapValue)
-        }
-        outIsAscii = isAscii
-        return map.span(for: region)
-    }
-    
     static func unwrapFloatingPoint<T : BinaryFloatingPoint>(from mapValue: BPlistMap.Value, in map: BPlistMap, for codingPathNode: _CodingPathNode, _ additionalKey: (some CodingKey)?) throws -> T {
         try mapValue.realValue(in: map, as: T.self, for: codingPathNode, additionalKey)
     }

--- a/Sources/FoundationEssentials/PropertyList/BPlistScanner.swift
+++ b/Sources/FoundationEssentials/PropertyList/BPlistScanner.swift
@@ -134,16 +134,6 @@ class BPlistMap : PlistDecodingMap {
             return try closure($0.buffer[region], $0.buffer)
         }
     }
-    
-    @_lifetime(self)
-    @inline(__always)
-    func span(for region: Region) -> Span<UInt8> {
-        let escaped = dataLock.withLock {
-            $0.buffer[region]
-        }
-        // We're just going to assume that the data itself is going to stay alive as long as this map does.
-        return _overrideLifetime(escaped.span, borrowing: self)
-    }
 
     deinit {
         dataLock.withLock {


### PR DESCRIPTION
I updated #1721 to use a "with" function style but didn't remove the unsafe Span API that it replaced. This fixes that.