### PR TITLE
Add documentation/comments to layout of __DataStorage allocation

### DIFF
--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -106,8 +106,9 @@ internal final class __DataStorage : @unchecked Sendable {
     //   <─ slice.lowerBound ─>
     //   <────── slice.upperBound ───────────>
     //
-    //   The bounds of the slice are relative to the beginning of the prior prefix, not the start of the current allocation (_bytes)
-    //   This guarantees that indices remain stable for slices that are mutated
+    //   The bounds of the slice are relative to the beginning of the prior prefix, not the start
+    //   of the current allocation (_bytes). This guarantees that indices remain stable for slices
+    //   that are mutated
 
     /// A pointer to the start of the referenced byte allocation
     @usableFromInline var _bytes: UnsafeMutableRawPointer?
@@ -118,7 +119,8 @@ internal final class __DataStorage : @unchecked Sendable {
     /// The total capacity of the initialized portion of the referenced byte allocation
     @usableFromInline var _capacity: Int
 
-    /// The size of the prior slice's prefix if the allocation was copied from a slice (to maintain stable indexing)
+    /// The size of the prior slice's prefix if the allocation was copied from a slice (to maintain
+    /// stable indexing)
     @usableFromInline var _offset: Int
 
     /// The deallocator to use when discarding the byte allocation
@@ -126,12 +128,17 @@ internal final class __DataStorage : @unchecked Sendable {
 
     /// Whether the uninitialized portion of the byte allocation needs to be cleared before use
     ///
-    /// When creating an allocation, the uninitialized portion may or may not be zeroed. When `true`, `_needToZero` indicates the uninitialized portion has nondeterministic contents and needs to be cleared. When `false`, the uninitialized portion is guaranteed to already be zeroed and does not need to be cleared before use.
+    /// When creating an allocation, the uninitialized portion may or may not be zeroed. When
+    /// `true`, `_needToZero` indicates the uninitialized portion has nondeterministic contents and
+    /// needs to be cleared. When `false`, the uninitialized portion is guaranteed to already be
+    /// zeroed and does not need to be cleared before use.
     @usableFromInline var _needToZero: Bool
 
     /// A pointer to the referenced byte allocation, relative to the slice offsets
     ///
-    /// This is a pointer to the start of the symbolic allocation range that begins at index 0. This pointer _must_ be offset by the slice's lowerBound. For slices that have been copied out of their original allocation, this may point to memory before the actual allocation.
+    /// This is a pointer to the start of the symbolic allocation range that begins at index 0. This
+    /// pointer _must_ be offset by the slice's lowerBound. For slices that have been copied out of
+    /// their original allocation, this may point to memory before the actual allocation.
     @inlinable // This is @inlinable as trivially computable.
     var bytes: UnsafeRawPointer? {
         return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
@@ -151,7 +158,9 @@ internal final class __DataStorage : @unchecked Sendable {
 
     /// A pointer to the mutable referenced byte allocation, relative to the slice offsets
     ///
-    /// This is a pointer to the start of the symbolic allocation range that begins at index 0. This pointer _must_ be offset by the slice's lowerBound. For slices that have been copied out of their original allocation, this may point to memory before the actual allocation.
+    /// This is a pointer to the start of the symbolic allocation range that begins at index 0. This
+    /// pointer _must_ be offset by the slice's lowerBound. For slices that have been copied out of
+    /// their original allocation, this may point to memory before the actual allocation.
     @inlinable // This is @inlinable as trivially computable.
     var mutableBytes: UnsafeMutableRawPointer? {
         return _bytes?.advanced(by: _offset &* -1) // _offset is guaranteed to be non-negative, so it can never overflow when negating


### PR DESCRIPTION
Adds documentation comments and diagrams to depict the layout of allocations managed by `__DataStorage`

### Motivation:

I often find myself needing to spend time understanding the layout of the allocation managed by `__DataStorage` when making changes to this type. In order to avoid continued repeated investigations into the management, I've found it helpful to create a diagram that visually depicts how the allocation is laid out and managed

### Modifications:

- Added diagrams depicting the layout of the referenced allocation
- Added documentation comments to the relevant stored properties referenced in the diagram

### Result:

Increased comments/documentation provided by `__DataStorage`

### Testing:

N/A - this is an internal documentation/comment-only change
