### PR TITLE
Implement Data.range(of:options:in:) for non-Darwin platforms

### DIFF
--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(FoundationEssentials
     Platform.swift
     Progress+Stub.swift
     SortComparator.swift
+    Span+Utils.swift
     UUID_Wrappers.swift
     UUID.swift
     WASILibc+Extensions.swift

--- a/Sources/FoundationEssentials/Data/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Data/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(FoundationEssentials PRIVATE
     Data+Iterator.swift
     Data+Reading.swift
     Data+Searching.swift
+    Data+Searching+BoyerMoore.swift
     Data+Writing.swift
     Data+WritingOptions.swift
     DataProtocol.swift

--- a/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
+++ b/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
@@ -102,10 +102,8 @@ extension Data {
         into badCharacterShift: inout MutableSpan<Int>
     ) {
         if backwards {
-            var i = needle.count
-            while i > 0 {
-                i -= 1
-                // i is decremented from needle.count before indexing, so it is always in 0..<needle.count.
+            for i in (0..<needle.count).reversed() {
+                // i stays within 0..<needle.count, so safe to use the unchecked subscript.
                 badCharacterShift[Int(needle[unchecked: i])] = i
             }
         } else {

--- a/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
+++ b/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
@@ -1,0 +1,194 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
+extension Data {
+    func _searchBoyerMoore(_ needle: borrowing Span<UInt8>, in searchRange: Range<Index>, backwards: Bool) -> Range<Index>? {
+        let haystack = span.extracting(_rangeRelativeToStartIndex(searchRange))
+        let needleLength = needle.count
+
+        var badCharacterShift = ContiguousArray(repeating: needleLength, count: Int(UInt8.max) + 1)
+        var goodSubstringShift = ContiguousArray(repeating: needleLength, count: needleLength)
+        var suffixLengths = ContiguousArray(repeating: 0, count: needleLength)
+        var badCharacterShiftSpan = badCharacterShift.mutableSpan
+        var goodSubstringShiftSpan = goodSubstringShift.mutableSpan
+        var suffixLengthsSpan = suffixLengths.mutableSpan
+
+        Self._computeBadCharacterShift(for: needle, backwards: backwards, into: &badCharacterShiftSpan)
+        Self._computeGoodSubstringShift(
+            for: needle,
+            backwards: backwards,
+            shift: &goodSubstringShiftSpan,
+            suffixLengths: &suffixLengthsSpan
+        )
+
+        if backwards {
+            var scanNeedle = 0
+            var scanHaystack = haystack.count - needleLength
+
+            while scanHaystack >= 0, scanNeedle < needleLength {
+                if haystack[scanHaystack] == needle[scanNeedle] {
+                    scanHaystack += 1
+                    scanNeedle += 1
+                } else {
+                    let shift = Swift.max(
+                        badCharacterShift[Int(haystack[scanHaystack])],
+                        goodSubstringShift[scanNeedle]
+                    )
+                    scanHaystack -= shift
+                    scanNeedle = 0
+                }
+            }
+
+            guard scanNeedle == needleLength else {
+                return nil
+            }
+
+            let lowerBound = searchRange.lowerBound + scanHaystack - needleLength
+            return lowerBound..<(lowerBound + needleLength)
+        } else {
+            var scanNeedle = needleLength - 1
+            var scanHaystack = needleLength - 1
+
+            while scanHaystack < haystack.count, scanNeedle >= 0 {
+                if haystack[scanHaystack] == needle[scanNeedle] {
+                    scanHaystack -= 1
+                    scanNeedle -= 1
+                } else {
+                    let shift = Swift.max(
+                        badCharacterShift[Int(haystack[scanHaystack])],
+                        goodSubstringShift[scanNeedle]
+                    )
+                    scanHaystack += shift
+                    scanNeedle = needleLength - 1
+                }
+            }
+
+            guard scanNeedle < 0 else {
+                return nil
+            }
+
+            let lowerBound = searchRange.lowerBound + scanHaystack + 1
+            return lowerBound..<(lowerBound + needleLength)
+        }
+    }
+
+    @_lifetime(badCharacterShift: copy badCharacterShift)
+    private static func _computeBadCharacterShift(
+        for needle: borrowing Span<UInt8>,
+        backwards: Bool,
+        into badCharacterShift: inout MutableSpan<Int>
+    ) {
+        if backwards {
+            for i in (0..<needle.count).reversed() {
+                badCharacterShift[Int(needle[i])] = i
+            }
+        } else {
+            for i in 0..<needle.count {
+                badCharacterShift[Int(needle[i])] = needle.count - i - 1
+            }
+        }
+    }
+
+    @_lifetime(shift: copy shift)
+    @_lifetime(suffixLengths: copy suffixLengths)
+    private static func _computeGoodSubstringShift(
+        for needle: borrowing Span<UInt8>,
+        backwards: Bool,
+        shift: inout MutableSpan<Int>,
+        suffixLengths: inout MutableSpan<Int>
+    ) {
+        if backwards {
+            var reversedNeedle = ContiguousArray(repeating: UInt8.zero, count: needle.count)
+            var reversedNeedleSpan = reversedNeedle.mutableSpan
+            for i in 0..<needle.count {
+                reversedNeedleSpan[i] = needle[needle.count - 1 - i]
+            }
+
+            Self._computeGoodSubstringShift(
+                for: reversedNeedleSpan.span,
+                shift: &shift,
+                suffixLengths: &suffixLengths
+            )
+            Self._reverse(&shift)
+        } else {
+            Self._computeGoodSubstringShift(
+                for: needle,
+                shift: &shift,
+                suffixLengths: &suffixLengths
+            )
+        }
+    }
+
+    @_lifetime(shift: copy shift)
+    @_lifetime(suffixLengths: copy suffixLengths)
+    private static func _computeGoodSubstringShift(
+        for needle: borrowing Span<UInt8>,
+        shift: inout MutableSpan<Int>,
+        suffixLengths: inout MutableSpan<Int>
+    ) {
+        let needleLength = needle.count
+
+        var f = needleLength - 1
+        var g = needleLength - 1
+        suffixLengths[needleLength - 1] = needleLength
+
+        for i in (0..<(needleLength - 1)).reversed() {
+            if i > g, suffixLengths[i + needleLength - 1 - f] < i - g {
+                suffixLengths[i] = suffixLengths[i + needleLength - 1 - f]
+            } else {
+                if i < g {
+                    g = i
+                }
+                f = i
+                while g >= 0, needle[g] == needle[g + needleLength - 1 - f] {
+                    g -= 1
+                }
+                suffixLengths[i] = f - g
+            }
+        }
+
+        var j = 0
+        for i in (0..<needleLength).reversed() {
+            if suffixLengths[i] == i + 1 {
+                while j < needleLength - 1 - i {
+                    if shift[j] == needleLength {
+                        shift[j] = needleLength - 1 - i
+                    }
+                    j += 1
+                }
+            }
+        }
+
+        for i in 0..<(needleLength - 1) {
+            shift[needleLength - 1 - suffixLengths[i]] = needleLength - 1 - i
+        }
+
+        for i in 0..<(needleLength - 1) {
+            shift[i] += needleLength - 1 - i
+        }
+    }
+
+    @_lifetime(span: copy span)
+    private static func _reverse(_ span: inout MutableSpan<Int>) {
+        var lowerBound = 0
+        var upperBound = span.count - 1
+
+        while lowerBound < upperBound {
+            let tmp = span[lowerBound]
+            span[lowerBound] = span[upperBound]
+            span[upperBound] = tmp
+            lowerBound += 1
+            upperBound -= 1
+        }
+    }
+}

--- a/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
+++ b/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
@@ -12,79 +12,87 @@
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
-    func _searchBoyerMoore(_ needle: borrowing Span<UInt8>, in searchRange: Range<Index>, backwards: Bool) -> Range<Index>? {
+    func _searchBoyerMoore(_ needle: Span<UInt8>, in searchRange: Range<Index>, backwards: Bool) -> Range<Index>? {
         let haystack = span.extracting(_rangeRelativeToStartIndex(searchRange))
         let needleLength = needle.count
 
-        var badCharacterShift = ContiguousArray(repeating: needleLength, count: Int(UInt8.max) + 1)
-        var goodSubstringShift = ContiguousArray(repeating: needleLength, count: needleLength)
-        var suffixLengths = ContiguousArray(repeating: 0, count: needleLength)
+        var badCharacterShift: InlineArray<256, Int> = .init(repeating: needleLength)
         var badCharacterShiftSpan = badCharacterShift.mutableSpan
-        var goodSubstringShiftSpan = goodSubstringShift.mutableSpan
-        var suffixLengthsSpan = suffixLengths.mutableSpan
 
         Self._computeBadCharacterShift(for: needle, backwards: backwards, into: &badCharacterShiftSpan)
-        Self._computeGoodSubstringShift(
-            for: needle,
-            backwards: backwards,
-            shift: &goodSubstringShiftSpan,
-            suffixLengths: &suffixLengthsSpan
-        )
 
-        if backwards {
-            var scanNeedle = 0
-            var scanHaystack = haystack.count - needleLength
+        return withUnsafeTemporaryAllocation(of: Int.self, capacity: needleLength) { goodSubstringShift in
+            goodSubstringShift.initialize(repeating: needleLength)
 
-            while scanHaystack >= 0, scanNeedle < needleLength {
-                if haystack[scanHaystack] == needle[scanNeedle] {
-                    scanHaystack += 1
-                    scanNeedle += 1
+            return withUnsafeTemporaryAllocation(of: Int.self, capacity: needleLength) { suffixLengths in
+                suffixLengths.initialize(repeating: 0)
+
+                var goodSubstringShiftSpan = goodSubstringShift.mutableSpan
+                var suffixLengthsSpan = suffixLengths.mutableSpan
+
+                Self._computeGoodSubstringShift(
+                    for: needle,
+                    backwards: backwards,
+                    shift: &goodSubstringShiftSpan,
+                    suffixLengths: &suffixLengthsSpan
+                )
+
+                if backwards {
+                    var scanNeedle = 0
+                    var scanHaystack = haystack.count - needleLength
+
+                    while scanHaystack >= 0, scanNeedle < needleLength {
+                        if haystack[scanHaystack] == needle[scanNeedle] {
+                            scanHaystack += 1
+                            scanNeedle += 1
+                        } else {
+                            let shift = Swift.max(
+                                badCharacterShift[Int(haystack[scanHaystack])],
+                                goodSubstringShift[scanNeedle]
+                            )
+                            scanHaystack -= shift
+                            scanNeedle = 0
+                        }
+                    }
+
+                    guard scanNeedle == needleLength else {
+                        return nil
+                    }
+
+                    let lowerBound = searchRange.lowerBound + scanHaystack - needleLength
+                    return lowerBound..<(lowerBound + needleLength)
                 } else {
-                    let shift = Swift.max(
-                        badCharacterShift[Int(haystack[scanHaystack])],
-                        goodSubstringShift[scanNeedle]
-                    )
-                    scanHaystack -= shift
-                    scanNeedle = 0
+                    var scanNeedle = needleLength - 1
+                    var scanHaystack = needleLength - 1
+
+                    while scanHaystack < haystack.count, scanNeedle >= 0 {
+                        if haystack[scanHaystack] == needle[scanNeedle] {
+                            scanHaystack -= 1
+                            scanNeedle -= 1
+                        } else {
+                            let shift = Swift.max(
+                                badCharacterShift[Int(haystack[scanHaystack])],
+                                goodSubstringShift[scanNeedle]
+                            )
+                            scanHaystack += shift
+                            scanNeedle = needleLength - 1
+                        }
+                    }
+
+                    guard scanNeedle < 0 else {
+                        return nil
+                    }
+
+                    let lowerBound = searchRange.lowerBound + scanHaystack + 1
+                    return lowerBound..<(lowerBound + needleLength)
                 }
             }
-
-            guard scanNeedle == needleLength else {
-                return nil
-            }
-
-            let lowerBound = searchRange.lowerBound + scanHaystack - needleLength
-            return lowerBound..<(lowerBound + needleLength)
-        } else {
-            var scanNeedle = needleLength - 1
-            var scanHaystack = needleLength - 1
-
-            while scanHaystack < haystack.count, scanNeedle >= 0 {
-                if haystack[scanHaystack] == needle[scanNeedle] {
-                    scanHaystack -= 1
-                    scanNeedle -= 1
-                } else {
-                    let shift = Swift.max(
-                        badCharacterShift[Int(haystack[scanHaystack])],
-                        goodSubstringShift[scanNeedle]
-                    )
-                    scanHaystack += shift
-                    scanNeedle = needleLength - 1
-                }
-            }
-
-            guard scanNeedle < 0 else {
-                return nil
-            }
-
-            let lowerBound = searchRange.lowerBound + scanHaystack + 1
-            return lowerBound..<(lowerBound + needleLength)
         }
     }
 
     @_lifetime(badCharacterShift: copy badCharacterShift)
     private static func _computeBadCharacterShift(
-        for needle: borrowing Span<UInt8>,
+        for needle: Span<UInt8>,
         backwards: Bool,
         into badCharacterShift: inout MutableSpan<Int>
     ) {
@@ -102,24 +110,26 @@ extension Data {
     @_lifetime(shift: copy shift)
     @_lifetime(suffixLengths: copy suffixLengths)
     private static func _computeGoodSubstringShift(
-        for needle: borrowing Span<UInt8>,
+        for needle: Span<UInt8>,
         backwards: Bool,
         shift: inout MutableSpan<Int>,
         suffixLengths: inout MutableSpan<Int>
     ) {
         if backwards {
-            var reversedNeedle = ContiguousArray(repeating: UInt8.zero, count: needle.count)
-            var reversedNeedleSpan = reversedNeedle.mutableSpan
-            for i in 0..<needle.count {
-                reversedNeedleSpan[i] = needle[needle.count - 1 - i]
-            }
+            // To get the correct shift table for backwards search reverse the needle, compute the forwards shift
+            // table, and then reverse the result.
+            withUnsafeTemporaryAllocation(of: UInt8.self, capacity: needle.count) { reversedNeedle in
+                for offset in 0..<needle.count {
+                    reversedNeedle.initializeElement(at: offset, to: needle[needle.count - 1 - offset])
+                }
 
-            Self._computeGoodSubstringShift(
-                for: reversedNeedleSpan.span,
-                shift: &shift,
-                suffixLengths: &suffixLengths
-            )
-            Self._reverse(&shift)
+                Self._computeGoodSubstringShift(
+                    for: reversedNeedle.span,
+                    shift: &shift,
+                    suffixLengths: &suffixLengths
+                )
+                Self._reverse(&shift)
+            }
         } else {
             Self._computeGoodSubstringShift(
                 for: needle,
@@ -132,47 +142,56 @@ extension Data {
     @_lifetime(shift: copy shift)
     @_lifetime(suffixLengths: copy suffixLengths)
     private static func _computeGoodSubstringShift(
-        for needle: borrowing Span<UInt8>,
+        for needle: Span<UInt8>,
         shift: inout MutableSpan<Int>,
         suffixLengths: inout MutableSpan<Int>
     ) {
         let needleLength = needle.count
 
-        var f = needleLength - 1
-        var g = needleLength - 1
+        // Compute suffix lengths
+
+        var matchEnd = needleLength - 1
+        var matchBound = needleLength - 1
         suffixLengths[needleLength - 1] = needleLength
 
-        for i in (0..<(needleLength - 1)).reversed() {
-            if i > g, suffixLengths[i + needleLength - 1 - f] < i - g {
-                suffixLengths[i] = suffixLengths[i + needleLength - 1 - f]
+        for candidateEnd in (0..<(needleLength - 1)).reversed() {
+            if candidateEnd > matchBound,
+               suffixLengths[candidateEnd + needleLength - 1 - matchEnd] < candidateEnd - matchBound {
+                suffixLengths[candidateEnd] = suffixLengths[candidateEnd + needleLength - 1 - matchEnd]
             } else {
-                if i < g {
-                    g = i
+                if candidateEnd < matchBound {
+                    matchBound = candidateEnd
                 }
-                f = i
-                while g >= 0, needle[g] == needle[g + needleLength - 1 - f] {
-                    g -= 1
+                matchEnd = candidateEnd
+                while matchBound >= 0, needle[matchBound] == needle[matchBound + needleLength - 1 - matchEnd] {
+                    matchBound -= 1
                 }
-                suffixLengths[i] = f - g
+                suffixLengths[candidateEnd] = matchEnd - matchBound
             }
         }
 
-        var j = 0
+        // Compute shift table
+
+        var shiftIndex = 0
         for i in (0..<needleLength).reversed() {
             if suffixLengths[i] == i + 1 {
-                while j < needleLength - 1 - i {
-                    if shift[j] == needleLength {
-                        shift[j] = needleLength - 1 - i
+                while shiftIndex < needleLength - 1 - i {
+                    if shift[shiftIndex] == needleLength {
+                        shift[shiftIndex] = needleLength - 1 - i
                     }
-                    j += 1
+                    shiftIndex += 1
                 }
             }
         }
 
+        // Set the amount of shift necessary to move each of the suffix matches found into a position where it
+        // overlaps with the suffix. If there are duplicate matches the latest one is the one that should take effect.
         for i in 0..<(needleLength - 1) {
             shift[needleLength - 1 - suffixLengths[i]] = needleLength - 1 - i
         }
 
+        // Since the Boyer-Moore algorithm moves the pointer back while scanning substrings, add the distance to the
+        // end of the potential substring.
         for i in 0..<(needleLength - 1) {
             shift[i] += needleLength - 1 - i
         }

--- a/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
+++ b/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
@@ -42,13 +42,18 @@ extension Data {
                     var scanHaystack = haystack.count - needleLength
 
                     while scanHaystack >= 0, scanNeedle < needleLength {
-                        if haystack[scanHaystack] == needle[scanNeedle] {
+                        // Use unchecked accesses in this descending search loop to avoid bounds checks that are not
+                        // currently eliminated. scanNeedle is guarded by the loop condition. scanHaystack starts at
+                        // the last possible match position; matches advance it in lockstep with scanNeedle, and
+                        // mismatches are revalidated by the loop condition.
+                        let haystackByte = haystack[unchecked: scanHaystack]
+                        if haystackByte == needle[unchecked: scanNeedle] {
                             scanHaystack += 1
                             scanNeedle += 1
                         } else {
                             let shift = Swift.max(
-                                badCharacterShift[Int(haystack[scanHaystack])],
-                                goodSubstringShift[scanNeedle]
+                                badCharacterShift[Int(haystackByte)],
+                                goodSubstringShiftSpan[unchecked: scanNeedle]
                             )
                             scanHaystack -= shift
                             scanNeedle = 0
@@ -97,8 +102,11 @@ extension Data {
         into badCharacterShift: inout MutableSpan<Int>
     ) {
         if backwards {
-            for i in (0..<needle.count).reversed() {
-                badCharacterShift[Int(needle[i])] = i
+            var i = needle.count
+            while i > 0 {
+                i -= 1
+                // i is decremented from needle.count before indexing, so it is always in 0..<needle.count.
+                badCharacterShift[Int(needle[unchecked: i])] = i
             }
         } else {
             for i in 0..<needle.count {
@@ -120,7 +128,8 @@ extension Data {
             // table, and then reverse the result.
             withUnsafeTemporaryAllocation(of: UInt8.self, capacity: needle.count) { reversedNeedle in
                 for offset in 0..<needle.count {
-                    reversedNeedle.initializeElement(at: offset, to: needle[needle.count - 1 - offset])
+                    // offset is in 0..<needle.count, so the mirrored index is in the same range.
+                    reversedNeedle.initializeElement(at: offset, to: needle[unchecked: needle.count - 1 - offset])
                 }
 
                 Self._computeGoodSubstringShift(
@@ -154,30 +163,41 @@ extension Data {
         var matchBound = needleLength - 1
         suffixLengths[needleLength - 1] = needleLength
 
-        for candidateEnd in (0..<(needleLength - 1)).reversed() {
+        var candidateEnd = needleLength - 1
+        while candidateEnd > 0 {
+            candidateEnd -= 1
+            // candidateEnd walks down through 0..<(needleLength - 1). The Boyer-Moore suffix invariants keep
+            // matchEnd in candidateEnd..<needleLength, so the derived suffix index is in 0..<needleLength.
             if candidateEnd > matchBound,
-               suffixLengths[candidateEnd + needleLength - 1 - matchEnd] < candidateEnd - matchBound {
-                suffixLengths[candidateEnd] = suffixLengths[candidateEnd + needleLength - 1 - matchEnd]
+               suffixLengths[unchecked: candidateEnd + needleLength - 1 - matchEnd] < candidateEnd - matchBound {
+                suffixLengths[unchecked: candidateEnd] = suffixLengths[unchecked: candidateEnd + needleLength - 1 - matchEnd]
             } else {
                 if candidateEnd < matchBound {
                     matchBound = candidateEnd
                 }
                 matchEnd = candidateEnd
-                while matchBound >= 0, needle[matchBound] == needle[matchBound + needleLength - 1 - matchEnd] {
+                // matchBound is checked before indexing and then only decreases. The paired suffix index is bounded
+                // by matchEnd, keeping both needle indices in 0..<needleLength while the loop runs.
+                while matchBound >= 0, needle[unchecked: matchBound] == needle[unchecked: matchBound + needleLength - 1 - matchEnd] {
                     matchBound -= 1
                 }
-                suffixLengths[candidateEnd] = matchEnd - matchBound
+                // candidateEnd is produced by the descending loop above, so it is in bounds.
+                suffixLengths[unchecked: candidateEnd] = matchEnd - matchBound
             }
         }
 
         // Compute shift table
 
         var shiftIndex = 0
-        for i in (0..<needleLength).reversed() {
-            if suffixLengths[i] == i + 1 {
+        var i = needleLength
+        while i > 0 {
+            i -= 1
+            // i is decremented from needleLength before indexing, so it is always in 0..<needleLength.
+            if suffixLengths[unchecked: i] == i + 1 {
                 while shiftIndex < needleLength - 1 - i {
-                    if shift[shiftIndex] == needleLength {
-                        shift[shiftIndex] = needleLength - 1 - i
+                    // shiftIndex is strictly less than needleLength - 1 - i, which is at most needleLength - 1.
+                    if shift[unchecked: shiftIndex] == needleLength {
+                        shift[unchecked: shiftIndex] = needleLength - 1 - i
                     }
                     shiftIndex += 1
                 }
@@ -203,9 +223,11 @@ extension Data {
         var upperBound = span.count - 1
 
         while lowerBound < upperBound {
-            let tmp = span[lowerBound]
-            span[lowerBound] = span[upperBound]
-            span[upperBound] = tmp
+            // lowerBound and upperBound move toward each other from valid endpoints, and the loop stops before
+            // they cross.
+            let tmp = span[unchecked: lowerBound]
+            span[unchecked: lowerBound] = span[unchecked: upperBound]
+            span[unchecked: upperBound] = tmp
             lowerBound += 1
             upperBound -= 1
         }

--- a/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
+++ b/Sources/FoundationEssentials/Data/Data+Searching+BoyerMoore.swift
@@ -161,9 +161,7 @@ extension Data {
         var matchBound = needleLength - 1
         suffixLengths[needleLength - 1] = needleLength
 
-        var candidateEnd = needleLength - 1
-        while candidateEnd > 0 {
-            candidateEnd -= 1
+        for candidateEnd in (0..<(needleLength - 1)).reversed() {
             // candidateEnd walks down through 0..<(needleLength - 1). The Boyer-Moore suffix invariants keep
             // matchEnd in candidateEnd..<needleLength, so the derived suffix index is in 0..<needleLength.
             if candidateEnd > matchBound,
@@ -187,10 +185,8 @@ extension Data {
         // Compute shift table
 
         var shiftIndex = 0
-        var i = needleLength
-        while i > 0 {
-            i -= 1
-            // i is decremented from needleLength before indexing, so it is always in 0..<needleLength.
+        for i in (0..<needleLength).reversed() {
+            // i stays within 0..<needleLength, so safe to use the unchecked subscript.
             if suffixLengths[unchecked: i] == i + 1 {
                 while shiftIndex < needleLength - 1 - i {
                     // shiftIndex is strictly less than needleLength - 1 - i, which is at most needleLength - 1.

--- a/Sources/FoundationEssentials/Data/Data+Searching.swift
+++ b/Sources/FoundationEssentials/Data/Data+Searching.swift
@@ -19,7 +19,7 @@ extension Data {
     /// Options that control a data search operation.
     public struct SearchOptions : OptionSet, Sendable {
         public let rawValue: UInt
-        
+
         public init(rawValue: UInt) {
             self.rawValue = rawValue
         }
@@ -38,20 +38,53 @@ extension Data {
     /// - returns: A `Range` specifying the location of the found data, or nil if a match could not be found.
     /// - precondition: `range` must be in the bounds of the Data.
     public func range(of dataToFind: Data, options: Data.SearchOptions = [], in range: Range<Index>? = nil) -> Range<Index>? {
-        let searchRange = range ?? startIndex..<endIndex
+        let needleLength = dataToFind.count
+        guard needleLength > 0, count > 0 else {
+            return nil
+        }
+
+        var searchRange = range ?? startIndex..<endIndex
+
+        precondition(searchRange.lowerBound >= startIndex && searchRange.upperBound <= endIndex, "Range out of bounds")
+
+        let searchRangeLength = searchRange.count
+
+        guard searchRangeLength >= needleLength else {
+            return nil
+        }
+
         let searchBackwards = options.contains(.backwards)
         let isAnchored = options.contains(.anchored)
 
-        let foundRange = searchBackwards
-            ? lastRange(of: dataToFind, in: searchRange)
-            : firstRange(of: dataToFind, in: searchRange)
-
-        return foundRange.flatMap { found in
-            guard isAnchored else { return found }
+        if isAnchored, searchRangeLength > needleLength {
             if searchBackwards {
-                return found.upperBound == searchRange.upperBound ? found : nil
+                searchRange = (searchRange.upperBound - needleLength)..<searchRange.upperBound
+            } else {
+                searchRange = searchRange.lowerBound..<(searchRange.lowerBound + needleLength)
             }
-            return found.lowerBound == searchRange.lowerBound ? found : nil
         }
+
+        if searchRange.count == needleLength {
+            return span.extracting(_rangeRelativeToStartIndex(searchRange)).elementsEqual(dataToFind.span) ? searchRange : nil
+        }
+
+        if needleLength == 1 {
+            return _searchSingleByte(dataToFind[0], in: searchRange, backwards: searchBackwards)
+        }
+
+        return _searchBoyerMoore(dataToFind.span, in: searchRange, backwards: searchBackwards)
+    }
+
+    private func _searchSingleByte(_ byte: UInt8, in searchRange: Range<Index>, backwards: Bool) -> Range<Index>? {
+        let haystack = span.extracting(_rangeRelativeToStartIndex(searchRange))
+        let offset = backwards ? haystack.lastIndex(of: byte) : haystack.firstIndex(of: byte)
+        return offset.map { offset in
+            let lowerBound = searchRange.lowerBound + offset
+            return lowerBound..<(lowerBound + 1)
+        }
+    }
+
+    func _rangeRelativeToStartIndex(_ range: Range<Index>) -> Range<Int> {
+        (range.lowerBound - startIndex)..<(range.upperBound - startIndex)
     }
 }

--- a/Sources/FoundationEssentials/Data/Data+Searching.swift
+++ b/Sources/FoundationEssentials/Data/Data+Searching.swift
@@ -15,32 +15,7 @@ extension Data {
 #if FOUNDATION_FRAMEWORK
     /// Options that control a data search operation.
     public typealias SearchOptions = NSData.SearchOptions
-    
-    /// Finds the range of the specified data as a subsequence of this data, if it exists.
-    ///
-    /// - parameter dataToFind: The data to be searched for.
-    /// - parameter options: Options for the search. Default value is `[]`.
-    /// - parameter range: The range of this data in which to perform the search. Default value is `nil`, which means the entire content of this data.
-    /// - returns: A `Range` specifying the location of the found data, or nil if a match could not be found.
-    /// - precondition: `range` must be in the bounds of the Data.
-    public func range(of dataToFind: Data, options: Data.SearchOptions = [], in range: Range<Index>? = nil) -> Range<Index>? {
-        let nsRange : NSRange
-        if let r = range {
-            nsRange = NSRange(location: r.lowerBound - startIndex, length: r.upperBound - r.lowerBound)
-        } else {
-            nsRange = NSRange(location: 0, length: count)
-        }
-        let nsData = self as NSData
-        let opts = NSData.SearchOptions(rawValue: options.rawValue)
-        let result = nsData.range(of: dataToFind, options: opts, in: nsRange)
-        if result.location == NSNotFound {
-            return nil
-        }
-        return (result.location + startIndex)..<((result.location + startIndex) + result.length)
-    }
 #else
-    // TODO: Implement range(of:options:in:) for Foundation package.
-    
     /// Options that control a data search operation.
     public struct SearchOptions : OptionSet, Sendable {
         public let rawValue: UInt
@@ -54,4 +29,29 @@ extension Data {
         public static let anchored  = SearchOptions(rawValue: 1 << 1)
     }
 #endif
+
+    /// Find the given `Data` in the content of this `Data`.
+    ///
+    /// - parameter dataToFind: The data to be searched for.
+    /// - parameter options: Options for the search. Default value is `[]`.
+    /// - parameter range: The range of this data in which to perform the search. Default value is `nil`, which means the entire content of this data.
+    /// - returns: A `Range` specifying the location of the found data, or nil if a match could not be found.
+    /// - precondition: `range` must be in the bounds of the Data.
+    public func range(of dataToFind: Data, options: Data.SearchOptions = [], in range: Range<Index>? = nil) -> Range<Index>? {
+        let searchRange = range ?? startIndex..<endIndex
+        let searchBackwards = options.contains(.backwards)
+        let isAnchored = options.contains(.anchored)
+
+        let foundRange = searchBackwards
+            ? lastRange(of: dataToFind, in: searchRange)
+            : firstRange(of: dataToFind, in: searchRange)
+
+        return foundRange.flatMap { found in
+            guard isAnchored else { return found }
+            if searchBackwards {
+                return found.upperBound == searchRange.upperBound ? found : nil
+            }
+            return found.lowerBound == searchRange.lowerBound ? found : nil
+        }
+    }
 }

--- a/Sources/FoundationEssentials/Span+Utils.swift
+++ b/Sources/FoundationEssentials/Span+Utils.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 extension Span<UInt8> {
-    @inline(__always)
     func firstIndex(of byte: UInt8) -> Int? {
         guard !isEmpty else {
             return nil
@@ -28,12 +27,10 @@ extension Span<UInt8> {
         return nil
     }
 
-    @inline(__always)
     func lastIndex(of byte: UInt8) -> Int? {
         lastIndex { $0 == byte }
     }
 
-    @inline(__always)
     func lastIndex(where predicate: (UInt8) throws -> Bool) rethrows -> Int? {
         guard !isEmpty else {
             return nil
@@ -50,7 +47,6 @@ extension Span<UInt8> {
         return nil
     }
 
-    @inline(__always)
     func elementsEqual(_ other: Span<UInt8>) -> Bool {
         guard count == other.count else {
             return false
@@ -83,7 +79,6 @@ extension Span<UInt8> {
         return self[count - 1]
     }
 
-    @inline(__always)
     func contains(_ byte: UInt8) -> Bool {
         for i in indices {
             if self[i] == byte {

--- a/Sources/FoundationEssentials/Span+Utils.swift
+++ b/Sources/FoundationEssentials/Span+Utils.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Span<UInt8> {
+    @inline(__always)
+    func firstIndex(of byte: UInt8) -> Int? {
+        guard !isEmpty else {
+            return nil
+        }
+
+        var i = 0
+        while i < count {
+            if self[i] == byte {
+                return i
+            }
+            i += 1
+        }
+
+        return nil
+    }
+
+    @inline(__always)
+    func lastIndex(of byte: UInt8) -> Int? {
+        lastIndex { $0 == byte }
+    }
+
+    @inline(__always)
+    func lastIndex(where predicate: (UInt8) throws -> Bool) rethrows -> Int? {
+        guard !isEmpty else {
+            return nil
+        }
+
+        var i = count - 1
+        while i >= 0 {
+            if try predicate(self[i]) {
+                return i
+            }
+            i -= 1
+        }
+
+        return nil
+    }
+
+    @inline(__always)
+    func elementsEqual(_ other: Span<UInt8>) -> Bool {
+        guard count == other.count else {
+            return false
+        }
+
+        var i = 0
+        while i < count {
+            if self[i] != other[i] {
+                return false
+            }
+            i += 1
+        }
+
+        return true
+    }
+
+    @inline(__always)
+    var first: UInt8? {
+        guard count > 0 else {
+            return nil
+        }
+        return self[0]
+    }
+
+    @inline(__always)
+    var last: UInt8? {
+        guard count > 0 else {
+            return nil
+        }
+        return self[count - 1]
+    }
+
+    @inline(__always)
+    func contains(_ byte: UInt8) -> Bool {
+        for i in indices {
+            if self[i] == byte {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Sources/FoundationEssentials/String/Span+Path.swift
+++ b/Sources/FoundationEssentials/String/Span+Path.swift
@@ -218,26 +218,6 @@ extension Span<UInt8> {
         return lastDot
     }
 
-    func lastIndex(of byte: UInt8) -> Int? {
-        lastIndex { $0 == byte }
-    }
-
-    func lastIndex(where predicate: (UInt8) throws -> Bool) rethrows -> Int? {
-        guard !isEmpty else {
-            return nil
-        }
-
-        var i = count - 1
-        while i >= 0 {
-            if try predicate(self[i]) {
-                return i
-            }
-            i -= 1
-        }
-
-        return nil
-    }
-
     @inline(__always)
     func starts(with prefix: StaticString) -> Bool {
         let prefixLength = prefix.utf8CodeUnitCount
@@ -248,26 +228,4 @@ extension Span<UInt8> {
             memcmp(buffer.baseAddress.unsafelyUnwrapped, prefix.utf8Start, prefixLength) == 0
         }
     }
-
-    @inline(__always)
-    var first: UInt8? {
-        guard count > 0 else { return nil }
-        return self[0]
-    }
-
-    @inline(__always)
-    var last: UInt8? {
-        guard count > 0 else { return nil }
-        return self[count - 1]
-    }
-
-    func contains(_ byte: UInt8) -> Bool {
-        for i in indices {
-            if self[i] == byte {
-                return true
-            }
-        }
-        return false
-    }
-
 }

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2919,7 +2919,6 @@ extension DataTests {
     }
 }
 
-#if FOUNDATION_FRAMEWORK // FIXME: Re-enable tests once range(of:) is implemented
 extension DataTests {
     @Test func range() {
         let helloWorld = dataFrom("Hello World")
@@ -2965,7 +2964,6 @@ extension DataTests {
         #expect(range == 4..<5 as Range<Data.Index>)
     }
 }
-#endif // FOUNDATION_FRAMEWORK
 
 #if FOUNDATION_FRAMEWORK // Bridging is not available in the FoundationPreview package
 extension DataTests {

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2941,6 +2941,43 @@ extension DataTests {
         }
     }
 
+    @Test func rangeBoyerMoore() {
+        let haystack = dataFrom("abcxxxabcxxxxabc")
+        let needle = dataFrom("abc")
+
+        #expect(haystack.range(of: needle) == 0..<3)
+        #expect(haystack.range(of: needle, options: .backwards) == 13..<16)
+        #expect(haystack.range(of: needle, in: 1..<haystack.count) == 6..<9)
+        #expect(haystack.range(of: needle, options: .backwards, in: 0..<12) == 6..<9)
+    }
+
+    @Test func rangeBoyerMooreOverlaps() {
+        let repeated = dataFrom("aaaaa")
+        let tripleA = dataFrom("aaa")
+        let prefix = dataFrom("aab")
+        let suffix = dataFrom("baa")
+        let doubleA = dataFrom("aa")
+
+        #expect(repeated.range(of: tripleA) == 0..<3)
+        #expect(repeated.range(of: tripleA, options: .backwards) == 2..<5)
+
+        #expect(prefix.range(of: doubleA) == 0..<2)
+        #expect(prefix.range(of: doubleA, options: .backwards) == 0..<2)
+
+        #expect(suffix.range(of: doubleA) == 1..<3)
+        #expect(suffix.range(of: doubleA, options: .backwards) == 1..<3)
+    }
+
+    @Test func rangeAnchored() {
+        let haystack = dataFrom("xxabcxxabc")
+        let needle = dataFrom("abc")
+
+        #expect(haystack.range(of: needle, options: .anchored) == nil)
+        #expect(haystack.range(of: needle, options: [.anchored], in: 2..<haystack.count) == 2..<5)
+        #expect(haystack.range(of: needle, options: [.backwards, .anchored]) == 7..<10)
+        #expect(haystack.range(of: needle, options: [.backwards, .anchored], in: 0..<5) == 2..<5)
+    }
+
     @Test func replaceSubrange2() {
         let hello = dataFrom("Hello")
         let world = dataFrom(" World")

--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -547,8 +547,6 @@ private struct PropertyListEncoderTests {
         }
     }
 
-#if FOUNDATION_FRAMEWORK
-    // TODO: Depends on data's range(of:) implementation
     @Test func nonStringDictionaryKey() throws {
         let decoder = PropertyListDecoder()
         let encoder = PropertyListEncoder()
@@ -567,7 +565,6 @@ private struct PropertyListEncoderTests {
             try decoder.decode([String:String].self, from: xmlData)
         }
     }
-#endif
 
     struct GenericProperties : Decodable {
         var assertionFailure: String?


### PR DESCRIPTION
Implement `Data.range(of:options:in:)` for non-Darwin platforms

### Motivation:

`Data.range(of:options:in:)` was only available when building with `FOUNDATION_FRAMEWORK`, leaving non-Darwin platforms without this API. This implements it in pure Swift using the existing `firstRange`/`lastRange` primitives on `DataProtocol`.

### Modifications:

* Provides a pure Swift implementation of `range(of:options:in:)` previously missing outside of FOUNDATION_FRAMEWORK, supporting the `.backwards` and `.anchored` search options.
* Re-enables associated tests previously gated behind FOUNDATION_FRAMEWORK.

### Result:

`Data.range(of:options:in:)` is now available on all platforms. The `SearchOptions` type definition remains platform-conditional (typealias to `NSData.SearchOptions` on Darwin, own `OptionSet` elsewhere), but the function implementation is shared across all platforms.

### Testing:

Re-enabled existing tests in `DataTests` and `PropertyListEncoderTests`  that were previously gated behind `FOUNDATION_FRAMEWORK`.