### PR TITLE
[6.3] [wasm] Unlock FTS-related code on WASI

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -205,8 +205,7 @@ extension _FileManagerImpl {
             }
         }
         return results
-#elseif os(WASI) || os(OpenBSD)
-        // wasi-libc does not support FTS for now
+#elseif os(OpenBSD)
         throw CocoaError.errorWithFilePath(.featureUnsupported, path)
 #else
         return try path.withFileSystemRepresentation { fileSystemRep in

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -130,9 +130,6 @@ internal import _FoundationCShims
 
 // MARK: Directory Iteration
 
-// No FTS support in wasi-libc for now (https://github.com/WebAssembly/wasi-libc/issues/520)
-#if !os(WASI)
-
 struct _FTSSequence: Sequence {
     enum Element {
         struct SwiftFTSENT {
@@ -328,8 +325,6 @@ extension Sequence<_FTSSequence.Element> {
         }
     }
 }
-
-#endif // !os(WASI)
 
 struct _POSIXDirectoryContentsSequence: Sequence {
     #if canImport(Darwin)

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -533,13 +533,6 @@ enum _FileOperations {
             throw CocoaError.removeFileError(errno, resolve(path: pathStr))
         }
 
-        #if os(WASI)
-
-        // wasi-libc does not support FTS, so we don't support removing non-empty directories on WASI for now.
-        throw CocoaError.errorWithFilePath(.featureUnsupported, pathStr)
-
-        #else
-
         let seq = _FTSSequence(path, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT)
         let iterator = seq.makeIterator()
         var isFirst = true
@@ -588,8 +581,6 @@ enum _FileOperations {
                 }
             }
         }
-        #endif
-        
     }
     #endif
 #endif
@@ -1094,51 +1085,6 @@ enum _FileOperations {
         #endif
     }
 
-    #if os(WASI)
-    private static func _linkOrCopyFile(_ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
-        let src = String(cString: srcPtr)
-        let dst = String(cString: dstPtr)
-        guard delegate.shouldPerformOnItemAtPath(src, to: dst) else { return }
-
-        var stat = stat()
-        guard lstat(srcPtr, &stat) == 0 else {
-            try delegate.throwIfNecessary(errno, src, dst)
-            return
-        }
-        let copyFile = delegate.copyData
-        guard !stat.isDirectory else {
-            // wasi-libc does not support FTS for now, so we don't support copying/linking
-            // directories on WASI for now.
-            let error = CocoaError.errorWithFilePath(.featureUnsupported, src, variant: copyFile ? "Copy" : "Link", source: src, destination: dst)
-            try delegate.throwIfNecessary(error, src, dst)
-            return
-        }
-
-        // For now, we support only copying regular files and symlinks.
-        // After we get FTS support (https://github.com/WebAssembly/wasi-libc/pull/522),
-        // we can remove this method and use the below FTS-based implementation.
-
-        if stat.isSymbolicLink {
-            try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { tempBuff in
-                tempBuff.initialize(repeating: 0)
-                defer { tempBuff.deinitialize() }
-                let len = readlink(srcPtr, tempBuff.baseAddress!, FileManager.MAX_PATH_SIZE - 1)
-                if len >= 0, symlink(tempBuff.baseAddress!, dstPtr) != -1 {
-                    return
-                }
-                try delegate.throwIfNecessary(errno, src, dst)
-            }
-        } else {
-            if copyFile {
-                try _copyRegularFile(srcPtr, dstPtr, delegate: delegate)
-            } else {
-                if link(srcPtr, dstPtr) != 0 {
-                    try delegate.throwIfNecessary(errno, src, dst)
-                }
-            }
-        }
-    }
-    #else
     private static func _linkOrCopyFile(_ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
         try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
             let dstLen = Platform.copyCString(dst: buffer.baseAddress!, src: dstPtr, size: FileManager.MAX_PATH_SIZE)
@@ -1240,7 +1186,6 @@ enum _FileOperations {
             }
         }
     }
-    #endif
     
     private static func linkOrCopyFile(_ src: String, dst: String, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
         try src.withFileSystemRepresentation { srcPtr in


### PR DESCRIPTION
- **Explanation**:
  wasi-libc now supports FTS. Therefore, I have removed the compile-time branches for WASI and enabled the original implementations utilizing FTS. This fixes `subpathsOfDirectory`, `removeItem` for non-empty directories, and `copyItem`/`linkItem` when the source is a directory on WASI.
- **Scope**:
  Only affects WASI.
- **Issues**:
  - #1785
- **Original PRs**:
  - #1786
- **Risk**:
  The risk is low because it only affects WASI and the original implementations of `subpathsOfDirectory`/`removeItem`/`copyItem`/`linkItem` have been well tested on other platforms.
- **Testing**:
  - I locally tested by the same way described in #1786 with the [6.3](https://github.com/kkebo/wasi-removeitem-demo/tree/6.3) branch.
  - We currently don't run unit tests on WASI in CI, but my changes are covered by the following tests, so they will prevent regression in the future.
    - My changes and the tests covering each change:
      - `Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift`
        - `_FTSSequence`
          - used in `_FileManagerImpl.subpathsOfDirectory(atPath:)` (described below)
          - used in `_FileOperations.removeFile(_:with:)` (only when the path a non-empty directory) (described below)
          - used in `_FileOperations._linkOrCopyFile(_:_:with:delegate:)` (only when the source path is a directory) (described below)
      - `Sources/FoundationEssentials/FileManager/FileManager+Directories.swift`
        - `_FileManagerImpl.subpathsOfDirectory(atPath:)`
          - covered by https://github.com/swiftlang/swift-foundation/blob/708e79c642a476511a359cc4e536633f53295c88/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift#L310
      - `Sources/FoundationEssentials/FileManager/FileOperations.swift`
        - `_FileOperations.removeFile(_:with:)` (only when the path a non-empty directory)
          - called in `_FileManagerImpl.removeItem(atPath:)`
            - covered by https://github.com/swiftlang/swift-foundation/blob/708e79c642a476511a359cc4e536633f53295c88/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift#L617
        - `_FileOperations._linkOrCopyFile(_:_:with:delegate:)` (only when the source path is a directory)
          - called in `_FileOperations.linkOrCopyFile(_:dst:with:delegate:)`
            - called in `_FileOperations.copyFile(_:to:with:options:)`
              - called in `_FileManagerImpl.copyItem(atPath:toPath:options:)`
                - covered by https://github.com/swiftlang/swift-foundation/blob/708e79c642a476511a359cc4e536633f53295c88/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift#L577
            - called in `_FileOperations.linkFile(_:to:with:)`
              - called in `_FileManagerImpl.linkItem(atPath:toPath:)`
                - not covered (but covered via tests for `copyFile`)
- **Reviewers**:
  @jmschonfeld, @kateinoigakukun
- **Additional note**:
  In swift-corelibs-foundation, similar changes have already been cherry-picked into 6.3. (https://github.com/swiftlang/swift-corelibs-foundation/pull/5419)