### PR TITLE
Fix benchmarks build on non-Darwin

### DIFF
--- a/Benchmarks/Benchmarks/CharacterSet/BenchmarkCharacterSet.swift
+++ b/Benchmarks/Benchmarks/CharacterSet/BenchmarkCharacterSet.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
 import Benchmark
 import func Benchmark.blackHole
 
@@ -22,7 +21,7 @@ import Foundation
 #endif
 
 let benchmarks = {
-    
+    #if FOUNDATION_FRAMEWORK
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo
@@ -162,5 +161,5 @@ let benchmarks = {
             blackHole(!CharacterSet.alphanumerics.isSuperset(of: CharacterSet(charactersIn: invalidAlphanumericsInput)))
         }
     }
+    #endif // FOUNDATION_FRAMEWORK
 }
-#endif

--- a/Benchmarks/Benchmarks/Internationalization/InternationalizationBenchmark.swift
+++ b/Benchmarks/Benchmarks/Internationalization/InternationalizationBenchmark.swift
@@ -1,7 +1,7 @@
 import Benchmark
 
 
-#if os(macOS) && USE_PACKAGE
+#if !FOUNDATION_FRAMEWORK
 let benchmarks = {
     calendarBenchmarks()
     localeBenchmarks()


### PR DESCRIPTION
Fix `swift package benchmark` build failure on non-Darwin due to `benchmarks` variable being hidden by some `#if` guards.

### Motivation:

Run benchmarks on Linux/Windows et al.

### Modifications:

- Move `#if FOUNDATION_FRAMEWORK` in `BenchmarkCharacterSet.swift` to within the `benchmarks` declaration so the plugin can find the variable, but it has no benchmarks to run outside of `FOUNDATION_FRAMEWORK`.
- Change `#if os(macOS) && USE_PACKAGE` to `#if !FOUNDATION_FRAMEWORK` in `InternationalizationBenchmark.swift`, matching the `#if` guard within the individual benchmark files.

### Result:

`swift package benchmark` succeeds on non-Darwin.

### Testing:

Tested benchmarks on Ubuntu 24.04, `FOUNDATION_FRAMEWORK` macOS, and non-`FOUNDATION_FRAMEWORK` macOS.
