### PR TITLE
Support nesting Decodable types in CommonDecodable types

### DIFF
--- a/Sources/NewCodable/CommonCodablePrimitive.swift
+++ b/Sources/NewCodable/CommonCodablePrimitive.swift
@@ -17,8 +17,7 @@ import Foundation
 #endif
 
 /// An internal enum representing all the types that `CommonDecoder` supports.
-/// This serves as the `DecodedValue` type for bridging between CommonDecoder and standard Decodable.
-internal enum CommonElement {
+internal enum CommonCodablePrimitive {
     case bool(Bool)
     case int64(Int64)
     case uint64(UInt64)
@@ -28,98 +27,94 @@ internal enum CommonElement {
     case string(String)
     case bytes([UInt8])
     case null
-    case dictionary([(key: String, value: CommonElement)])
-    case array([CommonElement])
+    case dictionary([(key: String, value: CommonCodablePrimitive)])
+    case array([CommonCodablePrimitive])
 }
 
-/// A visitor that adapts decoded values for use with standard `Decodable` types.
-///
-/// This visitor captures raw values from `decodeAny` as `CommonElement` values
-/// and then converts them to `AdaptorDecoder` for standard decoding.
-internal struct CommonElementVisitor: CommonDecodingVisitor {
-    typealias DecodedValue = CommonElement
+/// This visitor captures raw values from `decodeAny` as `CommonCodablePrimitive` values
+internal struct CommonPrimitiveVisitor: CommonDecodingVisitor {
+    typealias DecodedValue = CommonCodablePrimitive
     
     init() {}
     
-    func visit(_ value: Bool) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Bool) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .bool(value)
     }
     
-    func visit(_ value: Int) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Int) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .int64(Int64(value))
     }
     
-    func visit(_ value: Int8) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Int8) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .int64(Int64(value))
     }
     
-    func visit(_ value: Int16) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Int16) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .int64(Int64(value))
     }
     
-    func visit(_ value: Int32) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Int32) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .int64(Int64(value))
     }
     
-    func visit(_ value: Int64) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Int64) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .int64(value)
     }
     
-    func visit(_ value: Int128) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Int128) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .int128(value)
     }
     
-    func visit(_ value: UInt) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: UInt) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .uint64(UInt64(value))
     }
     
-    func visit(_ value: UInt8) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: UInt8) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .uint64(UInt64(value))
     }
     
-    func visit(_ value: UInt16) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: UInt16) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .uint64(UInt64(value))
     }
     
-    func visit(_ value: UInt32) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: UInt32) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .uint64(UInt64(value))
     }
     
-    func visit(_ value: UInt64) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: UInt64) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .uint64(value)
     }
     
-    func visit(_ value: UInt128) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: UInt128) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .uint128(value)
     }
     
-    func visit(_ value: Float) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Float) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .double(Double(value))
     }
     
-    func visit(_ value: Double) throws(CodingError.Decoding) -> CommonElement {
+    func visit(_ value: Double) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .double(value)
     }
     
-    func visitString(_ value: String) throws(CodingError.Decoding) -> CommonElement {
+    func visitString(_ value: String) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .string(value)
     }
     
-    func visitUTF8Bytes(_ buffer: UTF8Span) throws(CodingError.Decoding) -> CommonElement {
-        // Convert UTF8Span to String using the proper API
+    func visitUTF8Bytes(_ buffer: UTF8Span) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         let string = String(copying: buffer)
         return .string(string)
     }
     
-    func visitBytes(_ array: [UInt8]) throws(CodingError.Decoding) -> CommonElement {
+    func visitBytes(_ array: [UInt8]) throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .bytes(array)
     }
     
