### PR TITLE
Update swift-collections version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,7 @@ if let useLocalDepsEnv = Context.environment["SWIFTCI_USE_LOCAL_DEPS"], !useLoca
         [
             .package(
                 url: "https://github.com/apple/swift-collections",
-                exact: "1.1.6"),
+                .upToNextMinor(from: "1.4.0")),
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
                 branch: "main"),


### PR DESCRIPTION
`release/6.3` and `main` dropped the `swift-collections` version to one that didn't have the `BasicContainers` package. We'll need to diverge from swift-foundation standards right now, which is fine, since we're not destined to live here forever.