### PR TITLE
Fixed bug in Currency formatter when `.grouping(.never)` is used with other modifiers

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -853,7 +853,7 @@ extension CurrencyFormatStyleConfiguration.Collection {
             s += roundingIncrement.skeleton + " "
         }
         if let group = group {
-            s += group.skeleton
+            s += group.skeleton + " "
         }
         if let signDisplayStrategy = signDisplayStrategy {
             s += signDisplayStrategy.skeleton + " "

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleICUSkeletonTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleICUSkeletonTests.swift
@@ -87,6 +87,22 @@ private struct NumberFormatStyleICUSkeletonTests {
         #expect(isoCodeFormatter.skeleton == "currency/USD unit-width-iso-code sign-never")
     }
 
+    @Test func currencySkeleton_groupingWithRounding() throws {
+        let style: IntegerFormatStyle<Int>.Currency = .init(code: "USD", locale: Locale(identifier: "en_US"))
+
+        let groupedFormatter = ICUCurrencyNumberFormatter.create(for: style.grouping(.never))!
+        #expect(groupedFormatter.skeleton == "currency/USD unit-width-short group-off")
+
+        let roundedFormatter = ICUCurrencyNumberFormatter.create(for: style.rounded(rule: .toNearestOrEven))!
+        #expect(roundedFormatter.skeleton == "currency/USD unit-width-short rounding-mode-half-even")
+
+        let combinedFormatter = ICUCurrencyNumberFormatter.create(for: style.grouping(.never).rounded(rule: .toNearestOrEven))!
+        #expect(combinedFormatter.skeleton == "currency/USD unit-width-short group-off rounding-mode-half-even")
+
+        let reversedFormatter = ICUCurrencyNumberFormatter.create(for: style.rounded(rule: .toNearestOrEven).grouping(.never))!
+        #expect(reversedFormatter.skeleton == "currency/USD unit-width-short group-off rounding-mode-half-even")
+    }
+
     @Test func styleSkeleton_integer_precisionAndRounding() throws {
         let style: IntegerFormatStyle<Int> = .init(locale: Locale(identifier: "en_US"))
         #expect(style.precision(.fractionLength(3...3)).rounded(increment: 5).collection.skeleton == "precision-increment/5.000 rounding-mode-half-even")

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -337,6 +337,16 @@ private struct NumberFormatStyleTests {
 
     }
 
+    @Test func decimalFormatStyle_Currency_groupingWithRounding() throws {
+        let style = Decimal.FormatStyle.Currency(code: "USD", locale: enUSLocale)
+
+        _testNegativePositiveDecimal(style.grouping(.never), [ "$87650.00", "$8765.00", "$876.50", "$87.65", "$8.76", "$0.88", "$0.09", "$0.01", "$0.00", "-$0.01", "-$876.50", "-$87650.00" ], "currency grouping(.never)")
+        _testNegativePositiveDecimal(style.rounded(rule: .toNearestOrEven), [ "$87,650.00", "$8,765.00", "$876.50", "$87.65", "$8.76", "$0.88", "$0.09", "$0.01", "$0.00", "-$0.01", "-$876.50", "-$87,650.00" ], "currency rounded")
+
+        _testNegativePositiveDecimal(style.rounded(rule: .toNearestOrEven).grouping(.never), [ "$87650.00", "$8765.00", "$876.50", "$87.65", "$8.76", "$0.88", "$0.09", "$0.01", "$0.00", "-$0.01", "-$876.50", "-$87650.00" ], "currency rounded + grouping(.never)")
+        _testNegativePositiveDecimal(style.grouping(.never).rounded(rule: .toNearestOrEven), [ "$87650.00", "$8765.00", "$876.50", "$87.65", "$8.76", "$0.88", "$0.09", "$0.01", "$0.00", "-$0.01", "-$876.50", "-$87650.00" ], "currency grouping(.never) + rounded")
+    }
+
     @Test func decimal_withCustomShorthand() async {
         await usingCurrentInternationalizationPreferences {
             // This test can only be run with the system set to the en_US language


### PR DESCRIPTION
Combining `.rounded()` and `.grouping(.never)` on `Currency` format styles (e.g. `IntegerFormatStyle.Currency`) produces broken output: the currency symbol and fraction digits are lost.

### Motivation:

Certain combinations of currency style modifiers loses all formatting:

```swift
  1234.formatted(.currency(code: "USD").rounded().grouping(.never))
  // Expected: "$1234.00"
  // Actual:   "1234"
```

### Modifications:

Add + " " after `group.skeleton` in CurrencyFormatStyleConfiguration.Collection.skeleton, matching the pattern used by all other tokens and by the non-currency equivalent.

### Result:

Currency formatting with `.grouping(.never)` combined with other modifiers works correctly.

### Testing:

Added unit tests.
