### PR TITLE
Use the given CFAllocator for copying CFURL file system path

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_C+Encoding.swift
+++ b/Sources/FoundationEssentials/URL/URL_C+Encoding.swift
@@ -144,17 +144,18 @@ extension NSURL {
     /// a trailing slash if present.
     ///
     /// - Note: Interprets the decoded file system representation as UTF8.
-    static func __copySwiftPOSIXPath(forFileURLString string: String) -> String {
+    static func __copySwiftPOSIXPath(forFileURLString string: String, allocator: CFAllocator) -> Unmanaged<CFString>? {
         assert(string.utf8.starts(with: "file://".utf8))
         var mut = string
         return mut.withUTF8 { buffer in
             let filePrefixSize = 7 // "file://"
-            return String(unsafeUninitializedCapacity: buffer.count - filePrefixSize) { outputBuffer in
-                guard let pathLength = URLEncoder.percentDecode(
+            return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: buffer.count - filePrefixSize) { outputBuffer in
+                guard let baseAddress = outputBuffer.baseAddress,
+                      var pathLength = URLEncoder.percentDecode(
                     input: UnsafeBufferPointer(rebasing: buffer[filePrefixSize...]),
                     output: outputBuffer
                 ) else {
-                    return 0
+                    return nil
                 }
                 let rootLength = rootLength(
                     pathBuffer: UnsafeBufferPointer(outputBuffer),
@@ -162,9 +163,14 @@ extension NSURL {
                 )
                 if pathLength > rootLength && outputBuffer[pathLength - 1] == UInt8(ascii: "/") {
                     // Strip the trailing slash
-                    return pathLength - 1
+                    pathLength -= 1
                 }
-                return pathLength
+                guard let result = CFStringCreateWithBytes(
+                    allocator, baseAddress, pathLength, CFStringBuiltInEncodings.UTF8.rawValue, false
+                ) else {
+                    return nil
+                }
+                return Unmanaged.passRetained(result)
             }
         }
     }


### PR DESCRIPTION
Honor the `CFAllocator` used to create the `CFURL` when creating its file system path.

### Motivation:

Be more compatible with previous behavior, which used the given `CFAllocator` instead of the default/Swift allocator.

### Modifications:

When copying the POSIX file system path from a canonical file `CFURL`, take in as input the allocator used to create the `CFURL` and use it when creating a `CFString` from the UTF8 bytes instead of creating a Swift String and bridging.

### Result:

No change in swift-foundation behavior. The given `CFAllocator` is used to allocate the resulting path when the Swift implementation is enabled for `CFURL`.

### Testing:

`CFURL` testing with the Swift implementation enabled.
