### PR TITLE
Adopt Span in ICU.ResourceBundle

### DIFF
--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -125,18 +125,6 @@ final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
 
         var status = U_ZERO_ERROR
-        // Use the already canonicalized `name` instead of `identifier` to initiate ICU time zone
-        let timeZone : UnsafeMutablePointer<UTimeZone?>? = Array(name.utf16).withUnsafeBufferPointer {
-            let uatimezone = uatimezone_open($0.baseAddress, Int32($0.count), &status)
-            guard status.isSuccess else {
-                return nil
-            }
-            return uatimezone
-        }
-
-        guard let timeZone else {
-            return nil
-        }
 
         self.name = name
         lock = LockedState(initialState: State())
@@ -145,6 +133,19 @@ final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
             self._timeZoneICUResource = timeZoneICUResource
             self._timeZone = nil
         } else {
+            // Use the already canonicalized `name` instead of `identifier` to initiate ICU time zone
+            let timeZone : UnsafeMutablePointer<UTimeZone?>? = Array(name.utf16).withUnsafeBufferPointer {
+                let uatimezone = uatimezone_open($0.baseAddress, Int32($0.count), &status)
+                guard status.isSuccess else {
+                    return nil
+                }
+                return uatimezone
+            }
+
+            guard let timeZone else {
+                return nil
+            }
+
             self._timeZone = .init(initialState:timeZone)
             self._timeZoneICUResource = nil
         }

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_SingleDSTRule.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_SingleDSTRule.swift
@@ -165,7 +165,7 @@ internal final class _TimeZoneSingleDSTRule: Sendable {
     }
 
 
-    func rawAndDaylightSavingTimeOffset(for date: Date, local: Bool, duplicatedTimePolicy: DaylightSavingTimePolicy, nonExistingTimePolicy: DaylightSavingTimePolicy) -> (rawOffset: Int, dstOffset: Int) {
+    func rawAndDaylightSavingTimeOffset(for date: Date, local: Bool, duplicatedTimePolicy: DaylightSavingTimePolicy, nonExistingTimePolicy: DaylightSavingTimePolicy) -> (rawOffset: Int, dstSavings: Int) {
         if local {
             let secondsOffsets = _rawAndDSTOffsetForLocalDate(date, nonExistingTimeOpt: nonExistingTimePolicy, duplicatedTimeOpt: duplicatedTimePolicy)
             return secondsOffsets
@@ -349,7 +349,7 @@ internal final class _TimeZoneSingleDSTRule: Sendable {
 
     // MARK: - Utility Methods
 
-    func _rawAndDSTOffsetForLocalDate(_ date: Date, nonExistingTimeOpt: DaylightSavingTimePolicy, duplicatedTimeOpt: DaylightSavingTimePolicy) -> (rawOffset: Int, dstOffset: Int) {
+    func _rawAndDSTOffsetForLocalDate(_ date: Date, nonExistingTimeOpt: DaylightSavingTimePolicy, duplicatedTimeOpt: DaylightSavingTimePolicy) -> (rawOffset: Int, dstSavings: Int) {
         var dstOffset = _gmtOffset(forLocalDate: date) - rawOffset
         // Need to recalculate if either
         // 1. We're in DST AND options say we should try standard time


### PR DESCRIPTION
Adopt Span in `ICU.ResourceBundle`. This allows us to delay creating an Array until when we really need it and save intermediate allocations.

Also remove an intermediate struct `FixedOffsetTimeZoneRule`. It only wraps two variables, and removing it allows reducing one wrapper.

### Testing:

No particular tests were added because this change shouldn't change any behavior. The profiling result does show that the intermediate allocation calls are gone after the change.