### PR TITLE
Adopt [SE-0503]: SuppressedAssociatedTypesWithDefaults

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -253,7 +253,7 @@ let package = Package(
             swiftSettings: [
                 .enableExperimentalFeature("BuiltinModule"),
                 .enableExperimentalFeature("Lifetimes"),
-                .enableExperimentalFeature("SuppressedAssociatedTypes"),
+                .enableExperimentalFeature("SuppressedAssociatedTypesWithDefaults"),
                 .enableUpcomingFeature("MemberImportVisibility"),
             ]
         ),


### PR DESCRIPTION
Newer toolchains are warning that the `SuppressedAssociatedTypes` experimental flag is deprecated, so migrate to the new version.