### PR TITLE
NSString addingPercentEncoding methods should return nil for invalid UTF-16

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_C+Encoding.swift
+++ b/Sources/FoundationEssentials/URL/URL_C+Encoding.swift
@@ -228,14 +228,34 @@ extension NSURL {
     }
 }
 
+internal import Foundation_Private.NSString
+
 @objc
 extension NSString {
+    /// Returns `nil` if `self` contains unpaired UTF-16 surrogates
+    private var _validatedString: String? {
+        if let fastCharacters = _fastCharacterContents() {
+            let charsBuffer = UnsafeBufferPointer(start: fastCharacters, count: length)
+            return String(validating: charsBuffer, as: UTF16.self)
+        } else if fastestEncoding == NSUnicodeStringEncoding {
+            if length == 0 { return "" }
+            return withUnsafeTemporaryAllocation(of: UInt16.self, capacity: length) { charsBuffer in
+                getCharacters(charsBuffer.baseAddress!, range: NSRange(location: 0, length: charsBuffer.count))
+                return String(validating: charsBuffer, as: UTF16.self)
+            }
+        } else {
+            // If a custom NSString subclass lies about fastestEncoding and
+            // contains unpaired surrogates, they'll get U+FFFD replacement.
+            return String(self)
+        }
+    }
+
     func __copySwiftStringByAddingPercentEncoding(withAllowedCharacters allowedCharacters: CharacterSet) -> String? {
-        (self as String).addingPercentEncoding(withAllowedCharacters: allowedCharacters)
+        _validatedString?.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
     }
 
     func __copySwiftStringByRemovingPercentEncoding() -> String? {
-        (self as String).removingPercentEncoding
+        _validatedString?.removingPercentEncoding
     }
 }
 


### PR DESCRIPTION
The new Swift implementation for `-[NSString addingPercentEncoding...]` methods should return `nil` for `NSString`s with invalid (unpaired) UTF-16 surrogates instead of using the `U+FFFD` replacement character.

### Motivation:

Restore previous behavior of returning `nil` when an `NSString` contains an unpaired UTF-16 surrogate.

### Modifications:

The extensions now validate UTF-16 backed `NSString`s via `String(validating: ..., as: UTF16.self)` instead of just bridging to `String` (which replaces invalid UTF-16 with `U+FFFD` when accessing the bytes via `.withUTF8 { ... }`).

### Result:

No behavior change for swift-foundation. On Darwin, these `NSString` methods maintain their old behavior when the Swift implementation is enabled.

### Testing:

`NSString` testing of these methods for strings containing unpaired UTF-16 surrogates.
