### PR TITLE
Shorten Codable error messages so they are not redundant with debug descriptions from stdlib

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -640,7 +640,7 @@ extension JSONDecoderImpl: Decoder {
         if case .null = value {
             throw DecodingError.valueNotFound(expectedType, DecodingError.Context(
                 codingPath: codingPathNode.path(byAppending: additionalKey),
-                debugDescription: "Cannot get value of type \(expectedType) -- found null value instead"
+                debugDescription: ""
             ))
         }
     }
@@ -711,7 +711,7 @@ extension JSONDecoderImpl: Decoder {
         case .iso8601:
             let string = try self.unwrapString(from: mapValue, for: codingPathNode, additionalKey)
             guard let date = try? Date.ISO8601FormatStyle().parse(string) else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted, but found '\(string)'."))
             }
             return date
 
@@ -1110,7 +1110,7 @@ extension JSONDecoderImpl: Decoder {
     private func createTypeMismatchError(type: Any.Type, for path: [CodingKey], value: JSONMap.Value) -> DecodingError {
         return DecodingError.typeMismatch(type, .init(
             codingPath: path,
-            debugDescription: "Expected to decode \(type) but found \(value.debugDataTypeDescription) instead."
+            debugDescription: "found \(value.debugDataTypeDescription) instead."
         ))
     }
 }
