### PR TITLE
[6.3] Avoid corruption when downsizing Data via replaceSubrange

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: Test (SwiftPM)
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.10
     with:
       linux_swift_versions: '["nightly-6.3"]'
       windows_swift_versions: '["nightly-6.3"]'
@@ -44,7 +44,7 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.10
     with:
       license_header_check_project_name: "Swift.org"
       license_header_check_enabled: false

--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,7 @@ if let useLocalDepsEnv = Context.environment["SWIFTCI_USE_LOCAL_DEPS"], !useLoca
         [
             .package(
                 url: "https://github.com/apple/swift-collections",
-                from: "1.1.0"),
+                exact: "1.1.6"),
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
                 branch: "main"),

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -1734,8 +1734,8 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
                             if subrange.lowerBound > 0 {
                                 inlineBuffer.baseAddress?.copyMemory(from: buffer.baseAddress!, byteCount: subrange.lowerBound)
                             }
-                            if subrange.upperBound < resultingUpper {
-                                inlineBuffer.baseAddress?.advanced(by: subrange.upperBound).copyMemory(from: buffer.baseAddress!.advanced(by: subrange.upperBound), byteCount: resultingUpper - subrange.upperBound)
+                            if subrange.upperBound < slice.endIndex {
+                                inlineBuffer.baseAddress?.advanced(by: subrange.lowerBound + cnt).copyMemory(from: buffer.baseAddress!.advanced(by: subrange.upperBound), byteCount: slice.endIndex - subrange.upperBound)
                             }
                         }
                     }

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2639,4 +2639,20 @@ struct LargeDataTests {
             #expect($0.baseAddress == originalPointer)
         }
     }
+
+    @Test func downgradeLargeToInline() {
+        var large = Data(capacity: largeCount)
+        large.append(0xAA)
+        #expect(large.count == 1)
+        #expect(large[0] == 0xAA)
+
+        large = Data(count: largeCount)
+        large[large.count - 1] = 0xCC
+        large[0] = 0xAA
+        large.replaceSubrange(1 ..< large.count - 1, with: CollectionOfOne(0xBB))
+        #expect(large.count == 3)
+        #expect(large[0] == 0xAA)
+        #expect(large[1] == 0xBB)
+        #expect(large[2] == 0xCC)
+    }
 }


### PR DESCRIPTION
Avoids memory corruption when a `Data` is downsized from a large slice to an inline representation

### Motivation:

When downsizing a `Data` from a large slice to an inline slice, the implementation copies over 3 chunks of bytes:

- The bytes prior to the replacement
- The bytes of the replacement
- The bytes after the replacement

Due to some incorrect indexing math, the third segment above is written over the replaced bytes leading to data corruption.

### Modifications:

Corrected the index arithmetic of these buffer copies

### Result:

Data is copied correctly and no longer corrupted

Resolves #1900 

### Testing:

Additional unit test added

### Future Directions:

In the future, we can investigate updating the `Data` implementation to avoid downsizing entirely (like other collection types) so that manually set capacities are not thrown away by RRC calls.
