### PR TITLE
NSURL should reject invalid ASCII in host when IDNA-encoding

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Parsing.swift
+++ b/Sources/FoundationEssentials/URL/URL_Parsing.swift
@@ -595,6 +595,14 @@ internal func parse<T: _URLEncoding, Impl: _URLParseable>(
         } else if !validate(span: span.extracting(hostRange), component: .host) {
             guard allowEncoding else { return false }
             guard span[hostRange.startIndex] != UInt8(ascii: "[") else { return false }
+            if useModernParsing && flags.contains(.hasSpecialScheme) {
+                // We will IDNA-encode the host, which doesn't encode ASCII
+                // characters. If there's an invalid ASCII character in the
+                // host, it would remain in the final string, so fail now.
+                if containsInvalidASCII(host: span.extracting(hostRange)) {
+                    return false
+                }
+            }
             flags.insert(.shouldEncodeHost)
             shouldEncode = true
         }

--- a/Sources/FoundationEssentials/URL/URL_Validation.swift
+++ b/Sources/FoundationEssentials/URL/URL_Validation.swift
@@ -38,6 +38,19 @@ internal func validate<T: UnsignedInteger & FixedWidthInteger>(
     return true
 }
 
+internal func containsInvalidASCII<T: UnsignedInteger & FixedWidthInteger>(
+    host: borrowing Span<T>
+) -> Bool {
+    let allowedSet = URLComponentAllowedSet.host
+    for i in host.indices {
+        let codeUnit = host[i]
+        if codeUnit < 128 && !allowedSet.contains(codeUnit) {
+            return true
+        }
+    }
+    return false
+}
+
 private func isHexDigit<T: UnsignedInteger & FixedWidthInteger>(
     _ codeUnit: T
 ) -> Bool {


### PR DESCRIPTION
Reject invalid ASCII characters such as `"{"` that appear in the IDNA-encodable host of a `NSURL`.

### Motivation:

For an `NSURL` such as `"https://{example"`, `"{"` is considered an invalid character in the host according to RFC 3986. We do identify the host is invalid and needs encoding, and for `https` URLs, we use IDNA-encoding, which delegates to `uidna_nameToASCII`.

That particular function, however, only encodes non-ASCII Unicode characters, and otherwise leaves ASCII alone. This means that `uidna_nameToASCII` returns the original ASCII string, including the invalid `"{"`. The parser for `URLComponents`, which also IDNA-encodes, validates the host string once more after encoding to prevent this, but I missed that check in the Swift parser for `NSURL`.

### Modifications:

In the case where host validation fails and we're planning to IDNA-encode the host, we can first check if the host contains any invalid ASCII characters. If it does, we can short-circuit the parsing to return `nil` instead of continuing through all the encoding flow.

### Result:

No behavior change in swift-foundation. When the Swift implementation for `NSURL` is enabled, this maintains prior behavior of rejecting invalid ASCII in the host.

### Testing:

Unit tests for `NSURL` to confirm hosts with invalid ASCII are rejected whether or not they contain non-ASCII Unicode characters.
