### PR TITLE
Fix `ProgressManager` Bugs 

### DIFF
--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager+Interop.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager+Interop.swift
@@ -303,6 +303,44 @@ extension ProgressManager {
         }
     }
     
+    /// Notifies interop bridge observers so that grandchild progress propagates
+    /// through the SubprogressBridge to the parent NSProgress.
+    internal func notifyInteropObserversOfChildUpdate() {
+        // Phase 1: Collect bridge manager and dirty children info
+        let info: (bridgeManager: ProgressManager, updates: [PendingChildUpdateInfo]?)? = state.withLock { state in
+            guard case .interopObservation(let observation) = state.interopType,
+                  let bridgeManager = observation.subprogressBridge?.manager else {
+                return nil
+            }
+            return (bridgeManager, state.pendingChildrenUpdates())
+        }
+
+        guard let info, let updates = info.updates else {
+            return
+        }
+
+        // Phase 2: Resolve each dirty child's fraction
+        var childrenUpdates: [PendingChildUpdate] = []
+        for update in updates {
+            let updatedFraction = update.manager.updatedProgressFraction()
+            childrenUpdates.append(PendingChildUpdate(
+                index: update.index,
+                updatedFraction: updatedFraction,
+                assignedCount: update.assignedCount
+            ))
+        }
+
+        // Phase 3: Apply updates and compute fraction
+        let observerState = state.withLock { state in
+            state.updateChildrenProgressFraction(updates: childrenUpdates)
+            let fraction = state.overallFraction
+            return ObserverState(totalCount: fraction.total ?? 0, completedCount: fraction.completed)
+        }
+
+        // Notify bridge
+        info.bridgeManager.notifyObservers(with: observerState)
+    }
+    
     internal func addBridge(reporterBridge: ProgressReporterBridge? = nil, nsProgressBridge: Foundation.Progress? = nil) {
         state.withLock { state in
             var interopObservation = InteropObservation(subprogressBridge: nil)

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager+Interop.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager+Interop.swift
@@ -124,34 +124,22 @@ internal final class SubprogressBridge: Sendable {
     internal let progressBridge: Progress
     internal let manager: ProgressManager
     
-    // A fixed denominator for the bridge Progress. Using a large constant ensures:
-    // 1. Intermediate fractions are representable as integers (e.g. 50% = 500000)
-    // 2. totalUnitCount never changes, avoiding NSProgress issues where decreasing
-    //    totalUnitCount while completedUnitCount is large corrupts the parent's math.
-    private static let progressScale = 1000000
-
     init(parent: Progress, portion: Int64, manager: ProgressManager) {
-        self.progressBridge = Progress(totalUnitCount: Int64(SubprogressBridge.progressScale), parent: parent, pendingUnitCount: portion)
+        self.progressBridge = Progress(totalUnitCount: 1, parent: parent, pendingUnitCount: portion)
         self.manager = manager
 
         manager.addObserver { [weak self] observerState in
             guard let self else {
                 return
             }
-
-            let total = observerState.totalCount
-            let completed = observerState.completedCount
-            guard total > 0 else { return }
-
-            // Scale to a fixed denominator instead of passing values through directly.
-            // overallFraction's denominator changes when children finish — finished
-            // children are excluded from the sum and their assignedCount is collapsed
-            // into selfFraction (e.g. 50/100 becomes 1/1 instead of 100/100).
-            // Passing these changing denominators through corrupt NSProgress's parent accounting.
-            let fractionCompleted = Double(completed) / Double(total)
-            self.progressBridge.completedUnitCount = min(
-                Int64(SubprogressBridge.progressScale),
-                Int64((fractionCompleted * Double(SubprogressBridge.progressScale)).rounded())
+            
+            // Use atomic update to avoid corrupting NSProgress's parent accounting.
+            // overallFraction's denominator changes when children finish, and setting
+            // totalUnitCount and completedUnitCount separately causes a momentary spike
+            // that permanently corrupts the parent's bookkeeping.
+            self.progressBridge._setCompletedUnitCount(
+                Int64(observerState.completedCount),
+                totalUnitCount: Int64(observerState.totalCount)
             )
         }
     }

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager+Interop.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager+Interop.swift
@@ -124,18 +124,35 @@ internal final class SubprogressBridge: Sendable {
     internal let progressBridge: Progress
     internal let manager: ProgressManager
     
+    // A fixed denominator for the bridge Progress. Using a large constant ensures:
+    // 1. Intermediate fractions are representable as integers (e.g. 50% = 500000)
+    // 2. totalUnitCount never changes, avoiding NSProgress issues where decreasing
+    //    totalUnitCount while completedUnitCount is large corrupts the parent's math.
+    private static let progressScale = 1000000
+
     init(parent: Progress, portion: Int64, manager: ProgressManager) {
-        self.progressBridge = Progress(totalUnitCount: 1, parent: parent, pendingUnitCount: portion)
+        self.progressBridge = Progress(totalUnitCount: Int64(SubprogressBridge.progressScale), parent: parent, pendingUnitCount: portion)
         self.manager = manager
 
         manager.addObserver { [weak self] observerState in
             guard let self else {
                 return
             }
-            
-            // This needs to change totalUnitCount before completedUnitCount otherwise progressBridge will finish and mess up the math
-            self.progressBridge.totalUnitCount = Int64(observerState.totalCount)
-            self.progressBridge.completedUnitCount = Int64(observerState.completedCount)
+
+            let total = observerState.totalCount
+            let completed = observerState.completedCount
+            guard total > 0 else { return }
+
+            // Scale to a fixed denominator instead of passing values through directly.
+            // overallFraction's denominator changes when children finish — finished
+            // children are excluded from the sum and their assignedCount is collapsed
+            // into selfFraction (e.g. 50/100 becomes 1/1 instead of 100/100).
+            // Passing these changing denominators through corrupt NSProgress's parent accounting.
+            let fractionCompleted = Double(completed) / Double(total)
+            self.progressBridge.completedUnitCount = min(
+                Int64(SubprogressBridge.progressScale),
+                Int64((fractionCompleted * Double(SubprogressBridge.progressScale)).rounded())
+            )
         }
     }
 }

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
@@ -387,6 +387,49 @@ internal import _FoundationCollections
             markSelfDirty(parents: parents)
         }
         self.withMutation(keyPath: \.completedCount) {}
+        notifyInteropObserversOfChildUpdate()
+    }
+
+    /// Notifies interop bridge observers so that grandchild progress propagates
+    /// through the SubprogressBridge to the parent NSProgress.
+    private func notifyInteropObserversOfChildUpdate() {
+#if FOUNDATION_FRAMEWORK
+        // Phase 1: Collect bridge manager and dirty children info
+        let info: (bridgeManager: ProgressManager, updates: [PendingChildUpdateInfo]?)? = state.withLock { state in
+            guard case .interopObservation(let observation) = state.interopType,
+                  let bridgeManager = observation.subprogressBridge?.manager else {
+                return nil
+            }
+            return (bridgeManager, state.pendingChildrenUpdates())
+        }
+
+        guard let info else { return }
+
+        // Phase 2: Resolve each dirty child's fraction
+        var childrenUpdates: [PendingChildUpdate] = []
+        if let updates = info.updates {
+            for update in updates {
+                let updatedFraction = update.manager.updatedProgressFraction()
+                childrenUpdates.append(PendingChildUpdate(
+                    index: update.index,
+                    updatedFraction: updatedFraction,
+                    assignedCount: update.assignedCount
+                ))
+            }
+        }
+
+        // Phase 3: Apply updates and compute fraction
+        let observerState = state.withLock { state in
+            if !childrenUpdates.isEmpty {
+                state.updateChildrenProgressFraction(updates: childrenUpdates)
+            }
+            let fraction = state.overallFraction
+            return ObserverState(totalCount: fraction.total ?? 0, completedCount: fraction.completed)
+        }
+
+        // Notify bridge
+        info.bridgeManager.notifyObservers(with: observerState)
+#endif
     }
     
     internal func updatedProgressFraction() -> ProgressFraction {

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
@@ -387,7 +387,9 @@ internal import _FoundationCollections
             markSelfDirty(parents: parents)
         }
         self.withMutation(keyPath: \.completedCount) {}
+        #if FOUNDATION_FRAMEWORK
         notifyInteropObserversOfChildUpdate()
+        #endif
     }
 
     /// Notifies interop bridge observers so that grandchild progress propagates

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
@@ -403,26 +403,24 @@ internal import _FoundationCollections
             return (bridgeManager, state.pendingChildrenUpdates())
         }
 
