### PR TITLE
Fully qualify PredicateExpression function calls in #Predicate expansion

### DIFF
--- a/Tests/FoundationMacrosTests/PredicateMacroBasicTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroBasicTests.swift
@@ -23,7 +23,7 @@ private struct PredicateMacroBasicTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                return PredicateExpressions.build_Arg(
+                return PredicateExpressions.\(foundationModuleName)::build_Arg(
                     true
                 )
             })
@@ -40,7 +40,7 @@ private struct PredicateMacroBasicTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_Arg(
+                PredicateExpressions.\(foundationModuleName)::build_Arg(
                     true
                 )
             })
@@ -57,7 +57,7 @@ private struct PredicateMacroBasicTests {
             """,
             """
             \(foundationModuleName).Predicate({ input in
-                PredicateExpressions.build_Arg(
+                PredicateExpressions.\(foundationModuleName)::build_Arg(
                     true
                 )
             })
@@ -74,7 +74,7 @@ private struct PredicateMacroBasicTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({
-                PredicateExpressions.build_Arg(
+                PredicateExpressions.\(foundationModuleName)::build_Arg(
                     $0
                 )
             })
@@ -90,8 +90,8 @@ private struct PredicateMacroBasicTests {
             }
             """,
             """
-            \(foundationModuleName).Predicate<Int, String>({ (a: PredicateExpressions.Variable<Int>, b: PredicateExpressions.Variable<String>) in
-                PredicateExpressions.build_Arg(
+            \(foundationModuleName).Predicate<Int, String>({ (a: PredicateExpressions.\(foundationModuleName)::Variable<Int>, b: PredicateExpressions.\(foundationModuleName)::Variable<String>) in
+                PredicateExpressions.\(foundationModuleName)::build_Arg(
                     true
                 )
             })
@@ -151,8 +151,8 @@ private struct PredicateMacroBasicTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
+                PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                    root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                     keyPath: \\.foo
                 )
             })
@@ -166,8 +166,8 @@ private struct PredicateMacroBasicTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg(input),
+                PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                    root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                     keyPath: \\.foo
                 )
             })
@@ -181,9 +181,9 @@ private struct PredicateMacroBasicTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
+                PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                    root: PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                         keyPath: \\.foo
                     ),
                     keyPath: \\.bar
@@ -204,7 +204,7 @@ private struct PredicateMacroBasicTests {
             """
             // comment
             \(foundationModuleName).Predicate<Object>({ input in
-                return PredicateExpressions.build_Arg(
+                return PredicateExpressions.\(foundationModuleName)::build_Arg(
                     true // comment
                 )
             }) // comment

--- a/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
@@ -23,9 +23,9 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_subscript(
-                    PredicateExpressions.build_Arg(input),
-                    PredicateExpressions.build_Arg(1)
+                PredicateExpressions.\(foundationModuleName)::build_subscript(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(1)
                 )
             })
             """
@@ -39,10 +39,10 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_subscript(
-                    PredicateExpressions.build_Arg(input),
-                    PredicateExpressions.build_Arg(1),
-                    default: PredicateExpressions.build_Arg("Hello")
+                PredicateExpressions.\(foundationModuleName)::build_subscript(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(1),
+                    default: PredicateExpressions.\(foundationModuleName)::build_Arg("Hello")
                 )
             })
             """
@@ -56,23 +56,23 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input, input2, input3 in
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.build_subscript(
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_subscript(
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.dictionary
                         ),
-                        PredicateExpressions.build_Arithmetic(
-                            lhs: PredicateExpressions.build_Arg(input2),
-                            rhs: PredicateExpressions.build_Arg(1),
+                        PredicateExpressions.\(foundationModuleName)::build_Arithmetic(
+                            lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(input2),
+                            rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(1),
                             op: .add
                         ),
-                        default: PredicateExpressions.build_Equal(
-                            lhs: PredicateExpressions.build_Arg(input3),
-                            rhs: PredicateExpressions.build_Arg(input2)
+                        default: PredicateExpressions.\(foundationModuleName)::build_Equal(
+                            lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(input3),
+                            rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(input2)
                         )
                     ),
-                    rhs: PredicateExpressions.build_Arg(false)
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(false)
                 )
             })
             """
