### PR TITLE
Specialize AttributedString.CharacterView to String conversion

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -519,6 +519,10 @@ let benchmarks = {
             blackHole(manyAttributesString.runs)
         }
     }
+
+    Benchmark("stringConversion") { benchmark in
+        blackHole(String(longString.characters))
+    }
 }
 
 

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -27,19 +27,19 @@ extension String {
         self.init(characters._characters)
     }
 
-    #if false // FIXME: Make this public.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    @backDeployed(before: macOS 14, iOS 17, tvOS 17, watchOS 10)
+    @_alwaysEmitIntoClient
     public init(_ characters: AttributedString.CharacterView) {
-        if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
-            self.init(_characters: characters)
+        #if FOUNDATION_FRAMEWORK
+        guard #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) else {
+            // Forward to the slice overload above, which somehow did end up shipping in
+            // the original AttributedString release.
+            self.init(characters[...])
             return
         }
-        // Forward to the slice overload above, which somehow did end up shipping in
-        // the original AttributedString release.
-        self.init(characters[...])
+        #endif
+        self.init(_characters: characters)
     }
-    #endif
 
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     @usableFromInline


### PR DESCRIPTION
Adds a specialized entry point for `AttributedString.CharacterView` to `String` conversion

### Motivation:

When we originally shipped `AttributedString`, we intended for developers to convert to a string via `String(attrStr.characters)`. We did end up shipping a `public init(_: Slice<AttributedString.CharacterView>)` on `String`, but somehow did not end up shipping a `public init(_: AttributedString.CharacterView)`. Instead, today `String(attrStr.characters)` goes through the generic `public init(_: some Sequence<Character>)` on `String` which is significantly slower than the conversion we can provide. We've had an internal version of this entry point for quite some time, but haven't exposed this and I think it's time we do so.

I'm proposing this change without API review because it does not actually change the API surface - everything this new initializer allows could already have been done with the same source code previously. Rather, this introduces a specialize entry point for faster conversion when a specific type is provided. Therefore there are no new API considerations since it follows the API declaration provided by `String` already.

### Modifications:

- Expose the specialized entry point as `public`
- Update it to use `@_alwaysEmitIntoClient` instead of `@backDeployed` (since we already have an availability check ourselves since we provide our own ABI entry point that we can use)
- Put the availability check within `#if FOUNDATION_FRAMEWORK` so it isn't present on non-ABI stable platforms

### Result:

The provided benchmark indicates a ~90,000% improvement in throughput for `String` conversion

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (wall clock) (ns) *         |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |      3277 |      3297 |      3318 |      3363 |      3523 |      3631 |      3658 |       298 |
|                   new                    |         4 |         4 |         4 |         4 |         4 |         5 |        17 |     10000 |
|                    Δ                     |     -3273 |     -3293 |     -3314 |     -3359 |     -3519 |     -3626 |     -3641 |      9702 |
|              Improvement %               |       100 |       100 |       100 |       100 |       100 |       100 |       100 |      9702 |

<p>
</details>

<details><summary>Time (total CPU): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (total CPU) (ns) *          |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |      3277 |      3297 |      3318 |      3365 |      3525 |      3633 |      3655 |       298 |
|                   new                    |         4 |         4 |         5 |         5 |         5 |         6 |        18 |     10000 |
|                    Δ                     |     -3273 |     -3293 |     -3313 |     -3360 |     -3520 |     -3627 |     -3637 |      9702 |
|              Improvement %               |       100 |       100 |       100 |       100 |       100 |       100 |       100 |      9702 |

<p>
</details>

<details><summary>Throughput (# / s): results within specified thresholds, fold down for details.</summary>
<p>

|          Throughput (# / s) (M)          |        p0 |       p25 |       p50 |       p75 |       p90 |       p99 |      p100 |   Samples |
|:----------------------------------------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                   main                   |       305 |       303 |       302 |       297 |       284 |       275 |       273 |       298 |
|                   new                    |    282406 |    275967 |    272895 |    266751 |    263935 |    212479 |     60002 |     10000 |
|                    Δ                     |    282101 |    275664 |    272593 |    266454 |    263651 |    212204 |     59729 |      9702 |
|              Improvement %               |     92492 |     90978 |     90263 |     89715 |     92835 |     77165 |     21879 |      9702 |

<p>
</details>

### Testing:

This entry point is covered by a variety of existing tests
