### PR TITLE
[wasm] Unlock FTS-related code on WASI

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -205,8 +205,7 @@ extension _FileManagerImpl {
             }
         }
         return results
-#elseif os(WASI) || os(OpenBSD)
-        // wasi-libc does not support FTS for now
+#elseif os(OpenBSD)
         throw CocoaError.errorWithFilePath(.featureUnsupported, path)
 #else
         return try path.withFileSystemRepresentation { fileSystemRep in

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -130,9 +130,6 @@ internal import _FoundationCShims
 
 // MARK: Directory Iteration
 
-// No FTS support in wasi-libc for now (https://github.com/WebAssembly/wasi-libc/issues/520)
-#if !os(WASI)
-
 struct _FTSSequence: Sequence {
     enum Element {
         struct SwiftFTSENT {
@@ -328,8 +325,6 @@ extension Sequence<_FTSSequence.Element> {
         }
     }
 }
-
-#endif // !os(WASI)
 
 struct _POSIXDirectoryContentsSequence: Sequence {
     #if canImport(Darwin)

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -532,13 +532,6 @@ enum _FileOperations {
             throw CocoaError.removeFileError(errno, resolve(path: pathStr))
         }
 
-        #if os(WASI)
-
-        // wasi-libc does not support FTS, so we don't support removing non-empty directories on WASI for now.
-        throw CocoaError.errorWithFilePath(.featureUnsupported, pathStr)
-
-        #else
-
         let seq = _FTSSequence(path, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT)
         let iterator = seq.makeIterator()
         var isFirst = true
@@ -587,8 +580,6 @@ enum _FileOperations {
                 }
             }
         }
-        #endif
-        
     }
     #endif
 #endif
@@ -1114,51 +1105,6 @@ enum _FileOperations {
         #endif
     }
 
-    #if os(WASI)
-    private static func _linkOrCopyFile(_ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
-        let src = String(cString: srcPtr)
-        let dst = String(cString: dstPtr)
-        guard delegate.shouldPerformOnItemAtPath(src, to: dst) else { return }
-
-        var stat = stat()
-        guard lstat(srcPtr, &stat) == 0 else {
-            try delegate.throwIfNecessary(errno, src, dst)
-            return
-        }
-        let copyFile = delegate.copyData
-        guard !stat.isDirectory else {
-            // wasi-libc does not support FTS for now, so we don't support copying/linking
-            // directories on WASI for now.
-            let error = CocoaError.errorWithFilePath(.featureUnsupported, src, variant: copyFile ? "Copy" : "Link", source: src, destination: dst)
-            try delegate.throwIfNecessary(error, src, dst)
-            return
-        }
-
-        // For now, we support only copying regular files and symlinks.
-        // After we get FTS support (https://github.com/WebAssembly/wasi-libc/pull/522),
-        // we can remove this method and use the below FTS-based implementation.
-
-        if stat.isSymbolicLink {
-            try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { tempBuff in
-                tempBuff.initialize(repeating: 0)
-                defer { tempBuff.deinitialize() }
-                let len = readlink(srcPtr, tempBuff.baseAddress!, FileManager.MAX_PATH_SIZE - 1)
-                if len >= 0, symlink(tempBuff.baseAddress!, dstPtr) != -1 {
-                    return
-                }
-                try delegate.throwIfNecessary(errno, src, dst)
-            }
-        } else {
-            if copyFile {
-                try _copyRegularFile(srcPtr, dstPtr, delegate: delegate)
-            } else {
-                if link(srcPtr, dstPtr) != 0 {
-                    try delegate.throwIfNecessary(errno, src, dst)
-                }
-            }
-        }
-    }
-    #else
     private static func _linkOrCopyFile(_ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
         try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
             let dstLen = Platform.copyCString(dst: buffer.baseAddress!, src: dstPtr, size: FileManager.MAX_PATH_SIZE)
@@ -1260,7 +1206,6 @@ enum _FileOperations {
             }
         }
     }
-    #endif
     
     private static func linkOrCopyFile(_ src: String, dst: String, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
         try src.withFileSystemRepresentation { srcPtr in


### PR DESCRIPTION
fixes #1785 

### Motivation:

- #1785

### Modifications:

Similar to https://github.com/swiftlang/swift-corelibs-foundation/pull/5418, I have unlocked all FTS-related code on WASI.

### Result:

`FileManager.removeItem` can now remove a non-empty directory.

### Testing:

Running `swift build --swift-sdk "$(swiftc -print-target-info | jq -r '.swiftCompilerTag')_wasm"` on this repository succeeded.

And, I created a repository to confirm that the issue reported in #1785 has been resolved: https://github.com/kkebo/wasi-removeitem-demo.

- [Before modification](https://github.com/kkebo/wasi-removeitem-demo/commit/9257f6df50a2a768fc090ccc8fe8166207f47b96): `swift run --swift-sdk "$(swiftc -print-target-info | jq -r '.swiftCompilerTag')_wasm"` failed as described in #1785.
- [After modification](https://github.com/kkebo/wasi-removeitem-demo/commit/74eb83d396a52e0ad5b48e260fd8e41b0648787c): `swift run --swift-sdk "$(swiftc -print-target-info | jq -r '.swiftCompilerTag')_wasm"` succeeded.