### PR TITLE
Fix NSURL range updates for IDNA-encoded hosts that decrease in size

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Parsing.swift
+++ b/Sources/FoundationEssentials/URL/URL_Parsing.swift
@@ -958,43 +958,43 @@ private func encode<T: _URLEncoding, Impl: _URLParseable>(
 
         @inline(__always)
         func updateUserRange(_ start: Int, _ end: Int) {
-            guard updateRanges && extraBytesAdded > 0 else { return }
+            guard updateRanges && extraBytesAdded != 0 else { return }
             impl.pointee.userRange = start..<end
         }
 
         @inline(__always)
         func updatePasswordRange(_ start: Int, _ end: Int) {
-            guard updateRanges && extraBytesAdded > 0 else { return }
+            guard updateRanges && extraBytesAdded != 0 else { return }
             impl.pointee.passwordRange = start..<end
         }
 
         @inline(__always)
         func updateHostRange(_ start: Int, _ end: Int) {
-            guard updateRanges && extraBytesAdded > 0 else { return }
+            guard updateRanges && extraBytesAdded != 0 else { return }
             impl.pointee.hostRange = start..<end
         }
 
         @inline(__always)
         func updatePortRange(_ start: Int, _ end: Int) {
-            guard updateRanges && extraBytesAdded > 0 else { return }
+            guard updateRanges && extraBytesAdded != 0 else { return }
             impl.pointee.portRange = start..<end
         }
 
         @inline(__always)
         func updatePathRange(_ start: Int, _ end: Int) {
-            guard updateRanges && extraBytesAdded > 0 else { return }
+            guard updateRanges && extraBytesAdded != 0 else { return }
             impl.pointee.pathRange = start..<end
         }
 
         @inline(__always)
         func updateQueryRange(_ start: Int, _ end: Int) {
-            guard updateRanges && extraBytesAdded > 0 else { return }
+            guard updateRanges && extraBytesAdded != 0 else { return }
             impl.pointee.queryRange = start..<end
         }
 
         @inline(__always)
         func updateFragmentRange(_ start: Int, _ end: Int) {
-            guard updateRanges && extraBytesAdded > 0 else { return }
+            guard updateRanges && extraBytesAdded != 0 else { return }
             impl.pointee.fragmentRange = start..<end
         }
 


### PR DESCRIPTION
Update the `NSURL` encode-and-update-ranges-in-place logic to correctly handle IDNA-encoded hosts that are shorter than their original representation.

### Motivation:

Percent-encoding will always increase the size of a URL component, but IDNA-encoding can actually decrease the size of a host component if the host contains characters that `uidna_nameToASCII` removes entirely. Examples of these characters include soft hyphen (U+00AD), zero-width space (U+200B), zero-width non-joiner (U+200C), and zero-width joiner (U+200D).

The encode-and-update-ranges-in-place logic tracks a cumulative `extraBytesAdded` variable to adjust component ranges after encoding. It previously only updated ranges when `extraBytesAdded > 0`, which doesn't account for IDNA encoding producing a shorter result. This can leave subsequent component ranges extending beyond the end of the encoded string, causing a crash on access.

### Modifications:

Update ranges whenever `extraBytesAdded != 0` instead of `extraBytesAdded > 0`, so that ranges are corrected when IDNA encoding shrinks the host.

### Result:

No behavior change for swift-foundation. When the Swift `NSURL` implementation is enabled, component ranges are correct after encoding, regardless of whether IDNA encoding increases or decreases the host size.

### Testing:

Added `NSURL` unit tests for IDNA-shortened hosts with various combinations of percent-encoded components before and after the host.

