### PR TITLE
Change `UInt16(_:)` to `UInt16(ascii:)` in OpenStepPlist.swift

### DIFF
--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -520,7 +520,7 @@ private func lineNumberStrings(_ pInfo: _ParseInfo) -> Int {
             count += 1
 
             let nextIdx = pInfo.utf16.index(after: p)
-            if nextIdx < pInfo.utf16.endIndex && nextIdx < pInfo.curr && pInfo.utf16[nextIdx] == UInt16("\n") {
+            if nextIdx < pInfo.utf16.endIndex && nextIdx < pInfo.curr && pInfo.utf16[nextIdx] == UInt16(ascii: "\n") {
                 p = nextIdx
             }
         } else if pInfo.utf16[p] == UInt16(ascii: "\n") {

--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -872,6 +872,23 @@ private struct PropertyListEncoderTests {
         }
     }
 
+    @Test func oldStylePlist_errors() {
+        let oldStyleWithErrors = "{ hello = there; }\r\nextra stuff at end"
+
+        let data = oldStyleWithErrors.data(using: .ascii)!
+
+        struct Thing : Decodable {
+            var hello: String
+        }
+        let plistDecoder = PropertyListDecoder()
+
+        #expect {
+            try plistDecoder.decode(Thing.self, from: data)
+        } throws: {
+            String(describing: $0).contains("Junk after plist at line 2")
+        }
+    }
+
     // <rdar://problem/34321354> Microsoft: Microsoft vso 1857102 : High Sierra regression that caused data loss : CFBundleCopyLocalizedString returns incorrect string
     // Escaped octal chars can be shorter than 3 chars long; i.e. \5 ≡ \05 ≡ \005.
     @Test func oldStylePlist_getSlashedChars_octal() throws {


### PR DESCRIPTION
This was calling the failable (String) -> UInt16? init, which always returns nil when given "\n". This was not intended.

Found by inspection while testing some Swift type checker changes.

Thanks to @parkera for the test case!

Fixes https://github.com/swiftlang/swift-foundation/issues/1779.
