### PR TITLE
Remove incorrect logic in `Data.replaceSubrange(_:with:UnsafeBufferPointer<T>)`

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -606,8 +606,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - parameter buffer: The replacement bytes.
     @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public mutating func replaceSubrange<SourceType>(_ subrange: Range<Index>, with buffer: UnsafeBufferPointer<SourceType>) {
-        guard !buffer.isEmpty  else { return }
-        replaceSubrange(subrange, with: buffer.baseAddress!, count: buffer.count * MemoryLayout<SourceType>.stride)
+        replaceSubrange(subrange, with: UnsafeRawBufferPointer(buffer))
     }
 
     /// Replace a region of bytes in the data with new bytes from a collection.

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -281,6 +281,12 @@ private final class DataTests {
         #expect(Data([1, 9, 8, 4, 5]) == d)
     }
 
+    @Test func replaceSubrangeEmptyBuffer() {
+        var d = Data([1, 2, 3, 4])
+        d.replaceSubrange(1 ..< 3, with: UnsafeBufferPointer<Int>(start: nil, count: 0))
+        #expect(d == Data([1, 4]))
+    }
+
     @Test func insertData() {
         let hello = dataFrom("Hello")
         let world = dataFrom(" World")


### PR DESCRIPTION
Removes incorrect logic in `Data.replaceSubrange(_:with:UnsafeBufferPointer<T>)` when provided with an empty buffer

### Motivation:

Replacing a subrange with an empty buffer is not a no-op, rather it should remove that subrange.

### Modifications:

Update `Data.replaceSubrange(_:with:UnsafeBufferPointer<T>)` to trivially forward to the funnel point which handles empty buffers appropriately rather than using separate (incorrect) logic.

### Result:

Replacing a subrange with an empty buffer now removes that subrange rather than doing nothing

### Testing:

Added an additional unit test which previously failed but now passes
