### PR TITLE
[Compile Time Performance] Add an overload to Data for concatination

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -1089,3 +1089,14 @@ extension Data : Codable {
         }
     }
 }
+
+
+extension Data {
+    @_alwaysEmitIntoClient
+    @inline(__always)
+    public static func + (_ lhs: Data, _ rhs: Data) -> Data {
+        var result = lhs
+        result.append(rhs)
+        return result
+    }
+}


### PR DESCRIPTION
The default implementation of `+ (Data, Data) -> Data` ended up causing the compiler to take considerably longer than expected. This change adds an overload to not only improve that performance of resolution to reasonable timeframes but also ensure the runtime implementation is funneled to the most appropriate performance implementation for data concatenation. 

### Motivation:

Performance of compile time.

### Modifications:

Added a singular overload for Data's + operator. This overload is always inline and emitted into the client so that the performance improvements are enjoyed by all releases (not just the most recent).

### Result:

Faster compile times

### Testing:

The tests for this are housed in the swift performance benchmarks.