### PR TITLE
Remove unused NSURL-recore code

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1336,10 +1336,6 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.bridgeToNSURL()
     }
 
-    internal func isFileReferenceURL() -> Bool {
-        return _url.isFileReferenceURL()
-    }
-
 #endif // FOUNDATION_FRAMEWORK
 
     internal var _swiftURL: _SwiftURL? {
@@ -1388,8 +1384,8 @@ extension URL {
         case windows
     }
 
-    internal func fileSystemPath(style: URL.PathStyle = URL.defaultPathStyle, resolveAgainstBase: Bool = true, compatibility: Bool = false) -> String {
-        _url.fileSystemPath(style: style, resolveAgainstBase: resolveAgainstBase, compatibility: compatibility)
+    internal func fileSystemPath(style: URL.PathStyle = URL.defaultPathStyle, resolveAgainstBase: Bool = true) -> String {
+        _url.fileSystemPath(style: style, resolveAgainstBase: resolveAgainstBase)
     }
 
     #if os(Windows)

--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -92,22 +92,6 @@ final class URLParseInfo: Sendable {
         return (startIndex..<endIndex)
     }
 
-    var netLocation: Substring? {
-        guard let netLocationRange else {
-            return nil
-        }
-        return urlString[netLocationRange]
-    }
-
-    // Does not include the "?" or "#" separator at the beginning
-    var cfResourceSpecifierRange: Range<String.Index>? {
-        guard let startIndex = queryRange?.lowerBound
-                ?? fragmentRange?.lowerBound else {
-            return nil
-        }
-        return startIndex..<urlString.endIndex
-    }
-
     var user: Substring? {
         guard let userRange else {
             return nil
@@ -1195,14 +1179,6 @@ internal extension UInt8 {
 // MARK: - Compatibility Parsing
 
 extension RFC3986Parser {
-    /// Parses the URL string into its component parts with no encoding or validation.
-    /// Only used for `CFURLGetByteRangeForComponent`.
-    /// - Note: The `URLParseInfo` returned may refer to an invalid URL.
-    static func rawParse(urlString: String) -> URLParseInfo? {
-        // Can only be nil if the port string is wildly invalid.
-        return compatibilityParse(urlString: urlString)
-    }
-
     static func compatibilityParse(urlString: String, encodingInvalidCharacters: Bool) -> URLParseInfo? {
         guard let parseInfo = compatibilityParse(urlString: urlString) else {
             return nil

--- a/Sources/FoundationEssentials/URL/URL_Bridge.swift
+++ b/Sources/FoundationEssentials/URL/URL_Bridge.swift
@@ -239,9 +239,9 @@ internal final class _BridgedURL: NSObject, _URLProtocol, @unchecked Sendable {
         return nil
     }
 
-    func fileSystemPath(style: URL.PathStyle, resolveAgainstBase: Bool, compatibility: Bool) -> String {
+    func fileSystemPath(style: URL.PathStyle, resolveAgainstBase: Bool) -> String {
         let path = resolveAgainstBase ? absolutePath(percentEncoded: true) : relativePath(percentEncoded: true)
-        return _SwiftURL.fileSystemPath(for: path, style: style, compatibility: compatibility)
+        return _SwiftURL.fileSystemPath(for: path, style: style)
     }
 
     func withUnsafeFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType {
@@ -411,7 +411,7 @@ internal final class _BridgedURL: NSObject, _URLProtocol, @unchecked Sendable {
         return _url
     }
 
-    func isFileReferenceURL() -> Bool {
+    private func isFileReferenceURL() -> Bool {
         #if NO_FILESYSTEM
         return false
         #else

--- a/Sources/FoundationEssentials/URL/URL_Protocol.swift
+++ b/Sources/FoundationEssentials/URL/URL_Protocol.swift
@@ -64,7 +64,7 @@ internal protocol _URLProtocol: AnyObject, Sendable {
     var fragment: String? { get }
     func fragment(percentEncoded: Bool) -> String?
 
-    func fileSystemPath(style: URL.PathStyle, resolveAgainstBase: Bool, compatibility: Bool) -> String
+    func fileSystemPath(style: URL.PathStyle, resolveAgainstBase: Bool) -> String
     func withUnsafeFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType
 
     var hasDirectoryPath: Bool { get }
@@ -90,7 +90,6 @@ internal protocol _URLProtocol: AnyObject, Sendable {
     var debugDescription: String { get }
 
     func bridgeToNSURL() -> NSURL
-    func isFileReferenceURL() -> Bool
 
     /// We must not store a `_URLProtocol` in `URL` without running it through this function.
     /// This makes sure that we do not hold a file reference URL, which changes the nullability of many functions.

--- a/Sources/FoundationEssentials/URL/URL_Swift.swift
+++ b/Sources/FoundationEssentials/URL/URL_Swift.swift
@@ -50,15 +50,9 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
 
     #if FOUNDATION_FRAMEWORK
     // Used frequently for NS/CFURL behaviors
-    internal var isDecomposable: Bool {
+    private var isDecomposable: Bool {
         return _parseInfo.scheme == nil || hasAuthority || _parseInfo.path.utf8.first == ._slash
     }
-
-    // For use by CoreServicesInternal to cache property values.
-    internal final class ResourceInfo: @unchecked Sendable {
-        let ref = LockedState<CFTypeRef?>(initialState: nil)
-    }
-    internal let _resourceInfo = ResourceInfo()
 
     // Note: We use a lock instead of a lazy var to ensure that we always
     // bridge to the same NSURL even if the URL was copied across threads.
@@ -302,11 +296,11 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         return _parseInfo.urlString
     }
 
-    internal func absoluteString(original: Bool) -> String {
+    var absoluteString: String {
         guard let baseURL else {
-            return original ? originalString : relativeString
+            return relativeString
         }
-        var builder = URLStringBuilder(parseInfo: _parseInfo, original: original)
+        var builder = URLStringBuilder(parseInfo: _parseInfo)
         if builder.scheme != nil {
             builder.path = builder.path.removingDotSegments
             return builder.string
@@ -318,18 +312,15 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
             return builder.string
         }
         let baseParseInfo = baseURL._swiftURL?._parseInfo
-        // If we aren't in the special case where we need the original
-        // string, always leave the base components encoded.
-        let baseComponentsToDecode = !original ? [] : baseParseInfo?.encodedComponents ?? []
-        if let baseUser = baseURL.user(percentEncoded: !baseComponentsToDecode.contains(.user)) {
+        if let baseUser = baseURL.user(percentEncoded: true) {
             builder.user = baseUser
         }
-        if let basePassword = baseURL.password(percentEncoded: !baseComponentsToDecode.contains(.password)) {
+        if let basePassword = baseURL.password(percentEncoded: true) {
             builder.password = basePassword
         }
         if let baseHost = baseParseInfo?.host {
-            builder.host = baseComponentsToDecode.contains(.host) && baseParseInfo!.didPercentEncodeHost ? Parser.percentDecode(baseHost) : String(baseHost)
-        } else if let baseHost = baseURL.host(percentEncoded: !baseComponentsToDecode.contains(.host)) {
+            builder.host = String(baseHost)
+        } else if let baseHost = baseURL.host(percentEncoded: true) {
             builder.host = baseHost
         }
         if let basePort = baseParseInfo?.portString {
@@ -338,8 +329,8 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
             builder.portString = String(basePort)
         }
         if builder.path.isEmpty {
-            builder.path = baseURL.path(percentEncoded: !baseComponentsToDecode.contains(.path))
-            if builder.query == nil, let baseQuery = baseURL.query(percentEncoded: !baseComponentsToDecode.contains(.query)) {
+            builder.path = baseURL.path(percentEncoded: true)
+            if builder.query == nil, let baseQuery = baseURL.query(percentEncoded: true) {
                 builder.query = baseQuery
             }
         } else {
@@ -348,15 +339,11 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
             } else if baseURL.hasAuthority && baseURL.path().isEmpty {
                 "/" + builder.path
             } else {
-                baseURL.path(percentEncoded: !baseComponentsToDecode.contains(.path)).merging(relativePath: builder.path)
+                baseURL.path(percentEncoded: true).merging(relativePath: builder.path)
             }
             builder.path = newPath.removingDotSegments
         }
         return builder.string
-    }
-
-    var absoluteString: String {
-        return absoluteString(original: false)
     }
 
     var baseURL: URL? {
@@ -365,38 +352,12 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
 
     private var absoluteSwiftURL: _SwiftURL {
         guard baseURL != nil else { return self }
-        return _SwiftURL(stringOrEmpty: absoluteString(original: false), encoding: _encoding, compatibility: true) ?? self
+        return _SwiftURL(stringOrEmpty: absoluteString, encoding: _encoding, compatibility: true) ?? self
     }
 
     var absoluteURL: URL? {
         guard baseURL != nil else { return nil }
         return absoluteSwiftURL.url
-    }
-
-    // Compatibility mode for CFURLCreateAbsoluteURLWithBytes
-    internal var compatibilityAbsoluteString: String {
-        guard let baseURL = baseURL?._swiftURL else {
-            return URLStringBuilder(parseInfo: _parseInfo, original: true).removingDotSegments.string
-        }
-        let first = originalString.utf8.first
-        if first == nil || first == UInt8(ascii: "?") || first == UInt8(ascii: "#") {
-            return URLStringBuilder(parseInfo: baseURL._parseInfo, original: true).removingDotSegments.string + originalString
-        }
-        var builder = URLStringBuilder(parseInfo: _parseInfo, original: true)
-        if let scheme {
-            guard scheme == baseURL.scheme else {
-                return URLStringBuilder(parseInfo: _parseInfo, original: true).removingDotSegments.string
-            }
-            builder.scheme = nil
-        }
-        guard let newURL = _SwiftURL(stringOrEmpty: builder.string, relativeTo: _baseURL, encodingInvalidCharacters: true, encoding: _encoding, compatibility: true) else {
-            return absoluteString(original: true)
-        }
-        return newURL.absoluteString(original: true)
-    }
-
-    internal var compatibilityAbsoluteURL: URL? {
-        return _SwiftURL(stringOrEmpty: compatibilityAbsoluteString, encodingInvalidCharacters: true, encoding: _encoding, compatibility: true)?.url
     }
 
     // MARK: - Components
@@ -415,16 +376,6 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
 
     var hasAuthority: Bool {
         return _parseInfo.hasAuthority
-    }
-
-    internal var netLocation: String? {
-        guard hasAuthority else {
-            return baseURL?._swiftURL?.netLocation
-        }
-        guard let netLocation = _parseInfo.netLocation else {
-            return nil
-        }
-        return String(netLocation)
     }
 
     var user: String? {
@@ -626,21 +577,17 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         #endif
     }
 
-    internal static func fileSystemPath(for urlPath: String, style: URL.PathStyle = URL.defaultPathStyle, compatibility: Bool = false) -> String {
-        let slashDropper: (String) -> String = if compatibility {
-            { $0._droppingTrailingSlash }
-        } else {
-            { $0._droppingTrailingSlashes }
-        }
+    internal static func fileSystemPath(for urlPath: String, style: URL.PathStyle = URL.defaultPathStyle) -> String {
+        let slashDropper: (String) -> String = { $0._droppingTrailingSlashes }
         switch style {
         case .posix: return decodeFilePath(slashDropper(urlPath))
         case .windows: return windowsPath(for: urlPath, slashDropper: slashDropper)
         }
     }
 
-    internal func fileSystemPath(style: URL.PathStyle = URL.defaultPathStyle, resolveAgainstBase: Bool = true, compatibility: Bool = false) -> String {
+    internal func fileSystemPath(style: URL.PathStyle = URL.defaultPathStyle, resolveAgainstBase: Bool = true) -> String {
         let urlPath = resolveAgainstBase ? absolutePath(percentEncoded: true) : relativePath(percentEncoded: true)
-        return Self.fileSystemPath(for: urlPath, style: style, compatibility: compatibility)
+        return Self.fileSystemPath(for: urlPath, style: style)
     }
 
     func withUnsafeFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType {
@@ -708,7 +655,7 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         return appending(path: component, directoryHint: directoryHint, encodingSlashes: true)
     }
 
-    internal func appending<S: StringProtocol>(path: S, directoryHint: URL.DirectoryHint, encodingSlashes: Bool, compatibility: Bool = false) -> URL? {
+    internal func appending<S: StringProtocol>(path: S, directoryHint: URL.DirectoryHint, encodingSlashes: Bool) -> URL? {
         guard !path.isEmpty || !_parseInfo.path.isEmpty || _parseInfo.netLocationRange?.isEmpty == false else {
             return nil
         }
@@ -725,17 +672,10 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         }
         #endif
 
-        if !encodingSlashes && !compatibility {
-            pathToAppend = Parser.percentEncode(pathComponent: pathToAppend)
+        if encodingSlashes {
+            pathToAppend = Parser.percentEncode(pathComponent: pathToAppend, including: [._slash])
         } else {
-            var toEncode = Set<UInt8>()
-            if encodingSlashes {
-                toEncode.insert(._slash)
-            }
-            if compatibility {
-                toEncode.insert(._semicolon)
-            }
-            pathToAppend = Parser.percentEncode(pathComponent: pathToAppend, including: toEncode)
+            pathToAppend = Parser.percentEncode(pathComponent: pathToAppend)
         }
 
         func appendedPath() -> String {
@@ -908,7 +848,7 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         return _SwiftURL(stringOrEmpty: string, relativeTo: baseURL)?.url
     }
     
-    internal func appendingPathExtension(_ pathExtension: String, compatibility: Bool) -> URL? {
+    func appendingPathExtension(_ pathExtension: String) -> URL? {
         guard !pathExtension.isEmpty, !_parseInfo.path.isEmpty else {
             return nil
         }
@@ -921,19 +861,11 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         #endif
         var components = URLComponents(parseInfo: _parseInfo)
         // pathExtension might need to be percent-encoded
-        let encodedExtension = if compatibility {
-            Parser.percentEncode(pathComponent: pathExtension, including: [._semicolon])
-        } else {
-            Parser.percentEncode(pathComponent: pathExtension)
-        }
+        let encodedExtension = Parser.percentEncode(pathComponent: pathExtension)
         let newPath = components.percentEncodedPath.appendingPathExtension(encodedExtension)
         components.percentEncodedPath = newPath
         let string = components._uncheckedString(original: false)
         return _SwiftURL(string: string, relativeTo: baseURL)?.url
-    }
-
-    func appendingPathExtension(_ pathExtension: String) -> URL? {
-        return appendingPathExtension(pathExtension, compatibility: false)
     }
 
     func deletingPathExtension() -> URL? {
@@ -1014,7 +946,7 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
         return _nsurl
     }
 
-    internal func isFileReferenceURL() -> Bool {
+    private func isFileReferenceURL() -> Bool {
         #if NO_FILESYSTEM
         return false
         #else
@@ -1067,31 +999,30 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
             return user != nil || password != nil || host != nil || portString != nil
         }
 
-        init(parseInfo: URLParseInfo, original: Bool) {
-            let encodedComponents = original ? parseInfo.encodedComponents : []
+        init(parseInfo: URLParseInfo) {
             if let scheme = parseInfo.scheme {
                 self.scheme = String(scheme)
             }
             if let user = parseInfo.user{
-                self.user = encodedComponents.contains(.user) ? Parser.percentDecode(user) : String(user)
+                self.user = String(user)
             }
             if let password = parseInfo.password {
-                self.password = encodedComponents.contains(.password) ? Parser.percentDecode(password) : String(password)
+                self.password = String(password)
             }
             if let host = parseInfo.host {
                 // We don't need to check for IDNA-encoding since only CFURL uses
                 // the original string, and CFURL does not support INDA-encoding.
-                self.host = encodedComponents.contains(.host) ? Parser.percentDecode(host) : String(host)
+                self.host = String(host)
             }
             if let portString = parseInfo.portString {
                 self.portString = String(portString)
             }
-            self.path = encodedComponents.contains(.path) ? Parser.percentDecode(parseInfo.path) ?? "" : String(parseInfo.path)
+            self.path = String(parseInfo.path)
             if let query = parseInfo.query {
-                self.query = encodedComponents.contains(.query) ? Parser.percentDecode(query) : String(query)
+                self.query = String(query)
             }
             if let fragment = parseInfo.fragment {
-                self.fragment = encodedComponents.contains(.fragment) ? Parser.percentDecode(fragment) : String(fragment)
+                self.fragment = String(fragment)
             }
         }
 


### PR DESCRIPTION
When landing #1675 to re-core `CFURL` in Swift, I removed most of the compatibility code left over from the earlier `NSURL` re-core attempt. This cleans up the rest I missed.

### Motivation:

Declutter/simplify the Swift URL implementation.

### Modifications:

Removes unused functions and compatibility paths.

### Result:

No behavior changes.

### Testing:

Building and unit testing to confirm functions are unused/behavior is the same.