### PR TITLE
enable DST timezone test

### DIFF
--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -86,8 +86,7 @@ private struct TimeZoneTests {
 
         test("America/Los_Angeles", "zh_TW", .shortStandard, "PST", "PST")
 
-        // Disabled because it fails when there is DST in Europe
-        //test("Europe/Paris",       "zh_TW", .shortStandard, "GMT+1", "GMT+2")
+        test("Europe/Paris",       "zh_TW", .shortStandard, "GMT+1", "GMT+1")
 
         test("Antarctica/Davis",   "zh_TW", .shortStandard, "GMT+7", "GMT+7")
         test("Asia/Chongqing",      "zh_TW", .shortStandard, "GMT+8", "GMT+8")

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -87,6 +87,7 @@ private struct TimeZoneTests {
         test("America/Los_Angeles", "zh_TW", .shortStandard, "PST", "PST")
 
         test("Europe/Paris",       "zh_TW", .shortStandard, "GMT+1", "GMT+1")
+        test("Europe/Paris",       "zh_TW", .shortDaylightSaving, "GMT+1", "GMT+2")
 
         test("Antarctica/Davis",   "zh_TW", .shortStandard, "GMT+7", "GMT+7")
         test("Asia/Chongqing",      "zh_TW", .shortStandard, "GMT+8", "GMT+8")


### PR DESCRIPTION
enable DST timezone test as it was disabled [here](https://github.com/swiftlang/swift-foundation/commit/31466acfc1f39799ac82cc0bdbe46a5941b796ce).
Add a test case for Europe daylight saving.

### Motivation:

Enable and extend test cases for Europe timezone.

### Modifications:

changed to GMT+1

### Result:

Tested both in current time and setting local time to winter(date returns a time in winter).

### Testing:

Test passes again.