-        guard let info else { return }
+        guard let info, let updates = info.updates else {
+            return
+        }
 
         // Phase 2: Resolve each dirty child's fraction
         var childrenUpdates: [PendingChildUpdate] = []
-        if let updates = info.updates {
-            for update in updates {
-                let updatedFraction = update.manager.updatedProgressFraction()
-                childrenUpdates.append(PendingChildUpdate(
-                    index: update.index,
-                    updatedFraction: updatedFraction,
-                    assignedCount: update.assignedCount
-                ))
-            }
+        for update in updates {
+            let updatedFraction = update.manager.updatedProgressFraction()
+            childrenUpdates.append(PendingChildUpdate(
+                index: update.index,
+                updatedFraction: updatedFraction,
+                assignedCount: update.assignedCount
+            ))
         }
 
         // Phase 3: Apply updates and compute fraction
         let observerState = state.withLock { state in
-            if !childrenUpdates.isEmpty {
-                state.updateChildrenProgressFraction(updates: childrenUpdates)
-            }
+            state.updateChildrenProgressFraction(updates: childrenUpdates)
             let fraction = state.overallFraction
             return ObserverState(totalCount: fraction.total ?? 0, completedCount: fraction.completed)
         }

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
@@ -391,46 +391,6 @@ internal import _FoundationCollections
         notifyInteropObserversOfChildUpdate()
         #endif
     }
