### PR TITLE
Optional fields should be decoded as optionals to account for literal 'nulls' in the input

### DIFF
--- a/Sources/NewCodableMacros/JSONDecodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONDecodableMacro.swift
@@ -236,7 +236,11 @@ extension JSONDecodableMacro: ExtensionMacro {
             }.joined(separator: "\n            ")
 
             let switchCases = properties.map { prop in
-                "case .\(prop.name): \(prop.name) = try valueDecoder.decode(\(prop.typeName).self)"
+                if prop.isOptional {
+                    return "case .\(prop.name): \(prop.name) = try valueDecoder.decode(\(prop.typeName)?.self)"
+                } else {
+                    return "case .\(prop.name): \(prop.name) = try valueDecoder.decode(\(prop.typeName).self)"
+                }
             }.joined(separator: "\n                            ")
 
             let requiredProperties = properties.filter { $0.isRequired }

--- a/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
@@ -154,7 +154,7 @@ struct JSONCodableMacroTests {
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name: name = try valueDecoder.decode(String.self)
-                            case .rating: rating = try valueDecoder.decode(Double.self)
+                            case .rating: rating = try valueDecoder.decode(Double?.self)
                             case .unknown: break
                             }
                         }

--- a/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
@@ -136,7 +136,7 @@ struct JSONDecodableMacroTests {
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name: name = try valueDecoder.decode(String.self)
-                            case .rating: rating = try valueDecoder.decode(Double.self)
+                            case .rating: rating = try valueDecoder.decode(Double?.self)
                             case .unknown: break
                             }
                         }
@@ -200,8 +200,8 @@ struct JSONDecodableMacroTests {
                             _codingField = try fieldDecoder.decode(CodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
-                            case .theme: theme = try valueDecoder.decode(String.self)
-                            case .fontSize: fontSize = try valueDecoder.decode(Int.self)
+                            case .theme: theme = try valueDecoder.decode(String?.self)
+                            case .fontSize: fontSize = try valueDecoder.decode(Int?.self)
                             case .unknown: break
                             }
                         }
@@ -760,7 +760,7 @@ struct JSONDecodableMacroTests {
                             _codingField = try fieldDecoder.decode(CodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
-                            case .locale: locale = try valueDecoder.decode(String.self)
+                            case .locale: locale = try valueDecoder.decode(String?.self)
                             case .unknown: break
                             }
                         }


### PR DESCRIPTION
This detail evaded my notice in the original macro PR.