@@ -1526,7 +1526,7 @@ extension JSONDecoderImpl {
             guard let value = dictionary[key.stringValue] else {
                 throw DecodingError.keyNotFound(key, .init(
                     codingPath: self.codingPath,
-                    debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."
+                    debugDescription: ""
                 ))
             }
             return value
@@ -1538,7 +1538,7 @@ extension JSONDecoderImpl {
 
         private func createTypeMismatchError(type: Any.Type, forKey key: K, value: JSONMap.Value) -> DecodingError {
             return DecodingError.typeMismatch(type, .init(
-                codingPath: self.codingPathNode.path(byAppending: key), debugDescription: "Expected to decode \(type) but found \(value.debugDataTypeDescription) instead."
+                codingPath: self.codingPathNode.path(byAppending: key), debugDescription: "found \(value.debugDataTypeDescription) instead."
             ))
         }
 

--- a/Sources/FoundationEssentials/PropertyList/PlistDecoderGeneric.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDecoderGeneric.swift
@@ -122,7 +122,7 @@ extension _PlistDecoder {
         if Format.valueIsNull(value) {
             throw DecodingError.valueNotFound(expectedType, DecodingError.Context(
                 codingPath: codingPathNode.path(byAppending: additionalKey),
-                debugDescription: "Cannot get value of \(expectedType) -- found null value instead"
+                debugDescription: "Found null value instead"
             ))
         }
     }
@@ -635,7 +635,7 @@ struct _PlistUnkeyedDecodingContainer<Format : PlistDecodingFormat> : UnkeyedDec
     @inline(never)
     private func errorForEndOfContainer<T>(type: T.Type) -> DecodingError {
         var message = "Unkeyed container is at end."
-        if T.self is any UnkeyedDecodingContainer {
+        if T.self == (any UnkeyedDecodingContainer).self {
             message = "Cannot get nested unkeyed container -- unkeyed container is at end."
         }
         if T.self == Decoder.self {

--- a/Tests/FoundationEssentialsTests/JSONDecoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONDecoderTests.swift
@@ -1,0 +1,354 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import TestSupport
+
+#if canImport(FoundationEssentials)
+@_spi(SwiftCorelibsFoundation)
+import FoundationEssentials
+#endif
+
+// MARK: - Test Suite
+
+@Suite("JSONDecoder") private struct JSONDecoderTests {
+    @Test func keyNotFound() throws {
+        struct MyStruct: Decodable {
+            var a: String
+            var b: String
+        }
+
+        try expectJSONString(
+            """
+            [
+                {
+                    "a": "A!"
+                }
+            ]
+            """,
+            decodingAs: [MyStruct].self,
+            validator: DecodingErrorValidator.keyNotFound(
+                keyStringValue: "b",
+                codingPath: ["Index 0"],
+                debugDescription: ""
+            )
+        )
+    }
+
+    @Suite struct TypeMismatch {
+        @Test func stringForInt() throws {
+            try expectJSONString(
+                """
+                [
+                    { "int here": "actually I am a string" }
+                ]
+                """,
+                decodingAs: [[String: Int]].self,
+                validator: DecodingErrorValidator.typeMismatch(
+                    expectedType: Int.self,
+                    codingPath: ["Index 0", "int here"],
+                    debugDescription: "found a string instead."
+                )
+            )
+        }
+
+        @Test func stringForBool() throws {
+            try expectJSONString(
+                """
+                [
+                    { "a real bool": true },
+                    { "not a bool at all": "see, I told you" }
+                ]
+                """,
+                decodingAs: [[String: Bool]].self,
+                validator: DecodingErrorValidator.typeMismatch(
+                    expectedType: Bool.self,
+                    codingPath: ["Index 1", "not a bool at all"],
+                    debugDescription: "found a string instead."
+                )
+            )
+        }
+
+        @Test func stringForDecimal() throws {
+            try expectJSONString(
+                """
+                { "decimal": "nope" }
+                """,
+                decodingAs: [String: Decimal].self,
+                validator: DecodingErrorValidator.typeMismatch(
+                    expectedType: Decimal.self,
+                    codingPath: ["decimal"],
+                    debugDescription: ""
+                )
+            )
+        }
+
+        @Test func `string instead of unkeyed container`() throws {
+            try expectJSONString(
+                """
+                { "not": "an array" }
+                """,
+                decodingAs: [String: [Int]].self,
+                validator: DecodingErrorValidator.typeMismatch(
+                    expectedType: [Any].self,
+                    codingPath: ["not"],
+                    debugDescription: "Expected to decode Array<Any> but found a string instead."
+                )
+            )
+        }
+
+        @Test func `string instead of nested dictionary`() throws {
+            try expectJSONString(
+                """
+                { "dictionary": "not a dictionary" }
+                """,
+                decodingAs: [String: [String: Int]].self,
+                validator: DecodingErrorValidator.typeMismatch(
+                    expectedType: [String: Any].self,
+                    codingPath: ["dictionary"],
+                    debugDescription: "Expected to decode Dictionary<String, Any> but found a string instead."
+                )
+            )
+        }
+
+        @Test func `string instead of nested dictionary, non-default coding keys`() throws {
+            try expectJSONString(
+                """
+                { "dictionaryGoesHere": "not a dictionary" }
+                """,
+                decodingAs: [String: [String: Int]].self,
+                updatingDecoder: {
+                    $0.keyDecodingStrategy = .convertFromSnakeCase
+                },
+                validator: DecodingErrorValidator.typeMismatch(
+                    expectedType: [String: Any].self,
+                    codingPath: ["dictionaryGoesHere"],
+                    debugDescription: "Expected to decode Dictionary<String, Any> but found a string instead."
+                )
+            )
+        }
+    }
+
+    @Suite struct ValueNotFound {
+        @Test func `expected value is null`() throws {
+            try expectJSONString(
+                """
+                { "value goes here": null }
+                """,
+                decodingAs: [String: Int].self,
+                validator: DecodingErrorValidator.valueNotFound(
+                    expectedType: Int.self,
+                    codingPath: ["value goes here"],
+                    debugDescription: ""
+                )
+            )
+        }
+
+        @Suite struct `Un-keyed container reaches end` {
+            @Test func `root un-keyed container`() throws {
+                try expectJSONString(
+                    """
+                    ["a-string"]
+                    """,
+                    decodingAs: TwoUnkeyedOf<String>.self,
+                    validator: DecodingErrorValidator.valueNotFound(
+                        expectedType: String.self,
+                        codingPath: ["Index 1"],
+                        debugDescription: "Unkeyed container is at end."
+                    )
+                )
+            }
+
+            @Test func `nested un-keyed container`() throws {
+                try expectJSONString(
+                    """
+                    [
+                        ["a", "b", "c"]
+                    ]
+                    """,
+                    decodingAs: TwoUnkeyedOf<TwoUnkeyedOf<String>>.self,
+                    validator: DecodingErrorValidator.valueNotFound(
+                        expectedType: TwoUnkeyedOf<String>.self,
+                        codingPath: ["Index 1"],
+                        debugDescription: "Unkeyed container is at end."
+                    )
+                )
+            }
+
+            @Test func `nestedUnkeyedContainer past end`() throws {
+                try expectJSONString(
+                    """
+                    ["only"]
+                    """,
+                    decodingAs: AsksForNestedUnkeyedContainerAtEnd.self,
+                    validator: DecodingErrorValidator.valueNotFound(
+                        expectedType: UnkeyedDecodingContainer.self,
+                        codingPath: ["Index 1"],
+                        debugDescription: "Unkeyed container is at end."
+                    )
+                )
+            }
+
+            @Test func `superDecoder past end`() throws {
+                try expectJSONString(
+                    """
+                    ["only"]
+                    """,
+                    decodingAs: AsksForSuperDecoderAtEnd.self,
+                    validator: DecodingErrorValidator.valueNotFound(
+                        expectedType: Decoder.self,
+                        codingPath: ["Index 1"],
+                        debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."
+                    )
+                )
+            }
+        }
+
+        @Test
+        func `found null instead of keyed container`() throws {
+            try expectJSONString(
+                """
+                [
+                    {
+                        "values": null,
+                    }
+                ]
+                """,
+                decodingAs: [[String: [String: Date]]].self,
+                validator: DecodingErrorValidator.valueNotFound(
+                    expectedType: [String: Any].self,
+                    codingPath: ["Index 0", "values"],
+                    debugDescription: "Cannot get keyed decoding container -- found null value instead"
+                )
+            )
+        }
+
+        @Test func `found null instead of unkeyed container`() throws {
+            try expectJSONString(
+                """
+                [
+                    ["a-string", "b-string"],
+                    null   
+                ]
+                """,
+                decodingAs: [TwoUnkeyedOf<String>].self,
+                validator: DecodingErrorValidator.valueNotFound(
+                    expectedType: [Any].self,
+                    codingPath: ["Index 1"],
+                    debugDescription: "Cannot get unkeyed decoding container -- found null value instead"
+                )
+            )
+        }
+    }
+
+    @Suite struct DataCorrupted {
+        @Test func `invalid JSON`() throws {
+            // Invalid JSON (missing value before comma)
+            try expectJSONString(
+                """
+                {"a": ,}
+                """,
+                decodingAs: [String: Int].self,
+                validator: DecodingErrorValidator.dataCorrupted(
+                    codingPath: [],
+                    debugDescription: "The given data was not valid JSON."
+                )
+            )
+        }
+
+        @Test func `ISO 8601 Date`() throws {
+            try expectJSONString(
+                """
+                { "date": "Tuesday" }
+                """,
+                decodingAs: [String: Date].self,
+                updatingDecoder: {
+                    $0.dateDecodingStrategy = .iso8601
+                },
+                validator: DecodingErrorValidator.dataCorrupted(
+                    codingPath: [],
+                    debugDescription: "Expected date string to be ISO8601-formatted, but found 'Tuesday'."
+                )
+            )
+        }
+
+        @Test func intForURL() throws {
+            try expectJSONString(
+                """
+                { "url": "" }
+                """,
+                decodingAs: [String: URL].self,
+                validator: DecodingErrorValidator.dataCorrupted(
+                    codingPath: ["url"],
+                    debugDescription: "Invalid URL string."
+                )
+            )
+        }
+    }
+}
+
+// MARK: - Helpers
+
+@discardableResult
+private func expectJSONString<Value: Decodable>(
+    _ string: String,
+    decodingAs _: Value.Type,
+    updatingDecoder updateDecoder: (JSONDecoder) -> Void = { _ in },
+    validator: DecodingErrorValidator.Validator,
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws -> DecodingError {
+    let jsonData = Data(string.utf8)
+
+    let decoder = JSONDecoder()
+    updateDecoder(decoder)
+
+    let error = #expect(throws: DecodingError.self, sourceLocation: sourceLocation) {
+        _ = try decoder.decode(Value.self, from: jsonData)
+    }
+
+    let unwrappedError = try #require(error, sourceLocation: sourceLocation)
+
+    _ = validator(unwrappedError)
+
+    return unwrappedError
+}
+
+/// Attempts to decode two values of type `T` from an un-keyed container.
+private struct TwoUnkeyedOf<T: Decodable>: Decodable {
+    init(from decoder: any Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        _ = try container.decode(T.self)
+        _ = try container.decode(T.self)
+    }
+}
+
+/// Decodes an un-keyed container, consumes exactly 1 element, then attempts to
+/// request a nested un-keyed container from an already-ended un-keyed container.
+private struct AsksForNestedUnkeyedContainerAtEnd: Decodable {
+    init(from decoder: any Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        #expect(container.count == 1, "use this type with a container that contains a single element")
+        _ = try container.decode(String.self)
+        _ = try container.nestedUnkeyedContainer() // this will always fail
+    }
+}
+
+/// Decodes an unkeyed container, consumes exactly 1 element, then attempts to
+/// request a `superDecoder()` from an already-ended unkeyed container.
+private struct AsksForSuperDecoderAtEnd: Decodable {
+    init(from decoder: any Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        #expect(container.count == 1, "use this type with a container that contains a single element")
+        _ = try container.decode(String.self)
+        _ = try container.superDecoder() // this will always fail
+    }
+}

--- a/Tests/FoundationEssentialsTests/PropertyListDecoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListDecoderTests.swift
@@ -1,0 +1,299 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import TestSupport
+
+#if canImport(FoundationEssentials)
+@_spi(SwiftCorelibsFoundation)
+import FoundationEssentials
+#endif
+
+// MARK: - Test Suite
+
+@Suite("PropertyListDecoder") private struct PropertyListDecoderTests {
+    @Suite struct DataCorrupted {
+        @Suite struct OpenStep {
+            @Test func `empty data`() throws {
+                let (_, underlyingError) = try expectPlistData(
+                    Data(),
+                    decodingAs: [String: String].self,
+                    validator: DecodingErrorValidator.dataCorrupted(
+                        codingPath: [],
+                        debugDescription: "The given data was not a valid property list."
+                    )
+                )
+
+                let underlying = try #require(underlyingError)
+                let cocoaError = try #require(underlying as? CocoaError)
+
+                #expect(cocoaError.code == .propertyListReadCorrupt)
+            }
+
+            @Test func `invalid plist`() throws {
+
+            }
+        }
+
+        /// Make sure our utility function works as expected
+        @Test func plistEncoded() throws {
+            let binary = try [String: String]()
+                .plistEncoded(as: .binary)
+            #expect(binary.count == 42)
+
+            let xml = try [String: String]()
+                .plistEncoded(as: .xml)
+            #expect(String(decoding: xml, as: UTF8.self) == """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                <plist version="1.0">
+                <dict/>
+                </plist>
+
+                """)
+        }
+
+        @Test func `invalid binary plist`() throws {
+            let data = try [String: String]()
+                .plistEncoded(as: .binary)
+                .dropLast(1)
+
+            try expectPlistData(
+                data,
+                decodingAs: [String: String].self,
+                validator: DecodingErrorValidator.dataCorrupted(
+                    codingPath: [],
+                    debugDescription: "The given data was not a valid property list."
+                )
+            )
+        }
+
+        @Test func `invalid xml plist`() throws {
+            let data = try [String: String]()
+                .plistEncoded(as: .xml)
+                .dropLast(10)
+
+            try expectPlistData(
+                data,
+                decodingAs: [String: String].self,
+                validator: DecodingErrorValidator.dataCorrupted(
+                    codingPath: [],
+                    debugDescription: "The given data was not a valid property list."
+                )
+            )
+        }
+
+        @Test func `unknown encoding`() throws {
+            try expectPlistData(
+                Data(
+                """
+                <?xml version="1.0" encoding="ABC-123"?>
+                """.utf8
+                ),
+                decodingAs: [String: String].self,
+                validator: DecodingErrorValidator.dataCorrupted(
+                    codingPath: [],
+                    debugDescription: "Encountered unknown encoding"
+                )
+            )
+        }
+
+        @Test func `incomplete encoding name`() throws {
+            try expectPlistData(
+                Data(
+                """
+                <?xml version="1.0" encod
+                """.utf8
+                ),
+                decodingAs: [String: String].self,
+                validator: DecodingErrorValidator.dataCorrupted(
+                    codingPath: [],
+                    debugDescription: "End of buffer while looking for encoding name"
+                )
+            )
+        }
+
+        @Test func `cannot convert input to UTF-16`() throws {
+            // If UTF-8 decoding fails, PropertyListDecoder falls back to parsing
+            // the data as an OpenStep plist, which requires UTF-16 encoding. So
+            // we need to use code points that are both invalid UTF-8 and invalid
+            // UTF-16 to reach the code path we want to test here.
+            //
+            // UTF-8:
+            // 0xC3 starts a 2-byte UTF-8 sequence, but 0x28 is not a valid continuation byte
+            // (continuations must be in 0x80...0xBF), so this data is not valid UTF-8.
+            //
+            // UTF-16:
+            // The code in question does not actually do a check for whether the
+            // string is UTF-16, since it bails out if the string is not UTF-8,
+            // but the error message says it is not UTF-16. We check for the
+            // existing error message to document the current behavior in this test.
+            let data = Data([0xC3, 0x28])
+
+            try expectPlistData(
+                data,
+                decodingAs: [String: String].self,
+                validator: DecodingErrorValidator.dataCorrupted(
+                    codingPath: [],
+                    debugDescription: "Cannot convert input to UTF-16"
+                )
+            )
+        }
+    }
+
+    @Suite struct ValueNotFound {
+        @Test func `expected value is null`() throws {
+            let data = try [
+                "integer": (nil as Int?),
+            ].plistEncoded(as: .xml)
+
+            try expectPlistData(
+                data,
+                decodingAs: [String: String].self,
+                validator: DecodingErrorValidator.valueNotFound(
+                    expectedType: String.self,
+                    codingPath: ["integer"],
+                    debugDescription: "Found null value instead"
+                )
+            )
+        }
+
+        @Suite struct `Un-keyed container reaches end` {
+            @Test func `root un-keyed container`() throws {
+                let data = try ["a-string"]
+                    .plistEncoded(as: .xml)
+
+                try expectPlistData(
+                    data,
+                    decodingAs: TwoUnkeyedOf<String>.self,
+                    validator: DecodingErrorValidator.valueNotFound(
+                        expectedType: String.self,
+                        codingPath: ["Index 1"],
+                        debugDescription: "Unkeyed container is at end."
+                    )
+                )
+            }
+
+            @Test func `nested un-keyed container`() throws {
+                let data = try [["a", "b", "c"]]
+                    .plistEncoded(as: .xml)
+
+                try expectPlistData(
+                    data,
+                    decodingAs: TwoUnkeyedOf<TwoUnkeyedOf<String>>.self,
+                    validator: DecodingErrorValidator.valueNotFound(
+                        expectedType: TwoUnkeyedOf<String>.self,
+                        codingPath: ["Index 1"],
+                        debugDescription: "Unkeyed container is at end."
+                    )
+                )
+            }
+
+            @Test func `nestedUnkeyedContainer past end`() throws {
+                let data = try ["only"]
+                    .plistEncoded(as: .xml)
+
+                try expectPlistData(
+                    data,
+                    decodingAs: AsksForNestedUnkeyedContainerAtEnd.self,
+                    validator: DecodingErrorValidator.valueNotFound(
+                        expectedType: UnkeyedDecodingContainer.self,
+                        codingPath: ["Index 1"],
+                        debugDescription: "Cannot get nested unkeyed container -- unkeyed container is at end."
+                    )
+                )
+            }
+
+            @Test func `superDecoder past end`() throws {
+                let data = try ["only"]
+                    .plistEncoded(as: .xml)
+
+                try expectPlistData(
+                    data,
+                    decodingAs: AsksForSuperDecoderAtEnd.self,
+                    validator: DecodingErrorValidator.valueNotFound(
+                        expectedType: UnkeyedDecodingContainer.self,
+                        codingPath: ["Index 1"],
+                        debugDescription: "Cannot get nested unkeyed container -- unkeyed container is at end."
+                        // ⚠️ Does not match JSONDecoder, which mentions superDecoder() in error for equivalent situation
+                    )
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension Encodable {
+    func plistEncoded(
+        as format: PropertyListDecoder.PropertyListFormat
+    ) throws -> Data {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = format
+        let data = try encoder.encode(self)
+        return data
+    }
+}
+
+@discardableResult
+private func expectPlistData<Value: Decodable>(
+    _ data: Data,
+    decodingAs _: Value.Type,
+    updatingDecoder updateDecoder: (PropertyListDecoder) -> Void = { _ in },
+    validator: DecodingErrorValidator.Validator,
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws -> (error: DecodingError, underlyingError: (any Error)?) {
+    let decoder = PropertyListDecoder()
+    updateDecoder(decoder)
+
+    let error = #expect(throws: DecodingError.self, sourceLocation: sourceLocation) {
+        _ = try decoder.decode(Value.self, from: data)
+    }
+
+    let unwrappedError = try #require(error, sourceLocation: sourceLocation)
+
+    let underlyingError = validator(unwrappedError)
+
+    return (unwrappedError, underlyingError)
+}
+
+/// Attempts to decode two values of type `T` from an un-keyed container.
+private struct TwoUnkeyedOf<T: Decodable>: Decodable {
+    init(from decoder: any Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        _ = try container.decode(T.self)
+        _ = try container.decode(T.self)
+    }
+}
+
+/// Decodes an un-keyed container, consumes exactly 1 element, then attempts to
+/// request a nested un-keyed container from an already-ended un-keyed container.
+private struct AsksForNestedUnkeyedContainerAtEnd: Decodable {
+    init(from decoder: any Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        #expect(container.count == 1, "use this type with a container that contains a single element")
+        _ = try container.decode(String.self)
+        _ = try container.nestedUnkeyedContainer() // this will always fail
+    }
+}
+
+/// Decodes an unkeyed container, consumes exactly 1 element, then attempts to
+/// request a `superDecoder()` from an already-ended unkeyed container.
+private struct AsksForSuperDecoderAtEnd: Decodable {
+    init(from decoder: any Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        #expect(container.count == 1, "use this type with a container that contains a single element")
+        _ = try container.decode(String.self)
+        _ = try container.superDecoder() // this will always fail
+    }
+}

--- a/Tests/TestSupport/Utilities.swift
+++ b/Tests/TestSupport/Utilities.swift
@@ -250,6 +250,90 @@ public func checkHashableGroups<Groups: Collection>(
         sourceLocation: sourceLocation)
 }
 
+public enum DecodingErrorValidator {
+
+    /// Returns the underlying error of the decoding error, if any.
+    public typealias Validator = (DecodingError) -> (any Error)?
+
+    public static func typeMismatch<ExpectedType>(
+        expectedType _: ExpectedType.Type,
+        codingPath: [String],
+        debugDescription: String,
+        sourceLocation: SourceLocation = #_sourceLocation,
+    ) -> Validator {
+        { error in
+            switch error {
+            case .typeMismatch(let type, let context):
+                #expect(type == ExpectedType.self, sourceLocation: sourceLocation)
+                #expect(context.codingPath.map(\.stringValue) == codingPath, sourceLocation: sourceLocation)
+                #expect(context.debugDescription == debugDescription, sourceLocation: sourceLocation)
+                return context.underlyingError
+            default:
+                Issue.record(error, "Unexpected error case", sourceLocation: sourceLocation)
+                return nil
+            }
+        }
+    }
+
+    public static func valueNotFound<ExpectedType>(
+        expectedType _: ExpectedType.Type,
+        codingPath: [String],
+        debugDescription: String,
+        sourceLocation: SourceLocation = #_sourceLocation,
+    ) -> Validator {
+        { error in
+            switch error {
+            case .valueNotFound(let type, let context):
+                #expect(type == ExpectedType.self, sourceLocation: sourceLocation)
+                #expect(context.codingPath.map(\.stringValue) == codingPath, sourceLocation: sourceLocation)
+                #expect(context.debugDescription == debugDescription, sourceLocation: sourceLocation)
+                return context.underlyingError
+            default:
+                Issue.record(error, "Unexpected error case", sourceLocation: sourceLocation)
+                return nil
+            }
+        }
+    }
+
+    public static func keyNotFound(
+        keyStringValue: String,
+        codingPath: [String],
+        debugDescription: String,
+        sourceLocation: SourceLocation = #_sourceLocation,
+    ) -> Validator {
+        { error in
+            switch error {
+            case .keyNotFound(let key, let context):
+                #expect(key.stringValue == keyStringValue, sourceLocation: sourceLocation)
+                #expect(context.codingPath.map(\.stringValue) == codingPath, sourceLocation: sourceLocation)
+                #expect(context.debugDescription == debugDescription, sourceLocation: sourceLocation)
+                return context.underlyingError
+            default:
+                Issue.record(error, "Unexpected error case", sourceLocation: sourceLocation)
+                return nil
+            }
+        }
+    }
+
+    public static func dataCorrupted(
+        codingPath: [String],
+        debugDescription: String,
+        sourceLocation: SourceLocation = #_sourceLocation,
+    ) -> Validator {
+        { error in
+            switch error {
+            case .dataCorrupted(let context):
+                #expect(context.codingPath.map(\.stringValue) == codingPath, sourceLocation: sourceLocation)
+                #expect(context.debugDescription == debugDescription, sourceLocation: sourceLocation)
+                return context.underlyingError
+            default:
+                Issue.record(error, "Unexpected error case", sourceLocation: sourceLocation)
+                return nil
+            }
+        }
+    }
+}
+
 // MARK: - Private Types
 
 private class Box<T> {


### PR DESCRIPTION
Shorten error messages from built-in encoders and decoders so they are not redundant with debug descriptions from `EncodingError` and `DecodingError` in the stdlib.

### Motivation:

Consider the following error message:

> `typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [_CodingKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "address", intValue: nil), CodingKeys(stringValue: "city", intValue: nil), CodingKeys(stringValue: "birds", intValue: nil), _CodingKey(stringValue: "Index 1", intValue: 1), CodingKeys(stringValue: "name", intValue: nil)], debugDescription: "Expected to decode String but found number instead.", underlyingError: nil))`

Following changes from [SE-0489](https://github.com/swiftlang/swift/pull/85770), it is shortened to the following:

> `DecodingError.typeMismatch: expected value of type String. Path: [0].address.city.birds[1].name. Debug description: Expected to decode String but found number instead.`

But we can do better. Note that there is still redundant information making the error message unnecessarily long. Let's break it down into pieces:

| Message component | Origin |
|--------|--------|
| `DecodingError.typeMismatch: expected value of type String. Path: [0].address.city.birds[1].name. Debug description: ` | `Swift.DecodingError.debugDescription` |
| `Expected to decode String but found number instead` | `Foundation.JSONDecoder` |
| `.` | `Swift.DecodingError.debugDescription` |

The stdlib already says what kind of value we expected (a `String`), but not what type was expected. Foundation provides the expected type a second time, as well as the actual found type.

### Modifications:

1. Shortened error messages generated by encoders and decoders in Foundation so as not to carry information redundant to the messages from the stdlib.
1. Included, in the debug description, the date string that causes IS08601 decoding failures. I imagine there are cases where we might want to be careful and avoid printing the full string, though?
1. I caught a case where `PlistDecoderGeneric` was seemingly doing an invalid check for `is any UnkeyedDecodingContainer` - that check was failing on a test case which did not fail with `JSONDecoder`, so I modified the check in `PlistDecoderGeneric` to match.

### Testing:

I added unit tests for the errors generated by decoders in Foundation. I'm not testing the full `debugDescription` of the resulting error, since that's controlled by the stdlib, but that choice makes it hard to see the full impact of this change. In order to see the full change, capture the error thrown by the encoding/decoding failure and print `String(reflecting: error)`. I'm wondering whether there's anything I can do to improve this setup?

### Open Questions:

1. I found a few parts of `JSONDecoder` and `PropertyListDecoder` that seem to be unreachable. Are they in fact unreachable?
1. Is the change to cast in `PlistDecoderGeneric` ok?
2. Should we merge https://github.com/swiftlang/swift/pull/87408? If so, it will slightly impact the strings we end up with in this PR. It was the initial investigation for this Foundation PR that led me to notice the discrepancy with null values in the stdlib.
1. In general, does this approach seem good and worthwhile? I've identified almost 100 additional thrown errors in the plist decoder, but I want to get some encouragement that I'm going in the right direction before I devote more time to this.