-
-    #if FOUNDATION_FRAMEWORK
-    /// Notifies interop bridge observers so that grandchild progress propagates
-    /// through the SubprogressBridge to the parent NSProgress.
-    private func notifyInteropObserversOfChildUpdate() {
-        // Phase 1: Collect bridge manager and dirty children info
-        let info: (bridgeManager: ProgressManager, updates: [PendingChildUpdateInfo]?)? = state.withLock { state in
-            guard case .interopObservation(let observation) = state.interopType,
-                  let bridgeManager = observation.subprogressBridge?.manager else {
-                return nil
-            }
-            return (bridgeManager, state.pendingChildrenUpdates())
-        }
-
-        guard let info, let updates = info.updates else {
-            return
-        }
-
-        // Phase 2: Resolve each dirty child's fraction
-        var childrenUpdates: [PendingChildUpdate] = []
-        for update in updates {
-            let updatedFraction = update.manager.updatedProgressFraction()
-            childrenUpdates.append(PendingChildUpdate(
-                index: update.index,
-                updatedFraction: updatedFraction,
-                assignedCount: update.assignedCount
-            ))
-        }
-
-        // Phase 3: Apply updates and compute fraction
-        let observerState = state.withLock { state in
-            state.updateChildrenProgressFraction(updates: childrenUpdates)
-            let fraction = state.overallFraction
-            return ObserverState(totalCount: fraction.total ?? 0, completedCount: fraction.completed)
-        }
-
-        // Notify bridge
-        info.bridgeManager.notifyObservers(with: observerState)
-    }
-    #endif
     
     internal func updatedProgressFraction() -> ProgressFraction {
         // Get information about dirty children (Acquire and release self's lock)

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
@@ -392,10 +392,10 @@ internal import _FoundationCollections
         #endif
     }
 
