### PR TITLE
Field utf8span property

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -254,6 +254,7 @@ let package = Package(
                 .enableExperimentalFeature("BuiltinModule"),
                 .enableExperimentalFeature("Lifetimes"),
                 .enableExperimentalFeature("SuppressedAssociatedTypes"),
+                .enableExperimentalFeature("CoroutineAccessors"),
                 .enableUpcomingFeature("MemberImportVisibility"),
             ]
         ),
@@ -272,6 +273,7 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableExperimentalFeature("Lifetimes"),
+                .enableExperimentalFeature("CoroutineAccessors"),
                 .enableUpcomingFeature("MemberImportVisibility"),
             ]
         ),
@@ -289,6 +291,7 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableExperimentalFeature("Lifetimes"),
+                .enableExperimentalFeature("CoroutineAccessors"),
                 .enableUpcomingFeature("MemberImportVisibility"),
             ]
         ),

--- a/Sources/NewCodable/CommonEncodableProtocols.swift
+++ b/Sources/NewCodable/CommonEncodableProtocols.swift
@@ -338,9 +338,7 @@ public extension CommonEncoder where Self: ~Copyable & ~Escapable {
     @inline(__always)
     @_lifetime(self: copy self)
     mutating func encodeEnumCase(_ field: some EncodingField) throws(CodingError.Encoding) {
-        try field.withUTF8Span { span throws(CodingError.Encoding) in
-            try self.encodeEnumCase(span)
-        }
+        try self.encodeEnumCase(field.utf8Span)
     }
     
     @_disfavoredOverload
@@ -373,9 +371,7 @@ public extension CommonEncoder where Self: ~Copyable & ~Escapable {
     @inline(__always)
     @_lifetime(self: copy self)
     mutating func encodeEnumCase(_ field: some EncodingField, associatedValueCount: Int, _ associatedValueClosure: (inout StructEncoder) throws(CodingError.Encoding) -> Void) throws(CodingError.Encoding) {
-        try field.withUTF8Span { span throws(CodingError.Encoding) in
-            try self.encodeEnumCase(span, associatedValueCount: associatedValueCount, associatedValueClosure)
-        }
+        try self.encodeEnumCase(field.utf8Span, associatedValueCount: associatedValueCount, associatedValueClosure)
     }
     
     @_disfavoredOverload
@@ -530,18 +526,14 @@ public extension CommonStructEncoder where Self: ~Copyable & ~Escapable {
     @_alwaysEmitIntoClient
     @_lifetime(self: copy self)
     mutating func encode(field: some EncodingField, valueEncoder: (inout ValueEncoder) throws(CodingError.Encoding) -> Void) throws(CodingError.Encoding) {
-        try field.withUTF8Span { span throws(CodingError.Encoding) in
-            try self.encode(key: span, valueEncoder: valueEncoder)
-        }
+        try self.encode(key: field.utf8Span, valueEncoder: valueEncoder)
     }
 
     @inline(__always)
     @_alwaysEmitIntoClient
     @_lifetime(self: copy self)
     mutating func encode(field: some EncodingField, value: borrowing some CommonEncodable & ~Copyable) throws(CodingError.Encoding) {
-        try field.withUTF8Span { span throws(CodingError.Encoding) in
-            try self.encode(key: span) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
-        }
+        try self.encode(key: field.utf8Span) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
     @inline(__always)
@@ -563,9 +555,7 @@ public extension CommonStructEncoder where Self: ~Copyable & ~Escapable {
     @_alwaysEmitIntoClient
     @_lifetime(self: copy self)
     mutating func encode(field: some EncodingField, value: some Encodable) throws(CodingError.Encoding) {
-        try field.withUTF8Span { span throws(CodingError.Encoding) in
-            try self.encode(key: span) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
-        }
+        try self.encode(key: field.utf8Span) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
     @_disfavoredOverload
@@ -605,9 +595,7 @@ public extension CommonStructEncoder where Self: CommonDictionaryEncoder & ~Copy
     @_alwaysEmitIntoClient
     @_lifetime(self: copy self)
     mutating func encode(field: some EncodingField, value: some Encodable) throws(CodingError.Encoding) {
-        try field.withUTF8Span { span throws(CodingError.Encoding) in
-            try self.encode(key: span) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
-        }
+        try self.encode(key: field.utf8Span) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
     @_disfavoredOverload

--- a/Sources/NewCodable/JSON/JSONEncoderProtocols.swift
+++ b/Sources/NewCodable/JSON/JSONEncoderProtocols.swift
@@ -48,8 +48,11 @@ public protocol JSONOptimizedCodingField: JSONOptimizedDecodingField, JSONOptimi
 public extension JSONOptimizedCodingField where Self: ~Escapable {
     @_alwaysEmitIntoClient
     @inline(__always)
-    func withUTF8Span<T: ~Copyable, E>(_ closure: (UTF8Span) throws(E) -> T) throws(E) -> T {
-        try self.staticString.withUTF8SpanForCodable(closure)
+    var utf8Span: UTF8Span {
+        @_lifetime(borrow self)
+        yielding borrow {
+            yield self.staticString._utf8SpanForCodingField
+        }
     }
 }
 

--- a/Sources/NewCodable/JSON/NewJSONEncoder.swift
+++ b/Sources/NewCodable/JSON/NewJSONEncoder.swift
@@ -795,18 +795,14 @@ extension JSONDirectEncoder.DictionaryEncoder {
     @_alwaysEmitIntoClient
     @_lifetime(self: copy self)
     public mutating func encode(field: some EncodingField, valueEncoder: (inout JSONDirectEncoder) throws(CodingError.Encoding) -> Void) throws(CodingError.Encoding) {
-        try field.withUTF8Span { span throws(CodingError.Encoding) in
-            try self.encode(key: span, checkForEscapes: true, valueEncoder: valueEncoder)
-        }
+        try self.encode(key: field.utf8Span, checkForEscapes: true, valueEncoder: valueEncoder)
     }
     
     @inline(__always)
     @_alwaysEmitIntoClient
     @_lifetime(self: copy self)
     public mutating func encode(field: some JSONOptimizedEncodingField, valueEncoder: (inout JSONDirectEncoder) throws(CodingError.Encoding) -> Void) throws(CodingError.Encoding) {
-        try field.withUTF8Span { span throws(CodingError.Encoding) in
-            try self.encode(key: span, checkForEscapes: false, valueEncoder: valueEncoder)
-        }
+        try self.encode(key: field.utf8Span, checkForEscapes: false, valueEncoder: valueEncoder)
     }
     
     /// Convenience: encode a JSONEncodable value for a key.

--- a/Sources/NewCodable/SharedTypes.swift
+++ b/Sources/NewCodable/SharedTypes.swift
@@ -390,9 +390,7 @@ public protocol DecodingField: ~Escapable {
     
     @_alwaysEmitIntoClient
     @inline(__always)
-    // TODO: This doesn't work in the unfortunate case where a StaticString is not a pointer representation.
-//    var utf8Span: UTF8Span { @_lifetime(borrow self) get }
-    func withUTF8Span<T: ~Copyable, E>(_ closure: (UTF8Span) throws(E) -> T) throws(E) -> T
+    var utf8Span: UTF8Span { @_lifetime(borrow self) yielding borrow }
 }
 
 public extension DecodingField where Self: ~Escapable {
@@ -405,10 +403,8 @@ public extension DecodingField where Self: ~Escapable {
     
     @_alwaysEmitIntoClient
     func matches(_ key: UTF8Span) -> Bool {
-        return self.withUTF8Span { thisSpan in
-            let comparator = UTF8SpanComparator(thisSpan)
-            return comparator.matchesSpan(key)
-        }
+        let comparator = UTF8SpanComparator(self.utf8Span)
+        return comparator.matchesSpan(key)
     }
     
     @_alwaysEmitIntoClient
@@ -439,16 +435,22 @@ public extension DecodingField where Self: ~Escapable, Self: StaticStringDecodin
     
     @_alwaysEmitIntoClient
     @inline(__always)
-    func withUTF8Span<T: ~Copyable, E>(_ closure: (UTF8Span) throws(E) -> T) throws(E) -> T {
-        try self.staticString.withUTF8SpanForCodable(closure)
+    var utf8Span: UTF8Span {
+        @_lifetime(borrow self)
+        yielding borrow {
+            yield self.staticString._utf8SpanForCodingField
+        }
     }
 }
 
 public extension EncodingField where Self: ~Escapable, Self: StaticStringEncodingField {
     @_alwaysEmitIntoClient
     @inline(__always)
-    func withUTF8Span<T: ~Copyable, E>(_ closure: (UTF8Span) throws(E) -> T) throws(E) -> T {
-        try self.staticString.withUTF8SpanForCodable(closure)
+    var utf8Span: UTF8Span {
+        @_lifetime(borrow self)
+        yielding borrow {
+            yield self.staticString._utf8SpanForCodingField
+        }
     }
 }
 
@@ -460,13 +462,9 @@ public extension RawByteEquivalenceDecodingField where Self: ~Escapable & Static
 }
 
 public protocol EncodingField: ~Escapable {
-    
     @_alwaysEmitIntoClient
     @inline(__always)
-    // TODO: This doesn't work in the unfortunate case where a StaticString is not a pointer representation.
-//    var utf8Span: UTF8Span { @_lifetime(borrow self) get }
-    func withUTF8Span<T: ~Copyable, E>(_ closure: (UTF8Span) throws(E) -> T) throws(E) -> T
-
+    var utf8Span: UTF8Span { @_lifetime(borrow self) yielding borrow }
 }
 
 public protocol StaticStringEncodingField: EncodingField, ~Escapable {
@@ -479,9 +477,11 @@ public protocol StaticStringCodingField: StaticStringDecodingField, StaticString
 public extension CodingField where Self: StaticStringCodingField & ~Escapable {
     @_alwaysEmitIntoClient
     @inline(__always)
-//    var utf8Span: UTF8Span { @_lifetime(borrow self) get }
-    func withUTF8Span<T: ~Copyable, E>(_ closure: (UTF8Span) throws(E) -> T) throws(E) -> T {
-        try self.staticString.withUTF8SpanForCodable(closure)
+    var utf8Span: UTF8Span {
+        @_lifetime(borrow self)
+        yielding borrow {
+            yield self.staticString._utf8SpanForCodingField
+        }
     }
 }
 
@@ -489,17 +489,23 @@ public extension CodingField where Self: StaticStringCodingField & ~Escapable {
 extension StaticString {
     @_alwaysEmitIntoClient
     @inline(__always)
-    internal func withUTF8SpanForCodable<T: ~Copyable, E>(_ closure: (UTF8Span) throws(E) -> T) throws(E) -> T {
-        if self.hasPointerRepresentation {
-            let utf8Span = UTF8Span(unchecked: .init(_unsafeStart: self.utf8Start, count: self.utf8CodeUnitCount), isKnownASCII: isASCII)
-            return try closure(utf8Span)
-        } else {
+    internal var _utf8SpanForCodingField: UTF8Span {
+        @_lifetime(borrow self)
+        yielding borrow {
+            if self.hasPointerRepresentation {
+                yield UTF8Span(unchecked: .init(
+                    _unsafeStart: self.utf8Start,
+                    count: self.utf8CodeUnitCount
+                ), isKnownASCII: self.isASCII)
+            } else {
 #if $Embedded
             fatalError("non-pointer representation not supported in embedded Swift")
 #else
-            // TODO: More efficient without allocations.
-            return try closure(String(self.unicodeScalar).utf8Span)
+                let str = String(self.unicodeScalar)
+                yield str.utf8Span
+                extendLifetime(str)
 #endif
+            }
         }
     }
 }


### PR DESCRIPTION
Swap `withUTF8Span` for `utf8Span` with a yielding borrow accessor.

### Motivation:

The `withUTF8Span` API on `CodingField` was an unfortunate accommodation since `StaticString`'s could not guarantee an immortal lifetime for non-pointer-representation strings. This was especially unfortunate given how rare these strings are.

### Modifications:

Use `yielding borrow` accessors to maintain the lifetime of a `UTF8Span` so we don't need the closure.

### Result:

No more unfortunate closures.

### Testing:

The `utf8Span` property implementation is specified by default implementation on `StaticStringCodingField`, so any test/benchmark types currently using that will automatically get this.