### PR TITLE
Add Cache for Built-In CharacterSet for Performance Improvements

### DIFF
--- a/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
@@ -152,10 +152,8 @@ internal struct BuiltInUnicodeScalarSet {
             }
             let set = BuiltInUnicodeScalarSet(type: type)
             let (_, data) = set.bitmap(forPlane: 0, isInverted: isInverted)
-            let bitmap: Data
-            bitmap = data
-            cache[key] = bitmap
-            return bitmap
+            cache[key] = data
+            return data
         }
     }
     


### PR DESCRIPTION
Introduce a cache for BMP of built-in CharacterSet options. 

### Motivation:

To improve performance. 

### Modifications:

Introduced a lazy cache for BMPs to create a fast path for frequently-called `getBitmap` method. 

### Result:

No change is expected. 

### Testing:

All pre-existing unit tests pass. 