### PR TITLE
Test updates to support --build-system swiftbuild

### DIFF
--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -161,7 +161,7 @@ private struct ProcessInfoTests {
 #if FOUNDATION_FRAMEWORK
         let targetNames = ["TestHost"]
 #elseif os(Linux) || os(Windows) || os(Android) || os(FreeBSD)
-        let targetNames = ["swift-foundationPackageTests.xctest"]
+        let targetNames = ["swift-foundationPackageTests.xctest", "FoundationEssentialsTests-test-runner", "FoundationEssentialsTests-test-runner.exe"]
 #else
         let targetNames = ["swiftpm-testing-helper", "xctest"]
 #endif

--- a/Tests/FoundationEssentialsTests/ResourceUtilities.swift
+++ b/Tests/FoundationEssentialsTests/ResourceUtilities.swift
@@ -52,22 +52,24 @@ func testData(forResource resource: String, withExtension ext: String, subdirect
     return try? Data(contentsOf: essentialsURL)
 #else
     // swiftpm drops the resources next to the executable, at:
-    // ./swift-foundation_FoundationEssentialsTests.resources/Resources/
+    // ./swift-foundation_FoundationEssentialsTests.{resources|bundle}/Resources/
     // Hard-coding the path is unfortunate, but a temporary need until we have a better way to handle this
 
-    var toolsResourcesDir = URL(filePath: ProcessInfo.processInfo.arguments[0])
+    let execDir = URL(filePath: ProcessInfo.processInfo.arguments[0])
         .deletingLastPathComponent()
-        .appending(component: "swift-foundation_FoundationEssentialsTests-tool.resources", directoryHint: .isDirectory)
 
-    // On Linux the tests are built for the "host" because there are macro tests, on Windows
-    // the tests are only built for the "target" so we need to figure out whether `-tools`
-    // resources exist and if so, use them.
-    let resourcesDir = if FileManager.default.fileExists(atPath: toolsResourcesDir.path) {
-        toolsResourcesDir
-    } else {
-        URL(filePath: ProcessInfo.processInfo.arguments[0])
-            .deletingLastPathComponent()
-            .appending(component: "swift-foundation_FoundationEssentialsTests.resources", directoryHint: .isDirectory)
+    // Check for -tool variants first (used when macros are present with --build-system native), then non-tool variants.
+    // Check both .resources (--build-system native) and .bundle (--build-system swiftbuild) extensions.
+    let candidates = [
+        "swift-foundation_FoundationEssentialsTests-tool.resources",
+        "swift-foundation_FoundationEssentialsTests.resources",
+        "swift-foundation_FoundationEssentialsTests.bundle",
+    ]
+
+    guard let resourcesDir = candidates
+        .map({ execDir.appending(component: $0, directoryHint: .isDirectory) })
+        .first(where: { FileManager.default.fileExists(atPath: $0.path) }) else {
+        return nil
     }
 
     var path = resourcesDir.appending(component: "Resources", directoryHint: .isDirectory)


### PR DESCRIPTION
Similar to the changes in corelibs-foundation in https://github.com/swiftlang/swift-corelibs-foundation/commit/9c46a72b0f96bfd75d372afe135ae79c0652edd1:
- Update test resource lookup to support either --build-system native or --build-system swiftbuild
- Update process name tests to accommodate different test runner naming schemes