### PR TITLE
Mark legacy ABI as obsoleted rather than as spi

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -501,9 +501,13 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
 
 #if DATA_LEGACY_ABI
     @abi(func withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R)
-    @_spi(FoundationLegacyABI)
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
     @usableFromInline
-    internal func _legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
+    internal func __legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
         try withUnsafeBytes(body)
     }
 #endif // DATA_LEGACY_ABI
@@ -567,9 +571,13 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
 
 #if DATA_LEGACY_ABI
     @abi(mutating func withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R)
-    @_spi(FoundationLegacyABI)
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
     @usableFromInline
-    internal mutating func _legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
+    internal mutating func __legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
         try withUnsafeMutableBytes(body)
     }
 #endif // DATA_LEGACY_ABI
@@ -672,8 +680,13 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     #if FOUNDATION_FRAMEWORK
-    @usableFromInline // Pre-existing ABI replaced by the below emitted fast paths
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
     @abi(mutating func append(contentsOf bytes: [UInt8]))
+    @usableFromInline // Pre-existing ABI replaced by the below emitted fast paths
     internal mutating func __legacy_append(contentsOf bytes: [UInt8]) {
         self.append(contentsOf: bytes)
     }
@@ -786,8 +799,13 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - precondition: The bounds of `subrange` must be valid indices of the collection.
     /// - parameter subrange: The range in the data to replace. If `subrange.lowerBound == data.count && subrange.count == 0` then this operation is an append.
     /// - parameter data: The replacement data.
-    @usableFromInline // Pre-existing ABI replaced by the below emitted fast paths
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
     @abi(mutating func replaceSubrange(_ subrange: Range<Index>, with data: Data))
+    @usableFromInline // Pre-existing ABI replaced by the below emitted fast paths
     internal mutating func __legacy_replaceSubrange(_ subrange: Range<Index>, with data: Data) {
         self.replaceSubrange(subrange, with: data)
     }

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -162,9 +162,13 @@ extension Data {
         }
 
         @abi(func withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R)
-        @_spi(FoundationLegacyABI)
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @usableFromInline
-        internal func _legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
+        internal func __legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
             try withUnsafeBytes(body)
         }
 
@@ -177,9 +181,13 @@ extension Data {
         }
 
         @abi(mutating func withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R)
-        @_spi(FoundationLegacyABI)
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @usableFromInline
-        internal mutating func _legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
+        internal mutating func __legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
             try withUnsafeMutableBytes(body)
         }
 

--- a/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
@@ -121,9 +121,14 @@ extension Data {
 
         #if FOUNDATION_FRAMEWORK
         // Legacy ABI entry point for clients built against an older @inlinable reserveCapacity
-        @usableFromInline
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @abi(mutating func reserveCapacity(_ minimumCapacity: Int))
-        mutating func __legacy_reserveCapacity(_ minimumCapacity: Int) {
+        @usableFromInline
+        internal mutating func __legacy_reserveCapacity(_ minimumCapacity: Int) {
             reserveCapacity(minimumCapacity)
         }
         #endif
@@ -180,9 +185,13 @@ extension Data {
         }
 
         @abi(func withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R)
-        @_spi(FoundationLegacyABI)
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @usableFromInline
-        internal func _legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
+        internal func __legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
             try withUnsafeBytes(body)
         }
 
@@ -194,9 +203,13 @@ extension Data {
         }
 
         @abi(mutating func withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R)
-        @_spi(FoundationLegacyABI)
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @usableFromInline
-        internal mutating func _legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
+        internal mutating func __legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
             try withUnsafeMutableBytes(body)
         }
 

--- a/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
@@ -120,9 +120,14 @@ extension Data {
 
         #if FOUNDATION_FRAMEWORK
         // Legacy ABI entry point for clients built against an older @inlinable reserveCapacity
-        @usableFromInline
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @abi(mutating func reserveCapacity(_ minimumCapacity: Int))
-        mutating func __legacy_reserveCapacity(_ minimumCapacity: Int) {
+        @usableFromInline
+        internal mutating func __legacy_reserveCapacity(_ minimumCapacity: Int) {
             reserveCapacity(minimumCapacity)
         }
         #endif
@@ -169,9 +174,13 @@ extension Data {
         }
 
         @abi(func withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R)
-        @_spi(FoundationLegacyABI)
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @usableFromInline
-        internal func _legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
+        internal func __legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
             try withUnsafeBytes(body)
         }
 
@@ -183,9 +192,13 @@ extension Data {
         }
 
         @abi(mutating func withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R)
-        @_spi(FoundationLegacyABI)
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @usableFromInline
-        internal mutating func _legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
+        internal mutating func __legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
             try withUnsafeMutableBytes(body)
         }
 

--- a/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
@@ -323,9 +323,13 @@ extension Data {
         }
 
         @abi(func withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R)
-        @_spi(FoundationLegacyABI)
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @usableFromInline
-        internal func _legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
+        internal func __legacy_withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) throws -> ResultType {
             try withUnsafeBytes(body)
         }
 
