### PR TITLE
Fix BenchmarkTimeZone build failure

### DIFF
--- a/Benchmarks/Benchmarks/Internationalization/BenchmarkTimeZone.swift
+++ b/Benchmarks/Benchmarks/Internationalization/BenchmarkTimeZone.swift
@@ -154,7 +154,6 @@ func timeZoneBenchmarks() {
         fatalError("unexpected failure when creating time zone")
     }
 
-    let locale = Locale(identifier: "jp_JP")
     let PacificTimeConfiguration = Benchmark.Configuration(scalingFactor: .mega)
 
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -44,8 +44,8 @@ private func _timeZoneIdentifier_ICU(forWindowsIdentifier windowsIdentifier: Str
 internal import _ForSwiftFoundation
 
 internal func foundation_swift_ICUResourceTimeZone_feature_enabled() -> Bool {
-     _foundation_swift_ICUResourceTimeZone_feature_enabled()
- }
+    _foundation_swift_ICUResourceTimeZone_feature_enabled()
+}
 #else
 internal func foundation_swift_ICUResourceTimeZone_feature_enabled() -> Bool { return false }
 #endif


### PR DESCRIPTION
There's a build failure because `locale` is declared twice.