### PR TITLE
Resolve various warnings that were recently introduced

### DIFF
--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -241,6 +241,7 @@ extension Data : MutableDataProtocol {
     }
 }
 
+@available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
     /// Copy the contents of the data to a pointer.
     ///

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -368,7 +368,9 @@ extension Platform {
         if let processPath = CommandLine.arguments.first {
             return processPath
         }
+        return nil
+#else
+        return nil
 #endif
-    return nil
     }
 }

--- a/Sources/FoundationEssentials/Predicate/Archiving/EncodingContainers+PredicateExpression.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/EncodingContainers+PredicateExpression.swift
@@ -70,10 +70,7 @@ extension UnkeyedDecodingContainer {
     public mutating func decodePredicateExpression<each Input>(input: repeat (each Input).Type, predicateConfiguration: PredicateCodableConfiguration) throws -> (expression: any PredicateExpression<Bool>, variable: (repeat PredicateExpressions.Variable<each Input>)) {
         var container = try self.nestedContainer(keyedBy: PredicateExpressionCodingKeys.self)
         let (expr, variable) = try container._decode(input: repeat each input, output: Bool.self, predicateConfiguration: predicateConfiguration)
-        guard let casted = expr as? any PredicateExpression<Bool> else {
-            throw DecodingError.dataCorruptedError(in: self, debugDescription: "This expression has an unsupported output type of \(_typeName(type(of: expr).outputType)) (expected Bool)")
-        }
-        return (casted, variable)
+        return (expr as any PredicateExpression<Bool>, variable)
     }
     
     public mutating func decodePredicateExpressionIfPresent<each Input>(input: repeat (each Input).Type, predicateConfiguration: PredicateCodableConfiguration) throws -> (expression: any PredicateExpression<Bool>, variable: (repeat PredicateExpressions.Variable<each Input>))? {

--- a/Sources/FoundationEssentials/ProgressManager/ProgressFraction.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressFraction.swift
@@ -297,7 +297,7 @@ internal struct ProgressFraction : Sendable, Equatable, CustomDebugStringConvert
     }
     
     internal var debugDescription : String {
-        return "\(completed) / \(total) (\(fractionCompleted)), overflowed: \(overflowed)"
+        return "\(completed) / \(total, default: "unknown") (\(fractionCompleted)), overflowed: \(overflowed)"
     }
     
     // ----
@@ -305,12 +305,13 @@ internal struct ProgressFraction : Sendable, Equatable, CustomDebugStringConvert
     private static func _fromDouble(_ d : Double) -> (Int, Int) {
         // This simplistic algorithm could someday be replaced with something better.
         // Basically - how many 1/Nths is this double?
-        var denominator: Int
-        switch Int.bitWidth {
-            case 32:  denominator = 1048576    // 2^20 - safe for 32-bit
-            case 64:  denominator = 1073741824 // 2^30 - high precision for 64-bit
-            default:  denominator = 131072       // 2^17 - ultra-safe fallback
-        }
+        #if _pointerBitWidth(_32)
+        let denominator = 1048576    // 2^20 - safe for 32-bit
+        #elseif _pointerBitWidth(_64)
+        let denominator = 1073741824 // 2^30 - high precision for 64-bit
+        #else
+        let denominator = 131072       // 2^17 - ultra-safe fallback
+        #endif
         let numerator = Int(d / (1.0 / Double(denominator)))
         return (numerator, denominator)
     }

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -1737,7 +1737,7 @@ private final class DataTests {
         #expect(span.count == count)
         let v = UInt8.random(in: 10..<100)
         span[i] = v
-        var sub = span.extracting(i ..< i+1)
+        var sub = span._mutatingExtracting(i ..< i+1)
         sub.update(repeating: v)
         #expect(source[i] == v)
 #endif
@@ -1751,7 +1751,7 @@ private final class DataTests {
         var span = source.mutableSpan
         #expect(span.count == count)
         let i = try #require(span.indices.randomElement())
-        var sub = span.extracting(i..<i+1)
+        var sub = span._mutatingExtracting(i..<i+1)
         sub.update(repeating: .max)
         #expect(source[i] == .max)
 #endif
@@ -1773,7 +1773,7 @@ private final class DataTests {
         let byteCount = span.byteCount
         #expect(byteCount == count)
         let v = UInt8.random(in: 10..<100)
-        var sub = span.extracting(i..<i+1)
+        var sub = span._mutatingExtracting(i..<i+1)
         sub.storeBytes(of: v, as: UInt8.self)
         #expect(source[i] == v)
     }

--- a/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerTests.swift
@@ -399,10 +399,10 @@ extension Tag {
         
         manager.complete(count: 1)
         
-        var subprogress: Subprogress? = manager.subprogress(assigningCount: 1)
-        #expect(manager.fractionCompleted == 0.5)
-        
-        subprogress = nil
+        withExtendedLifetime(manager.subprogress(assigningCount: 1)) {
+            #expect(manager.fractionCompleted == 0.5)
+        }
+
         #expect(manager.fractionCompleted == 1.0)
     }
     

--- a/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
@@ -485,7 +485,7 @@ private struct TestDateAnchoredRelativeDiscreteConformance {
                 sourceLocation: sourceLocation)
         }
 
-        var now = try date("2021-06-10 12:00:00Z")
+        var now = date("2021-06-10 12:00:00Z")
 
         assertEvaluation(
             of: .init(anchor: now, presentation: .numeric, unitsStyle: .abbreviated),
@@ -565,7 +565,7 @@ private struct TestDateAnchoredRelativeDiscreteConformance {
                 "8 mo. ago",
             ])
 
-        now = try date("2023-05-15 08:47:20Z")
+        now = date("2023-05-15 08:47:20Z")
 
         assertEvaluation(
             of: .init(anchor: now, allowedFields: [.month, .week], presentation: .numeric, unitsStyle: .abbreviated),
@@ -685,7 +685,7 @@ private struct TestDateAnchoredRelativeDiscreteConformance {
                 "8 mo. ago",
             ])
 
-        now = try date("2019-06-03 09:41:00Z")
+        now = date("2019-06-03 09:41:00Z")
 
         assertEvaluation(
             of: .init(anchor: now, allowedFields: [.year, .month, .day, .hour, .minute], presentation: .named, unitsStyle: .wide),


### PR DESCRIPTION
While resolving a few specific warnings related to `Sendable` annotations, I noticed a handful of warnings introduced that can easily be resolved and decided to fix them.

### Motivation:

Reduces the number of warnings when building foundation so that the set of produced warnings are more manageable and indicate true issues rather than spurious problems.

### Modifications:

A variety of modifications to update the code based on the mentioned warnings

### Result:

Resolves about 10-15 warnings overall

### Testing:

Covered by existing unit test coverage
