### PR TITLE
Enable `Span`-based `URL` implementation

### DIFF
--- a/Sources/FoundationEssentials/String/CMakeLists.txt
+++ b/Sources/FoundationEssentials/String/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(FoundationEssentials PRIVATE
     BuiltInUnicodeScalarSet.swift
     IANACharsetNames.swift
     RegexPatternCache.swift
+    Span+Path.swift
     String+Bridging.swift
     String+Comparison.swift
     String+Encoding.swift

--- a/Sources/FoundationEssentials/URL/CMakeLists.txt
+++ b/Sources/FoundationEssentials/URL/CMakeLists.txt
@@ -15,10 +15,17 @@
 target_sources(FoundationEssentials PRIVATE
     URL.swift
     URL_Bridge.swift
+    URL_File.swift
+    URL_Impl.swift
+    URL_Info.swift
+    URL_Parsing.swift
     URL_Protocol.swift
+    URL_Resolution.swift
     URL_Swift.swift
+    URL_Validation.swift
     URLComponents.swift
     URLComponents_ObjC.swift
+    URLEncoder.swift
     URLParser.swift
     URLTemplate_Expression.swift
     URLTemplate_PercentEncoding.swift

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -620,13 +620,7 @@ internal func foundation_swift_url_v2_enabled() -> Bool {
 }
 #else
 internal func foundation_swift_url_enabled() -> Bool { return true }
-internal func foundation_swift_url_v2_enabled() -> Bool {
-    #if FOUNDATION_SWIFT_URL_V2
-    return true
-    #else
-    return false
-    #endif
-}
+internal func foundation_swift_url_v2_enabled() -> Bool { return true }
 #endif
 
 #if canImport(os)
@@ -662,12 +656,7 @@ public struct URL: Equatable, Sendable, Hashable {
         }
     }
 #else
-    #if FOUNDATION_SWIFT_URL_V2
     internal typealias _Impl = _URL
-    #else
-    internal typealias _Impl = _SwiftURL
-    #endif
-
     private static let _type = _Impl.self
 #endif
 
@@ -1354,7 +1343,7 @@ public struct URL: Equatable, Sendable, Hashable {
 
 #endif // FOUNDATION_FRAMEWORK
 
-#if FOUNDATION_FRAMEWORK || !FOUNDATION_SWIFT_URL_V2
+#if FOUNDATION_FRAMEWORK
     internal var _swiftURL: _SwiftURL? {
         #if FOUNDATION_FRAMEWORK
         if let swift = _url as? _SwiftURL { return swift }

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1341,18 +1341,12 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.bridgeToNSURL()
     }
 
-#endif // FOUNDATION_FRAMEWORK
-
-#if FOUNDATION_FRAMEWORK
     internal var _swiftURL: _SwiftURL? {
-        #if FOUNDATION_FRAMEWORK
         if let swift = _url as? _SwiftURL { return swift }
         return _SwiftURL(stringOrEmpty: _url.relativeString, relativeTo: _url.baseURL)
-        #else
-        return _url
-        #endif
     }
-#endif
+
+#endif // FOUNDATION_FRAMEWORK
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(relativeString)

--- a/Sources/FoundationEssentials/URL/URL_Impl.swift
+++ b/Sources/FoundationEssentials/URL/URL_Impl.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK || FOUNDATION_SWIFT_URL_V2
-
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Android)
@@ -1489,4 +1487,3 @@ extension _URL {
 }
 
 #endif // FOUNDATION_FRAMEWORK
-#endif // FOUNDATION_FRAMEWORK || FOUNDATION_SWIFT_URL_V2

--- a/Sources/FoundationEssentials/URL/URL_Protocol.swift
+++ b/Sources/FoundationEssentials/URL/URL_Protocol.swift
@@ -12,8 +12,9 @@
 
 #if FOUNDATION_FRAMEWORK
 /// In `FOUNDATION_FRAMEWORK`, the inner class types of `struct URL` conform to this protocol.
-/// Outside `FOUNDATION_FRAMEWORK`, only `_SwiftURL` is used, so the protocol is not needed.
-/// - `class _SwiftURL` is the new Swift implementation for a true Swift `URL`.
+/// Outside `FOUNDATION_FRAMEWORK`, only `_URL` is used, so the protocol is not needed.
+/// - `class _SwiftURL` is the first Swift implementation for a true Swift `URL`.
+/// - `class _URL` is the current, faster Swift implementation for a true Swift `URL`.
 /// - `class _BridgedURL` wraps an `NSURL` implementation bridged to Swift, including custom subclasses.
 /// - Note: Except for `baseURL`, a nil `URL?` return value means that `struct URL` will return `self`.
 internal protocol _URLProtocol: AnyObject, Sendable {

--- a/Sources/FoundationEssentials/URL/URL_Swift.swift
+++ b/Sources/FoundationEssentials/URL/URL_Swift.swift
@@ -10,30 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK || !FOUNDATION_SWIFT_URL_V2
-
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Android)
-@preconcurrency import Android
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif os(Windows)
-import WinSDK
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#endif
+#if FOUNDATION_FRAMEWORK
 
 #if canImport(os)
 internal import os
 #endif
-
-#if FOUNDATION_FRAMEWORK
 internal import _ForSwiftFoundation
-#endif
-
 internal import Synchronization
 
 /// `_SwiftURL` provides the new Swift implementation for `URL`, using the same parser
@@ -1087,7 +1069,6 @@ private extension String {
     }
 }
 
