### PR TITLE
Add Distributions.md and README section on obtaining Foundation

### DIFF
--- a/Distributions.md
+++ b/Distributions.md
@@ -40,17 +40,16 @@ each client.
 
 ## Caveats when using swift-foundation as a package
 
-Although Foundation is available as a Swift package, and hence you _can_ declare a
-dependency on [swift-foundation][] during development, it is not suitable for
-use in a package or app that you intend to ship. Doing so has several
-downsides:
+Although Foundation is available as a Swift package, and hence you _can_ declare 
+a dependency on [swift-foundation][] during development, it is not suitable for
+use in a package or app that you intend to ship. Doing so has several downsides:
 
-* **It requires building Foundation and its dependencies from source.** This significantly increases
-  your build time.
+* **It requires building Foundation and its dependencies from source.** 
+  This significantly increases your build time.
 * **You may encounter build failures when another package uses a built-in
   Foundation.** If you use swift-foundation as a package, but you depend on a
   library from another package which uses a built-in copy of Foundation (as
-  this document recommends), this can cause build failures due to ambiguity
+  this document recommends), this can cause build failures due to ambiguous
   symbol definitions or module conflicts.
 
 ## When to use swift-foundation as a package
@@ -65,8 +64,7 @@ validate how changes made to Foundation will impact tools or libraries that
 depend on it, or to test changes to both Foundation and a related project in
 conjunction with each other. When using one of these workflows locally, it's
 important to be mindful of the [caveats][] above, but during local development
-it's often possible to take extra care and control things sufficiently to avoid
-those problems.
+it's often possible to take extra care to avoid those problems.
 
 [apple-platforms]: https://developer.apple.com/documentation/foundation
 [install]: https://www.swift.org/install

--- a/Distributions.md
+++ b/Distributions.md
@@ -3,7 +3,7 @@
 <!--
 This source file is part of the Swift.org open source project
 
-Copyright (c) 2025 Apple Inc. and the Swift project authors
+Copyright (c) 2026 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
@@ -24,8 +24,6 @@ Foundation is distributed in the following places:
   framework built into the operating system.
 * In [Swift.org toolchains][install], versions 6.0 and later (for
   [supported platforms][]), as a library included in the toolchain.
-* In Apple's [Xcode IDE][], versions 16.0 and later.
-* In Apple's [Command Line Tools for Xcode package][], versions 16.0 and later.
 
 The locations above are considered **built-in** because they're included with a
 larger collection of software (such as an operating system, toolchain, or IDE)
@@ -39,9 +37,7 @@ and consist of _pre-compiled_ copies of the `FoundationEssentials` and
 Foundation is also available as a Swift **package library product** from the
 [swiftlang/swift-foundation][swift-foundation] repository. This copy is _not_
 considered built-in because it must be downloaded and compiled separately by
-each client. The package version is generally considered to have a lower level
-of support than the built-in copies above due to the [known caveats][caveats]
-described in the following section.
+each client.
 
 ## Caveats when using swift-foundation as a package
 
@@ -49,18 +45,8 @@ Although Foundation is available as a Swift package and you _can_ declare a
 dependency on [swift-foundation][] to use it, doing so is not generally
 recommended because it has several downsides:
 
