### PR TITLE
FoundationEssentials: Force unwrap the result of a `realloc()` when reading Data

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -381,7 +381,7 @@ internal func readBytesFromFile(path inPath: borrowing some FileSystemRepresenta
             if length != chunkSize {
                 break
             }
-            ptr = realloc(ptr, totalRead + chunkSize)
+            ptr = realloc(ptr, totalRead + chunkSize)!
         }
         result = ReadBytesResult(bytes: ptr, length: totalRead, deallocator: .free)
         #else


### PR DESCRIPTION
The new safe C interop mode added in swiftlang/swift#87131 found this when cross-compiling to Android now.

On Android, the declaration is `void* _Nullable realloc(void* _Nullable __ptr, size_t __byte_count) __BIONIC_ALLOC_SIZE(2) __wur;` but Swift long and seemingly wrongly accepted this assignment, with it [starting to fail](https://ci.swift.org/job/swift-PR-swift-sdk-for-android/8/console) on [the Android CI lately](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/253/console).

@hnrklssn, could you confirm that your safe Interop pull corrected this?