### PR TITLE
Improve String dictionary key strategy tests to verify nested value conversion

### DIFF
--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -545,12 +545,15 @@ private struct JSONEncoderTests {
     }
 
     @Test func decodingDictionaryStringKeyConversionUntouched() throws {
-        let input = "{\"leave_me_alone\":\"test\"}".data(using: .utf8)!
+        // String dictionary keys should NOT be converted by key decoding strategy,
+        // but nested struct properties should still be converted.
+        let input = "{\"leave_me_alone\":{\"this_is_camel_case\":\"test\"}}".data(using: .utf8)!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        let result = try decoder.decode([String: String].self, from: input)
+        let result = try decoder.decode([String: DecodeMe3].self, from: input)
 
-        #expect(["leave_me_alone": "test"] == result)
+        let value = try #require(result["leave_me_alone"])
+        #expect(value.thisIsCamelCase == "test")
     }
     
     @Test func decodingDictionaryCodingKeyRepresentableKeyConversionUntouched() throws {
@@ -2339,8 +2342,10 @@ extension JSONEncoderTests {
     }
 
     @Test func encodingDictionaryStringKeyConversionUntouched() throws {
-        let expected = "{\"leaveMeAlone\":\"test\"}"
-        let toEncode: [String: String] = ["leaveMeAlone": "test"]
+        // String dictionary keys should NOT be converted by key encoding strategy,
+        // but nested struct properties should still be converted.
+        let expected = "{\"leaveMeAlone\":{\"this_is_camel_case\":\"test\"}}"
+        let toEncode: [String: DecodeMe3] = ["leaveMeAlone": DecodeMe3(thisIsCamelCase: "test")]
 
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase


### PR DESCRIPTION
Update both tests to use a nested `Codable` struct as the dictionary value.

### Motivation:

While reviewing #1526, we noticed `encodingDictionaryStringKeyConversionUntouched` and 
`decodingDictionaryStringKeyConversionUntouched` only verify that String dictionary keys 
are preserved, but don't check that key strategies are still correctly applied to nested 
struct properties.

### Modifications:

- Update decodingDictionaryStringKeyConversionUntouched to use DecodeMe3 values
- Update encodingDictionaryStringKeyConversionUntouched to use DecodeMe3 values
- Verify String dictionary keys bypass strategy while nested properties apply it
- Ensures consistent comprehensive test coverage for dictionary key behavior

### Result:

Tests now verify that dictionary keys bypass the strategy AND nested properties apply it

### Testing:

- `encodingDictionaryStringKeyConversionUntouched`
- `decodingDictionaryStringKeyConversionUntouched`
