### PR TITLE
Fix Observations of ProgressManager's fractionCompleted updates 

### DIFF
--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
@@ -384,7 +384,9 @@ internal import _FoundationCollections
             state.markChildDirty(at: position)
         }
         if let parents = parents {
+            // rdar://172950622 (Async stream observation of ProgressManager's fractionCompleted does not receive updates from subsubprogress and beyond.)
             markSelfDirty(parents: parents)
+            self.withMutation(keyPath: \.completedCount) {}
         }
     }
     

--- a/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerTests.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 import Testing
+import Observation
+import Synchronization
 
 #if FOUNDATION_FRAMEWORK
 @testable import Foundation
@@ -791,5 +793,57 @@ extension Tag {
         }
 
         #expect(manager.completedCount == 1000)
+    }
+
+    // rdar://172950622 (Async stream observation of ProgressManager's fractionCompleted does not receive updates from subsubprogress and beyond.)
+    // Verify that observation propagates to all ancestors when a leaf node is mutated,
+    // and that re-subscribing works across repeated increments to completion,
+    // matching the real-world pattern where an async stream re-registers after each onChange.
+    @Test func observationPropagatesAcrossMultipleLevels() {
+        let root = ProgressManager(totalCount: 5)
+        let child = root.subprogress(assigningCount: 5).start(totalCount: 5)
+        let grandchild = child.subprogress(assigningCount: 5).start(totalCount: 5)
+        let greatGrandchild = grandchild.subprogress(assigningCount: 5).start(totalCount: 5)
+
+        for i in 1...5 {
+            let rootObserved = Mutex(false)
+            let childObserved = Mutex(false)
+            let grandchildObserved = Mutex(false)
+            let rootValue = Mutex(0.0)
+            let childValue = Mutex(0.0)
+
+            // Re-subscribe before each increment, just like an async stream would
+            withObservationTracking {
+                let _ = root.fractionCompleted
+            } onChange: {
+                rootObserved.withLock { $0 = true }
+                rootValue.withLock { $0 = root.fractionCompleted }
+            }
+
+            withObservationTracking {
+                let _ = child.fractionCompleted
+            } onChange: {
+                childObserved.withLock { $0 = true }
+                childValue.withLock { $0 = child.fractionCompleted }
+            }
+
+            withObservationTracking {
+                let _ = grandchild.fractionCompleted
+            } onChange: {
+                grandchildObserved.withLock { $0 = true }
+            }
+
+            greatGrandchild.complete(count: 1)
+
+            let expected = Double(i) / 5.0
+            #expect(grandchildObserved.withLock { $0 }, "Grandchild observation should fire on increment \(i)")
+            #expect(childObserved.withLock { $0 }, "Child observation should fire on increment \(i)")
+            #expect(rootObserved.withLock { $0 }, "Root observation should fire on increment \(i)")
+            #expect(rootValue.withLock { $0 } == expected, "Root should see \(expected) inside onChange on increment \(i)")
+            #expect(childValue.withLock { $0 } == expected, "Child should see \(expected) inside onChange on increment \(i)")
+        }
+
+        #expect(root.fractionCompleted == 1.0)
+        #expect(root.isFinished)
     }
 }


### PR DESCRIPTION
This PR adds a `self.withMutation(keyPath: \.completedCount) {}` call in `markChildDirty(at:)` after `markSelfDirty(parents:)` to make sure updates of `fractionCompleted` gets propagated up to top-of-tree. 

### Motivation:

When leaf node has updates, only its direct parent has updates and the root node that is more than one level above the leaf node does not get updates until the very end when `fractionCompleted` is 1.0. 

`markChildDirty` propagates dirty flags up the tree when a child's progress changes, but it never called `withMutation` on intermediate nodes. This means `withObservationTracking`'s `onChange` only fires for the direct parent — ancestors further up the tree never get notified. Async stream patterns like `for await update in Observations { pm.fractionCompleted }` silently miss updates at every level above the direct parent.

### Modifications:

Added a `self.withMutation(keyPath: \.completedCount) {}` call in markChildDirty(at:)`.

### Result:

When leaf node has updates, the root node that is more than one level above the leaf node will also get the updates. 

### Testing:

Added a unit test that reproduced this issue and is resolved with the change. 
