### PR TITLE
Update proposal reference from SF-0034 to SF-0038

### DIFF
--- a/Proposals/0037-generalize-closure-based-functions-in-Data.md
+++ b/Proposals/0037-generalize-closure-based-functions-in-Data.md
@@ -1,6 +1,6 @@
 # Generalize closure-based functions of `Data`
 
-* Proposal: [SF-0034](0034-generalize-closure-based-functions-in-Data.md)
+* Proposal: [SF-0037](0037-generalize-closure-based-functions-in-Data.md)
 * Authors: [Guillaume Lessard](https://github.com/glessard)
 * Review Manager: TBD
 * Status: **Awaiting implementation** or **Awaiting review**

--- a/Proposals/0038-generalize-closure-based-functions-in-Data.md
+++ b/Proposals/0038-generalize-closure-based-functions-in-Data.md
@@ -1,6 +1,6 @@
 # Generalize closure-based functions of `Data`
 
-* Proposal: [SF-0037](0037-generalize-closure-based-functions-in-Data.md)
+* Proposal: [SF-0038](0038-generalize-closure-based-functions-in-Data.md)
 * Authors: [Guillaume Lessard](https://github.com/glessard)
 * Review Manager: TBD
 * Status: **Awaiting implementation** or **Awaiting review**


### PR DESCRIPTION
### Description:
Current we have 2 SF-0034 in Proposals, "Generalize closure-based functions of Data" is waiting for review and implement. So I would like to index it to SF-0037.

### Modifications:

+ 0034-generalize-closure-based-functions-in-Data.md => 0037-generalize-closure-based-functions-in-Data.md

### Result:

+ Correct Index of Proposals that is only one 0034 existing.