-* **It requires building Foundation from source.** This significantly increases
-  your build time. Since builds for development are typically for debug
-  configuration, the locally-built copy will not include performance
-  optimizations.
-* **It requires building Foundation's dependencies.** This further increases
-  build time, as [swift-collections][], [swift-foundation-icu][], and
-  [swift-syntax][] must also be compiled locally.
-* **It may not integrate as well with supporting tools/IDEs as a built-in copy.**
-  Tools which integrate with Foundation, such as Swift Package Manager or
-  Apple's Xcode IDE, often optimize for the copy included in the same
-  distribution. Some features may not work as well or be missing entirely when
-  using Foundation as a package.
+* **It requires building Foundation and its dependencies from source.** This significantly increases
+  your build time.
 * **It may encounter build failures when another package uses a built-in
   Foundation.** If you use swift-foundation as a package, but you depend on a
   library from another package which uses a built-in copy of Foundation (as
@@ -70,7 +56,7 @@ recommended because it has several downsides:
 ## When to use swift-foundation as a package
 
 The primary reason swift-foundation is available as a Swift package is to
-support its own development. The core contributors regularly develop Foundation
+support development. The core contributors regularly develop Foundation
 by building it locally as a package, following workflows described in
 [Contributing][], and its CI builds that way as well.
 

--- a/Distributions.md
+++ b/Distributions.md
@@ -1,5 +1,3 @@
-# Obtaining Foundation
-
 <!--
 This source file is part of the Swift.org open source project
 
@@ -9,6 +7,8 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 -->
+
+# Obtaining Foundation
 
 There are multiple ways to obtain Foundation, and they have different tradeoffs
 to consider. This document discusses the various ways Foundation is distributed
@@ -22,8 +22,7 @@ Foundation is distributed in the following places:
 
 * In Apple's [macOS, iOS, and other Apple platforms][apple-platforms], as a
   framework built into the operating system.
-* In [Swift.org toolchains][install], versions 6.0 and later (for
-  [supported platforms][]), as a library included in the toolchain.
+* In [Swift.org toolchains][install], as a library included in the toolchain.
 
 The locations above are considered **built-in** because they're included with a
 larger collection of software (such as an operating system, toolchain, or IDE)
@@ -41,17 +40,17 @@ each client.
 
 ## Caveats when using swift-foundation as a package
 
-Although Foundation is available as a Swift package and you _can_ declare a
+Although Foundation is available as a Swift package, and hence you _can_ declare a
 dependency on [swift-foundation][] during development, it is not suitable for
 use in a package or app that you intend to ship. Doing so has several
 downsides:
 
 * **It requires building Foundation and its dependencies from source.** This significantly increases
   your build time.
-* **It may encounter build failures when another package uses a built-in
+* **You may encounter build failures when another package uses a built-in
   Foundation.** If you use swift-foundation as a package, but you depend on a
   library from another package which uses a built-in copy of Foundation (as
-  this document recommends), this can cause build failures due to duplicate
+  this document recommends), this can cause build failures due to ambiguity
   symbol definitions or module conflicts.
 
 ## When to use swift-foundation as a package

--- a/Distributions.md
+++ b/Distributions.md
@@ -42,8 +42,9 @@ each client.
 ## Caveats when using swift-foundation as a package
 
 Although Foundation is available as a Swift package and you _can_ declare a
-dependency on [swift-foundation][] to use it, doing so is not generally
-recommended because it has several downsides:
+dependency on [swift-foundation][] during development, it is not suitable for
+use in a package or app that you intend to ship. Doing so has several
+downsides:
 
 * **It requires building Foundation and its dependencies from source.** This significantly increases
   your build time.
@@ -55,10 +56,10 @@ recommended because it has several downsides:
 
 ## When to use swift-foundation as a package
 
-The primary reason swift-foundation is available as a Swift package is to
-support development. The core contributors regularly develop Foundation
-by building it locally as a package, following workflows described in
-[Contributing][], and its CI builds that way as well.
+If you are contributing to Foundation or otherwise working on its source code,
+building it as a Swift package is the recommended workflow. The core contributors
+regularly develop Foundation this way, and its CI builds as a package as well.
+See [Contributing][] for detailed steps on getting started.
 
 It's also sometimes helpful to use swift-foundation as a package in order to
 validate how changes made to Foundation will impact tools or libraries that

