### PR TITLE
Revert "[Compiletime Performance] Add an overload to Data for concatenation (#1828)"

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -1089,14 +1089,3 @@ extension Data : Codable {
         }
     }
 }
-
-
-extension Data {
-    @_alwaysEmitIntoClient
-    @inline(__always)
-    public static func + (_ lhs: Data, _ rhs: Data) -> Data {
-        var result = lhs
-        result.append(rhs)
-        return result
-    }
-}


### PR DESCRIPTION
The previous change ended up causing CI failures so this is being reverted to avoid ambiguity causing compatibility test suites to fail.