-#if FOUNDATION_FRAMEWORK
 internal import CoreFoundation_Private.CFURL
 
 /// This conformance is only needed in `FOUNDATION_FRAMEWORK`,
@@ -1344,4 +1325,3 @@ extension _SwiftURL {
     }
 }
 #endif // FOUNDATION_FRAMEWORK
-#endif // FOUNDATION_FRAMEWORK || !FOUNDATION_SWIFT_URL_V2


### PR DESCRIPTION
Enables the faster `Span`-based `URL` implementation from #1844 by removing the `FOUNDATION_SWIFT_URL_V2` build guard. See more implementation details in #1844

### Motivation:

Many common URL operations such as path manipulation or resolution (currently) involve repeated string allocations, percent-decoding, and re-parsing. By working directly with `Span`(s) of the underlying bytes and replacing just the encoded path during path manipulation (ensuring that nearby ranges and path-related flags are updated correctly), we see 5-8x speedup in use cases like appending or deleting path components.

The new backing type also consolidates and shares code from the Swift `NSURL`/`CFURL` implementation, which improves parsing, validation, encoding, and resolution performance (2-3x speedup), and makes it easier to maintain consistent behavior across all the types.

### Modifications:

Remove `FOUNDATION_SWIFT_URL_V2` guard so that the `_URL` backing class is used.

### Result:

<details>
<summary>Ubuntu 24.04 URL Performance vs. Baseline</summary>
<img width="813" height="1768" alt="Swift URL v2 vs v1 Performance Linux" src="https://github.com/user-attachments/assets/e5bb4b12-2faf-4e13-8743-f15a7d1ac138" />
</details>

`URL` operations are significantly faster, and `URL`, `NSURL`, and `CFURL` share the same Swift code for parsing, percent-encoding, file path initialization, and resolution.

**Bug fixes/compatibility behaviors:**
  - Prevents double-encoding of already-percent-encoded characters when another invalid character exists in the component (deviating from `URLComponents` encoding to match original `CFURL` byte encoding behavior and the behavior of most other RFC 3986 and WHATWG parsers). Resolves #1190.
  - ~Allows `[` and `]` unencoded in the path, query, and fragment via #1802, matching WHATWG behavior.~ This behavior was too lenient and caused discrepancies between `URL` and `URLComponents` APIs. Mostly reverted in #1875.
  - `standardized` now preserves leading `..` segments in relative paths so they're not removed until resolution.
  - File path colon-encoding in the first relative path segment is more lenient when the character preceding the colon cannot be part of a scheme (e.g. `%43:` is not mistaken for a scheme).
  - `appendingPathExtension` rejects extensions containing invalid characters that would be problematic when decoded (e.g. spaces or Unicode directional override characters) instead of storing them percent-encoded.

### Testing:

- Benchmarks for file and non-file URL path manipulation.
- Unit tests on Darwin, Linux, and Windows.