--- a/Distributions.md
+++ b/Distributions.md
@@ -1,0 +1,95 @@
+# Obtaining Foundation
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+There are multiple ways to obtain Foundation, and they have different tradeoffs
+to consider. This document discusses the various ways Foundation is distributed
+and offers recommended workflows.
+
+_This document was inspired by the equivalent [Distributions.md](https://github.com/swiftlang/swift-testing/blob/main/Distributions.md) in [swift-testing](https://github.com/swiftlang/swift-testing)._
+
+## Distribution locations
+
+Foundation is distributed in the following places:
+
+* In Apple's [macOS, iOS, and other Apple platforms][apple-platforms], as a
+  framework built into the operating system.
+* In [Swift.org toolchains][install], versions 6.0 and later (for
+  [supported platforms][]), as a library included in the toolchain.
+* In Apple's [Xcode IDE][], versions 16.0 and later.
+* In Apple's [Command Line Tools for Xcode package][], versions 16.0 and later.
+
+The locations above are considered **built-in** because they're included with a
+larger collection of software (such as an operating system, toolchain, or IDE)
+and consist of _pre-compiled_ copies of the `FoundationEssentials` and
+`FoundationInternationalization` modules.
+
+> [!IMPORTANT]
+> Prefer using a built-in copy of Foundation unless you're making changes to
+> Foundation itself.
+
+Foundation is also available as a Swift **package library product** from the
+[swiftlang/swift-foundation][swift-foundation] repository. This copy is _not_
+considered built-in because it must be downloaded and compiled separately by
+each client. The package version is generally considered to have a lower level
+of support than the built-in copies above due to the [known caveats][caveats]
+described in the following section.
+
+## Caveats when using swift-foundation as a package
+
+Although Foundation is available as a Swift package and you _can_ declare a
+dependency on [swift-foundation][] to use it, doing so is not generally
+recommended because it has several downsides:
+
+* **It requires building Foundation from source.** This significantly increases
+  your build time. Since builds for development are typically for debug
+  configuration, the locally-built copy will not include performance
+  optimizations.
+* **It requires building Foundation's dependencies.** This further increases
+  build time, as [swift-collections][], [swift-foundation-icu][], and
+  [swift-syntax][] must also be compiled locally.
+* **It may not integrate as well with supporting tools/IDEs as a built-in copy.**
+  Tools which integrate with Foundation, such as Swift Package Manager or
+  Apple's Xcode IDE, often optimize for the copy included in the same
+  distribution. Some features may not work as well or be missing entirely when
+  using Foundation as a package.
+* **It may encounter build failures when another package uses a built-in
+  Foundation.** If you use swift-foundation as a package, but you depend on a
+  library from another package which uses a built-in copy of Foundation (as
+  this document recommends), this can cause build failures due to duplicate
+  symbol definitions or module conflicts.
+
+## When to use swift-foundation as a package
+
+The primary reason swift-foundation is available as a Swift package is to
+support its own development. The core contributors regularly develop Foundation
+by building it locally as a package, following workflows described in
+[Contributing][], and its CI builds that way as well.
+
+It's also sometimes helpful to use swift-foundation as a package in order to
+validate how changes made to Foundation will impact tools or libraries that
+depend on it, or to test changes to both Foundation and a related project in
+conjunction with each other. When using one of these workflows locally, it's
+important to be mindful of the [caveats][] above, but during local development
+it's often possible to take extra care and control things sufficiently to avoid
+those problems.
+
+[apple-platforms]: https://developer.apple.com/documentation/foundation
+[install]: https://www.swift.org/install
+[supported platforms]: https://github.com/swiftlang/swift-foundation/blob/main/README.md
+[Xcode IDE]: https://developer.apple.com/xcode/
+[Command Line Tools for Xcode package]: https://developer.apple.com/documentation/xcode/installing-the-command-line-tools/
+[swift-foundation]: https://github.com/swiftlang/swift-foundation
+[swift-collections]: https://github.com/swiftlang/swift-collections
+[swift-foundation-icu]: https://github.com/swiftlang/swift-foundation-icu
+[swift-syntax]: https://github.com/swiftlang/swift-syntax
+[Contributing]: https://github.com/swiftlang/swift-foundation/blob/main/CONTRIBUTING.md
+[caveats]: #caveats-when-using-swift-foundation-as-a-package

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ On macOS, iOS, and other Apple platforms, apps should use the Foundation that co
 
 On all other Swift platforms, `swift-foundation` is available as part of the toolchain. Simply `import FoundationEssentials` or `import FoundationInternationalization` to use its API. It is also re-exported from [swift-corelibs-foundation](http://github.com/apple/swift-corelibs-foundation)'s `Foundation`, `FoundationXML`, and `FoundationNetworking` modules.
 
+## Obtaining Foundation
+
+Foundation is available in several forms — built into the OS on Apple platforms,
+included in Swift toolchains, and as a Swift package. For guidance on which to
+use and the tradeoffs involved, see [Distributions.md](Distributions.md).
+
+> [!IMPORTANT]
+> The swift-foundation package is intended to support development and testing of
+> Foundation itself. It is not recommended for use as a package dependency in
+> other projects. Prefer the built-in copy of Foundation that ships with your
+> toolchain or operating system instead.
+
 ## Building and Testing
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ use and the tradeoffs involved, see [Distributions.md](Distributions.md).
 
 > [!IMPORTANT]
 > The swift-foundation package is intended to support development and testing of
-> Foundation itself. It is not recommended for use as a package dependency in
-> other projects. Prefer the built-in copy of Foundation that ships with your
-> toolchain or operating system instead.
+> Foundation itself. It is not supported for use as a package dependency in
+> other shipping projects. Prefer the built-in copy of Foundation that ships with 
+> your toolchain or operating system instead.
 
 ## Building and Testing
 


### PR DESCRIPTION
Clarifies that the swift-foundation package exists to support development/testing workflow, and is not intended for use as a package dependency by other projects.