-    func visit(decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> CommonElement {
-        var result: [(key: String, value: CommonElement)] = []
+    func visit(decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> CommonCodablePrimitive {
+        var result: [(key: String, value: CommonCodablePrimitive)] = []
         
         try decoder.decodeEachKeyAndValue { key, valueDecoder throws(CodingError.Decoding) in
-            let elementVisitor = CommonElementVisitor()
+            let elementVisitor = CommonPrimitiveVisitor()
             let element = try valueDecoder.decodeAny(elementVisitor)
             result.append((key: key, value: element))
             return false
@@ -128,11 +123,11 @@ internal struct CommonElementVisitor: CommonDecodingVisitor {
         return .dictionary(result)
     }
     
-    func visit(decoder: inout some CommonArrayDecoder & ~Escapable) throws(CodingError.Decoding) -> CommonElement {
-        var result: [CommonElement] = []
+    func visit(decoder: inout some CommonArrayDecoder & ~Escapable) throws(CodingError.Decoding) -> CommonCodablePrimitive {
+        var result: [CommonCodablePrimitive] = []
         
         try decoder.decodeEachElement { elementDecoder throws(CodingError.Decoding) in
-            let elementVisitor = CommonElementVisitor()
+            let elementVisitor = CommonPrimitiveVisitor()
             let element = try elementDecoder.decodeAny(elementVisitor)
             result.append(element)
         }
@@ -140,29 +135,30 @@ internal struct CommonElementVisitor: CommonDecodingVisitor {
         return .array(result)
     }
     
-    func visitNone() throws(CodingError.Decoding) -> CommonElement {
+    func visitNone() throws(CodingError.Decoding) -> CommonCodablePrimitive {
         return .null
     }
 }
 
-extension CommonElement: AdaptableDecodableValue {
-    typealias ArrayIterator = Array<CommonElement>.Iterator
+/// Conformance that allows decoding Decodable types in a CommonDecoder.
+extension CommonCodablePrimitive: AdaptableDecodableValue {
+    typealias ArrayIterator = Array<CommonCodablePrimitive>.Iterator
     
-    func decodeNil(context: AdaptorDecodableValueContext<CommonElement>) -> Bool {
+    func decodeNil(context: AdaptorDecodableValueContext<CommonCodablePrimitive>) -> Bool {
         if case .null = self {
             return true
         }
         return false
     }
     
-    func decode(_ type: Bool.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Bool {
+    func decode(_ type: Bool.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Bool {
         if case .bool(let value) = self {
             return value
         }
         throw CodingError.dataCorrupted(debugDescription: "Expected Bool but found \(self)")
     }
     
-    func decode(_ type: Int.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int {
+    func decode(_ type: Int.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Int {
         switch self {
         case .int64(let value):
             guard let result = Int(exactly: value) else {
@@ -189,7 +185,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: Int8.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int8 {
+    func decode(_ type: Int8.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Int8 {
         switch self {
         case .int64(let value):
             guard let result = Int8(exactly: value) else {
@@ -216,7 +212,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: Int16.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int16 {
+    func decode(_ type: Int16.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Int16 {
         switch self {
         case .int64(let value):
             guard let result = Int16(exactly: value) else {
@@ -243,7 +239,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: Int32.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int32 {
+    func decode(_ type: Int32.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Int32 {
         switch self {
         case .int64(let value):
             guard let result = Int32(exactly: value) else {
@@ -270,7 +266,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: Int64.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int64 {
+    func decode(_ type: Int64.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Int64 {
         switch self {
         case .int64(let value):
             return value
@@ -294,7 +290,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: Int128.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int128 {
+    func decode(_ type: Int128.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Int128 {
         switch self {
         case .int64(let value):
             return Int128(value)
@@ -312,7 +308,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: UInt.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt {
+    func decode(_ type: UInt.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> UInt {
         switch self {
         case .int64(let value):
             guard let result = UInt(exactly: value) else {
@@ -339,7 +335,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: UInt8.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt8 {
+    func decode(_ type: UInt8.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> UInt8 {
         switch self {
         case .int64(let value):
             guard let result = UInt8(exactly: value) else {
@@ -366,7 +362,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: UInt16.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt16 {
+    func decode(_ type: UInt16.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> UInt16 {
         switch self {
         case .int64(let value):
             guard let result = UInt16(exactly: value) else {
@@ -393,7 +389,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: UInt32.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt32 {
+    func decode(_ type: UInt32.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> UInt32 {
         switch self {
         case .int64(let value):
             guard let result = UInt32(exactly: value) else {
@@ -420,7 +416,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: UInt64.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt64 {
+    func decode(_ type: UInt64.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> UInt64 {
         switch self {
         case .int64(let value):
             guard let result = UInt64(exactly: value) else {
@@ -444,7 +440,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: UInt128.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt128 {
+    func decode(_ type: UInt128.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> UInt128 {
         switch self {
         case .int64(let value):
             guard let result = UInt128(exactly: value) else {
@@ -465,7 +461,7 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func decode(_ type: Float.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Float {
+    func decode(_ type: Float.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Float {
         if case .double(let value) = self {
             guard let result = Float(exactly: value) else {
                 throw CodingError.dataCorrupted(debugDescription: "Double value \(value) cannot be represented as Float")
@@ -475,21 +471,21 @@ extension CommonElement: AdaptableDecodableValue {
         throw CodingError.dataCorrupted(debugDescription: "Expected Double but found \(self)")
     }
     
-    func decode(_ type: Double.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Double {
+    func decode(_ type: Double.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> Double {
         if case .double(let value) = self {
             return value
         }
         throw CodingError.dataCorrupted(debugDescription: "Expected Double but found \(self)")
     }
     
-    func decode(_ type: String.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> String {
+    func decode(_ type: String.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> String {
         if case .string(let value) = self {
             return value
         }
         throw CodingError.dataCorrupted(debugDescription: "Expected String but found \(self)")
     }
     
-    func decode<U: Decodable>(_ type: U.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> U {
+    func decode<U: Decodable>(_ type: U.Type, context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> U {
         // For generic Decodable types, we need to recursively create an AdaptorDecoder
         let decoder = AdaptorDecoder(value: self, decoderContext: context.decoderContext, codingPath: context.codingPath)
         do {
@@ -500,9 +496,9 @@ extension CommonElement: AdaptableDecodableValue {
         }
     }
     
-    func makeDictionary(context: AdaptorDecodableValueContext<CommonElement>) throws -> [String : CommonElement] {
+    func makeDictionary(context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> [String : CommonCodablePrimitive] {
         if case .dictionary(let keyValuePairs) = self {
-            var result: [String: CommonElement] = [:]
+            var result: [String: CommonCodablePrimitive] = [:]
             for pair in keyValuePairs {
                 result[pair.key] = pair.value
             }
@@ -511,7 +507,7 @@ extension CommonElement: AdaptableDecodableValue {
         throw CodingError.dataCorrupted(debugDescription: "Expected dictionary but found \(self)")
     }
     
-    func makeArrayIterator(context: AdaptorDecodableValueContext<CommonElement>) throws -> (Array<CommonElement>.Iterator, countHint: Int?) {
+    func makeArrayIterator(context: AdaptorDecodableValueContext<CommonCodablePrimitive>) throws -> (Array<CommonCodablePrimitive>.Iterator, countHint: Int?) {
         if case .array(let elements) = self {
             return (elements.makeIterator(), elements.count)
         }

--- a/Sources/NewCodable/CommonDecodableProtocols.swift
+++ b/Sources/NewCodable/CommonDecodableProtocols.swift
@@ -69,9 +69,6 @@ public protocol CommonDecoder: ~Escapable {
     associatedtype ArrayDecoder: CommonArrayDecoder & ~Escapable
     associatedtype FieldDecoder: CommonFieldDecoder & ~Escapable
     
-    // TODO: This is an interesting idea in potentially allowing a decoder to provide a more optimized form of "Content" for things like alternative enum formats. It needs more thought though. In lieu of this, or maybe even with it, we may need a standard "Content" type for macro to use with `decodeAny()`.
-//    associatedtype CommonCodingPrimitive: ~Copyable = Never
-    
     // TODO: This overload is a workaround for the inability for decoder to dynamically cast particular Copyable types to T: CommonDecodable & ~Copyable. It has a default implementation that calls into the normal ~Copyable path.
     @_lifetime(self: copy self)
     mutating func decode<T: CommonDecodable>(_: T.Type) throws(CodingError.Decoding) -> T
@@ -167,10 +164,6 @@ public protocol CommonDecoder: ~Escapable {
     
     @_lifetime(self: copy self)
     mutating func decodeAny<V: CommonDecodingVisitor>(_ visitor: V) throws(CodingError.Decoding) -> V.DecodedValue
-
-//    @_lifetime(self: copy self)
-//    mutating func decodePrimitive() throws(CodingError.Decoding) -> CommonCodingPrimitive
-
     
     /// Decode a value using a visitor, with a hint that a collection of bytes is expected in the encoded data.
     ///
@@ -180,6 +173,18 @@ public protocol CommonDecoder: ~Escapable {
     /// - throws: TBD. An error thrown by the `visitor`. Others?
     @_lifetime(self: copy self)
     mutating func decodeBytes<V: DecodingBytesVisitor>(visitor: V) throws(CodingError.Decoding) -> V.DecodedValue
+    
+    /// Decodes a value conforming to the standard `Decodable` protocol using `decodeAny` and an `AdaptorDecoder`.
+    ///
+    /// This method provides a bridge between the new `CommonDecoder` protocol and the existing `Decodable` protocol
+    /// by using `decodeAny` to capture the raw value and then wrapping it in an `AdaptorDecoder` for standard decoding.
+    ///
+    /// - parameter type: The type of value to decode.
+    /// - returns: The decoded value.
+    /// - throws: `CodingError.Decoding` if decoding fails.
+    @_disfavoredOverload
+    @_lifetime(self: copy self)
+    mutating func decode<D: Decodable>(_: D.Type) throws(CodingError.Decoding) -> D
 }
 
 extension CommonDecoder where Self: ~Escapable {
@@ -312,6 +317,26 @@ public extension CommonArrayDecoder where Self: ~Escapable {
         }
     }
     
+    @_disfavoredOverload
+    @_alwaysEmitIntoClient
+    @inline(__always)
+    @_lifetime(self: copy self)
+    mutating func decodeNext<T: Decodable>(_ t: T.Type) throws(CodingError.Decoding) -> T? {
+        try self.decodeNext { elementDecoder throws(CodingError.Decoding) in
+            try elementDecoder.decode(t)
+        }
+    }
+    
+    @_disfavoredOverload
+    @_alwaysEmitIntoClient
+    @inline(__always)
+    @_lifetime(self: copy self)
+    mutating func decodeRequiredNext<T: Decodable>(_ t: T.Type) throws(CodingError.Decoding) -> T {
+        return try decodeRequiredNext { elementDecoder throws(CodingError.Decoding) in
+            try elementDecoder.decode(t)
+        }
+    }
+    
     var sizeHint: Int? { nil }
 }
 
@@ -359,7 +384,7 @@ public extension CommonDecoder where Self: ~Escapable {
     mutating func decodeDictionary<T: ~Copyable>( _ closure: (inout DictionaryDecoder) throws(CodingError.Decoding) -> T) throws(CodingError.Decoding) -> T {
         throw CodingError.unsupportedDecodingType("dictionary")
     }
-        
+    
     @_lifetime(self: copy self)
     mutating func decodeArray<T: ~Copyable>(_ closure: (inout ArrayDecoder) throws(CodingError.Decoding) -> T) throws(CodingError.Decoding) -> T {
         throw CodingError.unsupportedDecodingType("array")
@@ -380,7 +405,7 @@ public extension CommonDecoder where Self: ~Escapable {
     ) throws(CodingError.Decoding) -> T {
         throw CodingError.unsupportedDecodingType("enum")
     }
-        
+    
     @_lifetime(self: copy self)
     mutating func decode(_: Bool.Type) throws(CodingError.Decoding) -> Bool { throw CodingError.unsupportedDecodingType("boolean") }
     
@@ -442,10 +467,10 @@ public extension CommonDecoder where Self: ~Escapable {
     
     @_lifetime(self: copy self)
     mutating func decodeAny<V: CommonDecodingVisitor>(_ visitor: V) throws(CodingError.Decoding) -> V.DecodedValue  { throw CodingError.unsupportedDecodingType("any") }
-
-//    @_lifetime(self: copy self)
-//    mutating func decodePrimitive() throws(CodingError.Decoding) -> CommonCodingPrimitive { throw CodingError.unsupportedDecodingType("primitive") }
-
+    
+    //    @_lifetime(self: copy self)
+    //    mutating func decodePrimitive() throws(CodingError.Decoding) -> CommonCodingPrimitive { throw CodingError.unsupportedDecodingType("primitive") }
+    
     
     /// Decode a value using a visitor, with a hint that a collection of bytes is expected in the encoded data.
     ///
@@ -455,7 +480,6 @@ public extension CommonDecoder where Self: ~Escapable {
     /// - throws: TBD. An error thrown by the `visitor`. Others?
     @_lifetime(self: copy self)
     mutating func decodeBytes<V: DecodingBytesVisitor>(visitor: V) throws(CodingError.Decoding) -> V.DecodedValue  { throw CodingError.unsupportedDecodingType("bytes") }
-
 }
 
 public extension CommonDecodingVisitor where Self: ~Copyable & ~Escapable {
@@ -481,5 +505,31 @@ public extension CommonDecodingVisitor where Self: ~Copyable & ~Escapable {
     
     func visitBytes(_ array: [UInt8]) throws(CodingError.Decoding) -> DecodedValue {
         throw CodingError.unsupportedDecodingType("bytes")
+    }
+}
+
+public extension CommonDecoder where Self: ~Escapable {
+    /// Default implementation for decoding standard `Decodable` types using `decodeAny` and `AdaptorDecoder`.
+    ///
+    /// This implementation uses a visitor pattern to capture the raw value as `CommonElement` via `decodeAny`,
+    /// then wraps it in an `AdaptorDecoder` to provide the standard `Decoder` interface expected by `Decodable` types.
+    @_lifetime(self: copy self)
+    mutating func decode<D: Decodable>(_: D.Type) throws(CodingError.Decoding) -> D {
+        guard self.supportsDecodeAny else {
+            throw CodingError.unsupportedDecodingType("any")
+        }
+        
+        let visitor = CommonElementVisitor()
+        let element = try self.decodeAny(visitor)
+        // TODO: Context?
+        // TODO: CodingPath
+        let decoder = AdaptorDecoder(value: element, decoderContext: [:], codingPath: [])
+        
+        do {
+            return try D(from: decoder)
+        } catch {
+            // TODO: Wrap error better.
+            throw CodingError.unsupportedDecodingType("Failed to decode \(D.self): \(error)")
+        }
     }
 }

--- a/Sources/NewCodable/CommonDecodableProtocols.swift
+++ b/Sources/NewCodable/CommonDecodableProtocols.swift
@@ -517,7 +517,7 @@ public extension CommonDecodingVisitor where Self: ~Copyable & ~Escapable {
 public extension CommonDecoder where Self: ~Escapable {
     /// Default implementation for decoding standard `Decodable` types using `decodeAny` and `AdaptorDecoder`.
     ///
-    /// This implementation uses a visitor pattern to capture the raw value as `CommonElement` via `decodeAny`,
+    /// This implementation uses a visitor pattern to capture the raw value as `CommonCodablePrimitive` via `decodeAny`,
     /// then wraps it in an `AdaptorDecoder` to provide the standard `Decoder` interface expected by `Decodable` types.
     @_lifetime(self: copy self)
     mutating func decode<D: Decodable>(_: D.Type) throws(CodingError.Decoding) -> D {
@@ -525,7 +525,7 @@ public extension CommonDecoder where Self: ~Escapable {
             throw CodingError.unsupportedDecodingType("any")
         }
         
-        let visitor = CommonElementVisitor()
+        let visitor = CommonPrimitiveVisitor()
         let element = try self.decodeAny(visitor)
         let decoder = AdaptorDecoder(value: element, decoderContext: [:], codingPath: self.codingPath.toCodingKeys())
         

--- a/Sources/NewCodable/CommonDecodableProtocols.swift
+++ b/Sources/NewCodable/CommonDecodableProtocols.swift
@@ -185,6 +185,8 @@ public protocol CommonDecoder: ~Escapable {
     @_disfavoredOverload
     @_lifetime(self: copy self)
     mutating func decode<D: Decodable>(_: D.Type) throws(CodingError.Decoding) -> D
+    
+    var codingPath: CodingPath { get }
 }
 
 extension CommonDecoder where Self: ~Escapable {
@@ -243,6 +245,7 @@ public protocol CommonStructDecoder: ~Escapable {
     mutating func decodeEachKeyAndValue(_ closure: (String, inout ValueDecoder) throws(CodingError.Decoding) -> Bool) throws(CodingError.Decoding)
     
     var sizeHint: Int? { get }
+    var codingPath: CodingPath { get }
 }
 
 public extension CommonStructDecoder where Self: ~Escapable {
@@ -274,6 +277,8 @@ public protocol CommonDictionaryDecoder: ~Escapable {
     
     @_lifetime(self: copy self)
     mutating func decodeKey(_ keyDecodingClosure: (inout KeyDecoder) throws(CodingError.Decoding) -> Void, andValue valueDecoderClosure: (inout ValueDecoder) throws(CodingError.Decoding) -> Void) throws(CodingError.Decoding) -> Bool
+    
+    var codingPath: CodingPath { get }
 }
 
 public protocol CommonArrayDecoder: ~Escapable {
@@ -286,6 +291,7 @@ public protocol CommonArrayDecoder: ~Escapable {
     mutating func decodeEachElement(_ closure: (inout ElementDecoder) throws(CodingError.Decoding) -> Void) throws(CodingError.Decoding)
     
     var sizeHint: Int? { get }
+    var codingPath: CodingPath { get }
 }
 
 public extension CommonArrayDecoder where Self: ~Escapable {
@@ -521,9 +527,7 @@ public extension CommonDecoder where Self: ~Escapable {
         
         let visitor = CommonElementVisitor()
         let element = try self.decodeAny(visitor)
-        // TODO: Context?
-        // TODO: CodingPath
-        let decoder = AdaptorDecoder(value: element, decoderContext: [:], codingPath: [])
+        let decoder = AdaptorDecoder(value: element, decoderContext: [:], codingPath: self.codingPath.toCodingKeys())
         
         do {
             return try D(from: decoder)

--- a/Sources/NewCodable/CommonElement.swift
+++ b/Sources/NewCodable/CommonElement.swift
@@ -1,0 +1,520 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif FOUNDATION_FRAMEWORK
+import Foundation
+#endif
+
+/// An internal enum representing all the types that `CommonDecoder` supports.
+/// This serves as the `DecodedValue` type for bridging between CommonDecoder and standard Decodable.
+internal enum CommonElement {
+    case bool(Bool)
+    case int64(Int64)
+    case uint64(UInt64)
+    case int128(Int128)
+    case uint128(UInt128)
+    case double(Double)
+    case string(String)
+    case bytes([UInt8])
+    case null
+    case dictionary([(key: String, value: CommonElement)])
+    case array([CommonElement])
+}
+
+/// A visitor that adapts decoded values for use with standard `Decodable` types.
+///
+/// This visitor captures raw values from `decodeAny` as `CommonElement` values
+/// and then converts them to `AdaptorDecoder` for standard decoding.
+internal struct CommonElementVisitor: CommonDecodingVisitor {
+    typealias DecodedValue = CommonElement
+    
+    init() {}
+    
+    func visit(_ value: Bool) throws(CodingError.Decoding) -> CommonElement {
+        return .bool(value)
+    }
+    
+    func visit(_ value: Int) throws(CodingError.Decoding) -> CommonElement {
+        return .int64(Int64(value))
+    }
+    
+    func visit(_ value: Int8) throws(CodingError.Decoding) -> CommonElement {
+        return .int64(Int64(value))
+    }
+    
+    func visit(_ value: Int16) throws(CodingError.Decoding) -> CommonElement {
+        return .int64(Int64(value))
+    }
+    
+    func visit(_ value: Int32) throws(CodingError.Decoding) -> CommonElement {
+        return .int64(Int64(value))
+    }
+    
+    func visit(_ value: Int64) throws(CodingError.Decoding) -> CommonElement {
+        return .int64(value)
+    }
+    
+    func visit(_ value: Int128) throws(CodingError.Decoding) -> CommonElement {
+        return .int128(value)
+    }
+    
+    func visit(_ value: UInt) throws(CodingError.Decoding) -> CommonElement {
+        return .uint64(UInt64(value))
+    }
+    
+    func visit(_ value: UInt8) throws(CodingError.Decoding) -> CommonElement {
+        return .uint64(UInt64(value))
+    }
+    
+    func visit(_ value: UInt16) throws(CodingError.Decoding) -> CommonElement {
+        return .uint64(UInt64(value))
+    }
+    
+    func visit(_ value: UInt32) throws(CodingError.Decoding) -> CommonElement {
+        return .uint64(UInt64(value))
+    }
+    
+    func visit(_ value: UInt64) throws(CodingError.Decoding) -> CommonElement {
+        return .uint64(value)
+    }
+    
+    func visit(_ value: UInt128) throws(CodingError.Decoding) -> CommonElement {
+        return .uint128(value)
+    }
+    
+    func visit(_ value: Float) throws(CodingError.Decoding) -> CommonElement {
+        return .double(Double(value))
+    }
+    
+    func visit(_ value: Double) throws(CodingError.Decoding) -> CommonElement {
+        return .double(value)
+    }
+    
+    func visitString(_ value: String) throws(CodingError.Decoding) -> CommonElement {
+        return .string(value)
+    }
+    
+    func visitUTF8Bytes(_ buffer: UTF8Span) throws(CodingError.Decoding) -> CommonElement {
+        // Convert UTF8Span to String using the proper API
+        let string = String(copying: buffer)
+        return .string(string)
+    }
+    
+    func visitBytes(_ array: [UInt8]) throws(CodingError.Decoding) -> CommonElement {
+        return .bytes(array)
+    }
+    
+    func visit(decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> CommonElement {
+        var result: [(key: String, value: CommonElement)] = []
+        
+        try decoder.decodeEachKeyAndValue { key, valueDecoder throws(CodingError.Decoding) in
+            let elementVisitor = CommonElementVisitor()
+            let element = try valueDecoder.decodeAny(elementVisitor)
+            result.append((key: key, value: element))
+            return false
+        }
+        
+        return .dictionary(result)
+    }
+    
+    func visit(decoder: inout some CommonArrayDecoder & ~Escapable) throws(CodingError.Decoding) -> CommonElement {
+        var result: [CommonElement] = []
+        
+        try decoder.decodeEachElement { elementDecoder throws(CodingError.Decoding) in
+            let elementVisitor = CommonElementVisitor()
+            let element = try elementDecoder.decodeAny(elementVisitor)
+            result.append(element)
+        }
+        
+        return .array(result)
+    }
+    
+    func visitNone() throws(CodingError.Decoding) -> CommonElement {
+        return .null
+    }
+}
+
+extension CommonElement: AdaptableDecodableValue {
+    typealias ArrayIterator = Array<CommonElement>.Iterator
+    
+    func decodeNil(context: AdaptorDecodableValueContext<CommonElement>) -> Bool {
+        if case .null = self {
+            return true
+        }
+        return false
+    }
+    
+    func decode(_ type: Bool.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Bool {
+        if case .bool(let value) = self {
+            return value
+        }
+        throw CodingError.dataCorrupted(debugDescription: "Expected Bool but found \(self)")
+    }
+    
+    func decode(_ type: Int.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int {
+        switch self {
+        case .int64(let value):
+            guard let result = Int(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as Int")
+            }
+            return result
+        case .uint64(let value):
+            guard let result = Int(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as Int")
+            }
+            return result
+        case .int128(let value):
+            guard let result = Int(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as Int")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = Int(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as Int")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: Int8.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int8 {
+        switch self {
+        case .int64(let value):
+            guard let result = Int8(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as Int8")
+            }
+            return result
+        case .uint64(let value):
+            guard let result = Int8(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as Int8")
+            }
+            return result
+        case .int128(let value):
+            guard let result = Int8(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as Int8")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = Int8(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as Int8")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: Int16.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int16 {
+        switch self {
+        case .int64(let value):
+            guard let result = Int16(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as Int16")
+            }
+            return result
+        case .uint64(let value):
+            guard let result = Int16(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as Int16")
+            }
+            return result
+        case .int128(let value):
+            guard let result = Int16(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as Int16")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = Int16(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as Int16")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: Int32.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int32 {
+        switch self {
+        case .int64(let value):
+            guard let result = Int32(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as Int32")
+            }
+            return result
+        case .uint64(let value):
+            guard let result = Int32(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as Int32")
+            }
+            return result
+        case .int128(let value):
+            guard let result = Int32(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as Int32")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = Int32(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as Int32")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: Int64.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int64 {
+        switch self {
+        case .int64(let value):
+            return value
+        case .uint64(let value):
+            guard let result = Int64(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as Int64")
+            }
+            return result
+        case .int128(let value):
+            guard let result = Int64(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as Int64")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = Int64(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as Int64")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: Int128.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Int128 {
+        switch self {
+        case .int64(let value):
+            return Int128(value)
+        case .uint64(let value):
+            return Int128(value)
+        case .int128(let value):
+            return value
+        case .uint128(let value):
+            guard let result = Int128(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as Int128")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: UInt.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt {
+        switch self {
+        case .int64(let value):
+            guard let result = UInt(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as UInt")
+            }
+            return result
+        case .uint64(let value):
+            guard let result = UInt(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as UInt")
+            }
+            return result
+        case .int128(let value):
+            guard let result = UInt(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as UInt")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = UInt(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as UInt")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: UInt8.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt8 {
+        switch self {
+        case .int64(let value):
+            guard let result = UInt8(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as UInt8")
+            }
+            return result
+        case .uint64(let value):
+            guard let result = UInt8(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as UInt8")
+            }
+            return result
+        case .int128(let value):
+            guard let result = UInt8(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as UInt8")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = UInt8(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as UInt8")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: UInt16.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt16 {
+        switch self {
+        case .int64(let value):
+            guard let result = UInt16(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as UInt16")
+            }
+            return result
+        case .uint64(let value):
+            guard let result = UInt16(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as UInt16")
+            }
+            return result
+        case .int128(let value):
+            guard let result = UInt16(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as UInt16")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = UInt16(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as UInt16")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: UInt32.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt32 {
+        switch self {
+        case .int64(let value):
+            guard let result = UInt32(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as UInt32")
+            }
+            return result
+        case .uint64(let value):
+            guard let result = UInt32(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt64 value \(value) cannot be represented as UInt32")
+            }
+            return result
+        case .int128(let value):
+            guard let result = UInt32(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as UInt32")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = UInt32(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as UInt32")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: UInt64.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt64 {
+        switch self {
+        case .int64(let value):
+            guard let result = UInt64(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as UInt64")
+            }
+            return result
+        case .uint64(let value):
+            return value
+        case .int128(let value):
+            guard let result = UInt64(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as UInt64")
+            }
+            return result
+        case .uint128(let value):
+            guard let result = UInt64(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "UInt128 value \(value) cannot be represented as UInt64")
+            }
+            return result
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: UInt128.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> UInt128 {
+        switch self {
+        case .int64(let value):
+            guard let result = UInt128(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int64 value \(value) cannot be represented as UInt128")
+            }
+            return result
+        case .uint64(let value):
+            return UInt128(value)
+        case .int128(let value):
+            guard let result = UInt128(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Int128 value \(value) cannot be represented as UInt128")
+            }
+            return result
+        case .uint128(let value):
+            return value
+        default:
+            throw CodingError.dataCorrupted(debugDescription: "Expected integer but found \(self)")
+        }
+    }
+    
+    func decode(_ type: Float.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Float {
+        if case .double(let value) = self {
+            guard let result = Float(exactly: value) else {
+                throw CodingError.dataCorrupted(debugDescription: "Double value \(value) cannot be represented as Float")
+            }
+            return result
+        }
+        throw CodingError.dataCorrupted(debugDescription: "Expected Double but found \(self)")
+    }
+    
+    func decode(_ type: Double.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> Double {
+        if case .double(let value) = self {
+            return value
+        }
+        throw CodingError.dataCorrupted(debugDescription: "Expected Double but found \(self)")
+    }
+    
+    func decode(_ type: String.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> String {
+        if case .string(let value) = self {
+            return value
+        }
+        throw CodingError.dataCorrupted(debugDescription: "Expected String but found \(self)")
+    }
+    
+    func decode<U: Decodable>(_ type: U.Type, context: AdaptorDecodableValueContext<CommonElement>) throws -> U {
+        // For generic Decodable types, we need to recursively create an AdaptorDecoder
+        let decoder = AdaptorDecoder(value: self, decoderContext: context.decoderContext, codingPath: context.codingPath)
+        do {
+            return try U(from: decoder)
+        } catch {
+            // Convert any error to CodingError.unsupportedDecodingType
+            throw CodingError.dataCorrupted(debugDescription: "Failed to decode \(U.self): \(error)")
+        }
+    }
+    
+    func makeDictionary(context: AdaptorDecodableValueContext<CommonElement>) throws -> [String : CommonElement] {
+        if case .dictionary(let keyValuePairs) = self {
+            var result: [String: CommonElement] = [:]
+            for pair in keyValuePairs {
+                result[pair.key] = pair.value
+            }
+            return result
+        }
+        throw CodingError.dataCorrupted(debugDescription: "Expected dictionary but found \(self)")
+    }
+    
+    func makeArrayIterator(context: AdaptorDecodableValueContext<CommonElement>) throws -> (Array<CommonElement>.Iterator, countHint: Int?) {
+        if case .array(let elements) = self {
+            return (elements.makeIterator(), elements.count)
+        }
+        throw CodingError.dataCorrupted(debugDescription: "Expected array but found \(self)")
+    }
+}

--- a/Sources/NewCodable/CommonEncodableProtocols.swift
+++ b/Sources/NewCodable/CommonEncodableProtocols.swift
@@ -296,6 +296,8 @@ public protocol CommonEncoder: ~Copyable, ~Escapable {
     @_disfavoredOverload
     @_lifetime(self: copy self)
     mutating func encode(_ value: some Encodable) throws(CodingError.Encoding)
+    
+    var codingPath: CodingPath { get }
 }
 
 public extension CommonEncoder where Self: ~Copyable & ~Escapable {
@@ -454,6 +456,8 @@ public protocol CommonDictionaryEncoder: ~Copyable, ~Escapable {
     
     @_lifetime(self: copy self)
     mutating func encode(key: UTF8Span, valueEncoder: (inout ValueEncoder) throws(CodingError.Encoding) -> Void) throws(CodingError.Encoding)
+    
+    var codingPath: CodingPath { get }
 }
 
 public extension CommonDictionaryEncoder where Self: ~Copyable & ~Escapable {
@@ -516,6 +520,8 @@ public protocol CommonStructEncoder: ~Copyable, ~Escapable {
     
     @_lifetime(self: copy self)
     mutating func encode(key: UTF8Span, valueEncoder: (inout ValueEncoder) throws(CodingError.Encoding) -> Void) throws(CodingError.Encoding)
+    
+    var codingPath: CodingPath { get }
 }
 
 public extension CommonStructEncoder where Self: ~Copyable & ~Escapable {

--- a/Sources/NewCodable/JSON/JSONParserDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONParserDecoder.swift
@@ -1781,18 +1781,13 @@ extension JSONParserDecoder: CommonDecoder {
             case ._quote:
                 result = try self.decodeString(visitor) ^^ .decodingError
             case ._openbrace:
-                // TODO: Dict + array. Test when not all elements are parsed.
-                var dictDecoder: DictionaryDecoder
-                do throws(JSONError) { dictDecoder = try DictionaryDecoder(parserState: self.state, midContainer: false) } catch { throw .json(error) }
-                result = try visitor.visit(decoder: &dictDecoder) ^^ .decodingError
-                try dictDecoder._finish() ^^ .decodingError
-                self.state.copyRelevantState(from: dictDecoder.parserState)
+                result = try self.decodeDictionary { dictDecoder throws(CodingError.Decoding) in
+                    try visitor.visit(decoder: &dictDecoder)
+                } ^^ .decodingError
             case ._openbracket:
-                var seqDecoder: ArrayDecoder
-                do throws(JSONError) { seqDecoder = try ArrayDecoder(parserState: self.state, midContainer: false) } catch { throw .json(error) }
-                result = try visitor.visit(decoder: &seqDecoder) ^^ .decodingError
-                try seqDecoder._finish() ^^ .decodingError
-                self.state.copyRelevantState(from: seqDecoder.innerParser.state)
+                result = try self.decodeArray { seqDecoder throws(CodingError.Decoding) in
+                    try visitor.visit(decoder: &seqDecoder)
+                } ^^ .decodingError
             case UInt8(ascii: "f"), UInt8(ascii: "t"):
                 let bool = try state.reader.readBool() ^^ .jsonError
                 result = try visitor.visit(bool) ^^ .decodingError

--- a/Sources/NewCodable/JSON/NewJSONEncoder.swift
+++ b/Sources/NewCodable/JSON/NewJSONEncoder.swift
@@ -763,6 +763,10 @@ extension JSONDirectEncoder {
         
         // TODO: Integer implementations.
         
+        public var codingPath: CodingPath {
+            innerEncoder.codingPath
+        }
+        
         @_transparent
         @inline(__always)
         @_lifetime(encoder: copy encoder)
@@ -1004,7 +1008,6 @@ extension JSONDirectEncoder {
     @_lifetime(self: copy self)
     public mutating func encode<T: Encodable>(_ value: T) throws(CodingError.Encoding) {
         do {
-            // TODO: Encoder context
             let encoder = AdaptorEncoder<JSONPrimitive>(encoderContext: .init(userInfo: [:], options: state.options), codingPath: self.codingPath.toCodingKeys())
             try encoder.encode(value)
             let encodedValue = encoder.encodedValue

--- a/Tests/NewCodableTests/CodableRevolutionTests.swift
+++ b/Tests/NewCodableTests/CodableRevolutionTests.swift
@@ -798,9 +798,32 @@ struct NewCodableTests {
         let result = try decoder.decode(CodableStructWithAliasedProperty.self, from: qux)
         #expect(result.bar == "hello")
     }
+
+    @JSONCodable
+    struct Person: Equatable {
+        let name: String
+        let address: Address
+        
+        struct Address: Codable, Equatable {
+            let city: String
+            let state: String
+            let zip: Int
+        }
+    }
     
-    @Test func testEmbeddedEncodable() throws {
-        struct Person: JSONEncodable, JSONDecodable, Equatable {
+    @Test func testEmbeddedEncodableForJSON() throws {
+        let testValue = Person(
+            name: "John",
+            address: .init(city: "Cupertino", state: "CA", zip: 95014)
+        )
+        
+        let data = try NewJSONEncoder().encode(testValue)
+        let redecoded = try NewJSONDecoder().decode(Person.self, from: data)
+        #expect(testValue == redecoded)
+    }
+    
+    @Test func testEmbeddedEncodableForCommon() throws {
+        struct PersonCommon: CommonCodable, Equatable {
             let name: String
             let address: Address
             
@@ -810,45 +833,45 @@ struct NewCodableTests {
                 let zip: Int
             }
             
-            func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
-                try encoder.encodeDictionary { dictEncoder throws(CodingError.Encoding) in
+            func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                try encoder.encodeDictionary(elementCount: 2) { dictEncoder throws(CodingError.Encoding) in
                     try dictEncoder.encode(key: "name", value: name)
                     try dictEncoder.encode(key: "address", value: address)
                 }
             }
             
-            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
+            static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> PersonCommon {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var name: String?
                     var address: Address?
                     
                     try structDecoder.decodeEachKeyAndValue { key, valueDecoder throws(CodingError.Decoding) in
                         switch key {
-                        case "name": 
+                        case "name":
                             name = try valueDecoder.decode(String.self)
-                        case "address": 
+                        case "address":
                             address = try valueDecoder.decode(Address.self)
-                        default: 
+                        default:
                             break // Skip unknown keys
                         }
                         return false
                     }
                     
-                    guard let name, let address else { 
+                    guard let name, let address else {
                         throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
                     }
-                    return Person(name: name, address: address)
+                    return PersonCommon(name: name, address: address)
                 }
             }
         }
         
-        let testValue = Person(
+        let testValue = PersonCommon(
             name: "John",
             address: .init(city: "Cupertino", state: "CA", zip: 95014)
         )
         
         let data = try NewJSONEncoder().encode(testValue)
-        let redecoded = try NewJSONDecoder().decode(Person.self, from: data)
+        let redecoded = try NewJSONDecoder().decode(PersonCommon.self, from: data)
         #expect(testValue == redecoded)
     }
     

--- a/Tests/NewCodableTests/CodableRevolutionTests.swift
+++ b/Tests/NewCodableTests/CodableRevolutionTests.swift
@@ -47,7 +47,7 @@ struct NewCodableTests {
         struct Test: JSONDecodable {
             let numberStr: String
 
-            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Test {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Test {
                 let number = try decoder.decodeNumber()
                 return .init(numberStr: number.extendedPrecisionRepresentation)
             }
@@ -89,7 +89,7 @@ struct NewCodableTests {
                 case name
                 case address
                 
-                static func field(for key: UTF8Span) throws(NewCodable.CodingError.Decoding) -> Self {
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> Self {
                     switch UTF8SpanComparator(key) {
                     case "name": .name
                     case "address": .address
@@ -111,7 +111,7 @@ struct NewCodableTests {
                 let state: String
             }
             
-            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Person {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var name: String?
                     var address: Address?
@@ -146,6 +146,157 @@ struct NewCodableTests {
         #expect(person == expected)
     }
     
+    @Test func standardDecodableInteroperability() throws {
+        let json = Data("""
+            {
+                "title": "My Blog Post",
+                "author": { "name": "Alice", "email": "alice@example.com" },
+                "metadata": { "wordCount": 1500, "readTime": 5 },
+                "comments": [
+                    { "author": "Bob", "text": "Great post!" },
+                    { "author": "Charlie", "text": "Very helpful, thanks!" }
+                ]
+            }
+            """.utf8)
+        
+        // Standard Decodable types that don't conform to CommonDecodable
+        struct Author: Decodable, Equatable {
+            let name: String
+            let email: String
+        }
+        
+        struct Metadata: Decodable, Equatable {
+            let wordCount: Int
+            let readTime: Int
+        }
+        
+        struct Comment: Decodable, Equatable {
+            let author: String
+            let text: String
+        }
+        
+        // A CommonDecodable type that contains standard Decodable types
+        struct BlogPost: CommonDecodable, Equatable {
+            let title: String
+            let author: Author
+            let metadata: Metadata
+            let comments: [Comment]
+            
+            static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> BlogPost {
+                try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                    var title: String?
+                    var author: Author?
+                    var metadata: Metadata?
+                    var comments: [Comment]?
+                    
+                    try structDecoder.decodeEachKeyAndValue { key, valueDecoder throws(CodingError.Decoding) in
+                        switch key {
+                        case "title":
+                            title = try valueDecoder.decode(String.self)
+                        case "author":
+                            // This should use our new decode<D: Decodable> method!
+                            author = try valueDecoder.decode(Author.self)
+                        case "metadata":
+                            // This should use our new decode<D: Decodable> method!
+                            metadata = try valueDecoder.decode(Metadata.self)
+                        case "comments":
+                            // This should use our new decode<D: Decodable> method for the array elements!
+                            comments = try valueDecoder.decode([Comment].self)
+                        default:
+                            break // Skip unknown keys
+                        }
+                        return false
+                    }
+                    
+                    guard let title, let author, let metadata, let comments else {
+                        throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                    }
+                    return BlogPost(title: title, author: author, metadata: metadata, comments: comments)
+                }
+            }
+        }
+        
+        let decoder = NewJSONDecoder()
+        let blogPost = try decoder.decode(BlogPost.self, from: json)
+        
+        let expectedPost = BlogPost(
+            title: "My Blog Post",
+            author: Author(name: "Alice", email: "alice@example.com"),
+            metadata: Metadata(wordCount: 1500, readTime: 5),
+            comments: [
+                Comment(author: "Bob", text: "Great post!"),
+                Comment(author: "Charlie", text: "Very helpful, thanks!")
+            ]
+        )
+        
+        #expect(blogPost == expectedPost)
+    }
+    
+    @Test func standardDecodableWithPrimitives() throws {
+        let json = Data("""
+            {
+                "user": { "id": 42, "active": true },
+                "scores": [98.5, 87.2, 92.1],
+                "settings": { "notifications": true, "theme": "dark" }
+            }
+            """.utf8)
+        
+        // Standard Decodable types with various primitive types
+        struct User: Decodable, Equatable {
+            let id: Int
+            let active: Bool
+        }
+        
+        struct Settings: Decodable, Equatable {
+            let notifications: Bool
+            let theme: String
+        }
+        
+        struct Report: CommonDecodable, Equatable {
+            let user: User
+            let scores: [Double]
+            let settings: Settings
+            
+            static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Report {
+                try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                    var user: User?
+                    var scores: [Double]?
+                    var settings: Settings?
+                    
+                    try structDecoder.decodeEachKeyAndValue { key, valueDecoder throws(CodingError.Decoding) in
+                        switch key {
+                        case "user":
+                            user = try valueDecoder.decode(User.self)
+                        case "scores":
+                            scores = try valueDecoder.decode([Double].self, sizeHint: 0)
+                        case "settings":
+                            settings = try valueDecoder.decode(Settings.self)
+                        default:
+                            break
+                        }
+                        return false
+                    }
+                    
+                    guard let user, let scores, let settings else {
+                        throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                    }
+                    return Report(user: user, scores: scores, settings: settings)
+                }
+            }
+        }
+        
+        let decoder = NewJSONDecoder()
+        let report = try decoder.decode(Report.self, from: json)
+        
+        let expectedReport = Report(
+            user: User(id: 42, active: true),
+            scores: [98.5, 87.2, 92.1],
+            settings: Settings(notifications: true, theme: "dark")
+        )
+        
+        #expect(report == expectedReport)
+    }
+    
     @Test func testFlatten() throws {
         /*
          @Codable
@@ -171,7 +322,7 @@ struct NewCodableTests {
                 let city: String
                 let state: String
                 
-                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Address {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Address {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var city: String?
                         var state: String?
@@ -189,7 +340,7 @@ struct NewCodableTests {
                 }
             }
                         
-            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Person {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     let requiredFields = 1
                     var requiredFieldsSeen = 0
@@ -254,7 +405,7 @@ struct NewCodableTests {
                 case _1
                 case _2
                 
-                static func field(for key: UTF8Span) throws(NewCodable.CodingError.Decoding) -> Self {
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> Self {
                     switch UTF8SpanComparator(key) {
                     case "_0": ._0
                     case "_1": ._1
@@ -278,7 +429,7 @@ struct NewCodableTests {
                 case _1
                 case _2
                 
-                static func field(for key: UTF8Span) throws(NewCodable.CodingError.Decoding) -> Self {
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> Self {
                     switch UTF8SpanComparator(key) {
                     case "first": .first
                     case "_1": ._1
@@ -302,7 +453,7 @@ struct NewCodableTests {
                 case second
                 case third
                 
-                static func field(for key: UTF8Span) throws(NewCodable.CodingError.Decoding) -> Self {
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> Self {
                     switch UTF8SpanComparator(key) {
                     case "first": .first
                     case "second": .second
@@ -324,7 +475,7 @@ struct NewCodableTests {
             enum SingleUntaggedFields: Int, JSONOptimizedDecodingField {
                 case _0 = 0
                 
-                static func field(for key: UTF8Span) throws(NewCodable.CodingError.Decoding) -> Self {
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> Self {
                     switch UTF8SpanComparator(key) {
                     case "_0": ._0
                     default: throw CodingError.unknownKey(key)
@@ -345,7 +496,7 @@ struct NewCodableTests {
                 case allTagged
                 case singleUntagged
                 
-                static func field(for key: UTF8Span) throws(NewCodable.CodingError.Decoding) -> Self {
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> Self {
                     switch UTF8SpanComparator(key) {
                     case "allUntagged": .allUntagged
                     case "someTagged": .someTagged
@@ -366,7 +517,7 @@ struct NewCodableTests {
                 }
             }
             
-            static func decodeAllUntagged(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Tests {
+            static func decodeAllUntagged(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Tests {
                 var _0: Int?
                 var _1: Int?
                 var _2: Int?
@@ -386,7 +537,7 @@ struct NewCodableTests {
                 return .allUntagged(_0, _1, _2)
             }
             
-            static func decodeSomeTagged(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Tests {
+            static func decodeSomeTagged(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Tests {
                 var first: Int?
                 var _1: Int?
                 var _2: Int?
@@ -406,7 +557,7 @@ struct NewCodableTests {
                 return .someTagged(first: first, _1, _2)
             }
             
-            static func decodeAllTagged(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Tests {
+            static func decodeAllTagged(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Tests {
                 var first: Int?
                 var second: Int?
                 var third: Int?
@@ -426,7 +577,7 @@ struct NewCodableTests {
                 return .allTagged(first: first, second: second, third: third)
             }
             
-            static func decodeSingleUntagged(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Tests {
+            static func decodeSingleUntagged(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Tests {
                 var _0: Int?
                 var key: SingleUntaggedFields?
                 try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
@@ -442,7 +593,7 @@ struct NewCodableTests {
                 return .singleUntagged(_0)
             }
             
-            static func decode(from decoder: inout some NewCodable.JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> Tests {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Tests {
                 return try decoder.decodeEnumCase { fieldDecoder, valuesDecoder throws(CodingError.Decoding) in
                     let field = try fieldDecoder.decode(CodingFields.self)
                     return switch field {
@@ -483,7 +634,7 @@ struct NewCodableTests {
                 case two
                 case three
                 
-                static func field(for key: UTF8Span) throws(NewCodable.CodingError.Decoding) -> Self {
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> Self {
                     switch UTF8SpanComparator(key) {
                     case "one": .one
                     case "two": .two
@@ -502,7 +653,7 @@ struct NewCodableTests {
                 }
             }
             
-            static func decode(from decoder: inout some NewCodable.JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> NoAssociatedType {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> NoAssociatedType {
                 try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
                     let field = try fieldDecoder.decode(CodingFields.self)
                     return switch field {
@@ -547,7 +698,7 @@ struct NewCodableTests {
             case foo(label: String)
             case bar(other: String)
             
-            static func decodeFoo(from decoder: inout some NewCodable.JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> InternallyTagged {
+            static func decodeFoo(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> InternallyTagged {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var label: String?
                     try structDecoder.decodeEachKeyAndValue { key, valueDecoder throws(CodingError.Decoding) in
@@ -560,7 +711,7 @@ struct NewCodableTests {
                 }
             }
             
-            static func decodeBar(from decoder: inout some NewCodable.JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> InternallyTagged {
+            static func decodeBar(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> InternallyTagged {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var other: String?
                     try structDecoder.decodeEachKeyAndValue { key, valueDecoder throws(CodingError.Decoding) in
@@ -573,7 +724,7 @@ struct NewCodableTests {
                 }
             }
             
-            static func decode(from decoder: inout some NewCodable.JSONDecoderProtocol & ~Escapable) throws(NewCodable.CodingError.Decoding) -> InternallyTagged {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> InternallyTagged {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var decodedCase: String?
                     var contents = structDecoder.prepareIntermediateValueStorage()
@@ -1201,7 +1352,7 @@ struct NewCodableTests {
             let count: Int
             let suffixedStrings: [String]
             
-            static func decode(from decoder: inout some NewCodable.JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Aggregate {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Aggregate {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var count: Int?
                     var suffixedStrings: [String]?
@@ -1289,7 +1440,7 @@ struct NewCodableTests {
             let outerData: Data
             let inner: Inner
             
-            static func decode(from decoder: inout some NewCodable.JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Test {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Test {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var outerData: Data?
                     var inner: Inner?
@@ -1312,7 +1463,7 @@ struct NewCodableTests {
                 }
             }
             
-            func encode(to encoder: inout NewCodable.JSONDirectEncoder) throws(CodingError.Encoding) {
+            func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                 try encoder.encodeDictionary(elementCount: 2) { dictEncoder throws(CodingError.Encoding) in
                     try dictEncoder.encode(key: "outerData", value: outerData)
                     try dictEncoder.encode(key: "inner", value: inner)
@@ -1405,7 +1556,7 @@ struct NewCodableTests {
             let outerDate: Date
             let inner: Inner
             
-            static func decode(from decoder: inout some NewCodable.JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Test {
+            static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Test {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var outerDate: Date?
                     var inner: Inner?
@@ -1429,7 +1580,7 @@ struct NewCodableTests {
                 }
             }
             
-            func encode(to encoder: inout NewCodable.JSONDirectEncoder) throws(CodingError.Encoding) {
+            func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                 try encoder.encodeDictionary(elementCount: 2) { dictEncoder throws(CodingError.Encoding) in
                     try dictEncoder.encode(key: "outerDate", value: outerDate)
                     try dictEncoder.encode(key: "inner", value: inner)
@@ -1559,14 +1710,14 @@ struct NewCodableTests {
             let array: [Double]
             let old: OldCodable
             
-            func encode(to encoder: inout NewCodable.JSONDirectEncoder) throws(CodingError.Encoding) {
+            func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                 try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
                     try structEncoder.encode(key: "array", value: array)
                     try structEncoder.encode(key: "old", value: old)
                 }
             }
             
-            static func decode<D>(from decoder: inout D) throws(CodingError.Decoding) -> Test where D : NewCodable.JSONDecoderProtocol, D : ~Escapable {
+            static func decode<D>(from decoder: inout D) throws(CodingError.Decoding) -> Test where D : JSONDecoderProtocol, D : ~Escapable {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     var array: [Double]?
                     var old: OldCodable?
@@ -1614,7 +1765,7 @@ struct NewCodableTests {
     @Test func testPrettyEncoding() throws {
         // TODO: More extensive testing.
         struct Test: JSONEncodable {
-            func encode(to encoder: inout NewCodable.JSONDirectEncoder) throws(CodingError.Encoding) {
+            func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                 try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
                     try structEncoder.encode(key: "foo", value: "bar")
                     try structEncoder.encode(key: "num", value: 42)

--- a/Tests/NewCodableTests/CodableRevolutionTests.swift
+++ b/Tests/NewCodableTests/CodableRevolutionTests.swift
@@ -2157,6 +2157,74 @@ struct NewCodableTests {
         
         #expect(valueResult.capturedPaths == expectedPaths)
     }
+    
+    @Test func testCodingPathOfEmbeddedDecodable() throws {
+        struct ArrayContainer: CommonDecodable {
+            let items: [DecodableItem]
+            
+            static func decode(from decoder: inout some (CommonDecoder & ~Escapable)) throws(CodingError.Decoding) -> Self {
+                return try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                    var decodableItems: [DecodableItem] = []
+                    
+                    try structDecoder.decodeEachKeyAndValue { key, valueDecoder throws(CodingError.Decoding) in
+                        if key == "items" {
+                            decodableItems = try valueDecoder.decode([DecodableItem].self)
+                        }
+                        return false
+                    }
+                    
+                    return ArrayContainer(items: decodableItems)
+                }
+            }
+        }
+        
+        struct DecodableItem: Decodable {
+            let id: Int
+            let capturedCodingPath: [any CodingKey]
+            
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.capturedCodingPath = decoder.codingPath
+                self.id = try container.decode(Int.self, forKey: .id)
+            }
+            
+            enum CodingKeys: String, CodingKey {
+                case id
+            }
+        }
+        
+        let jsonString = """
+        {
+            "items": [
+                { "id": 100 },
+                { "id": 200 },
+                { "id": 300 }
+            ]
+        }
+        """
+        
+        let jsonData = jsonString.data(using: .utf8)!
+        let decoder = NewJSONDecoder()
+        let result = try decoder.decode(ArrayContainer.self, from: jsonData)
+        
+        #expect(result.items.count == 3)
+        
+        // Verify each item has the correct coding path with array indices
+        Testing.__checkBinaryOperation(result.items[0].capturedCodingPath.count,{ $0 == $1() },2,expression: .__fromBinaryOperation(.__fromSyntaxNode("result.items[0].capturedCodingPath.count"),"==",.__fromSyntaxNode("2")),comments: [.__line("// Verify each item has the correct coding path with array indices")],isRequired: false,sourceLocation: Testing.SourceLocation.__here()).__expected()
+        #expect(result.items[0].capturedCodingPath[0].stringValue == "items")
+        #expect(result.items[0].capturedCodingPath[1].intValue == 0)
+        #expect(result.items[0].id == 100)
+        
+        #expect(result.items[1].capturedCodingPath.count == 2)
+        #expect(result.items[1].capturedCodingPath[0].stringValue == "items")
+        #expect(result.items[1].capturedCodingPath[1].intValue == 1)
+        #expect(result.items[1].id == 200)
+        
+        #expect(result.items[2].capturedCodingPath.count == 2)
+        #expect(result.items[2].capturedCodingPath[0].stringValue == "items")
+        #expect(result.items[2].capturedCodingPath[1].intValue == 2)
+        #expect(result.items[2].id == 300)
+    }
 }
 
 extension Array where Element: BinaryFloatingPoint {


### PR DESCRIPTION
We need the ability to support embedded `Decodable` types in `CommonDecodable` types, like is currently supported for `JSONDecodable`.

### Modifications:

* Added `decode<Decodable>` requirement to `CommonDecodable`. This requires `decodeAny` support.
* Added `CommonCodablePrimitive` as `DecodedValue` for `decodeAny`.
* Added default implementation that uses `decodeAny` and `AdaptorDecoder`.
* Added `codingPath` requirement to `Common*` encoder/decoders and sub-encoder/decoders.

### Testing:

* Tests that embed `Decodable` and `Encodable` type in `Common*` types.
* Test that `Decodable` types see the correct `codingPath` provided by the `NewJSONDecoder`.