+    #if FOUNDATION_FRAMEWORK
     /// Notifies interop bridge observers so that grandchild progress propagates
     /// through the SubprogressBridge to the parent NSProgress.
     private func notifyInteropObserversOfChildUpdate() {
-#if FOUNDATION_FRAMEWORK
         // Phase 1: Collect bridge manager and dirty children info
         let info: (bridgeManager: ProgressManager, updates: [PendingChildUpdateInfo]?)? = state.withLock { state in
             guard case .interopObservation(let observation) = state.interopType,
@@ -429,8 +429,8 @@ internal import _FoundationCollections
 
         // Notify bridge
         info.bridgeManager.notifyObservers(with: observerState)
-#endif
     }
+    #endif
     
     internal func updatedProgressFraction() -> ProgressFraction {
         // Get information about dirty children (Acquire and release self's lock)

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
@@ -384,10 +384,9 @@ internal import _FoundationCollections
             state.markChildDirty(at: position)
         }
         if let parents = parents {
-            // rdar://172950622 (Async stream observation of ProgressManager's fractionCompleted does not receive updates from subsubprogress and beyond.)
             markSelfDirty(parents: parents)
-            self.withMutation(keyPath: \.completedCount) {}
         }
+        self.withMutation(keyPath: \.completedCount) {}
     }
     
     internal func updatedProgressFraction() -> ProgressFraction {
@@ -425,32 +424,30 @@ internal import _FoundationCollections
     
     //MARK: Parent - Child Relationship Methods
     internal func addChild(childManager: ProgressManager, assignedCount: Int, childFraction: ProgressFraction) -> Int {
-        self.withMutation(keyPath: \.completedCount) {
-            let (index, parents) = state.withLock { state in
-                let child = Child(manager: childManager,
-                                  assignedCount: assignedCount,
-                                  fraction: childFraction,
-                                  isFractionDirty: true,
-                                  totalFileCountSummary: PropertyStateInt(value: ProgressManager.Properties.TotalFileCount.defaultSummary, isDirty: false),
-                                  completedFileCountSummary: PropertyStateInt(value: ProgressManager.Properties.CompletedFileCount.defaultSummary, isDirty: false),
-                                  totalByteCountSummary: PropertyStateUInt64(value: ProgressManager.Properties.TotalByteCount.defaultSummary, isDirty: false),
-                                  completedByteCountSummary: PropertyStateUInt64(value: ProgressManager.Properties.CompletedByteCount.defaultSummary, isDirty: false),
-                                  throughputSummary: PropertyStateUInt64Array(value: ProgressManager.Properties.Throughput.defaultSummary, isDirty: false),
-                                  estimatedTimeRemainingSummary: PropertyStateDuration(value: ProgressManager.Properties.EstimatedTimeRemaining.defaultSummary, isDirty: false),
-                                  customPropertiesIntSummary: [:],
-                                  customPropertiesUInt64Summary: [:],
-                                  customPropertiesDoubleSummary: [:],
-                                  customPropertiesStringSummary: [:],
-                                  customPropertiesURLSummary: [:],
-                                  customPropertiesUInt64ArraySummary: [:],
-                                  customPropertiesDurationSummary: [:])
-                state.children.append(child)
-                return (state.children.count - 1, state.parents)
-            }
-            // Mark dirty all the way up to the root so that if the branch was marked not dirty right before this it will be marked dirty again (for optimization to work)
-            markSelfDirty(parents: parents)
-            return index
+        let (index, parents) = state.withLock { state in
+            let child = Child(manager: childManager,
+                              assignedCount: assignedCount,
+                              fraction: childFraction,
+                              isFractionDirty: true,
+                              totalFileCountSummary: PropertyStateInt(value: ProgressManager.Properties.TotalFileCount.defaultSummary, isDirty: false),
+                              completedFileCountSummary: PropertyStateInt(value: ProgressManager.Properties.CompletedFileCount.defaultSummary, isDirty: false),
+                              totalByteCountSummary: PropertyStateUInt64(value: ProgressManager.Properties.TotalByteCount.defaultSummary, isDirty: false),
+                              completedByteCountSummary: PropertyStateUInt64(value: ProgressManager.Properties.CompletedByteCount.defaultSummary, isDirty: false),
+                              throughputSummary: PropertyStateUInt64Array(value: ProgressManager.Properties.Throughput.defaultSummary, isDirty: false),
+                              estimatedTimeRemainingSummary: PropertyStateDuration(value: ProgressManager.Properties.EstimatedTimeRemaining.defaultSummary, isDirty: false),
+                              customPropertiesIntSummary: [:],
+                              customPropertiesUInt64Summary: [:],
+                              customPropertiesDoubleSummary: [:],
+                              customPropertiesStringSummary: [:],
+                              customPropertiesURLSummary: [:],
+                              customPropertiesUInt64ArraySummary: [:],
+                              customPropertiesDurationSummary: [:])
+            state.children.append(child)
+            return (state.children.count - 1, state.parents)
         }
+        // Mark dirty all the way up to the root so that if the branch was marked not dirty right before this it will be marked dirty again (for optimization to work)
+        markSelfDirty(parents: parents)
+        return index
     }
     
     internal func addParent(parentManager: ProgressManager, positionInParent: Int) {

--- a/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerInteropTests.swift
+++ b/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerInteropTests.swift
@@ -13,7 +13,6 @@ import Testing
 
 #if FOUNDATION_FRAMEWORK
 @testable import Foundation
-import Synchronization
 
 /// Unit tests for interop methods that support building Progress trees with both Progress and ProgressManager
 @Suite("Progress Manager Interop", .tags(.progressManager)) struct ProgressManagerInteropTests {
@@ -328,6 +327,110 @@ import Synchronization
         // Task 2 completes
         task2.complete(count: 100)
         #expect(overall.fractionCompleted == 1.0, "Both tasks complete should be 100%: expected 1.0, got \(overall.fractionCompleted)")
+    }
+
+    @Test func interopProgressParentProgressManagerGrandchildrenNonSequentialCompletion() async throws {
+        let overall = Progress.discreteProgress(totalUnitCount: 10)
+        let subprogress = overall.subprogress(assigningCount: 10)
+
+        let child = subprogress.start(totalCount: 2)
+        let task1 = ProgressManager(totalCount: 100)
+        let task2 = ProgressManager(totalCount: 100)
+        child.assign(count: 1, to: task1.reporter)
+        child.assign(count: 1, to: task2.reporter)
+
+        // Task 2 reports partial progress first
+        task2.complete(count: 50)
+        #expect(overall.fractionCompleted == 0.25, "Task 2 50% of half should be 25% overall: expected 0.25, got \(overall.fractionCompleted)")
+
+        // Task 2 completes before task 1
+        task2.complete(count: 50)
+        #expect(overall.fractionCompleted == 0.5, "Task 2 complete should be 50% overall: expected 0.5, got \(overall.fractionCompleted)")
+
+        // Task 1 completes
+        task1.complete(count: 100)
+        #expect(overall.fractionCompleted == 1.0, "Both tasks complete should be 100%: expected 1.0, got \(overall.fractionCompleted)")
+    }
+
+    @Test func interopProgressParentProgressManagerManyGrandchildren() async throws {
+        let overall = Progress.discreteProgress(totalUnitCount: 10)
+        let subprogress = overall.subprogress(assigningCount: 10)
+
+        let child = subprogress.start(totalCount: 5)
+        var tasks: [ProgressManager] = []
+        for _ in 0..<5 {
+            let task = ProgressManager(totalCount: 100)
+            child.assign(count: 1, to: task.reporter)
+            tasks.append(task)
+        }
+
+        // Complete each task one by one
+        for i in 0..<5 {
+            tasks[i].complete(count: 100)
+            let expected = Double(i + 1) / 5.0
+            #expect(overall.fractionCompleted == expected, "After \(i + 1) of 5 tasks complete: expected \(expected), got \(overall.fractionCompleted)")
+        }
+    }
+
+    @Test func interopProgressParentProgressManagerGrandchildrenPartialProgress() async throws {
+        let overall = Progress.discreteProgress(totalUnitCount: 10)
+        let subprogress = overall.subprogress(assigningCount: 10)
+
+        let child = subprogress.start(totalCount: 2)
+        let task1 = ProgressManager(totalCount: 100)
+        let task2 = ProgressManager(totalCount: 100)
+        child.assign(count: 1, to: task1.reporter)
+        child.assign(count: 1, to: task2.reporter)
+
+        // Task 1 at 25%
+        task1.complete(count: 25)
+        #expect(overall.fractionCompleted == 0.125, "Task 1 25% of half: expected 0.125, got \(overall.fractionCompleted)")
+
+        // Task 1 at 50%
+        task1.complete(count: 25)
+        #expect(overall.fractionCompleted == 0.25, "Task 1 50% of half: expected 0.25, got \(overall.fractionCompleted)")
+
+        // Task 2 at 50%
+        task2.complete(count: 50)
+        #expect(overall.fractionCompleted == 0.5, "Both at 50%: expected 0.5, got \(overall.fractionCompleted)")
+
+        // Task 1 completes
+        task1.complete(count: 50)
+        #expect(overall.fractionCompleted == 0.75, "Task 1 done, task 2 at 50%: expected 0.75, got \(overall.fractionCompleted)")
+
+        // Task 2 completes
+        task2.complete(count: 50)
+        #expect(overall.fractionCompleted == 1.0, "Both complete: expected 1.0, got \(overall.fractionCompleted)")
+    }
+
+    @Test func interopProgressParentProgressManagerIndeterminateGrandchild() async throws {
+        let overall = Progress.discreteProgress(totalUnitCount: 10)
+        let subprogress = overall.subprogress(assigningCount: 10)
+
+        let child = subprogress.start(totalCount: 2)
+        let task1 = ProgressManager(totalCount: nil) // indeterminate
+        let task2 = ProgressManager(totalCount: 100)
+        child.assign(count: 1, to: task1.reporter)
+        child.assign(count: 1, to: task2.reporter)
+
+        // Indeterminate task should not affect overall progress
+        #expect(overall.fractionCompleted == 0.0, "No progress yet: expected 0.0, got \(overall.fractionCompleted)")
+
+        // Determinate task reports progress
+        task2.complete(count: 50)
+        #expect(overall.fractionCompleted == 0.25, "Task 2 50% of half: expected 0.25, got \(overall.fractionCompleted)")
+
+        // Indeterminate task becomes determinate
+        task1.setCounts { completed, total in
+            total = 100
+        }
+        task1.complete(count: 50)
+        #expect(overall.fractionCompleted == 0.5, "Both at 50%: expected 0.5, got \(overall.fractionCompleted)")
+
+        // Both complete
+        task1.complete(count: 50)
+        task2.complete(count: 50)
+        #expect(overall.fractionCompleted == 1.0, "Both complete: expected 1.0, got \(overall.fractionCompleted)")
     }
 
     #if FOUNDATION_EXIT_TESTS

--- a/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerInteropTests.swift
+++ b/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerInteropTests.swift
@@ -305,6 +305,31 @@ import Synchronization
         #expect(overallProgress2.totalUnitCount == 0)
     }
 
+    @Test func interopProgressParentProgressManagerChildAndGrandchildren() async throws {
+        // Caller's NSProgress
+        let overall = Progress.discreteProgress(totalUnitCount: 10)
+        let subprogress = overall.subprogress(assigningCount: 10)
+        
+        // Receiver calls start(), then assigns work to sub-tasks via ProgressReporter
+        let child = subprogress.start(totalCount: 2)
+        let task1 = ProgressManager(totalCount: 100)
+        let task2 = ProgressManager(totalCount: 100)
+        child.assign(count: 1, to: task1.reporter)
+        child.assign(count: 1, to: task2.reporter)
+        
+        // Task 1 reports partial progress
+        task1.complete(count: 50)
+        #expect(overall.fractionCompleted == 0.25, "Task 1 50% of half should be 25% overall: expected 0.25, got \(overall.fractionCompleted)")
+        
+        // Task 1 completes
+        task1.complete(count: 50)
+        #expect(overall.fractionCompleted == 0.5, "Task 1 complete should be 50% overall: expected 0.5, got \(overall.fractionCompleted)")
+        
+        // Task 2 completes
+        task2.complete(count: 100)
+        #expect(overall.fractionCompleted == 1.0, "Both tasks complete should be 100%: expected 1.0, got \(overall.fractionCompleted)")
+    }
+
     #if FOUNDATION_EXIT_TESTS
     @Test func indirectParticipationOfProgressInAcyclicGraph() async throws {
         await #expect(processExitsWith: .failure) {

--- a/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerInteropTests.swift
+++ b/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerInteropTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 #if FOUNDATION_FRAMEWORK
 @testable import Foundation
+import Synchronization
 
 /// Unit tests for interop methods that support building Progress trees with both Progress and ProgressManager
 @Suite("Progress Manager Interop", .tags(.progressManager)) struct ProgressManagerInteropTests {
@@ -303,7 +304,7 @@ import Testing
         receiveProgress(progress: interopChild)
         #expect(overallProgress2.totalUnitCount == 0)
     }
-    
+
     #if FOUNDATION_EXIT_TESTS
     @Test func indirectParticipationOfProgressInAcyclicGraph() async throws {
         await #expect(processExitsWith: .failure) {

--- a/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/ProgressManager/ProgressManagerTests.swift
@@ -846,4 +846,32 @@ extension Tag {
         #expect(root.fractionCompleted == 1.0)
         #expect(root.isFinished)
     }
+    
+    @Test func isFinishedObservationNotConsumedByAddChild() async throws {
+        let parent = ProgressManager(totalCount: 1)
+        let subprogress = parent.subprogress(assigningCount: 1)
+
+        // Track how many times onChange fires and what isFinished value it sees
+        let onChangeCount = Mutex(0)
+        let observedIsFinished = Mutex(false)
+        withObservationTracking {
+            _ = parent.isFinished
+        } onChange: {
+            onChangeCount.withLock { $0 += 1 }
+            observedIsFinished.withLock { $0 = parent.isFinished }
+        }
+
+        // start() calls addChild — addChild should NOT consume the observation
+        let child = subprogress.start(totalCount: 10)
+
+        // Verify addChild did not fire the observation
+        #expect(onChangeCount.withLock { $0 } == 0, "addChild should not fire observation — onChange count was \(onChangeCount.withLock { $0 })")
+
+        // Complete the child — this should fire the observation with isFinished == true
+        child.complete(count: 10)
+
+        #expect(parent.isFinished, "Parent should be finished after child completes")
+        #expect(onChangeCount.withLock { $0 } == 1, "onChange should fire exactly once (on child completion) — count was \(onChangeCount.withLock { $0 })")
+        #expect(observedIsFinished.withLock { $0 }, "isFinished observation should fire with true when child completes, not be consumed earlier by addChild")
+    }
 }


### PR DESCRIPTION
This PR fixes two bugs in `ProgressManager`. 

### Motivation:

**Bug A: `ProgressManager` observation consumed by addChild before child `ProgressManager` completes**
`addChild` fired `withMutation(keyPath: \.completedCount)` even though `completedCount` has not changed. This causes the one-shot `withObservationTracking` handlers to be consumed before child `ProgressManager`  reports any progress, so the actual `isFinished` transition, which depends on the change in either `completedCount` or `totalCount`, never got observed. 

Additionally, `markChildDirty` gated `withMutation(keyPath: \.completedCount)` behind the dirty-flag check. This flag is only cleared when `fractionCompleted` or `isFinished` is read. If they are not read between `start` and `complete`, `markChildDirty` skips the `withMutation` call and observation never fires. 

**Bug B: `NSProgress` parent does not receive updates from `ProgressManager` grandchildren** 
When a `Subprogress` is created from `NSProgress` via `Progress.subprogress(assigningCount:)`, and the method consuming this `Subprogress` creates more children which are grandchildren of `NSProgress`, updates from the grandchildren do not propagate up to `NSProgress`.

The interop bridge worked for two-levels, when `complete(count:)` is called on the `ProgressManager` that holds the `SubprogressBridge`, `complete(by:)` notifies the bridge observer via `notifyObservers`, which allows `NSProgress` to receive updates. 
However, when updates are from a child via `markChildDirty`, the code path never called `notifyObservers` on the `SubprogressBridge`, so the `NSProgress` did not receive the updates.

### Modifications:

**Bug A: ProgressManager observation consumed by addChild before child `ProgressManager` completes**
Remove `withMutation` call from `addChild`. Move `withMutation` call in `markChildDirty` outside dirty-flag guard so that it fires unconditionally. 

**Bug B: NSProgress parent does not receive updates from ProgressManager grandchildren** 
Add `notifyInteropObserversOfChildUpdates()` helper method, and call it within `markChildDirty`, which resolves dirty children for interop cases and notifies `SubprogressBridge`. `SubprogressBridge` also sets the `NSProgress` `totalUnitCount` and `completedUnitCount` atomically to avoid a limitation that we hit when `NSProgress` denominator changes from a larger number to a much smaller number.

### Result:

`withObservationTracking` on `isFinished` correctly fires only when values actually change, not on `addChild`.

Updates from descendants of a root `ProgressManager` that are below its direct children are correctly propagated through `SubprogressBridge` to `NSProgress` parents. 

### Testing:

Added unit tests to validate behavior changes. 
