### PR TITLE
Do not attempt to use `FICLONE` on Linux+Musl.

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -906,7 +906,7 @@ enum _FileOperations {
 
         // Attempt to clone the file using platform-specific API. If this operation fails, don't throw
         // an error and just fall back to chunked writes.
-        #if os(Linux)
+        #if os(Linux) && canImport(Glibc)
         if ioctl(dstfd, _filemanager_shims_FICLONE(), srcfd) != -1 {
             return
         }

--- a/Sources/_FoundationCShims/include/filemanager_shims.h
+++ b/Sources/_FoundationCShims/include/filemanager_shims.h
@@ -47,7 +47,7 @@
 extern int _mkpath_np(const char *path, mode_t omode, const char **firstdir);
 #endif
 
-#if TARGET_OS_LINUX
+#if TARGET_OS_LINUX && __has_include(<linux/fs.h>)
 #include <linux/fs.h>
 
 static inline unsigned long _filemanager_shims_FICLONE(void) { return FICLONE; }


### PR DESCRIPTION
The header that defines `FICLONE`, `<linux/fs.h>`, is not available when building the static SDK on Linux with Musl, so don't try to use it there.