### PR TITLE
Avoid materializing String in SwiftFTSEnt.name

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -133,20 +133,27 @@ internal import _FoundationCShims
 struct _FTSSequence: Sequence {
     enum Element {
         struct SwiftFTSENT {
-            fileprivate let ptr: UnsafeMutablePointer<FTSENT>
-            
+            private let ptr: UnsafeMutablePointer<FTSENT>
+
             var ftsEnt: FTSENT { ptr.pointee }
-            var name: String {
-                // FTSENT incorrectly represents the `fts_name` property so we must access it directly via the pointer rather than the pointee struct value
-                let nameOffset = MemoryLayout<FTSENT>.offset(of: \.fts_name)!
-                let len = Int(ptr.pointee.fts_namelen)
-                return UnsafeRawPointer(ptr).advanced(by: nameOffset).withMemoryRebound(to: UTF8.CodeUnit.self, capacity: len) { namePtr in
-                    String(decoding: UnsafeBufferPointer(start: namePtr, count: len), as: UTF8.self)
+
+            var name: Span<UInt8> {
+                @_lifetime(borrow self)
+                get {
+                    // FTSENT incorrectly represents the `fts_name` property so we must access it directly via the pointer rather than the pointee struct value
+                    let nameOffset = MemoryLayout<FTSENT>.offset(of: \.fts_name)!
+                    let len = Int(ptr.pointee.fts_namelen)
+                    let span = Span<UInt8>(_unsafeStart: UnsafeRawPointer(ptr).advanced(by: nameOffset), byteCount: len)
+                    return _overrideLifetime(span, borrowing: self)
                 }
             }
             
             init(_ ptr: UnsafeMutablePointer<FTSENT>) {
                 self.ptr = ptr
+            }
+
+            func skip(in fts: UnsafeMutablePointer<FTS>) {
+                _ = fts_set(fts, ptr, FTS_SKIP)
             }
         }
         case entry(SwiftFTSENT)
@@ -200,9 +207,10 @@ struct _FTSSequence: Sequence {
         private func _shouldFilter(_ swiftEnt: Element.SwiftFTSENT) -> Bool {
             let ent = swiftEnt.ftsEnt
             let ftsName = swiftEnt.name
-            
+            let nameStartsWithDotUnderscore = ftsName.count >= 2 && ftsName[0] == ._dot && ftsName[1] == ._underscore
+
             // If we're being requested to iterate a directory that begins with a ._ we should do it.
-            if lastDeviceInode == 0 && ftsName.hasPrefix("._") {
+            if lastDeviceInode == 0 && nameStartsWithDotUnderscore {
                 return false
             }
             
@@ -230,7 +238,7 @@ struct _FTSSequence: Sequence {
                 lastDeviceInode = currentDev
             }
             
-            if shouldFilterUnderbars && ftsName.hasPrefix("._") {
+            if shouldFilterUnderbars && nameStartsWithDotUnderscore {
                 // Don't report ._ files on filesystems that require them.
                 return true
             }
@@ -270,7 +278,7 @@ struct _FTSSequence: Sequence {
         
         func skipDescendants(of entry: Element.SwiftFTSENT, skipPostProcessing: Bool = false) {
             guard case .stream(let fts) = state else { return }
-            _ = fts_set(fts, entry.ptr, FTS_SKIP)
+            entry.skip(in: fts)
             if skipPostProcessing {
                 assert(Int32(entry.ftsEnt.fts_info) == FTS_D)
                 _ = self.next() // Skip the FTS_DP entry for this directory


### PR DESCRIPTION
Uses `Span` instead of a materialized `String` when providing the name of an FTS entry

### Motivation:

`SwiftFTSEnt` is a Swift wrapper around a pointer to an `FTSENT`. It has a `name` property which previously materialized a `String` for the path. However, the only caller of this API just uses the name for a prefix check. Instead of creating a `String` and performing `String` comparison, we can instead vend a `Span<UInt8>` of the path's bytes to the caller. This should be much more performant because we no longer create a `String` on a per-subpath basis if not required, and the prefix comparison no longer performs string normalization.

### Modifications:

`SwiftFTSEnt` is now a lifetime-bound `Span<UInt8>` instead of a `String`. While I was here, I also moved the `fts_skip` call into `SwiftFTSEnt` to avoid escaping the `FTSENT` pointer out of the `SwiftFTSEnt` to decrease the chances of any lifetime issues (in the long term, `SwiftFTSEnt` should be `~Escapable` but we don't have the ability to produce a sequence of `~Escapable` values yet).

### Result:

`SwiftFTSEnt.name` no longer creates a `String`

### Testing:

Existing `FileManager` unit tests cover this code path
