### PR TITLE
Correct Data.endIndex doc comment

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -948,7 +948,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
 
     /// The end `Index` into the data.
     ///
-    /// This is the "one-past-the-end" position, and will always be equal to the `count`.
+    /// This is the "one-past-the-end" position—that is, the position one greater than the last valid subscript argument.
     @inlinable // This is @inlinable as trivially forwarding.
     public var endIndex: Index {
         get {


### PR DESCRIPTION
Removes an incorrect statement from the documentation of `Data.endindex`

### Motivation:

Since `Data` is a self-slicing type, there is no guarantee that `endIndex == count`

Resolves https://github.com/swiftlang/swift-foundation/issues/1764

### Modifications:

Updates the documentation to use phrasing from [`Collection.endIndex`](https://developer.apple.com/documentation/swift/collection/endindex) instead of mentioning the `count`

### Result:

Documentation for `Data.endIndex` is corrected.

### Testing:

This is a documentation-only change so unit testing is not applicable.
