### PR TITLE
Un-inline _grow to reduce register spill cost on hot path

### DIFF
--- a/Sources/NewCodable/GrowableEncodingBytes.swift
+++ b/Sources/NewCodable/GrowableEncodingBytes.swift
@@ -120,6 +120,7 @@ extension GrowableEncodingBytes {
     }
     
     @usableFromInline
+    @inline(never)
     internal mutating func _grow(ensuringCapacity capacity: Int) {
         // TODO: Round/scale up to good value
         let newCapacity = capacity * 3 / 2


### PR DESCRIPTION
Un-inline `_grow` to reduce register spill on the hot path. This gets us about 20 MB/s boost in the Twitter encode benchmark.