### PR TITLE
Group swiftlang GH Action dependency updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      swiftlang-actions:
+        patterns:
+          - "swiftlang/github-workflows/*"


### PR DESCRIPTION
Group swiftlang GitHub Action dependency updates together in Dependabot

### Motivation:

When Dependabot updates the tag for the swiftlang/github-workflows repo, it does so via 3 PRs, one for each workflow used (ex. https://github.com/swiftlang/swift-foundation/pull/1771 https://github.com/swiftlang/swift-foundation/pull/1772 https://github.com/swiftlang/swift-foundation/pull/1773). Instead, I believe this should group all of the workflows together so Dependabot creates a single PR to update them all. That way it imposes less administrative overhead on us for managing multiple PRs / running CI multiple times on the same dependency bump.

### Modifications:

Adds a group to `dependabot.yml` to encompass all swiftlang workflows

### Result:

We should see Dependabot only open a single PR

### Testing:

I'm unsure how to test Dependabot changes