### PR TITLE
Add NewCodable to swift-foundation products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -94,6 +94,7 @@ let package = Package(
     products: [
         .library(name: "FoundationEssentials", targets: ["FoundationEssentials"]),
         .library(name: "FoundationInternationalization", targets: ["FoundationInternationalization"]),
+        .library(name: "NewCodable", targets: ["NewCodable"])
     ],
     dependencies: dependencies,
     targets: [


### PR DESCRIPTION
Add omitted `NewCodable` library to swift-foundation's products declaration.