### PR TITLE
Add support for `wasm32-unknown-emscripten` platform

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -22,6 +22,8 @@ internal import os
 import CRT
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -22,6 +22,8 @@ internal import os
 import CRT
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 

--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -16,6 +16,12 @@ import Darwin
 @preconcurrency import Bionic
 #elseif canImport(Glibc)
 @preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(WASILibc)
+@preconcurrency import WASILibc
+#elseif canImport(EmscriptenLibc)
+@preconcurrency import EmscriptenLibc
 #endif
 
 //===----------------------------------------------------------------------===//

--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -23,6 +23,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 import WASILibc
+#elseif os(Emscripten)
+import EmscriptenLibc
 #elseif HAS_FOUNDATION_DARWIN_EXTRAS
 internal import _FoundationDarwinExtras
 #elseif canImport(stdlib_h)

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -29,6 +29,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if FOUNDATION_FRAMEWORK && NO_FILESYSTEM

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -33,6 +33,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if !NO_FILESYSTEM
@@ -134,12 +136,12 @@ private func cleanupTemporaryDirectory(at inPath: String?) {
 }
 
 /// Caller is responsible for calling `close` on the `Int32` file descriptor.
-#if os(WASI)
-@available(*, unavailable, message: "WASI does not have temporary directories")
+#if os(WASI) || os(Emscripten)
+@available(*, unavailable, message: "WASI/Emscripten does not have temporary directories")
 #endif
 private func createTemporaryFile(at destinationPath: String, inPath: borrowing some FileSystemRepresentable & ~Copyable, prefix: String, options: Data.WritingOptions, variant: String? = nil) throws -> (Int32, String) {
-#if os(WASI)
-    // WASI does not have temp directories
+#if os(WASI) || os(Emscripten)
+    // WASI/Emscripten does not have temp directories
     throw CocoaError(.featureUnsupported)
 #else
     var directoryPath = destinationPath
@@ -236,12 +238,12 @@ private func createTemporaryFile(at destinationPath: String, inPath: borrowing s
 
 /// Returns `(file descriptor, temporary file path, temporary directory path)`
 /// Caller is responsible for calling `close` on the `Int32` file descriptor and calling `cleanupTemporaryDirectory` on the temporary directory path. The temporary directory path may be nil, if it does not need to be cleaned up.
-#if os(WASI)
-@available(*, unavailable, message: "WASI does not have temporary directories")
+#if os(WASI) || os(Emscripten)
+@available(*, unavailable, message: "WASI/Emscripten does not have temporary directories")
 #endif
 private func createProtectedTemporaryFile(at destinationPath: String, inPath: borrowing some FileSystemRepresentable & ~Copyable, options: Data.WritingOptions, variant: String? = nil) throws -> (Int32, String, String?) {
-#if os(WASI)
-    // WASI does not have temp directories
+#if os(WASI) || os(Emscripten)
+    // WASI/Emscripten does not have temp directories
     throw CocoaError(.featureUnsupported)
 #else
 #if FOUNDATION_FRAMEWORK
@@ -354,7 +356,7 @@ extension NSData {
 #endif
 
 internal func writeToFile(path inPath: borrowing some FileSystemRepresentable & ~Copyable, buffer: RawSpan, options: Data.WritingOptions, attributes: [String : Data] = [:], reportProgress: Bool = false) throws {
-#if os(WASI) // `.atomic` is unavailable on WASI
+#if os(WASI) || os(Emscripten) // `.atomic` is unavailable on WASI/Emscripten
     try writeToFileNoAux(path: inPath, buffer: buffer, options: options, attributes: attributes, reportProgress: reportProgress)
 #else
     if options.contains(.atomic) {
@@ -366,12 +368,12 @@ internal func writeToFile(path inPath: borrowing some FileSystemRepresentable & 
 }
 
 /// Create a new file out of `Data` at a path, using atomic writing.
-#if os(WASI)
-@available(*, unavailable, message: "atomic writing is unavailable in WASI because temporary files are not supported")
+#if os(WASI) || os(Emscripten)
+@available(*, unavailable, message: "atomic writing is unavailable in WASI/Emscripten because temporary files are not supported")
 #endif
 private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable & ~Copyable, buffer: RawSpan, options: Data.WritingOptions, attributes: [String : Data], reportProgress: Bool) throws {
-#if os(WASI)
-    // `.atomic` is unavailable on WASI
+#if os(WASI) || os(Emscripten)
+    // `.atomic` is unavailable on WASI/Emscripten
     throw CocoaError(.featureUnsupported)
 #else
     assert(options.contains(.atomic))
@@ -651,7 +653,7 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
 
 /// Create a new file out of `Data` at a path, not using atomic writing.
 private func writeToFileNoAux(path inPath: borrowing some FileSystemRepresentable & ~Copyable, buffer: RawSpan, options: Data.WritingOptions, attributes: [String : Data], reportProgress: Bool) throws {
-#if !os(WASI) // `.atomic` is unavailable on WASI
+#if !os(WASI) && !os(Emscripten) // `.atomic` is unavailable on WASI/Emscripten
     assert(!options.contains(.atomic))
 #endif
 
@@ -757,8 +759,8 @@ extension Data {
         public init(rawValue: UInt) { self.rawValue = rawValue }
         
         /// An option to write data to an auxiliary file first and then replace the original file with the auxiliary file when the write completes.
-#if os(WASI)
-        @available(*, unavailable, message: "atomic writing is unavailable in WASI because temporary files are not supported")
+#if os(WASI) || os(Emscripten)
+        @available(*, unavailable, message: "atomic writing is unavailable in WASI/Emscripten because temporary files are not supported")
 #endif
         public static let atomic = WritingOptions(rawValue: 1 << 0)
         
@@ -788,7 +790,7 @@ extension Data {
     /// - parameter options: Options for writing the data. Default value is `[]`.
     /// - throws: An error in the Cocoa domain, if there is an error writing to the `URL`.
     public func write(to url: URL, options: Data.WritingOptions = []) throws {
-#if !os(WASI) // `.atomic` is unavailable on WASI
+#if !os(WASI) && !os(Emscripten) // `.atomic` is unavailable on WASI/Emscripten
         if options.contains(.withoutOverwriting) && options.contains(.atomic) {
             fatalError("withoutOverwriting is not supported with atomic")
         }

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -46,6 +46,13 @@
 @usableFromInline let memset = WASILibc.memset
 @usableFromInline let memcpy = WASILibc.memcpy
 @usableFromInline let memcmp = WASILibc.memcmp
+#elseif canImport(EmscriptenLibc)
+@usableFromInline let calloc = EmscriptenLibc.calloc
+@usableFromInline let malloc = EmscriptenLibc.malloc
+@usableFromInline let free = EmscriptenLibc.free
+@usableFromInline let memset = EmscriptenLibc.memset
+@usableFromInline let memcpy = EmscriptenLibc.memcpy
+@usableFromInline let memcmp = EmscriptenLibc.memcmp
 #elseif HAS_FOUNDATION_DARWIN_EXTRAS
 @usableFromInline let memset = _FoundationDarwinExtras.memset
 @usableFromInline let memcpy = _FoundationDarwinExtras.memcpy
@@ -85,6 +92,8 @@ internal func malloc_good_size(_ size: Int) -> Int {
 import ucrt
 #elseif canImport(WASILibc)
 @preconcurrency import WASILibc
+#elseif canImport(EmscriptenLibc)
+@preconcurrency import EmscriptenLibc
 #elseif HAS_FOUNDATION_DARWIN_EXTRAS
 internal import _FoundationDarwinExtras.POSIX.sys.mman
 #elseif canImport(string_h)

--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -20,6 +20,8 @@ import Darwin
 import ucrt
 #elseif canImport(WASILibc)
 @preconcurrency import WASILibc
+#elseif canImport(EmscriptenLibc)
+@preconcurrency import EmscriptenLibc
 #elseif canImport(stdlib_h)
 import stdlib_h
 #endif

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -22,6 +22,8 @@ import Darwin
 import ucrt
 #elseif canImport(WASILibc)
 @preconcurrency import WASILibc
+#elseif canImport(EmscriptenLibc)
+@preconcurrency import EmscriptenLibc
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(string_h)

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -20,6 +20,8 @@ import Darwin
 import ucrt
 #elseif canImport(WASILibc)
 @preconcurrency import WASILibc
+#elseif canImport(EmscriptenLibc)
+@preconcurrency import EmscriptenLibc
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif HAS_FOUNDATION_DARWIN_EXTRAS

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -22,6 +22,8 @@ import Darwin
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if !FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -22,6 +22,8 @@ import Darwin
 import CRT
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 private let powerOfTen: [Decimal.VariableLengthInteger] = [

--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -26,6 +26,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 // MARK: - Error Creation with CocoaError.Code

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -23,6 +23,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if FOUNDATION_FRAMEWORK
@@ -141,7 +143,7 @@ extension POSIXError {
         return .EFAULT
     }
 
-    #if !os(Windows) && !os(WASI)
+    #if !os(Windows) && !os(WASI) && !os(Emscripten)
     /// Block device required.
     public static var ENOTBLK: POSIXErrorCode {
         return .ENOTBLK
@@ -304,7 +306,7 @@ extension POSIXError {
         return .EPROTONOSUPPORT
     }
 
-    #if !os(WASI)
+    #if !os(WASI) && !os(Emscripten)
     /// Socket type not supported.
     public static var ESOCKTNOSUPPORT: POSIXErrorCode {
         return .ESOCKTNOSUPPORT
@@ -320,7 +322,7 @@ extension POSIXError {
     #endif
 
     #if !os(Windows)
-    #if !os(WASI)
+    #if !os(WASI) && !os(Emscripten)
     /// Protocol family not supported.
     public static var EPFNOSUPPORT: POSIXErrorCode {
         return .EPFNOSUPPORT
@@ -386,7 +388,7 @@ extension POSIXError {
         return .ENOTCONN
     }
 
-    #if !os(WASI)
+    #if !os(WASI) && !os(Emscripten)
     /// Can't send after socket shutdown.
     public static var ESHUTDOWN: POSIXErrorCode {
         return .ESHUTDOWN
@@ -420,7 +422,7 @@ extension POSIXError {
     }
 
     #if !os(Windows)
-    #if !os(WASI)
+    #if !os(WASI) && !os(Emscripten)
     /// Host is down.
     public static var EHOSTDOWN: POSIXErrorCode {
         return .EHOSTDOWN
@@ -448,7 +450,7 @@ extension POSIXError {
     #endif
     
     #if !os(Windows)
-    #if !os(WASI)
+    #if !os(WASI) && !os(Emscripten)
     /// Too many users.
     public static var EUSERS: POSIXErrorCode {
         return .EUSERS
@@ -469,7 +471,7 @@ extension POSIXError {
         return .ESTALE
     }
 
-    #if !os(WASI)
+    #if !os(WASI) && !os(Emscripten)
     /// Too many levels of remote in path.
     public static var EREMOTE: POSIXErrorCode {
         return .EREMOTE
@@ -623,7 +625,7 @@ extension POSIXError {
         return .EMULTIHOP
     }
 
-    #if !os(WASI) && !os(FreeBSD)
+    #if !os(WASI) && !os(FreeBSD) && !os(Emscripten)
     /// No message available on STREAM.
     public static var ENODATA: POSIXErrorCode {
         return .ENODATA
@@ -635,7 +637,7 @@ extension POSIXError {
         return .ENOLINK
     }
 
-    #if !os(WASI) && !os(FreeBSD)
+    #if !os(WASI) && !os(FreeBSD) && !os(Emscripten)
     /// No STREAM resources.
     public static var ENOSR: POSIXErrorCode {
         return .ENOSR
@@ -653,7 +655,7 @@ extension POSIXError {
         return .EPROTO
     }
 
-    #if !os(OpenBSD) && !os(WASI) && !os(FreeBSD)
+    #if !os(OpenBSD) && !os(WASI) && !os(FreeBSD) && !os(Emscripten)
     /// STREAM ioctl timeout.
     public static var ETIME: POSIXErrorCode {
         return .ETIME

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -23,6 +23,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -30,6 +30,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 internal import _FoundationCShims
@@ -205,7 +207,7 @@ extension _FileManagerImpl {
             }
         }
         return results
-#elseif os(OpenBSD)
+#elseif os(OpenBSD) || os(Emscripten)
         throw CocoaError.errorWithFilePath(.featureUnsupported, path)
 #else
         return try path.withFileSystemRepresentation { fileSystemRep in

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -32,6 +32,8 @@ import WinSDK
 #elseif os(WASI)
 internal import _FoundationCShims
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 extension Date {
@@ -176,7 +178,7 @@ extension stat {
             .ownerAccountID : _writeFileAttributePrimitive(st_uid, as: UInt.self),
             .groupOwnerAccountID : _writeFileAttributePrimitive(st_gid, as: UInt.self)
         ]
-        #if !os(WASI)
+        #if !os(WASI) && !os(Emscripten)
         if let userName = Platform.name(forUID: st_uid) {
             result[.ownerAccountName] = userName
         }
@@ -260,8 +262,8 @@ extension _FileManagerImpl {
             }
             attr?[.protectionKey] = nil
         }
-        #elseif os(WASI)
-        // `.atomic` is unavailable on WASI
+        #elseif os(WASI) || os(Emscripten)
+        // `.atomic` is unavailable on WASI/Emscripten
         let opts: Data.WritingOptions = []
         #else
         let opts = Data.WritingOptions.atomic
@@ -462,7 +464,7 @@ extension _FileManagerImpl {
             parent = fileManager.currentDirectoryPath
         }
 
-#if os(Windows) || os(WASI)
+#if os(Windows) || os(WASI) || os(Emscripten)
         return fileManager.isWritableFile(atPath: parent) && fileManager.isWritableFile(atPath: path)
 #else
         guard fileManager.isWritableFile(atPath: parent),
@@ -485,7 +487,7 @@ extension _FileManagerImpl {
 #endif
     }
 
-#if !os(Windows) && !os(WASI) && !os(OpenBSD)
+#if !os(Windows) && !os(WASI) && !os(OpenBSD) && !os(Emscripten)
     private func _extendedAttribute(_ key: UnsafePointer<CChar>, at path: UnsafePointer<CChar>, followSymlinks: Bool) throws -> Data? {
         #if canImport(Darwin)
         var size = getxattr(path, key, nil, 0, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
@@ -647,7 +649,7 @@ extension _FileManagerImpl {
             
             var attributes = statAtPath.fileAttributes
             try? Self._catInfo(for: URL(filePath: path, directoryHint: .isDirectory), statInfo: statAtPath, into: &attributes)
-            #if !os(WASI) && !os(OpenBSD)
+            #if !os(WASI) && !os(OpenBSD) && !os(Emscripten)
             if let extendedAttrs = try? _extendedAttributes(at: fsRep, followSymlinks: false) {
                 attributes[._extendedAttributes] = extendedAttrs
             }
@@ -713,8 +715,8 @@ extension _FileManagerImpl {
                 ]
             }
         }
-#elseif os(WASI)
-        // WASI does not support file system attributes
+#elseif os(WASI) || os(Emscripten)
+        // WASI/Emscripten does not support file system attributes
         return [:]
 #else
         try fileManager.withFileSystemRepresentation(for: path) { rep in
@@ -913,8 +915,8 @@ extension _FileManagerImpl {
             // Like the immutable flag, if write permissions are being set, do it first. If they are being unset, do it last.
             var setMode: (() throws -> Void)?
             if let mode {
-                #if os(WASI)
-                // WASI does not have the concept of permissions
+                #if os(WASI) || os(Emscripten)
+                // WASI/Emscripten does not have the concept of permissions
                 throw CocoaError.errorWithFilePath(.featureUnsupported, path)
                 #else
                 setMode = {
@@ -936,8 +938,8 @@ extension _FileManagerImpl {
             let groupID = _readFileAttributePrimitive(attributes[.groupOwnerAccountID], as: UInt.self)
             
             if user != nil || userID != nil || group != nil || groupID != nil {
-                #if os(WASI)
-                // WASI does not have the concept of users or groups
+                #if os(WASI) || os(Emscripten)
+                // WASI/Emscripten does not have the concept of users or groups
                 throw CocoaError.errorWithFilePath(.featureUnsupported, path)
                 #else
                 // Bias toward userID & groupID - try to prevent round trips to getpwnam if possible.
@@ -953,8 +955,8 @@ extension _FileManagerImpl {
             try Self._setCatInfoAttributes(attributes, path: path)
             
             if let extendedAttrs = attributes[.init("NSFileExtendedAttributes")] as? [String : Data] {
-                #if os(WASI) || os(OpenBSD)
-                // WASI does not support extended attributes
+                #if os(WASI) || os(OpenBSD) || os(Emscripten)
+                // WASI/Emscripten does not support extended attributes
                 throw CocoaError.errorWithFilePath(.featureUnsupported, path)
                 #elseif canImport(Android)
                 // Android doesn't allow setting this for normal apps, so just skip it.

--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -25,6 +25,8 @@ import WinSDK
 internal import _FoundationCShims
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 extension _FileManagerImpl {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -36,6 +36,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if os(Windows)
@@ -178,7 +180,7 @@ extension _FileManagerImpl {
         #endif
     }
 
-#if !os(Windows) && !os(WASI) && !os(OpenBSD)
+#if !os(Windows) && !os(WASI) && !os(OpenBSD) && !os(Emscripten)
     static func _setAttribute(_ key: UnsafePointer<CChar>, value: Data, at path: UnsafePointer<CChar>, followSymLinks: Bool) throws {
         try value.withUnsafeBytes { buffer in
             #if canImport(Darwin)

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -126,10 +126,13 @@ internal import _FoundationCShims
 #elseif os(WASI)
 @preconcurrency import WASILibc
 internal import _FoundationCShims
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 // MARK: Directory Iteration
 
+#if !os(Emscripten) // Emscripten doesn't have fts.h
 struct _FTSSequence: Sequence {
     enum Element {
         struct SwiftFTSENT {
@@ -333,11 +336,12 @@ extension Sequence<_FTSSequence.Element> {
         }
     }
 }
+#endif // !os(Emscripten)
 
 struct _POSIXDirectoryContentsSequence: Sequence {
     #if canImport(Darwin)
     typealias DirectoryEntryPtr = UnsafeMutablePointer<DIR>
-    #elseif canImport(Android) || canImport(Glibc) || canImport(Musl) || os(WASI)
+    #elseif canImport(Android) || canImport(Glibc) || canImport(Musl) || os(WASI) || os(Emscripten)
     typealias DirectoryEntryPtr = OpaquePointer
     #endif
     

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -23,6 +23,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if FOUNDATION_FRAMEWORK
@@ -532,6 +534,12 @@ enum _FileOperations {
             throw CocoaError.removeFileError(errno, resolve(path: pathStr))
         }
 
+        #if os(Emscripten)
+        // Emscripten doesn't have fts.h; recursive directory removal is not yet supported.
+        // The rmdir above handles empty directories. For non-empty ones, we need a
+        // recursive implementation that doesn't depend on FTS.
+        throw CocoaError.removeFileError(ENOSYS, resolve(path: pathStr))
+        #else
         let seq = _FTSSequence(path, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT)
         let iterator = seq.makeIterator()
         var isFirst = true
@@ -580,6 +588,7 @@ enum _FileOperations {
                 }
             }
         }
+        #endif // !os(Emscripten)
     }
     #endif
 #endif
@@ -888,8 +897,7 @@ enum _FileOperations {
         }
         defer { close(dstfd) }
 
-        #if !os(WASI) // WASI doesn't have fchmod for now
-        // Set the file permissions using fchmod() instead of when open()ing to avoid umask() issues
+        #if !os(WASI) && !os(Emscripten) // WASI/Emscripten doesn't have fchmod for now
         let permissions = mode_t(fileInfo.st_mode) & ~S_IFMT
         guard fchmod(dstfd, permissions) == 0 else {
             try delegate.throwIfNecessary(errno, String(cString: srcPtr), String(cString: dstPtr))
@@ -932,7 +940,7 @@ enum _FileOperations {
         }
         var current: off_t = 0
         
-        #if os(WASI) || os(OpenBSD)
+        #if os(WASI) || os(OpenBSD) || os(Emscripten)
         // WASI doesn't have sendfile, so we need to do it in user space with read/write
         try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: chunkSize) { buffer in
             while current < total {
@@ -969,7 +977,7 @@ enum _FileOperations {
     
     #if !canImport(Darwin)
     private static func _copyDirectoryMetadata(srcFD: CInt, srcPath: @autoclosure () -> String, dstFD: CInt, dstPath: @autoclosure () -> String, delegate: some LinkOrCopyDelegate) throws {
-        #if !os(WASI) && !os(Android) && !os(OpenBSD)
+        #if !os(WASI) && !os(Android) && !os(OpenBSD) && !os(Emscripten)
         // Copy extended attributes
         #if os(FreeBSD)
         // FreeBSD uses the `extattr_*` calls for setting extended attributes. Unlike like, the namespace for the extattrs are not determined by prefix of the attribute
@@ -1045,7 +1053,7 @@ enum _FileOperations {
         #endif
         var statInfo = stat()
         if fstat(srcFD, &statInfo) == 0 {
-            #if !os(WASI) // WASI doesn't have fchown for now
+            #if !os(WASI) && !os(Emscripten) // WASI/Emscripten doesn't have fchown for now
             // Copy owner/group
             if fchown(dstFD, statInfo.st_uid, statInfo.st_gid) != 0 {
                 try delegate.throwIfNecessary(errno, srcPath(), dstPath())
@@ -1063,7 +1071,7 @@ enum _FileOperations {
                 }
             }
             
-            #if !os(WASI) // WASI doesn't have fchmod for now
+            #if !os(WASI) && !os(Emscripten) // WASI/Emscripten doesn't have fchmod for now
             // Copy permissions
             if fchmod(dstFD, mode_t(statInfo.st_mode)) != 0 {
                 try delegate.throwIfNecessary(errno, srcPath(), dstPath())
@@ -1106,6 +1114,10 @@ enum _FileOperations {
     }
 
     private static func _linkOrCopyFile(_ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
+        #if os(Emscripten)
+        // Emscripten doesn't have fts.h; recursive copy/link is not yet supported.
+        throw CocoaError.errorWithFilePath(.featureUnsupported, String(cString: srcPtr))
+        #else
         try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
             let dstLen = Platform.copyCString(dst: buffer.baseAddress!, src: dstPtr, size: FileManager.MAX_PATH_SIZE)
             let srcLen = strlen(srcPtr)
@@ -1205,8 +1217,9 @@ enum _FileOperations {
                 }
             }
         }
+        #endif // !os(Emscripten)
     }
-    
+
     private static func linkOrCopyFile(_ src: String, dst: String, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
         try src.withFileSystemRepresentation { srcPtr in
             guard let srcPtr else {

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -535,9 +535,7 @@ enum _FileOperations {
         }
 
         #if os(Emscripten)
-        // Emscripten doesn't have fts.h; recursive directory removal is not yet supported.
-        // The rmdir above handles empty directories. For non-empty ones, we need a
-        // recursive implementation that doesn't depend on FTS.
+        // Emscripten doesn't have fts.h; recursive directory removal is not yet supported. The `rmdir` above handles empty directories. For non-empty ones, we need a recursive implementation that doesn't depend on FTS.
         throw CocoaError.removeFileError(ENOSYS, resolve(path: pathStr))
         #else
         let seq = _FTSSequence(path, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT)

--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -22,6 +22,8 @@ import Darwin
 import CRT
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 // MARK: - BinaryInteger + Numeric string representation

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -30,6 +30,9 @@ fileprivate let _pageSize: Int = {
 #elseif os(WASI)
 // WebAssembly defines a fixed page size
 fileprivate let _pageSize: Int = 65_536
+#elseif os(Emscripten)
+// WebAssembly defines a fixed page size
+fileprivate let _pageSize: Int = 65_536
 #elseif canImport(Android)
 @preconcurrency import Android
 fileprivate let _pageSize: Int = Int(getpagesize())
@@ -128,7 +131,7 @@ private let _cachedUGIDs: (uid_t, gid_t) = {
 }()
 #endif
 
-#if !os(Windows) && !os(WASI)
+#if !os(Windows) && !os(WASI) && !os(Emscripten)
 extension Platform {
     private static var ROOT_USER: UInt32 { 0 }
     static func getUGIDs(allowEffectiveRootUID: Bool = true) -> (uid: UInt32, gid: UInt32) {
@@ -273,7 +276,7 @@ extension Platform {
         // FIXME: bionic implements this as `return 0;` and does not expose the
         // function via headers. We should be able to shim this and use the call
         // if it is available.
-#if !canImport(Android) && !os(WASI)
+#if !canImport(Android) && !os(WASI) && !os(Emscripten)
         guard issetugid() == 0 else { return nil }
 #endif
         if let value = getenv(name) {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -26,6 +26,8 @@ import unistd
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if !NO_PROCESS
@@ -189,8 +191,8 @@ final class _ProcessInfo: Sendable {
             return username
         }
         return ""
-#elseif os(WASI)
-        // WASI does not have user concept
+#elseif os(WASI) || os(Emscripten)
+        // WASI/Emscripten does not have user concept
         return ""
 #elseif os(Windows)
         var dwSize: DWORD = 0
@@ -223,7 +225,7 @@ final class _ProcessInfo: Sendable {
             return fullName
         }
         return ""
-#elseif os(WASI)
+#elseif os(WASI) || os(Emscripten)
         return ""
 #elseif os(Windows)
         var ulLength: ULONG = 0
@@ -360,6 +362,8 @@ extension _ProcessInfo {
         return "Haiku"
 #elseif os(WASI)
         return "WASI"
+#elseif os(Emscripten)
+        return "Emscripten"
 #else
         // On other systems at least return something.
         return "Unknown"

--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -20,6 +20,8 @@ import Darwin
 @preconcurrency import Musl
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 #if canImport(CRT)

--- a/Sources/FoundationEssentials/String/String+IO.swift
+++ b/Sources/FoundationEssentials/String/String+IO.swift
@@ -449,7 +449,7 @@ extension StringProtocol {
             attributes = [:]
         }
 
-#if os(WASI)
+#if os(WASI) || os(Emscripten)
         guard !useAuxiliaryFile else { throw CocoaError(.featureUnsupported) }
         let options : Data.WritingOptions = []
 #else
@@ -472,7 +472,7 @@ extension StringProtocol {
             attributes = [:]
         }
 
-#if os(WASI)
+#if os(WASI) || os(Emscripten)
         guard !useAuxiliaryFile else { throw CocoaError(.featureUnsupported) }
         let options : Data.WritingOptions = []
 #else

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -22,6 +22,8 @@ internal import os
 import WinSDK
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 internal import _FoundationCShims
@@ -388,7 +390,7 @@ extension String {
             return envVar.standardizingPath
         }
         
-        #if !os(WASI) // WASI does not have user concept
+        #if !os(WASI) && !os(Emscripten) // WASI/Emscripten does not have user concept
         // Next, attempt to find the home directory via getpwuid
         // We use the real UID instead of the EUID here when the EUID is the root user (i.e. a process has called seteuid(0))
         // In this instance, we historically do this to ensure a stable home directory location for processes that call seteuid(0)
@@ -457,7 +459,7 @@ extension String {
         if let envVar = Platform.getEnvSecure("CFFIXED_USER_HOME") {
             return envVar.standardizingPath
         }
-        #if !os(WASI) // WASI does not have user concept
+        #if !os(WASI) && !os(Emscripten) // WASI/Emscripten does not have user concept
         // Next, attempt to find the home directory via getpwnam
         return Platform.homeDirectory(forUserName: user)?.standardizingPath
         #else
@@ -500,7 +502,7 @@ extension String {
         }
         #endif // canImport(Darwin)
 
-        #if !os(WASI)
+        #if !os(WASI) && !os(Emscripten)
         if let envValue = Platform.getEnvSecure("TMPDIR") {
             return normalizedPath(with: envValue)
         }

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -405,7 +405,7 @@ extension TimeZone {
 
 extension TimeZone {
     internal static func dataFromTZFile(_ name: String) -> Data {
-#if NO_TZFILE || os(Windows) || os(WASI)
+#if NO_TZFILE || os(Windows) || os(WASI) || os(Emscripten)
         return Data()
 #else
         let path = TZDIR + "/" + name

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -139,8 +139,8 @@ struct TimeZoneCache : Sendable, ~Copyable {
                     return TimeZone(inner: result)
                 }
             }
-#elseif os(WASI)
-            // WASI doesn't provide a way to get the current timezone for now, so
+#elseif os(WASI) || os(Emscripten)
+            // WASI/Emscripten doesn't provide a way to get the current timezone for now, so
             // just return the default GMT timezone.
 #else
             let buffer = UnsafeMutableBufferPointer<CChar>.allocate(capacity: Int(PATH_MAX + 1))

--- a/Sources/FoundationEssentials/_ThreadLocal.swift
+++ b/Sources/FoundationEssentials/_ThreadLocal.swift
@@ -32,7 +32,7 @@ struct _ThreadLocal {
     fileprivate typealias PlatformKey = tss_t
 #elseif canImport(WinSDK)
     fileprivate typealias PlatformKey = DWORD
-#elseif os(WASI)
+#elseif os(WASI) || os(Emscripten)
     fileprivate typealias PlatformKey = UnsafeMutablePointer<UnsafeMutableRawPointer?>
 #endif
     
@@ -50,7 +50,7 @@ struct _ThreadLocal {
             self.key = key
 #elseif canImport(WinSDK)
             key = FlsAlloc(nil)
-#elseif os(WASI)
+#elseif os(WASI) || os(Emscripten)
             key = UnsafeMutablePointer<UnsafeMutableRawPointer?>.allocate(capacity: 1)
 #endif
         }
@@ -64,11 +64,11 @@ struct _ThreadLocal {
             tss_get(key)
 #elseif canImport(WinSDK)
             FlsGetValue(key)
-#elseif os(WASI)
+#elseif os(WASI) || os(Emscripten)
             key.pointee
 #endif
         }
-        
+
         set {
 #if canImport(Darwin) || canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_setspecific(key, newValue)
@@ -76,7 +76,7 @@ struct _ThreadLocal {
             tss_set(key, newValue)
 #elseif canImport(WinSDK)
             FlsSetValue(key, newValue)
-#elseif os(WASI)
+#elseif os(WASI) || os(Emscripten)
             key.pointee = newValue
 #endif
         }

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -26,6 +26,8 @@ import CRT
 import Darwin
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 internal import _FoundationICU

--- a/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
@@ -26,6 +26,8 @@ import Darwin
 import CRT
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Sources/_FoundationCShims/include/_CShimsTargetConditionals.h
+++ b/Sources/_FoundationCShims/include/_CShimsTargetConditionals.h
@@ -47,6 +47,12 @@
 #define TARGET_OS_WASI 0
 #endif
 
+#if defined(__EMSCRIPTEN__)
+#define TARGET_OS_EMSCRIPTEN 1
+#else
+#define TARGET_OS_EMSCRIPTEN 0
+#endif
+
 #if defined(__ANDROID__)
 #define TARGET_OS_ANDROID 1
 #else

--- a/Sources/_FoundationCShims/include/_CStdlib.h
+++ b/Sources/_FoundationCShims/include/_CStdlib.h
@@ -152,7 +152,7 @@
 #ifndef TZDEFAULT
 #define TZDEFAULT    "/etc/localtime"
 #endif /* !defined TZDEFAULT */
-#elif TARGET_OS_WINDOWS || TARGET_OS_WASI
+#elif TARGET_OS_WINDOWS || TARGET_OS_WASI || TARGET_OS_EMSCRIPTEN
 /* not required */
 #else
 #error "possibly define TZDIR and TZDEFAULT for this platform"


### PR DESCRIPTION
Now that both `swiftc` and `swift-frontend` support Emscripten target triple we can follow up on [the previously pitched Emscripte support](https://forums.swift.org/t/pitch-emscripten-target-support-for-swift/85310) in libraries like `swift-foundation`.