@@ -106,9 +106,9 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_contains(
-                    PredicateExpressions.build_Arg(inputA),
-                    PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_contains(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -122,9 +122,9 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<String>({ input in
-                PredicateExpressions.build_contains(
-                    PredicateExpressions.build_Arg(input),
-                    PredicateExpressions.build_Arg("foo")
+                PredicateExpressions.\(foundationModuleName)::build_contains(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg("foo")
                 )
             })
             """
@@ -142,10 +142,10 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_contains(
-                    PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_contains(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                     where: {
-                        PredicateExpressions.build_Arg(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(
                             $0
                         )
                     }
@@ -164,10 +164,10 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_contains(
-                    PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_contains(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                 ) {
-                    PredicateExpressions.build_Arg(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(
                         $0
                     )
                 }
@@ -187,10 +187,10 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_allSatisfy(
-                    PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_allSatisfy(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                     {
-                        PredicateExpressions.build_Arg(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(
                             $0
                         )
                     }
@@ -209,10 +209,10 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_allSatisfy(
-                    PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_allSatisfy(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                 ) {
-                    PredicateExpressions.build_Arg(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(
                         $0
                     )
                 }
@@ -232,10 +232,10 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_filter(
-                    PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_filter(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                     {
-                        PredicateExpressions.build_Arg(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(
                             $0
                         )
                     }
@@ -254,10 +254,10 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_filter(
-                    PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_filter(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                 ) {
-                    PredicateExpressions.build_Arg(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(
                         $0
                     )
                 }
@@ -274,12 +274,12 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_filter(
-                    PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_filter(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                     {
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg($0),
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                                 keyPath: \\.foo
                             ),
                             keyPath: \\.bar
@@ -300,9 +300,9 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_starts(
-                    PredicateExpressions.build_Arg(inputA),
-                    with: PredicateExpressions.build_Arg(\\Element.foo.bar)
+                PredicateExpressions.\(foundationModuleName)::build_starts(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    with: PredicateExpressions.\(foundationModuleName)::build_Arg(\\Element.foo.bar)
                 )
             })
             """
@@ -316,14 +316,14 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<[Object]>({ inputA in
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_filter(
-                        PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                    root: PredicateExpressions.\(foundationModuleName)::build_filter(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                         {
-                            PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_ForcedUnwrap(
-                                    PredicateExpressions.build_KeyPath(
-                                        root: PredicateExpressions.build_Arg($0),
+                            PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_ForcedUnwrap(
+                                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                        root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                                         keyPath: \\.foo
                                     )
                                 ),
@@ -357,9 +357,9 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_starts(
-                    PredicateExpressions.build_Arg(inputA),
-                    with: PredicateExpressions.build_Arg("foo")
+                PredicateExpressions.\(foundationModuleName)::build_starts(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    with: PredicateExpressions.\(foundationModuleName)::build_Arg("foo")
                 )
             })
             """
@@ -396,11 +396,11 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<[Int]>({ inputA in
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.build_min(
-                        PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_min(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                     ),
-                    rhs: PredicateExpressions.build_Arg(0)
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(0)
                 )
             })
             """
@@ -416,17 +416,18 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<[Int]>({ inputA in
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.build_max(
-                        PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_max(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                     ),
-                    rhs: PredicateExpressions.build_Arg(0)
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(0)
                 )
             })
             """
         )
     }
-    
+
+    #if FOUNDATION_FRAMEWORK
     @Test func localizedStandardContains() {
         AssertPredicateExpansion(
             """
@@ -436,9 +437,9 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<String>({ inputA in
-                PredicateExpressions.build_localizedStandardContains(
-                    PredicateExpressions.build_Arg(inputA),
-                    PredicateExpressions.build_Arg("foo")
+                PredicateExpressions.\(foundationModuleName)::build_localizedStandardContains(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg("foo")
                 )
             })
             """
@@ -472,9 +473,9 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<String>({ inputA in
-                PredicateExpressions.build_localizedCompare(
-                    PredicateExpressions.build_Arg(inputA),
-                    PredicateExpressions.build_Arg("foo")
+                PredicateExpressions.\(foundationModuleName)::build_localizedCompare(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg("foo")
                 )
             })
             """
@@ -526,16 +527,15 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<String>({ inputA in
-                PredicateExpressions.build_caseInsensitiveCompare(
-                    PredicateExpressions.build_Arg(inputA),
-                    PredicateExpressions.build_Arg("foo")
+                PredicateExpressions.\(foundationModuleName)::build_caseInsensitiveCompare(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg("foo")
                 )
             })
             """
         )
     }
-    
-    #if FOUNDATION_FRAMEWORK
+
     @Test func evaluate() {
         AssertPredicateExpansion(
             """
@@ -545,8 +545,8 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<String>({ input in
-                PredicateExpressions.build_evaluate(
-                    PredicateExpressions.build_Arg(other)
+                PredicateExpressions.\(foundationModuleName)::build_evaluate(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(other)
                 )
             })
             """
@@ -559,9 +559,9 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<String>({ input in
-                PredicateExpressions.build_evaluate(
-                    PredicateExpressions.build_Arg(other),
-                    PredicateExpressions.build_Arg(input)
+                PredicateExpressions.\(foundationModuleName)::build_evaluate(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(other),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(input)
                 )
             })
             """
@@ -574,10 +574,10 @@ private struct PredicateMacroFunctionCallTests {
             """,
             """
             \(foundationModuleName).Predicate<String>({ input in
-                PredicateExpressions.build_evaluate(
-                    PredicateExpressions.build_Arg(other),
-                    PredicateExpressions.build_Arg(input),
-                    PredicateExpressions.build_Arg(input)
+                PredicateExpressions.\(foundationModuleName)::build_evaluate(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(other),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(input)
                 )
             })
             """

--- a/Tests/FoundationMacrosTests/PredicateMacroLanguageOperatorTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroLanguageOperatorTests.swift
@@ -23,9 +23,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -41,9 +41,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                return PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB)
+                return PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -59,9 +59,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_NotEqual(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_NotEqual(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -77,9 +77,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Comparison(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB),
+                PredicateExpressions.\(foundationModuleName)::build_Comparison(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
                     op: .lessThan
                 )
             })
@@ -94,9 +94,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Comparison(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB),
+                PredicateExpressions.\(foundationModuleName)::build_Comparison(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
                     op: .lessThanOrEqual
                 )
             })
@@ -111,9 +111,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Comparison(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB),
+                PredicateExpressions.\(foundationModuleName)::build_Comparison(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
                     op: .greaterThan
                 )
             })
@@ -128,9 +128,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Comparison(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB),
+                PredicateExpressions.\(foundationModuleName)::build_Comparison(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
                     op: .greaterThanOrEqual
                 )
             })
@@ -147,9 +147,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Conjunction(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_Conjunction(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -165,9 +165,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Disjunction(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_Disjunction(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -183,9 +183,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Arithmetic(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB),
+                PredicateExpressions.\(foundationModuleName)::build_Arithmetic(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
                     op: .add
                 )
             })
@@ -200,9 +200,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Arithmetic(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB),
+                PredicateExpressions.\(foundationModuleName)::build_Arithmetic(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
                     op: .subtract
                 )
             })
@@ -217,9 +217,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Arithmetic(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB),
+                PredicateExpressions.\(foundationModuleName)::build_Arithmetic(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
                     op: .multiply
                 )
             })
@@ -236,9 +236,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Division(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_Division(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -254,9 +254,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Remainder(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_Remainder(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -272,8 +272,8 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Negation(
-                    PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_Negation(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                 )
             })
             """
@@ -289,8 +289,8 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_UnaryMinus(
-                    PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_UnaryMinus(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                 )
             })
             """
@@ -306,9 +306,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_NilCoalesce(
-                    lhs: PredicateExpressions.build_Arg(inputA),
-                    rhs: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_NilCoalesce(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -324,9 +324,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_Range(
-                    lower: PredicateExpressions.build_Arg(inputA),
-                    upper: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_Range(
+                    lower: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    upper: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -340,9 +340,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
-                PredicateExpressions.build_ClosedRange(
-                    lower: PredicateExpressions.build_Arg(inputA),
-                    upper: PredicateExpressions.build_Arg(inputB)
+                PredicateExpressions.\(foundationModuleName)::build_ClosedRange(
+                    lower: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    upper: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB)
                 )
             })
             """
@@ -358,11 +358,11 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ inputA in
-                PredicateExpressions.build_flatMap(
-                    PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                 ) {
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                         keyPath: \\.foo
                     )
                 }
@@ -380,11 +380,11 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ inputA in
-                PredicateExpressions.build_flatMap(
-                    PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                 ) {
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                         keyPath: \\.foo
                     )
                 }
@@ -400,14 +400,14 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_flatMap(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                         keyPath: \\.foo
                     )
                 ) {
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                         keyPath: \\.bar
                     )
                 }
@@ -423,18 +423,18 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ inputA in
-                PredicateExpressions.build_flatMap(
-                    PredicateExpressions.build_flatMap(
-                        PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                    PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                     ) {
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg($0),
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                             keyPath: \\.foo
                         )
                     }
                 ) {
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                         keyPath: \\.bar
                     )
                 }
@@ -450,15 +450,15 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_flatMap(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                         keyPath: \\.foo
                     )
                 ) {
-                    PredicateExpressions.build_contains(
-                        PredicateExpressions.build_Arg($0),
-                        PredicateExpressions.build_Arg(0)
+                    PredicateExpressions.\(foundationModuleName)::build_contains(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg($0),
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(0)
                     )
                 }
             })
@@ -485,20 +485,20 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({
-                PredicateExpressions.build_NilCoalesce(
-                    lhs: PredicateExpressions.build_flatMap(
-                        PredicateExpressions.build_Arg($0)
+                PredicateExpressions.\(foundationModuleName)::build_NilCoalesce(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg($0)
                     ) {
-                        PredicateExpressions.build_contains(
-                            PredicateExpressions.build_Arg($0)
+                        PredicateExpressions.\(foundationModuleName)::build_contains(
+                            PredicateExpressions.\(foundationModuleName)::build_Arg($0)
                         ) {
-                            PredicateExpressions.build_Equal(
-                                lhs: PredicateExpressions.build_Arg($0),
-                                rhs: PredicateExpressions.build_Arg("Test")
+                            PredicateExpressions.\(foundationModuleName)::build_Equal(
+                                lhs: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
+                                rhs: PredicateExpressions.\(foundationModuleName)::build_Arg("Test")
                             )
                         }
                     },
-                    rhs: PredicateExpressions.build_Arg(true)
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(true)
                 )
             })
             """
@@ -514,19 +514,19 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<[Object?]>({ objects in
-                PredicateExpressions.build_allSatisfy(
-                    PredicateExpressions.build_Arg(objects)
+                PredicateExpressions.\(foundationModuleName)::build_allSatisfy(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(objects)
                 ) {
-                    PredicateExpressions.build_Equal(
-                        lhs: PredicateExpressions.build_flatMap(
-                            PredicateExpressions.build_Arg($0)
+                    PredicateExpressions.\(foundationModuleName)::build_Equal(
+                        lhs: PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                            PredicateExpressions.\(foundationModuleName)::build_Arg($0)
                         ) {
-                            PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg($0),
+                            PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                                 keyPath: \\.bar
                             )
                         },
-                        rhs: PredicateExpressions.build_Arg(2)
+                        rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(2)
                     )
                 }
             })
@@ -543,9 +543,9 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ inputA in
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_ForcedUnwrap(
-                        PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                    root: PredicateExpressions.\(foundationModuleName)::build_ForcedUnwrap(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                     ),
                     keyPath: \\.foo
                 )
@@ -561,10 +561,10 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_ForcedUnwrap(
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                    root: PredicateExpressions.\(foundationModuleName)::build_ForcedUnwrap(
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                             keyPath: \\.foo
                         )
                     ),
@@ -582,11 +582,11 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ inputA in
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_ForcedUnwrap(
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_ForcedUnwrap(
-                                PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                    root: PredicateExpressions.\(foundationModuleName)::build_ForcedUnwrap(
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_ForcedUnwrap(
+                                PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                             ),
                             keyPath: \\.foo
                         )
@@ -605,14 +605,14 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ inputA in
-                PredicateExpressions.build_contains(
-                    PredicateExpressions.build_ForcedUnwrap(
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(inputA),
+                PredicateExpressions.\(foundationModuleName)::build_contains(
+                    PredicateExpressions.\(foundationModuleName)::build_ForcedUnwrap(
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
                             keyPath: \\.foo
                         )
                     ),
-                    PredicateExpressions.build_Arg(0)
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(0)
                 )
             })
             """
@@ -626,16 +626,16 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ inputA in
-                PredicateExpressions.build_flatMap(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_ForcedUnwrap(
-                            PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_ForcedUnwrap(
+                            PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                         ),
                         keyPath: \\.foo
                     )
                 ) {
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                         keyPath: \\.bar
                     )
                 }
@@ -651,13 +651,13 @@ private struct PredicateMacroLanguageOperatorTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ inputA in
-                PredicateExpressions.build_flatMap(
-                    PredicateExpressions.build_Arg(inputA)
+                PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA)
                 ) {
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_ForcedUnwrap(
-                            PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg($0),
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_ForcedUnwrap(
+                            PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                                 keyPath: \\.foo
                             )
                         ),

--- a/Tests/FoundationMacrosTests/PredicateMacroLanguageTokenTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroLanguageTokenTests.swift
@@ -23,10 +23,10 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object, Object>({ inputA, inputB, inputC in
-                PredicateExpressions.build_Conditional(
-                    PredicateExpressions.build_Arg(inputA),
-                    PredicateExpressions.build_Arg(inputB),
-                    PredicateExpressions.build_Arg(inputC)
+                PredicateExpressions.\(foundationModuleName)::build_Conditional(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputA),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(inputC)
                 )
             })
             """
@@ -42,8 +42,8 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.TypeCheck<_, Int>(
-                    PredicateExpressions.build_Arg(input)
+                PredicateExpressions.\(foundationModuleName)::TypeCheck<_, Int>(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(input)
                 )
             })
             """
@@ -59,11 +59,11 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.ConditionalCast<_, Bool>(
-                        PredicateExpressions.build_Arg(input)
+                PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::ConditionalCast<_, Bool>(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(input)
                     ),
-                    rhs: PredicateExpressions.build_Arg(true)
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(true)
                 )
             })
             """
@@ -77,11 +77,11 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.ForceCast<_, Bool>(
-                        PredicateExpressions.build_Arg(input)
+                PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::ForceCast<_, Bool>(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(input)
                     ),
-                    rhs: PredicateExpressions.build_Arg(true)
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(true)
                 )
             })
             """
@@ -95,11 +95,11 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.ForceCast<_, Bool>(
-                        PredicateExpressions.build_Arg(input)
+                PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::ForceCast<_, Bool>(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(input)
                     ),
-                    rhs: PredicateExpressions.build_Arg(true)
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(true)
                 )
             })
             """
@@ -119,13 +119,13 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_Conditional(
-                    PredicateExpressions.build_Arg(input),
-                    PredicateExpressions.build_Arg(
+                PredicateExpressions.\(foundationModuleName)::build_Conditional(
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_Arg(
                         input
                     ),
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                         keyPath: \\.foo
                     )
                 )
@@ -145,35 +145,35 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object, Object>({ input, inputB in
-                PredicateExpressions.build_Conditional(
-                    PredicateExpressions.build_Conjunction(
-                        lhs: PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                PredicateExpressions.\(foundationModuleName)::build_Conditional(
+                    PredicateExpressions.\(foundationModuleName)::build_Conjunction(
+                        lhs: PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.foo
                         ),
-                        rhs: PredicateExpressions.build_Conjunction(
-                            lhs: PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg(input),
+                        rhs: PredicateExpressions.\(foundationModuleName)::build_Conjunction(
+                            lhs: PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                                 keyPath: \\.abc
                             ),
-                            rhs: PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg(input),
+                            rhs: PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                                 keyPath: \\.xyz
                             )
                         )
                     ),
-                    PredicateExpressions.build_Conjunction(
-                        lhs: PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_Conjunction(
+                        lhs: PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.bar
                         ),
-                        rhs: PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                        rhs: PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.baz
                         )
                     ),
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg(inputB),
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg(inputB),
                         keyPath: \\.foobar
                     )
                 )
@@ -201,36 +201,36 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_Conditional(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg(input),
+                PredicateExpressions.\(foundationModuleName)::build_Conditional(
+                    PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                        root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                         keyPath: \\.foo
                     ),
-                    PredicateExpressions.build_Conditional(
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_Conditional(
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.bar
                         ),
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.baz
                         ),
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.foobar
                         )
                     ),
-                    PredicateExpressions.build_Conditional(
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.\(foundationModuleName)::build_Conditional(
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.bar
                         ),
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.foobar
                         ),
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(input),
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                             keyPath: \\.baz
                         )
                     )
@@ -264,16 +264,16 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ input in
-                PredicateExpressions.build_NilCoalesce(
-                    lhs: PredicateExpressions.build_flatMap(
-                        PredicateExpressions.build_Arg(input)
+                PredicateExpressions.\(foundationModuleName)::build_NilCoalesce(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(input)
                     ) { nonOpt in
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(nonOpt),
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(nonOpt),
                             keyPath: \\.foo
                         )
                     },
-                    rhs: PredicateExpressions.build_Arg(
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(
                         true
                     )
                 )
@@ -293,22 +293,22 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ input in
-                PredicateExpressions.build_NilCoalesce(
-                    lhs: PredicateExpressions.build_flatMap(
-                        PredicateExpressions.build_Arg(input)
+                PredicateExpressions.\(foundationModuleName)::build_NilCoalesce(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                        PredicateExpressions.\(foundationModuleName)::build_Arg(input)
                     ) { nonOpt in
-                        PredicateExpressions.build_flatMap(
-                            PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg(nonOpt),
+                        PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                            PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_Arg(nonOpt),
                                 keyPath: \\.foo
                             )
                         ) { nonOpt2 in
-                            PredicateExpressions.build_Arg(
+                            PredicateExpressions.\(foundationModuleName)::build_Arg(
                                 nonOpt2
                             )
                         }
                     },
-                    rhs: PredicateExpressions.build_Arg(
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(
                         true
                     )
                 )
@@ -328,26 +328,26 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                PredicateExpressions.build_NilCoalesce(
-                    lhs: PredicateExpressions.build_flatMap(
-                        PredicateExpressions.build_flatMap(
-                            PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg(input),
+                PredicateExpressions.\(foundationModuleName)::build_NilCoalesce(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                        PredicateExpressions.\(foundationModuleName)::build_flatMap(
+                            PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
                                 keyPath: \\.foo
                             )
                         ) {
-                            PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg($0),
+                            PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                                root: PredicateExpressions.\(foundationModuleName)::build_Arg($0),
                                 keyPath: \\.bar
                             )
                         }
                     ) { nonOpt in
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg(nonOpt),
+                        PredicateExpressions.\(foundationModuleName)::build_KeyPath(
+                            root: PredicateExpressions.\(foundationModuleName)::build_Arg(nonOpt),
                             keyPath: \\.baz
                         )
                     },
-                    rhs: PredicateExpressions.build_Arg(
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_Arg(
                         true
                     )
                 )
@@ -391,9 +391,9 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object?>({ input in
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.build_Arg(input),
-                    rhs: PredicateExpressions.build_NilLiteral()
+                PredicateExpressions.\(foundationModuleName)::build_Equal(
+                    lhs: PredicateExpressions.\(foundationModuleName)::build_Arg(input),
+                    rhs: PredicateExpressions.\(foundationModuleName)::build_NilLiteral()
                 )
             })
             """
@@ -518,7 +518,7 @@ private struct PredicateMacroLanguageTokenTests {
             """,
             """
             \(foundationModuleName).Predicate<Object>({ input in
-                return PredicateExpressions.build_Arg(
+                return PredicateExpressions.\(foundationModuleName)::build_Arg(
                     input
                 )
             })


### PR DESCRIPTION
Uses a newly-available syntax to fully qualify calls to `PredicateExpressions` functions with module names in `#Predicate`/`#Expression` expansions.

### Motivation:

With [SE-0491](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0491-module-selectors.md), you can now qualify function calls defined in extensions with a module name. Doing so limits the scope in which the compiler performs name lookup for these calls. This reduces the chance for ambiguity (in case any clients define overloads in this namespace that may become ambiguous - unlikely but possible) but, more importantly, I expect this should improve type checking performance since the module names are explicitly specified instead of inferred.

### Modifications:

- Every `PredicateExpressions` function call (or type reference) emitted by `#Predicate`/`#Expression` is now qualified with `Foundation::` or `FoundationEssentials::` accordingly
- Localization-specific APIs are now fully guarded by `FOUNDATION_FRAMEWORK` in the macro instead of just in the library (which ensures that emitting `FoundationInternationalization::` is not necessary at the moment)
- Unit tests are updated accordingly

### Result:

All existing unit tests in the library pass, and updated unit tests in the macro all pass

### Testing:

All macro unit tests have been updated accordingly, and existing library unit tests still verify the macro via the compiler.

Resolves rdar://165800976
