### PR TITLE
Fast path for initializing Data with NSData

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -409,6 +409,13 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
             _representation = contiguous.withUnsafeBytes { return _Representation($0) }
             return
         }
+
+        // This fast path should always be within the ABI function because Data(referencing:) is opaque anyways
+        if let nsData = elements as? NSData {
+            // If we have an NSData, bridge it rather than slow-copy it
+            self = Data(referencing: nsData)
+            return
+        }
         #endif
 
         // Copy as much as we can in one shot from the sequence.


### PR DESCRIPTION
Adds a fast path in `Data.init` for when the provided argument is an `NSData`

### Motivation:

Initializing a `Data` from an `NSData` currently goes down a byte-by-byte copy slow path. We can improve this a lot by dispatching to our bridging code to bridge lazily (when possible) or copy via a `memcpy` otherwise.

### Modifications:

Adds a fast path to `Data.init` when the argument is an `NSData` to dispatch to our bridging code

### Result:

Significant performance improvements when initializing a `Data` with an `NSData`

### Testing:

`NSData` tests are not applicable here
