### PR TITLE
Add inlined fast paths for Data's Sequence-based APIs

### DIFF
--- a/Benchmarks/Benchmarks/Data/BenchmarkData.swift
+++ b/Benchmarks/Benchmarks/Data/BenchmarkData.swift
@@ -31,6 +31,14 @@ let benchmarks = {
     typealias HalfInt = Int16
     #endif
 
+    func createSomeData(_ length: Int) -> Data {
+        var d = Data(repeating: 42, count: length)
+        // Set a byte to be another value just so we know we have a unique pointer to the backing
+        // For maximum inefficiency in the not equal case, set the last byte
+        d[length - 1] = UInt8.random(in: UInt8.min..<UInt8.max)
+        return d
+    }
+
     func createInlineData() -> Data {
         createSomeData(10) // 10B, Smaller than InlineData.Buffer
     }
@@ -77,6 +85,18 @@ let benchmarks = {
     }
     
     // MARK: -
+
+    Benchmark("DataInitSequence", configuration: .init(tags: ["kind": "inline"]), closure: { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(Data([1, 3, 5, 7]))
+        }
+    })
+
+    Benchmark("DataInitSequence", configuration: .init(tags: ["kind": "smallSlice"]), closure: { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(Data([1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33]))
+        }
+    })
 
     for (data, name) in dataKinds {
         Benchmark("DataEqual", configuration: .init(tags: ["kind": name]), closure: { _, box in

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -88,7 +88,7 @@ switch usePackage {
 
 let package = Package(
     name: "benchmarks",
-    platforms: [.macOS("15"), .iOS("18"), .tvOS("18"), .watchOS("11")], // Should match parent project
+    platforms: [.macOS("26"), .iOS("26"), .tvOS("26"), .watchOS("26"), .visionOS("26")], // Should match parent project
     dependencies: packageDependency,
     targets: [
         .executableTarget(
@@ -126,7 +126,7 @@ let package = Package(
             plugins: [
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
             ]
-        )
+        ),
         .executableTarget(
             name: "DataIOBenchmarks",
             dependencies: targetDependency,

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -44,7 +44,7 @@ extension Data {
 #endif
         @usableFromInline var length: UInt8
         
-        @inlinable // This is @inlinable as trivially computable.
+        @inlinable @inline(__always) // This is @inlinable as trivially computable.
         static func canStore(count: Int) -> Bool {
             return count <= MemoryLayout<Buffer>.size
         }
@@ -53,7 +53,7 @@ extension Data {
             return MemoryLayout<Buffer>.size
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ srcBuffer: UnsafeRawBufferPointer) {
             self.init(count: srcBuffer.count)
             if !srcBuffer.isEmpty {
@@ -63,7 +63,7 @@ extension Data {
             }
         }
         
-        @inlinable // This is @inlinable as a trivial initializer.
+        @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
         init(count: Int = 0) {
             assert(count <= MemoryLayout<Buffer>.size)
 #if _pointerBitWidth(_64)
@@ -76,7 +76,7 @@ extension Data {
             length = UInt8(count)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ slice: InlineSlice, count: Int) {
             self.init(count: count)
             Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
@@ -86,7 +86,7 @@ extension Data {
             }
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ slice: LargeSlice, count: Int) {
             self.init(count: count)
             Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in

--- a/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
@@ -30,64 +30,64 @@ extension Data {
         @usableFromInline var slice: Range<HalfInt>
         @usableFromInline var storage: __DataStorage
         
-        @inlinable // This is @inlinable as trivially computable.
+        @inlinable @inline(__always) // This is @inlinable as trivially computable.
         static func canStore(count: Int) -> Bool {
             return count < HalfInt.max
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ buffer: UnsafeRawBufferPointer) {
             assert(buffer.count < HalfInt.max)
             self.init(__DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(capacity: Int) {
             assert(capacity < HalfInt.max)
             self.init(__DataStorage(capacity: capacity), count: 0)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(count: Int) {
             assert(count < HalfInt.max)
             self.init(__DataStorage(length: count), count: count)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ inline: InlineData) {
             assert(inline.count < HalfInt.max)
             self.init(inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }, count: inline.count)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ inline: InlineData, range: Range<Int>) {
             assert(range.lowerBound < HalfInt.max)
             assert(range.upperBound < HalfInt.max)
             self.init(inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }, range: range)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ large: LargeSlice) {
             assert(large.range.lowerBound < HalfInt.max)
             assert(large.range.upperBound < HalfInt.max)
             self.init(large.storage, range: large.range)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ large: LargeSlice, range: Range<Int>) {
             assert(range.lowerBound < HalfInt.max)
             assert(range.upperBound < HalfInt.max)
             self.init(large.storage, range: range)
         }
         
-        @inlinable // This is @inlinable as a trivial initializer.
+        @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
         init(_ storage: __DataStorage, count: Int) {
             assert(count < HalfInt.max)
             self.storage = storage
             slice = 0..<HalfInt(count)
         }
         
-        @inlinable // This is @inlinable as a trivial initializer.
+        @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
         init(_ storage: __DataStorage, range: Range<Int>) {
             assert(range.lowerBound < HalfInt.max)
             assert(range.upperBound < HalfInt.max)

--- a/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
@@ -51,40 +51,41 @@ extension Data {
         @usableFromInline var slice: RangeReference
         @usableFromInline var storage: __DataStorage
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ buffer: UnsafeRawBufferPointer) {
             self.init(__DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(capacity: Int) {
             self.init(__DataStorage(capacity: capacity), count: 0)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(count: Int) {
             self.init(__DataStorage(length: count), count: count)
         }
         
-        @inlinable // This is @inlinable as a convenience initializer.
+        @inlinable @inline(__always) // This is @inlinable as a convenience initializer.
         init(_ inline: InlineData) {
             let storage = inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }
             self.init(storage, count: inline.count)
         }
         
-        @inlinable // This is @inlinable as a trivial initializer.
+        @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
         init(_ slice: InlineSlice) {
             self.storage = slice.storage
             self.slice = RangeReference(slice.range)
         }
         
-        @inlinable // This is @inlinable as a trivial initializer.
+        @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
         init(_ storage: __DataStorage, count: Int) {
             self.storage = storage
             self.slice = RangeReference(0..<count)
         }
         
         // Not exposed as ABI and only usable by internal, non-inlined code and therefore not @inlinable
+        @inline(__always)
         init(_ storage: __DataStorage, range: Range<Int>) {
             self.storage = storage
             self.slice = RangeReference(range)


### PR DESCRIPTION
Improves performance of `Data(_: Sequence<UInt8>)`, `Data.append(_: Sequence<UInt8>)` and `Data.replaceSubrange(_:with: Sequence<UInt8>)` by inlining fast paths into the client.

### Motivation:

For each of these APIs, `Data` accepts a generic `Sequence<UInt8>` and performs a set of quick checks:

- Perform a conditional cast to `ContiguousBytes` and use the underlying buffer if available
- Call `withContiguousStorageIfAvailable` and use the underlying buffer if available

And then uses an iterator based approach if both fails (it's not a contiguous sequence). These functions are `@inlinable`, however they don't get inlined in practice. The `as? ContiguousBytes` cast requires boxing via an existential which isn't optimized away and thwarts any optimizations across the casting boundary and the function generates enough code that the compiler rarely chooses to inline it fully.

Despite the above, for some cases there should be minimal overhead: initializing a `Data` from an array literal like `[1, 2, 3]` will always conform to `ContiguousBytes` and be able to provide a pointer to the buffer. Additionally, if that pointer extraction can be fully optimized, since the count is known, the switch over possible representations during initialization can be optimized away since the compiler can determine at compile time which variant of data will fit the bytes.

### Modifications:

- For each of the 3 `Sequence` APIs listed above:
    - Implement an always-inlined fast path for `Sequence<UInt8> & ContiguousBytes` that trivially extracts the pointer and forwards to the underlying representation
    - Implement an always-inlined fast path for `Sequence<UInt8>` that performs the `withContiguousStorageIfAvailable` check
    - Move the existing `@inlinable` entry point to a slow entry point only called by the client when the compiler can't guarantee one of the fast paths above will be used
- For each of `Data`'s representations, ensure that trivial initializers that simply set stored properties are always inlined
- Fix a few typos in the DataBenchmarks I introduced recently

### Result:

Initializing a `Data` from an array literal is significantly faster: over 400% faster for arrays that fit in the inline storage and 10% faster for larger arrays. Additionally, when a `Data` is created from an array literal and immediately use to retrieve a `RawSpan`, previously this involved >400 instructions initializing a `Data` but now those instructions are completely removed from the client binary and the materialization of the `Data` is completely optimized away.

<details>
<summary>Benchmark Results</summary>

### DataInitSequence (kind: inline) metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (wall clock) (ns) *         |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |         7 |         8 |         8 |         8 |         8 |        11 |        57 |    285479 |
|                   new                    |         1 |         2 |         2 |         2 |         2 |         2 |        26 |    808532 |
|                    Δ                     |        -6 |        -6 |        -6 |        -6 |        -6 |        -9 |       -31 |    523053 |
|              Improvement %               |        86 |        75 |        75 |        75 |        75 |        82 |        54 |    523053 |

<p>
</details>

<details><summary>Time (total CPU): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (total CPU) (ns) *          |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |         8 |         9 |         9 |         9 |         9 |        12 |        50 |    285479 |
|                   new                    |         2 |         2 |         2 |         2 |         3 |         3 |        22 |    808532 |
|                    Δ                     |        -6 |        -7 |        -7 |        -7 |        -6 |        -9 |       -28 |    523053 |
|              Improvement %               |        75 |        78 |        78 |        78 |        67 |        75 |        56 |    523053 |

<p>
</details>

<details><summary>Throughput (# / s): results within specified thresholds, fold down for details.</summary>
<p>

|          Throughput (# / s) (M)          |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |       134 |       123 |       122 |       121 |       119 |        93 |        18 |    285479 |
|                   new                    |       686 |       632 |       615 |       615 |       600 |       480 |        39 |    808532 |
|                    Δ                     |       552 |       509 |       493 |       494 |       481 |       387 |        21 |    523053 |
|              Improvement %               |       412 |       414 |       404 |       408 |       404 |       416 |       117 |    523053 |

<p>
</details>

### DataInitSequence (kind: smallSlice) metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (wall clock) (ns) *         |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |        54 |        58 |        58 |        59 |        62 |        74 |       103 |     48804 |
|                   new                    |        50 |        52 |        53 |        54 |        57 |        68 |       125 |     53504 |
|                    Δ                     |        -4 |        -6 |        -5 |        -5 |        -5 |        -6 |        22 |      4700 |
|              Improvement %               |         7 |        10 |         9 |         8 |         8 |         8 |       -21 |      4700 |

<p>
</details>

<details><summary>Time (total CPU): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (total CPU) (ns) *          |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |        55 |        59 |        59 |        60 |        63 |        74 |        98 |     48804 |
|                   new                    |        51 |        53 |        54 |        54 |        58 |        69 |        97 |     53504 |
|                    Δ                     |        -4 |        -6 |        -5 |        -6 |        -5 |        -5 |        -1 |      4700 |
|              Improvement %               |         7 |        10 |         8 |        10 |         8 |         7 |         1 |      4700 |

<p>
</details>

<details><summary>Throughput (# / s): results within specified thresholds, fold down for details.</summary>
<p>

|          Throughput (# / s) (M)          |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |        19 |        17 |        17 |        17 |        16 |        14 |        10 |     48804 |
|                   new                    |        20 |        19 |        19 |        19 |        18 |        15 |         8 |     53504 |
|                    Δ                     |         1 |         2 |         2 |         2 |         2 |         1 |        -2 |      4700 |
|              Improvement %               |         5 |        12 |        12 |        12 |        12 |         7 |       -20 |      4700 |

<p>
</details>

</details>

### Testing:

Existing unit tests cover these APIs
