### PR TITLE
[6.3] Update GitHub Actions to nightly-6.3

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,20 +15,20 @@ jobs:
     name: Test (SwiftPM)
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
-      linux_swift_versions: '["nightly-main"]'
-      windows_swift_versions: '["nightly-main"]'
+      linux_swift_versions: '["nightly-6.3"]'
+      windows_swift_versions: '["nightly-6.3"]'
       enable_macos_checks: false
       macos_xcode_versions: '["16.3"]'
       macos_versions: '["sequoia"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["nightly-main"]'
+      wasm_sdk_versions: '["nightly-6.3"]'
       enable_android_sdk_build: true
-      android_sdk_versions: '["nightly-main"]'
+      android_sdk_versions: '["nightly-6.3"]'
 
   cmake_build:
     name: Build (CMake)
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-noble
+    container: swiftlang/swift:nightly-6.3-noble
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v1


### PR DESCRIPTION
Updates the CI on the `release/6.3` branch to use the 6.3 toolchains instead of toolchains from main