### PR TITLE
Remove ContiguousBytes.withBytes protocol requirement

### DIFF
--- a/Sources/FoundationEssentials/Data/ContiguousBytes.swift
+++ b/Sources/FoundationEssentials/Data/ContiguousBytes.swift
@@ -57,12 +57,15 @@ public protocol ContiguousBytes: ~Escapable, ~Copyable {
     func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R
 #endif
 
+    /*
+     NOTE: For now, this is not a protocol requirement because adding it can be a source breaking change for clients with MemberImportVisibility enabled (such as swift-crypto)
     /// Calls the given closure with the contents of underlying storage.
     ///
     /// - note: Calling `withBytes` multiple times does not guarantee that
     ///         the same span will be passed in every time.
     @available(FoundationPreview 6.4, *)
     func withBytes<R, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R
+     */
 }
 
 extension ContiguousBytes where Self: ~Escapable, Self: ~Copyable {


### PR DESCRIPTION
Removes the `withBytes` requirement on `ContiguousBytes` due to source breaking changes in clients with `MemberImportVisibility` enabled

### Motivation:

Clients like swift-crypto fail to build with this requirement. In swift-crypto's case, there is a type (`MD5Digest`) defined in a file that does not import `FoundationEssentials`. It conforms to a protocol (`DigestPrivate: Digest`) which refines `ContiguousBytes` and is defined in a separate file that does import `FoundationEssentials`. In that scenario, `MD5Digest` conforms to `ContiguousBytes` but does not see the default implementation member of the protocol requirement where the type is declared.

### Modifications:

Removes the protocol requirement until this issue is resolved (but leaves the default implementation and implementations on concrete types so it can still be used without overriding the requirement).

### Result:

swift-crypto builds successfully

### Testing:

Locally confirmed that swift crypto builds successfully
