### PR TITLE
Improve performance of AttributedString.runs getter

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -513,6 +513,12 @@ let benchmarks = {
     Benchmark("range(of:)") { benchmark in
         longString.range(of: "cccc")
     }
+
+    Benchmark("runs") {benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(manyAttributesString.runs)
+        }
+    }
 }
 
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -45,6 +45,19 @@ extension AttributedString {
             self.init(guts, in: RangeSet(bounds))
         }
 
+        internal init(_ guts: Guts) {
+            _guts = guts
+            let strStart = _guts.string.unicodeScalars.startIndex
+            let strEnd = _guts.string.unicodeScalars.endIndex
+            _strBounds = RangeSet(strStart ..< strEnd)
+            _isDiscontiguous = false
+
+            let start = Index(_runIndex: _guts.runs.startIndex, startStringIndex: strStart, stringIndex: strStart, rangeOffset: 0, withinDiscontiguous: false)
+
+            let end = Index(_runIndex: _guts.runs.endIndex, startStringIndex: strEnd, stringIndex: strEnd, rangeOffset: 1, withinDiscontiguous: false)
+            self._bounds = start ..< end
+        }
+
         internal init(_ guts: Guts, in bounds: RangeSet<BigString.Index>) {
             _guts = guts
 
@@ -91,7 +104,7 @@ extension AttributedString {
     }
 
     public var runs: Runs {
-        Runs(_guts, in: _guts.string.startIndex ..< _guts.string.endIndex)
+        Runs(_guts)
     }
 }
 
@@ -122,7 +135,7 @@ extension AttributedString.Runs: Equatable {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs: CustomStringConvertible {
     public var description: String {
-        _guts.description(in: _strBounds)
+        AttributedString.Guts._description(in: self)
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -165,7 +165,7 @@ extension AttributedSubstring {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedStringProtocol { // CustomStringConvertible
     public var description: String {
-        __guts.description(in: _stringBounds)
+        AttributedString.Guts._description(in: runs)
     }
 }
 
@@ -176,13 +176,11 @@ extension AttributedStringProtocol { // Equatable, Hashable
     @_specialize(where Self == AttributedSubstring, RHS == AttributedString)
     @_specialize(where Self == AttributedSubstring, RHS == AttributedSubstring)
     public static func == <RHS: AttributedStringProtocol>(lhs: Self, rhs: RHS) -> Bool {
-        AttributedString.Guts.characterwiseIsEqual(
-            lhs.__guts, in: lhs._stringBounds,
-            to: rhs.__guts, in: rhs._stringBounds)
+        AttributedString.Guts._characterwiseIsEqual(lhs.runs, to: rhs.runs)
     }
 
     public func hash(into hasher: inout Hasher) {
-        __guts.characterwiseHash(in: _stringBounds, into: &hasher)
+        AttributedString.Guts.characterwiseHash(runs: runs, into: &hasher)
     }
 }
 


### PR DESCRIPTION
Significantly improves the performance of creating an `AttributedString.Runs` from a concrete `AttributedString`

### Motivation:

Creating an `AttributedString.Runs` from an `AttributedString` should be fairly trivial. `AttributedString.Runs` mostly just wraps the `AttributedString.Guts`, but it also records some information about index bounds. Since `AttributedString.Runs` can be discontiguous, these index calculations can be complex. However, in the case of `AttributedString` itself, we know that it is both not discontiguous and it represents the entirety of the `AttributedString.Guts`. In these cases we can eliminate a lot of overhead. `AttributedString.Runs` is used both directly by clients as well as indirectly via APIs like equality and hashing, so this has some substantial improvements for clients.

### Modifications:

- Add a new `AttributedString.Runs` initializer that does not accept a `Range` to slice with
- Use this new initializer from `AttributedString.runs`, `AttributedString.==`, `AttributedString.hash(into:)`, and `AttributedString.description` (leaving the `DIscontiguousAttributedSubstring` and `AttribtuedSubstring` types as-is).

### Result:

`AttributedString.runs` is more than 900% faster than before. When content is actually equal, the cost of verifying content equality outweighs the improvements here in `AttributedString.==`, but when contents are unequal (and the overhead of setup is much more noticeable) this also has significant improvements to `AttributedString.==` (`equalityDifferingCharacters` improved by 670%)

### Testing:

These changes are covered by existing unit tests. I've added new benchmarks to cover `AttributedString.runs` specifically