@@ -353,9 +357,13 @@ extension Data {
         }
 
         @abi(mutating func withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R)
-        @_spi(FoundationLegacyABI)
+        @available(macOS, obsoleted: 1.0)
+        @available(iOS, obsoleted: 1.0)
+        @available(watchOS, obsoleted: 1.0)
+        @available(tvOS, obsoleted: 1.0)
+        @available(visionOS, obsoleted: 1.0)
         @usableFromInline
-        internal mutating func _legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
+        internal mutating func __legacy_withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
             try withUnsafeMutableBytes(body)
         }
 

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -186,9 +186,13 @@ internal final class __DataStorage : @unchecked Sendable {
 
 #if DATA_LEGACY_ABI
     @abi(func withUnsafeBytes<R>(in: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> R) throws -> R)
-    @_spi(FoundationLegacyABI)
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
     @usableFromInline
-    func _legacy_withUnsafeBytes<Result>(in range: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> Result) throws -> Result {
+    func __legacy_withUnsafeBytes<Result>(in range: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> Result) throws -> Result {
         try withUnsafeBytes(in: range, apply: apply)
     }
 #endif // DATA_LEGACY_ABI
@@ -208,9 +212,13 @@ internal final class __DataStorage : @unchecked Sendable {
 
 #if DATA_LEGACY_ABI
     @abi(func withUnsafeMutableBytes<R>(in: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R)
-    @_spi(FoundationLegacyABI)
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
     @usableFromInline
-    internal func _legacy_withUnsafeMutableBytes<ResultType>(in range: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
+    internal func __legacy_withUnsafeMutableBytes<ResultType>(in range: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> ResultType) throws -> ResultType {
         try withUnsafeMutableBytes(in: range, apply: apply)
     }
 #endif // DATA_LEGACY_ABI

--- a/Tests/FoundationEssentialsTests/DataLegacyABITests.swift
+++ b/Tests/FoundationEssentialsTests/DataLegacyABITests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,8 +11,68 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_spi(FoundationLegacyABI) @testable import Foundation
+@testable import Foundation
 import Testing
+
+extension Foundation.Data {
+    @_silgen_name("$s10Foundation4DataV15withUnsafeBytesyxxSWKXEKlF")
+    func __testable_withUnsafeBytes<R>(body: (UnsafeRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation4DataV22withUnsafeMutableBytesyxxSwKXEKlF")
+    mutating func __testable_withUnsafeMutableBytes<R>(body: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation4DataV6append10contentsOfySays5UInt8VG_tF")
+    mutating func __testable_append(contentsOf bytes: [UInt8])
+
+    @_silgen_name("$s10Foundation4DataV15replaceSubrange_4withySnySiG_ACtF")
+    mutating func __testable_replaceSubrange(_ subrange: Range<Data.Index>, with data: Data)
+}
+
+extension Foundation.Data._Representation {
+    @_silgen_name("$s10Foundation4DataV15_RepresentationO15withUnsafeBytesyxxSWKXEKlF")
+    func __testable_withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation4DataV15_RepresentationO22withUnsafeMutableBytesyxxSwKXEKlF")
+    mutating func __testable_withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R
+}
+
+extension Foundation.Data.InlineData {
+    @_silgen_name("$s10Foundation4DataV06InlineB0V15withUnsafeBytesyxxSWKXEKlF")
+    func __testable_withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation4DataV06InlineB0V22withUnsafeMutableBytesyxxSwKXEKlF")
+    mutating func __testable_withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R
+}
+
+extension Foundation.Data.InlineSlice {
+    @_silgen_name("$s10Foundation4DataV11InlineSliceV15withUnsafeBytesyxxSWKXEKlF")
+    func __testable_withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation4DataV11InlineSliceV22withUnsafeMutableBytesyxxSwKXEKlF")
+    mutating func __testable_withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation4DataV11InlineSliceV15reserveCapacityyySiF")
+    mutating func __testable_reserveCapacity(_ minimumCapacity: Int)
+}
+
+extension Foundation.Data.LargeSlice {
+    @_silgen_name("$s10Foundation4DataV10LargeSliceV15withUnsafeBytesyxxSWKXEKlF")
+    func __testable_withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation4DataV10LargeSliceV22withUnsafeMutableBytesyxxSwKXEKlF")
+    mutating func __testable_withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation4DataV10LargeSliceV15reserveCapacityyySiF")
+    mutating func __testable_reserveCapacity(_ minimumCapacity: Int)
+}
+
+extension Foundation.__DataStorage {
+    @_silgen_name("$s10Foundation13__DataStorageC15withUnsafeBytes2in5applyxSnySiG_xSWKXEtKlF")
+    final func __testable_withUnsafeBytes<R>(in: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> R) throws -> R
+
+    @_silgen_name("$s10Foundation13__DataStorageC22withUnsafeMutableBytes2in5applyxSnySiG_xSwKXEtKlF")
+    final func __testable_withUnsafeMutableBytes<R>(in: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R
+}
 
 @Suite("Foundation Legacy ABI")
 private final class FoundationLegacyABITests {
@@ -20,13 +80,131 @@ private final class FoundationLegacyABITests {
     @Test func validateDataLegacyABI() throws {
         var data = Data()
 
-        // Test the existing API
-        data.withUnsafeBytes { _ in }
-        data.withUnsafeMutableBytes { _ in }
+        #expect(data.isEmpty)
+        data.__testable_append(contentsOf: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        #expect(data.count == 10)
 
-        try data._legacy_withUnsafeBytes { _ in }
-        try data._legacy_withUnsafeMutableBytes { _ in }
+        let count1 = try data.__testable_withUnsafeBytes { $0.count }
+        #expect(data[0] == 0)
+        #expect(count1 == Int(10))
+
+        let count2 = try data.__testable_withUnsafeMutableBytes {
+            $0[0] = 42
+            return Double($0.count)
+        }
+        #expect(data[0] == 42)
+        #expect(count2 == 10.0)
+
+        #expect(data.count == 10)
+        data.__testable_replaceSubrange(0..<10, with: Data())
+        #expect(data.isEmpty)
     }
+
+    @Test func validateDataRepresentationLegacyABI() throws {
+        let data = Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        var representation = data._representation
+        let count3 = try representation.__testable_withUnsafeBytes { UInt32($0.count) }
+        #expect(count3 == UInt32(10))
+
+        let count4 = try representation.__testable_withUnsafeMutableBytes {
+            $0[1] = 41
+            return Float($0.count)
+        }
+        #expect(representation[1] == 41)
+        #expect(count4 == 10.0)
+    }
+
+    @Test func validateInlineDataLegacyABI() throws {
+        let data = Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        guard case var .inline(inline) = data._representation else {
+            Issue.record("Unexpected representation of `Data`")
+            return
+        }
+
+        #expect(inline[2] == 2)
+        let count5 = try inline.__testable_withUnsafeBytes { Int16($0.count) }
+        #expect(count5 == Int16(10))
+
+        let count6 = try inline.__testable_withUnsafeMutableBytes {
+            $0[2] = 40
+            return $0.count.leadingZeroBitCount
+        }
+        #expect(inline[2] == 40)
+        #expect(count6 == 10.leadingZeroBitCount)
+    }
+
+    @Test func validateInlineSliceLegacyABI() throws {
+        let data = Data(count: 40)
+        guard case var .slice(slice) = data._representation else {
+            Issue.record("Unexpected representation of `Data`")
+            return
+        }
+
+        #expect(slice.count == 40)
+        let count7 = try slice.__testable_withUnsafeBytes { $0.count.trailingZeroBitCount }
+        #expect(count7 == 40.trailingZeroBitCount)
+
+        let count8 = try slice.__testable_withUnsafeMutableBytes {
+            $0[count7] = 37
+            return ($0.count, $0.count)
+        }
+        #expect(count8.0 == 40)
+
+        #expect(slice.capacity < 200)
+        slice.__testable_reserveCapacity(200)
+        #expect(slice.capacity >= 200)
+    }
+
+    @Test func validateDataStorageLegacyABI() throws {
+        let data = Data(0..<40)
+        let count7 = data.count.trailingZeroBitCount
+        guard case let .slice(slice) = data._representation else {
+            Issue.record("Unexpected representation of `Data`")
+            return
+        }
+
+        let storage = slice.storage
+
+        let count9 = try storage.__testable_withUnsafeBytes(in: count7..<40) {
+            #expect($0[0] == 3)
+            return $0.count
+        }
+        #expect(count9 == 40-count7)
+
+        let countA = try storage.__testable_withUnsafeMutableBytes(in: count7..<40) {
+            $0[0] = 31
+            return ($0.count, Double($0.count.leadingZeroBitCount))
+        }
+        #expect(slice[count7] == 31)
+        #expect(countA.0 == 40-count7)
+    }
+}
+
+extension LargeDataTests {
+    @Test func validateLargeSliceLegacyABI() throws {
+        let data = Data(repeating: 0, count: largeCount)
+        guard case var .large(slice) = data._representation else {
+            Issue.record("Unexpected representation of `Data`")
+            return
+        }
+
+        #expect(slice.count == largeCount)
+        let countA = try slice.__testable_withUnsafeBytes { $0.count }
+        #expect(countA == largeCount)
+
+        #expect(slice[largeCount/2] == 0)
+        let countB = try slice.__testable_withUnsafeMutableBytes {
+            $0[largeCount/2] = 10
+            return ($0.count, $0.count)
+        }
+        #expect(slice[largeCount/2] == 10)
+        #expect(countB.0 == largeCount)
+
+        #expect(slice.capacity >= largeCount)
+        // don't force a reallocation, but do call the ABI function
+        slice.__testable_reserveCapacity(200)
+    }
+
 }
 
 #endif // DATA_LEGACY_ABI


### PR DESCRIPTION
Addresses rdar://174193354

Using the `@_spi` annotation causes validation issues with the Foundation framework. We can use `obsoleted` annotations instead, at the cost of less straightforward testing. I took advantage of the process of figuring out these tests to round out the legacy ABI tests.