### PR TITLE
new-codable enum macro implementation

### DIFF
--- a/Sources/NewCodable/CommonDecodableProtocols.swift
+++ b/Sources/NewCodable/CommonDecodableProtocols.swift
@@ -83,17 +83,15 @@ public protocol CommonDecoder: ~Escapable {
     mutating func decodeArray<T: ~Copyable>(_ closure: (inout ArrayDecoder) throws(CodingError.Decoding) -> T) throws(CodingError.Decoding) -> T
     
     // MARK: - Enum Decoding
-    
-    /// Decodes an enum case with no associated values
+
+    /// Decodes an enum case using a two-phase callback pattern.
+    ///
+    /// The first closure decodes the case field/name. The second closure decodes the
+    /// associated values.
     @_lifetime(self: copy self)
     mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (inout FieldDecoder) throws(CodingError.Decoding) -> T
-    ) throws(CodingError.Decoding) -> T
-    
-    /// Decodes an enum case with associated values
-    @_lifetime(self: copy self)
-    mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (_ caseName: inout FieldDecoder, _ associatedValues: inout StructDecoder) throws(CodingError.Decoding) -> T
+        _ caseDecoder: (inout FieldDecoder) throws(CodingError.Decoding) -> Void,
+        associatedValues valueDecoder: (inout StructDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T
     
     @_lifetime(self: copy self)
@@ -397,17 +395,11 @@ public extension CommonDecoder where Self: ~Escapable {
     }
     
     // MARK: - Enum Decoding
-    
+
     @_lifetime(self: copy self)
     mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (inout FieldDecoder) throws(CodingError.Decoding) -> T
-    ) throws(CodingError.Decoding) -> T {
-        throw CodingError.unsupportedDecodingType("enum")
-    }
-    
-    @_lifetime(self: copy self)
-    mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (_ caseName: inout FieldDecoder, _ associatedValues: inout StructDecoder) throws(CodingError.Decoding) -> T
+        _ caseDecoder: (inout FieldDecoder) throws(CodingError.Decoding) -> Void,
+        associatedValues valueDecoder: (inout StructDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T {
         throw CodingError.unsupportedDecodingType("enum")
     }

--- a/Sources/NewCodable/JSON/JSONDecoderProtocols.swift
+++ b/Sources/NewCodable/JSON/JSONDecoderProtocols.swift
@@ -169,17 +169,15 @@ public protocol JSONDecoderProtocol: ~Escapable {
     mutating func decodeArray<T: ~Copyable>(_ closure: (inout ArrayDecoder) throws(CodingError.Decoding) -> T) throws(CodingError.Decoding) -> T
     
     // MARK: - Enum Decoding
-    
-    /// Decodes an enum case with no associated values from `{"caseName":{}}` format
+
+    /// Decodes an enum case from `{"caseName":{...}}` format using a two-phase callback pattern.
+    ///
+    /// The first closure decodes the case field/name. The second closure decodes the
+    /// associated values.
     @_lifetime(self: copy self)
     mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (inout FieldDecoder) throws(CodingError.Decoding) -> T
-    ) throws(CodingError.Decoding) -> T
-    
-    /// Decodes an enum case with associated values from `{"caseName":{"field1":value1,...}}` format
-    @_lifetime(self: copy self)
-    mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (_ caseName: inout FieldDecoder, _ associatedValues: inout StructDecoder) throws(CodingError.Decoding) -> T
+        _ caseDecoder: (inout FieldDecoder) throws(CodingError.Decoding) -> Void,
+        associatedValues valueDecoder: (inout StructDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T
     
     @_lifetime(self: copy self)

--- a/Sources/NewCodable/JSON/JSONParserDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONParserDecoder.swift
@@ -530,105 +530,22 @@ public struct JSONParserDecoder: JSONDecoderProtocol, ~Escapable {
     }
     
     // MARK: - Enum Decoding
-    
-    /// Decodes an enum case with no associated values from `{"caseName":{}}` format
+
+    /// Decodes an enum case from `{"caseName":{...}}` format using a two-phase callback pattern.
+    ///
+    /// Phase 1: Parses the outer `{`, reads the case name key, and calls `caseDecoder`.
+    /// Phase 2: Parses the `:`, then calls `valueDecoder` with a struct decoder for the
+    /// associated values (which may be empty `{}`).
     @_lifetime(self: copy self)
     public mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (inout FieldDecoder) throws(CodingError.Decoding) -> T
+        _ caseDecoder: (inout FieldDecoder) throws(CodingError.Decoding) -> Void,
+        associatedValues valueDecoder: (inout StructDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T {
         // Check depth limit before creating container
         guard state.depth < Self.maximumRecursionDepth else {
             throw JSONError.tooManyNestedArraysOrDictionaries(location: state.reader.sourceLocation).at(self.codingPath)
         }
-        
-        // Set up coding path node for the enum wrapper dictionary
-        var dictionaryNode: InlineArray = [
-            CodingPathNode.newDictionaryNode(withParent: state.currentTopCodingPathNode)
-        ]
-        var nodeSpan = dictionaryNode.mutableSpan
-        state.currentTopCodingPathNode = nodeSpan.withUnsafeMutableBufferPointer {
-            $0.baseAddress!
-        }
-        defer {
-            withExtendedLifetime(nodeSpan) {
-                state.currentTopCodingPathNode.unwindToParent()
-            }
-        }
-        
-        state.depth += 1
-        defer { state.depth -= 1 }
-        
-        do throws(_JSONDecodingError) {
-            // Parse opening brace
-            let openBrace = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
-            guard openBrace == ._openbrace else {
-                throw .json(JSONError.unexpectedCharacter(context: "expecting enum object", ascii: openBrace, location: state.reader.sourceLocation))
-            }
-            state.reader.moveReaderIndex(forwardBy: 1)
-            
-            // Parse the case name (key)
-            let openQuote = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
-            guard openQuote == ._quote else {
-                throw .json(JSONError.unexpectedCharacter(context: "expecting enum case name", ascii: openQuote, location: state.reader.sourceLocation))
-            }
-            state.reader.moveReaderIndex(forwardBy: 1)
-            
-            let caseName = try state.reader.parsedStringContentAndTrailingQuote()
-            
-            // Update coding path
-            state.currentTopCodingPathNode.pointee.setDictionaryKey(caseName.buffer)
-            
-            var fieldDecoder = FieldDecoder(string: caseName)
-            let result = try closure(&fieldDecoder) ^^ .decodingError
-            
-            // Parse colon
-            let colon = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
-            guard colon == ._colon else {
-                throw .json(JSONError.unexpectedCharacter(context: "after enum case name", ascii: colon, location: state.reader.sourceLocation))
-            }
-            state.reader.moveReaderIndex(forwardBy: 1)
-            
-            // Verify empty object value: {}
-            let valueOpenBrace = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
-            guard valueOpenBrace == ._openbrace else {
-                throw .json(JSONError.unexpectedCharacter(context: "expecting empty object for value-less enum", ascii: valueOpenBrace, location: state.reader.sourceLocation))
-            }
-            state.reader.moveReaderIndex(forwardBy: 1)
-            
-            let closeBrace = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
-            guard closeBrace == ._closebrace else {
-                throw .json(JSONError.unexpectedCharacter(context: "expecting empty object for value-less enum", ascii: closeBrace, location: state.reader.sourceLocation))
-            }
-            state.reader.moveReaderIndex(forwardBy: 1)
-            
-            // Parse closing brace of outer object
-            let outerCloseBrace = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
-            guard outerCloseBrace == ._closebrace else {
-                throw .json(JSONError.unexpectedCharacter(context: "after enum value", ascii: outerCloseBrace, location: state.reader.sourceLocation))
-            }
-            state.reader.moveReaderIndex(forwardBy: 1)
-            
-            return result
-        } catch {
-            switch error {
-            case .json(let error):
-                throw error.at(self.codingPath)
-            case .decoding(let error):
-                throw error
-            }
-        }
-    }
-    
-    /// Decodes an enum case with associated values from `{"caseName":{"field1":value1,...}}` format
-    @_lifetime(self: copy self)
-    public mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (_ caseName: inout FieldDecoder, _ associatedValues: inout StructDecoder) throws(CodingError.Decoding) -> T
-    ) throws(CodingError.Decoding) -> T {
-        // Check depth limit before creating container
-        guard state.depth < Self.maximumRecursionDepth else {
-            throw JSONError.tooManyNestedArraysOrDictionaries(location: state.reader.sourceLocation).at(self.codingPath)
-        }
-        
+
         // Set up coding path node for the enum wrapper dictionary
         var outerDictionaryNode: InlineArray = [
             CodingPathNode.newDictionaryNode(withParent: state.currentTopCodingPathNode)
@@ -642,10 +559,10 @@ public struct JSONParserDecoder: JSONDecoderProtocol, ~Escapable {
                 state.currentTopCodingPathNode.unwindToParent()
             }
         }
-        
+
         state.depth += 1
         defer { state.depth -= 1 }
-        
+
         do throws(_JSONDecodingError) {
             // Parse opening brace
             let openBrace = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
@@ -653,43 +570,38 @@ public struct JSONParserDecoder: JSONDecoderProtocol, ~Escapable {
                 throw .json(JSONError.unexpectedCharacter(context: "expecting enum object", ascii: openBrace, location: state.reader.sourceLocation))
             }
             state.reader.moveReaderIndex(forwardBy: 1)
-            
+
             // Parse the case name (key)
             let openQuote = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
             guard openQuote == ._quote else {
                 throw .json(JSONError.unexpectedCharacter(context: "expecting enum case name", ascii: openQuote, location: state.reader.sourceLocation))
             }
             state.reader.moveReaderIndex(forwardBy: 1)
-            
+
             let caseName = try state.reader.parsedStringContentAndTrailingQuote()
-            
+
             // Update coding path with case name
             state.currentTopCodingPathNode.pointee.setDictionaryKey(caseName.buffer)
-            
+
+            // Phase 1: decode the case field
             var fieldDecoder = FieldDecoder(string: caseName)
-            
+            try caseDecoder(&fieldDecoder) ^^ .decodingError
+
             // Parse colon
             let colon = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
             guard colon == ._colon else {
                 throw .json(JSONError.unexpectedCharacter(context: "after enum case name", ascii: colon, location: state.reader.sourceLocation))
             }
             state.reader.moveReaderIndex(forwardBy: 1)
-            
-            // Parse associated values dictionary - use midContainer: false so it handles the braces
-            let preValueOffset = state.reader.readOffset
-            var valueDecoder: StructDecoder
-            do throws(JSONError) { valueDecoder = try StructDecoder(parserState: state, midContainer: false) } catch { throw .json(error) }
-            let result = try closure(&fieldDecoder, &valueDecoder) ^^ .decodingError
-            
-            // Skip if not consumed, and finish the struct (consume closing brace)
-            if valueDecoder.parserState.reader.readOffset == preValueOffset {
-                try valueDecoder.parserState.skipValue() ^^ .decodingError
-            } else {
-                try valueDecoder._finish() ^^ .decodingError
-            }
-            
-            state.copyRelevantState(from: valueDecoder.parserState)
-            
+
+            // Phase 2: decode associated values via struct decoder
+            var innerDecoder: StructDecoder
+            do throws(JSONError) { innerDecoder = try StructDecoder(parserState: state, midContainer: false) } catch { throw .json(error) }
+            let result = try valueDecoder(&innerDecoder) ^^ .decodingError
+            try innerDecoder._finish() ^^ .decodingError
+
+            state.copyRelevantState(from: innerDecoder.parserState)
+
             // Parse closing brace of outer object
             let next = try state.reader.consumeWhitespaceAndPeek() ^^ .jsonError
             let foundCloseBrace: Bool
@@ -702,12 +614,12 @@ public struct JSONParserDecoder: JSONDecoderProtocol, ~Escapable {
             default:
                 foundCloseBrace = false
             }
-            
+
             guard foundCloseBrace else {
                 throw .json(JSONError.unexpectedCharacter(context: "after enum object", ascii: next, location: state.reader.sourceLocation))
             }
             state.reader.moveReaderIndex(forwardBy: 1)
-            
+
             return result
         } catch {
             switch error {

--- a/Sources/NewCodable/JSON/JSONPrimitiveDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONPrimitiveDecoder.swift
@@ -297,53 +297,33 @@ public struct JSONPrimitiveDecoder: JSONDecoderProtocol {
     }
     
     // MARK: - Enum Decoding
-    
-    /// Decodes an enum case with no associated values from `{"caseName":{}}` format
+
+    /// Decodes an enum case from `{"caseName":{...}}` format using a two-phase callback pattern.
     public mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (inout FieldDecoder) throws(CodingError.Decoding) -> T
+        _ caseDecoder: (inout FieldDecoder) throws(CodingError.Decoding) -> Void,
+        associatedValues valueDecoder: (inout StructDecoder) throws(CodingError.Decoding) -> T
     ) throws(CodingError.Decoding) -> T {
         guard case let .dictionary(elements) = value else {
             throw value.typeMismatchError(expectedTypeDescription: "dictionary", at: self.codingPath)
         }
-        
+
         guard elements.count == 1 else {
             throw CodingError.dataCorrupted(at: self.codingPath, debugDescription: "Expected exactly one key-value pair for enum case, has \(elements.count)")
         }
-        
+
         let (caseName, caseValue) = elements.first!
+
+        // Phase 1: decode the case field
         var fieldDecoder = FieldDecoder(string: caseName)
-        let result = try closure(&fieldDecoder)
-        
-        // Verify the value is an empty dictionary
-        guard case let .dictionary(innerElements) = caseValue, innerElements.isEmpty else {
-            throw CodingError.dataCorrupted(at: self.codingPath, debugDescription: "Expected empty dictionary for value-less enum case")
-        }
-        
-        return result
-    }
-    
-    /// Decodes an enum case with associated values from `{"caseName":{"field1":value1,...}}` format
-    public mutating func decodeEnumCase<T: ~Copyable>(
-        _ closure: (_ caseName: inout FieldDecoder, _ associatedValues: inout StructDecoder) throws(CodingError.Decoding) -> T
-    ) throws(CodingError.Decoding) -> T {
-        guard case let .dictionary(elements) = value else {
-            throw value.typeMismatchError(expectedTypeDescription: "dictionary", at: self.codingPath)
-        }
-        
-        guard elements.count == 1 else {
-            throw CodingError.dataCorrupted(at: self.codingPath, debugDescription: "Expected exactly one key-value pair for enum case, has \(elements.count)")
-        }
-        
-        let (caseName, caseValue) = elements.first!
-        var fieldDecoder = FieldDecoder(string: caseName)
-        
-        // The value should be a dictionary containing the associated values
+        try caseDecoder(&fieldDecoder)
+
+        // Phase 2: decode associated values via struct decoder
         guard case let .dictionary(associatedElements) = caseValue else {
             throw value.typeMismatchError(expectedTypeDescription: "dictionary", at: self.codingPath)
         }
-        
+
         var structDecoder = try StructDecoder(elements: associatedElements, options: self.options, codingPath: self.codingPath.appending(caseName), depth: self.depth)
-        return try closure(&fieldDecoder, &structDecoder)
+        return try valueDecoder(&structDecoder)
     }
         
     // TODO: See below on [Element] decoder for relevant comments.

--- a/Sources/NewCodableMacros/CommonCodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonCodableMacro.swift
@@ -24,11 +24,7 @@ extension CommonCodableMacro: ExtensionMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
-        guard validate(declaration: declaration, for: node, in: context) else {
-            return []
-        }
-        
-        guard let (typeName, properties) = extractTypeNameAndStoredProperties(
+        guard let typeDecl = CodableTypeDeclaration(
             attachedTo: declaration,
             for: node,
             providingExtensionsOf: type,
@@ -36,27 +32,32 @@ extension CommonCodableMacro: ExtensionMacro {
             return []
         }
         
-        let access = accessLevel(of: declaration)
-        let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: CommonCodingFieldExpansionKind.both)
-        let encodingImpl = makeEncodableExtension(for: typeName, with: properties, kind: CommonEncodableExpansionKind(), accessLevel: access)
-        let decodingImpl = makeDecodableExtension(for: typeName, with: properties, kind: CommonDecodableExpansionKind(), accessLevel: access)
-        return [codingFields, encodingImpl, decodingImpl].compactMap { $0 }
+        let expansion = CommonCodableExpansion(type: .both, accessLevel: accessLevel(of: declaration))
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
+        let encodingImpl = typeDecl.makeEncodableExtension(expansion: expansion)
+        let decodingImpl = typeDecl.makeDecodableExtension(expansion: expansion)
+        return codingFields + encodingImpl + decodingImpl
     }
 }
 
-enum CommonCodingFieldExpansionKind: CodingFieldExpansionKind {
-    case encodingOnly
-    case decodingOnly
-    case both
-
-    var protocolName: String {
-        switch self {
-        case .encodingOnly:
-            return "StaticStringEncodingField"
-        case .decodingOnly:
-            return "StaticStringDecodingField"
-        case .both:
-            return "StaticStringCodingField"
+struct CommonCodableExpansion: CodableExpansion {
+    let type: CodableExpansionType
+    let accessLevel: CodableDeclarationAccessLevel
+    
+    var fieldProtocolName: String {
+        switch type {
+        case .encodingOnly: "StaticStringEncodingField"
+        case .decodingOnly: "StaticStringDecodingField"
+        case .both: "StaticStringCodingField"
         }
     }
+    
+    let encodableProtocolName = "CommonEncodable"
+    let decodableProtocolName = "CommonDecodable"
+    let combinedProtocolName = "CommonCodable"
+    
+    let decoderType = "some CommonDecoder & ~Escapable"
+    let structDecoderType = "some CommonStructDecoder & ~Escapable"
+    
+    let encoderType = "some CommonEncoder & ~Copyable & ~Escapable"
 }

--- a/Sources/NewCodableMacros/CommonDecodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonDecodableMacro.swift
@@ -25,11 +25,7 @@ extension CommonDecodableMacro: ExtensionMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
-        guard validate(declaration: declaration, for: node, in: context) else {
-            return []
-        }
-        
-        guard let (typeName, properties) = extractTypeNameAndStoredProperties(
+        guard let typeDecl = CodableTypeDeclaration(
             attachedTo: declaration,
             for: node,
             providingExtensionsOf: type,
@@ -37,14 +33,9 @@ extension CommonDecodableMacro: ExtensionMacro {
             return []
         }
         
-        let access = accessLevel(of: declaration)
-        let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: CommonCodingFieldExpansionKind.decodingOnly)
-        let impl = makeDecodableExtension(for: typeName, with: properties, kind: CommonDecodableExpansionKind(), accessLevel: access)
-        return [codingFields, impl].compactMap { $0 }
+        let expansion = CommonCodableExpansion(type: .decodingOnly, accessLevel: accessLevel(of: declaration))
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
+        let impl = typeDecl.makeDecodableExtension(expansion: expansion)
+        return codingFields + impl
     }
-}
-
-struct CommonDecodableExpansionKind: DecodableExpansionKind {
-    var protocolName: String { "CommonDecodable" }
-    var decoderType: String { "inout some CommonDecoder & ~Escapable" }
 }

--- a/Sources/NewCodableMacros/CommonEncodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonEncodableMacro.swift
@@ -25,11 +25,7 @@ extension CommonEncodableMacro: ExtensionMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
-        guard validate(declaration: declaration, for: node, in: context) else {
-            return []
-        }
-        
-        guard let (typeName, properties) = extractTypeNameAndStoredProperties(
+        guard let typeDecl = CodableTypeDeclaration(
             attachedTo: declaration,
             for: node,
             providingExtensionsOf: type,
@@ -37,14 +33,9 @@ extension CommonEncodableMacro: ExtensionMacro {
             return []
         }
         
-        let access = accessLevel(of: declaration)
-        let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: CommonCodingFieldExpansionKind.encodingOnly)
-        let impl = makeEncodableExtension(for: typeName, with: properties, kind: CommonEncodableExpansionKind(), accessLevel: access)
-        return [codingFields, impl].compactMap { $0 }
+        let expansion = CommonCodableExpansion(type: .encodingOnly, accessLevel: accessLevel(of: declaration))
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
+        let impl = typeDecl.makeEncodableExtension(expansion: expansion)
+        return codingFields + impl
     }
-}
-
-struct CommonEncodableExpansionKind: EncodableExpansionKind {
-    var protocolName: String { "CommonEncodable" }
-    var encoderType: String { "inout some CommonEncoder & ~Copyable & ~Escapable" }
 }

--- a/Sources/NewCodableMacros/JSONCodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONCodableMacro.swift
@@ -24,11 +24,7 @@ extension JSONCodableMacro: ExtensionMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
-        guard validate(declaration: declaration, for: node, in: context) else {
-            return []
-        }
-        
-        guard let (typeName, properties) = extractTypeNameAndStoredProperties(
+        guard let typeDecl = CodableTypeDeclaration(
             attachedTo: declaration,
             for: node,
             providingExtensionsOf: type,
@@ -36,27 +32,32 @@ extension JSONCodableMacro: ExtensionMacro {
             return []
         }
         
-        let access = accessLevel(of: declaration)
-        let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: JSONCodingFieldKind.both)
-        let encodingImpl = makeEncodableExtension(for: typeName, with: properties, kind: JSONEncodableExpansionKind(), accessLevel: access)
-        let decodingImpl = makeDecodableExtension(for: typeName, with: properties, kind: JSONDecodableExpansionKind(), accessLevel: access)
-        return [codingFields, encodingImpl, decodingImpl].compactMap { $0 }
+        let expansion = JSONCodableExpanion(type: .both, accessLevel: accessLevel(of: declaration))
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
+        let encodingImpl = typeDecl.makeEncodableExtension(expansion: expansion)
+        let decodingImpl = typeDecl.makeDecodableExtension(expansion: expansion)
+        return codingFields + encodingImpl + decodingImpl
     }
 }
 
-enum JSONCodingFieldKind: CodingFieldExpansionKind {
-    case encodingOnly
-    case decodingOnly
-    case both
+struct JSONCodableExpanion: CodableExpansion {
+    let type: CodableExpansionType
+    let accessLevel: CodableDeclarationAccessLevel
     
-    var protocolName: String {
-        switch self {
-        case .encodingOnly:
-            return "JSONOptimizedEncodingField"
-        case .decodingOnly:
-            return "JSONOptimizedDecodingField"
-        case .both:
-            return "JSONOptimizedCodingField"
+    var fieldProtocolName: String {
+        switch type {
+        case .encodingOnly: "JSONOptimizedEncodingField"
+        case .decodingOnly: "JSONOptimizedDecodingField"
+        case .both: "JSONOptimizedCodingField"
         }
     }
+    
+    let encodableProtocolName = "JSONEncodable"
+    let decodableProtocolName = "JSONDecodable"
+    let combinedProtocolName = "JSONCodable"
+
+    let decoderType = "some JSONDecoderProtocol & ~Escapable"
+    let structDecoderType = "some JSONDictionaryDecoder & ~Escapable"
+    
+    let encoderType = "JSONDirectEncoder"
 }

--- a/Sources/NewCodableMacros/JSONDecodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONDecodableMacro.swift
@@ -25,11 +25,7 @@ extension JSONDecodableMacro: ExtensionMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
-        guard validate(declaration: declaration, for: node, in: context) else {
-            return []
-        }
-        
-        guard let (typeName, properties) = extractTypeNameAndStoredProperties(
+        guard let typeDecl = CodableTypeDeclaration(
             attachedTo: declaration,
             for: node,
             providingExtensionsOf: type,
@@ -37,15 +33,9 @@ extension JSONDecodableMacro: ExtensionMacro {
             return []
         }
         
-        let access = accessLevel(of: declaration)
-        let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: JSONCodingFieldKind.decodingOnly)
-        let impl = makeDecodableExtension(for: typeName, with: properties, kind: JSONDecodableExpansionKind(), accessLevel: access)
-        return [codingFields, impl].compactMap { $0 }
+        let expansion = JSONCodableExpanion(type: .decodingOnly, accessLevel: accessLevel(of: declaration))
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
+        let impl = typeDecl.makeDecodableExtension(expansion: expansion)
+        return codingFields + impl
     }
 }
-
-struct JSONDecodableExpansionKind: DecodableExpansionKind {
-    var protocolName: String { "JSONDecodable" }
-    var decoderType: String { "inout some JSONDecoderProtocol & ~Escapable" }
-}
-

--- a/Sources/NewCodableMacros/JSONEncodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONEncodableMacro.swift
@@ -25,11 +25,7 @@ extension JSONEncodableMacro: ExtensionMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
-        guard validate(declaration: declaration, for: node, in: context) else {
-            return []
-        }
-
-        guard let (typeName, properties) = extractTypeNameAndStoredProperties(
+        guard let typeDecl = CodableTypeDeclaration(
             attachedTo: declaration,
             for: node,
             providingExtensionsOf: type,
@@ -37,14 +33,9 @@ extension JSONEncodableMacro: ExtensionMacro {
             return []
         }
         
-        let access = accessLevel(of: declaration)
-        let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: JSONCodingFieldKind.encodingOnly)
-        let impl = makeEncodableExtension(for: typeName, with: properties, kind: JSONEncodableExpansionKind(), accessLevel: access)
-        return [codingFields, impl].compactMap { $0 }
+        let expansion = JSONCodableExpanion(type: .encodingOnly, accessLevel: accessLevel(of: declaration))
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
+        let impl = typeDecl.makeEncodableExtension(expansion: expansion)
+        return codingFields + impl
     }
-}
-
-struct JSONEncodableExpansionKind: EncodableExpansionKind {
-    var protocolName: String { "JSONEncodable" }
-    var encoderType: String { "inout JSONDirectEncoder" }
 }

--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -31,52 +31,152 @@ struct DetailedStoredProperty {
     }
 }
 
-/// Represents the kind of coding fields to generate
-protocol CodingFieldExpansionKind: Equatable {
-    static var encodingOnly: Self { get }
-    static var decodingOnly: Self { get }
-    static var both: Self { get }
-    
-    /// The protocol name that the generated enum should conform to
-    var protocolName: String { get }
-    
-    /// Whether the generated enum should include key lookup functionality
-    var includesKeyLookup: Bool { get }
-    
-    /// Whether the generated enum should include an "unknown" case
-    var includesUnknownCase: Bool { get }
-    
-    /// Whether this kind supports encoding operations
-    var supportsEncoding: Bool { get }
-    
-    /// Whether this kind supports decoding operations
-    var supportsDecoding: Bool { get }
+/// Represents an associated value of an enum case
+struct EnumCaseAssociatedValue {
+    /// The original label from the enum case declaration, or `nil` for unlabeled parameters.
+    let label: String?
+    /// The label if present, or the positional name (_0, _1, etc.)
+    let encodedName: String
+    let typeName: String
 }
 
-extension CodingFieldExpansionKind {
-    var includesKeyLookup: Bool {
-        supportsDecoding
-    }
+/// Represents a parsed enum case with its associated values
+struct EnumCaseInfo {
+    let name: String
+    let key: String
+    let aliases: [String]
+    let associatedValues: [EnumCaseAssociatedValue]
     
-    var includesUnknownCase: Bool {
-        supportsDecoding
-    }
+    var hasAssociatedValues: Bool { !associatedValues.isEmpty }
+}
+
+enum CodableExpansionType {
+    case encodingOnly
+    case decodingOnly
+    case both
+}
+
+/// Represents the kind of coding fields to generate
+protocol CodableExpansion: Equatable {
     
-    var supportsEncoding: Bool {
-        switch self {
-        case .encodingOnly, .both:
-            return true
-        default:
-            return false
+    /// Describes which set of protocol(s) we're expanding.
+    var type: CodableExpansionType { get }
+    
+    /// The access level that the macro should use for codable protocol conformances
+    var accessLevel: CodableDeclarationAccessLevel { get }
+
+    /// The name of the field protocol, which will differ depending on whether we're adding just encodable, just decodable, or both.
+    var fieldProtocolName: String { get }
+    
+    /// The encodable/decodable/combined protocol names.
+    var encodableProtocolName: String { get }
+    var decodableProtocolName: String { get }
+    var combinedProtocolName: String { get }
+    
+    /// The decoder parameter type in the decode function signature (without `inout`)
+    var decoderType: String { get }
+    
+    /// The struct decoder type for per-case decode methods (e.g. "some JSONDictionaryDecoder & ~Escapable")
+    var structDecoderType: String { get }
+    
+    /// The encoder parameter type in the encode function signature (without `inout`)
+    var encoderType: String { get }
+    
+    /// Whether the generated field enum should include key lookup functionality
+    var fieldTypeIncludesKeyLookup: Bool { get }
+    
+    /// Whether the generated field enum should include an "unknown" case
+    var fieldTypeIncludesUnknownCase: Bool { get }
+}
+
+extension CodableExpansion {
+    var fieldTypeIncludesKeyLookup: Bool {
+        switch self.type {
+        case .encodingOnly: false
+        default: true
         }
     }
     
-    var supportsDecoding: Bool {
+    var fieldTypeIncludesUnknownCase: Bool {
+        switch self.type {
+        case .encodingOnly: false
+        default: true
+        }
+    }
+}
+
+// MARK: - Codable Type Declaration
+
+/// Abstracts over struct and enum declarations for codable macro expansion.
+/// Validates the declaration, extracts the relevant data, and provides methods
+/// to generate the coding field, encodable, and decodable extensions.
+enum CodableTypeDeclaration {
+    case structDecl(typeName: TokenSyntax, properties: [DetailedStoredProperty])
+    case enumDecl(typeName: TokenSyntax, cases: [EnumCaseInfo])
+
+    init?(
+        attachedTo declaration: some DeclGroupSyntax,
+        for node: AttributeSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) {
+        let typeName: TokenSyntax
+        if let identifierType = type.as(IdentifierTypeSyntax.self) {
+            typeName = identifierType.name
+        } else {
+            typeName = TokenSyntax(.identifier(type.trimmedDescription), presence: .present)
+        }
+        
+        if declaration.is(EnumDeclSyntax.self) {
+            guard let cases = extractEnumCases(from: declaration.memberBlock, for: node, in: context) else {
+                return nil
+            }
+            self = .enumDecl(typeName: typeName, cases: cases)
+        } else if declaration.is(StructDeclSyntax.self) {
+            guard let properties = extractDetailedStoredProperties(from: declaration.memberBlock, for: node, in: context) else {
+                return nil
+            }
+            self = .structDecl(typeName: typeName, properties: properties)
+        } else {
+            context.diagnose(.init(
+                node: node,
+                message: SharedMacroDiagnostic.notAStructOrEnum(macroName: node.attributeName.trimmedDescription)
+            ))
+            return nil
+        }
+    }
+
+    func makeCodingFieldsExtension(expansion: some CodableExpansion) -> [ExtensionDeclSyntax] {
+        let ext: ExtensionDeclSyntax?
         switch self {
-        case .decodingOnly, .both:
-            return true
-        default:
-            return false
+        case .structDecl(let typeName, let properties):
+            ext = NewCodableMacros.makeCodingFieldsExtension(for: typeName, from: properties, expansion: expansion)
+        case .enumDecl(let typeName, let cases):
+            ext = makeEnumCodingFieldsExtension(for: typeName, from: cases, expansion: expansion)
+        }
+        return [ext].compactMap { $0 }
+    }
+
+    func makeEncodableExtension(expansion: some CodableExpansion) -> [ExtensionDeclSyntax] {
+        let ext: ExtensionDeclSyntax?
+        switch self {
+        case .structDecl(let typeName, let properties):
+            ext = NewCodableMacros.makeEncodableExtension(for: typeName, with: properties, expansion: expansion)
+        case .enumDecl(let typeName, let cases):
+            ext = makeEnumEncodableExtension(for: typeName, with: cases, expansion: expansion)
+        }
+        return [ext].compactMap { $0 }
+    }
+
+    func makeDecodableExtension(expansion: some CodableExpansion) -> [ExtensionDeclSyntax] {
+        switch self {
+        case .structDecl(let typeName, let properties):
+            if let ext = NewCodableMacros.makeDecodableExtension(for: typeName, with: properties, expansion: expansion) {
+                return [ext]
+            }
+            return []
+        case .enumDecl(let typeName, let cases):
+            return makeEnumDecodableExtension(for: typeName, with: cases, expansion: expansion)
         }
     }
 }
@@ -174,20 +274,73 @@ func extractDetailedStoredProperties(
 
 // MARK: - Access Level
 
+enum CodableDeclarationAccessLevel {
+    case `public`
+    case `package`
+    case unspecified
+    
+    var inlineDeclPrefix: String {
+        switch self {
+        case .public: "public "
+        case .package: "package "
+        case .unspecified: ""
+        }
+    }
+}
+
 /// Returns the access-level modifier (with trailing space) that should be applied to
 /// members generated inside an extension of `declaration`, or `""` when no modifier is needed.
-func accessLevel(of declaration: some DeclGroupSyntax) -> String {
+func accessLevel(of declaration: some DeclGroupSyntax) -> CodableDeclarationAccessLevel {
     for modifier in declaration.modifiers {
         switch modifier.name.tokenKind {
         case .keyword(.public), .keyword(.open):
-            return "public "
+            return .public
         case .keyword(.package):
-            return "package "
+            return .package
         default:
             continue
         }
     }
-    return ""
+    return .unspecified
+}
+
+// MARK: - Enum Case Extraction
+
+func extractEnumCases(
+    from members: MemberBlockSyntax,
+    for node: AttributeSyntax,
+    in context: some MacroExpansionContext
+) -> [EnumCaseInfo]? {
+    var cases: [EnumCaseInfo] = []
+
+    for member in members.members {
+        guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+            continue
+        }
+
+        let customKey = customCodingKey(from: caseDecl.attributes)
+        let aliases = decodableAliases(from: caseDecl.attributes)
+
+        for element in caseDecl.elements {
+            let caseName = element.name.trimmedDescription
+            let key = customKey ?? caseName
+            var parameters: [EnumCaseAssociatedValue] = []
+
+            if let paramClause = element.parameterClause {
+                for (index, param) in paramClause.parameters.enumerated() {
+                    var label = param.firstName?.trimmedDescription
+                    if label == "_" { label = nil }
+                    let encodedName = label ?? "_\(index)"
+                    let typeName = param.type.trimmedDescription
+                    parameters.append(EnumCaseAssociatedValue(label: label, encodedName: encodedName, typeName: typeName))
+                }
+            }
+
+            cases.append(EnumCaseInfo(name: caseName, key: key, aliases: aliases, associatedValues: parameters))
+        }
+    }
+
+    return cases
 }
 
 // MARK: - Attribute Parsing Utilities
@@ -243,26 +396,26 @@ func defaultValueExpression(from attributes: AttributeListSyntax) -> String? {
 
 // MARK: - Coding Fields Generation
 
-/// Unified function for generating coding fields with any expansion kind.
-func makeCodingFieldsExtension<T: CodingFieldExpansionKind>(
+/// Unified function for generating coding fields with any expansion kind
+func makeCodingFieldsExtension (
     for typeName: TokenSyntax,
     from properties: [DetailedStoredProperty],
-    kind: T
+    expansion: some CodableExpansion
 ) -> ExtensionDeclSyntax? {
     if properties.isEmpty {
         return nil
     }
     
-    let casesList = properties.map { "case \($0.name)" } + (kind.includesUnknownCase ? ["case unknown"] : [])
+    let casesList = properties.map { "case \($0.name)" } + (expansion.fieldTypeIncludesUnknownCase ? ["case unknown"] : [])
     let cases = casesList.joined(separator: "\n")
 
     let switchCasesList = properties.map {
         "case .\($0.name): \"\($0.key)\""
-    } + (kind.includesUnknownCase ? ["case .unknown: fatalError()"] : [])
+    } + (expansion.fieldTypeIncludesUnknownCase ? ["case .unknown: fatalError()"] : [])
     let joinedSwitchCases = switchCasesList.joined(separator: "\n")
 
     let decl: DeclSyntax
-    if kind.includesKeyLookup {
+    if expansion.fieldTypeIncludesKeyLookup {
         let fieldForKeyCasesList = properties.flatMap { prop -> [String] in
             var cases = ["case \"\(prop.key)\": .\(prop.name)"]
             for alias in prop.aliases {
@@ -272,11 +425,11 @@ func makeCodingFieldsExtension<T: CodingFieldExpansionKind>(
         }
         let fieldForKeyCases = fieldForKeyCasesList.joined(separator: "\n")
 
-        let defaultCase = kind.includesUnknownCase ? ".unknown" : "throw CodingError.unknownKey(key)"
+        let defaultCase = expansion.fieldTypeIncludesUnknownCase ? ".unknown" : "throw CodingError.unknownKey(key)"
 
         decl = """
         extension \(typeName) {
-            enum CodingFields: \(raw: kind.protocolName) {
+            enum CodingFields: \(raw: expansion.fieldProtocolName) {
                 \(raw: cases)
 
                 @_transparent
@@ -289,7 +442,8 @@ func makeCodingFieldsExtension<T: CodingFieldExpansionKind>(
                 static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
                     switch UTF8SpanComparator(key) {
                     \(raw: fieldForKeyCases)
-                    default: \(raw: defaultCase)
+                    default:
+                        \(raw: defaultCase)
                     }
                 }
             }
@@ -298,7 +452,7 @@ func makeCodingFieldsExtension<T: CodingFieldExpansionKind>(
     } else {
         decl = """
         extension \(typeName) {
-            enum CodingFields: \(raw: kind.protocolName) {
+            enum CodingFields: \(raw: expansion.fieldProtocolName) {
                 \(raw: cases)
 
                 @_transparent
@@ -316,26 +470,15 @@ func makeCodingFieldsExtension<T: CodingFieldExpansionKind>(
 
 // MARK: - Shared Diagnostics
 
-func validate(declaration: some DeclGroupSyntax, for node: AttributeSyntax, in context: some MacroExpansionContext) -> Bool {
-    guard declaration.is(StructDeclSyntax.self) else {
-        context.diagnose(.init(
-            node: node,
-            message: SharedMacroDiagnostic.notAStruct(macroName: node.attributeName.trimmedDescription)
-        ))
-        return false
-    }
-    return true
-}
-
 enum SharedMacroDiagnostic: DiagnosticMessage {
-    case notAStruct(macroName: String)
+    case notAStructOrEnum(macroName: String)
     case codingKeyOnMultipleBindings
     case missingTypeAnnotation(macroName: String)
 
     var message: String {
         switch self {
-        case .notAStruct(let macroName):
-            return "@\(macroName) can only be applied to structs"
+        case .notAStructOrEnum(let macroName):
+            return "@\(macroName) can only be applied to structs or enums"
         case .codingKeyOnMultipleBindings:
             return "@CodingKey cannot be applied to a declaration with multiple bindings"
         case .missingTypeAnnotation(let macroName):
@@ -345,7 +488,7 @@ enum SharedMacroDiagnostic: DiagnosticMessage {
     
     var id: String {
         switch self {
-        case .notAStruct: "notAStruct"
+        case .notAStructOrEnum: "notAStructOrEnum"
         case .codingKeyOnMultipleBindings: "codingKeyOnMultipleBindings"
         case .missingTypeAnnotation: "missingTypeAnnotation"
         }
@@ -360,26 +503,17 @@ enum SharedMacroDiagnostic: DiagnosticMessage {
 
 // MARK: - Encodable Extension Generation
 
-/// Abstracts over the differences between Common and JSON encodable macro expansions
-protocol EncodableExpansionKind {
-    /// The protocol the generated extension conforms to (e.g. "CommonEncodable", "JSONEncodable")
-    var protocolName: String { get }
-    
-    /// The encoder parameter type in the encode function signature
-    var encoderType: String { get }
-}
-
 func makeEncodableExtension(
     for typeName: TokenSyntax,
     with properties: [DetailedStoredProperty],
-    kind: some EncodableExpansionKind,
-    accessLevel: String = ""
+    expansion: some CodableExpansion
 ) -> ExtensionDeclSyntax? {
+    let accessLevelPrefix = expansion.accessLevel.inlineDeclPrefix
     let extensionDecl: DeclSyntax
     if properties.isEmpty {
         extensionDecl = """
-        extension \(typeName): \(raw: kind.protocolName) {
-            \(raw: accessLevel)func encode(to encoder: \(raw: kind.encoderType)) throws(CodingError.Encoding) {
+        extension \(typeName): \(raw: expansion.encodableProtocolName) {
+            \(raw: accessLevelPrefix)func encode(to encoder: inout \(raw: expansion.encoderType)) throws(CodingError.Encoding) {
                 try encoder.encodeStructFields(count: 0) { _ throws(CodingError.Encoding) in
                 }
             }
@@ -393,8 +527,8 @@ func makeEncodableExtension(
         let fieldCount = properties.count
 
         extensionDecl = """
-        extension \(typeName): \(raw: kind.protocolName) {
-            \(raw: accessLevel)func encode(to encoder: \(raw: kind.encoderType)) throws(CodingError.Encoding) {
+        extension \(typeName): \(raw: expansion.encodableProtocolName) {
+            \(raw: accessLevelPrefix)func encode(to encoder: inout \(raw: expansion.encoderType)) throws(CodingError.Encoding) {
                 try encoder.encodeStructFields(count: \(raw: fieldCount)) { structEncoder throws(CodingError.Encoding) in
                     \(raw: encodeStatements)
                 }
@@ -408,26 +542,17 @@ func makeEncodableExtension(
 
 // MARK: - Decodable Extension Generation
 
-/// Abstracts over the differences between Common and JSON decodable macro expansions
-protocol DecodableExpansionKind {
-    /// The protocol the generated extension conforms to (e.g. "CommonDecodable", "JSONDecodable")
-    var protocolName: String { get }
-    
-    /// The decoder parameter type in the decode function signature
-    var decoderType: String { get }
-}
-
 func makeDecodableExtension(
     for typeName: TokenSyntax,
     with properties: [DetailedStoredProperty],
-    kind: some DecodableExpansionKind,
-    accessLevel: String = ""
+    expansion: some CodableExpansion
 ) -> ExtensionDeclSyntax? {
+    let accessLevelPrefix = expansion.accessLevel.inlineDeclPrefix
     let decl: DeclSyntax
     if properties.isEmpty {
         decl = """
-        extension \(typeName): \(raw: kind.protocolName) {
-            \(raw: accessLevel)static func decode(from decoder: \(raw: kind.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
+        extension \(typeName): \(raw: expansion.decodableProtocolName) {
+            \(raw: accessLevelPrefix)static func decode(from decoder: inout \(raw: expansion.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
                 try decoder.decodeStruct { _ throws(CodingError.Decoding) in
                     \(typeName)()
                 }
@@ -479,8 +604,8 @@ func makeDecodableExtension(
         }
 
         decl = """
-        extension \(typeName): \(raw: kind.protocolName) {
-            \(raw: accessLevel)static func decode(from decoder: \(raw: kind.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
+        extension \(typeName): \(raw: expansion.decodableProtocolName) {
+            \(raw: accessLevelPrefix)static func decode(from decoder: inout \(raw: expansion.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     \(raw: varDeclarations)
                     var _codingField: CodingFields?
@@ -502,25 +627,284 @@ func makeDecodableExtension(
     return decl.as(ExtensionDeclSyntax.self)
 }
 
-// MARK: - Shared Macro Implementation Patterns
+// MARK: - Enum Coding Fields Generation
 
-func extractTypeNameAndStoredProperties(
-    attachedTo declaration: some DeclGroupSyntax,
-    for node: AttributeSyntax,
-    providingExtensionsOf type: some TypeSyntaxProtocol,
-    in context: some MacroExpansionContext,
-) -> (TokenSyntax, [DetailedStoredProperty])? {
-    guard let properties = extractDetailedStoredProperties(from: declaration.memberBlock, for: node, in: context) else {
+/// Generates the CodingFields enum extension for an enum type's case names,
+/// along with per-case field enums for cases with associated values.
+func makeEnumCodingFieldsExtension(
+    for typeName: TokenSyntax,
+    from cases: [EnumCaseInfo],
+    expansion: some CodableExpansion,
+) -> ExtensionDeclSyntax? {
+    if cases.isEmpty {
         return nil
     }
 
-    // Extract the type name as a TokenSyntax
-    let typeName: TokenSyntax
-    if let identifierType = type.as(IdentifierTypeSyntax.self) {
-        typeName = identifierType.name
-    } else {
-        // For complex types, we'll use the trimmed description as the identifier
-        typeName = TokenSyntax(.identifier(type.trimmedDescription), presence: .present)
+    let casesList = cases.map { "case \($0.name)" }
+    let joinedCases = casesList.joined(separator: "\n")
+
+    let switchCasesList = cases.map {
+        "case .\($0.name): \"\($0.key)\""
     }
-    return (typeName, properties)
+    let joinedSwitchCases = switchCasesList.joined(separator: "\n")
+
+    // Generate per-case field enums for cases with associated values
+    let casesWithAssociatedValues = cases.filter { $0.hasAssociatedValues }
+    let perCaseFieldEnums = casesWithAssociatedValues.map { enumCase -> String in
+        let fieldsEnumName = "\(capitalizedCaseName(enumCase.name))Fields"
+        let fieldCases = enumCase.associatedValues.map { "case \($0.encodedName)" }.joined(separator: "\n")
+        let fieldSwitchCases = enumCase.associatedValues.map {
+            "case .\($0.encodedName): \"\($0.encodedName)\""
+        }.joined(separator: "\n")
+
+        let decodeSection: String
+        if expansion.type != .encodingOnly {
+            let varDeclarations = enumCase.associatedValues.map {
+                "var \($0.encodedName): \($0.typeName)?"
+            }.joined(separator: "\n        ")
+
+            let decodeSwitchCases = enumCase.associatedValues.map {
+                "case .\($0.encodedName): \($0.encodedName) = try valueDecoder.decode(\($0.typeName).self)"
+            }.joined(separator: "\n            ")
+
+            let guardLetNames = enumCase.associatedValues.map { "let \($0.encodedName)" }.joined(separator: ", ")
+
+            let args = enumCase.associatedValues.map { param -> String in
+                if param.label != nil {
+                    return "\(param.encodedName): \(param.encodedName)"
+                } else {
+                    return "\(param.encodedName)"
+                }
+            }.joined(separator: ", ")
+
+            decodeSection = """
+
+
+                static func decode(from decoder: inout \(expansion.structDecoderType)) throws(CodingError.Decoding) -> \(typeName) {
+                    \(varDeclarations)
+                    var _field: \(fieldsEnumName)?
+                    try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                        _field = try fieldDecoder.decode(\(fieldsEnumName).self)
+                    } andValue: { valueDecoder throws(CodingError.Decoding) in
+                        switch _field! {
+                        \(decodeSwitchCases)
+                        }
+                    }
+                    guard \(guardLetNames) else {
+                        throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                    }
+                    return .\(enumCase.name)(\(args))
+                }
+            """
+        } else {
+            decodeSection = ""
+        }
+
+        if expansion.fieldTypeIncludesKeyLookup {
+            let fieldForKeyCases = enumCase.associatedValues.map {
+                "case \"\($0.encodedName)\": .\($0.encodedName)"
+            }.joined(separator: "\n")
+
+            return """
+            enum \(fieldsEnumName): \(expansion.fieldProtocolName) {
+                \(fieldCases)
+
+                @_transparent
+                var staticString: StaticString {
+                    switch self {
+                    \(fieldSwitchCases)
+                    }
+                }
+
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> \(fieldsEnumName) {
+                    switch UTF8SpanComparator(key) {
+                    \(fieldForKeyCases)
+                    default:
+                        throw CodingError.unknownKey(key)
+                    }
+                }\(decodeSection)
+            }
+            """
+        } else {
+            return """
+            enum \(fieldsEnumName): \(expansion.fieldProtocolName) {
+                \(fieldCases)
+
+                @_transparent
+                var staticString: StaticString {
+                    switch self {
+                    \(fieldSwitchCases)
+                    }
+                }\(decodeSection)
+            }
+            """
+        }
+    }.joined(separator: "\n\n")
+
+    let perCaseSection = perCaseFieldEnums.isEmpty ? "" : "\n\n\(perCaseFieldEnums)"
+
+    let decl: DeclSyntax
+    if expansion.fieldTypeIncludesKeyLookup {
+        let fieldForKeyCasesList = cases.flatMap { c -> [String] in
+            var entries = ["case \"\(c.key)\": .\(c.name)"]
+            for alias in c.aliases {
+                entries.append("case \"\(alias)\": .\(c.name)")
+            }
+            return entries
+        }
+        let fieldForKeyCases = fieldForKeyCasesList.joined(separator: "\n")
+
+        decl = """
+        extension \(typeName) {
+        enum CodingFields: \(raw: expansion.fieldProtocolName) {
+        \(raw: joinedCases)
+
+        @_transparent
+        var staticString: StaticString {
+            switch self {
+            \(raw: joinedSwitchCases)
+            }
+        }
+
+        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+            switch UTF8SpanComparator(key) {
+            \(raw: fieldForKeyCases)
+            default:
+                throw CodingError.unknownKey(key)
+            }
+        }\(raw: perCaseSection)
+        }
+        }
+        """
+    } else {
+        decl = """
+        extension \(typeName) {
+        enum CodingFields: \(raw: expansion.fieldProtocolName) {
+        \(raw: joinedCases)
+
+        @_transparent
+        var staticString: StaticString {
+            switch self {
+            \(raw: joinedSwitchCases)
+            }
+        }\(raw: perCaseSection)
+        }
+        }
+        """
+    }
+    return decl.as(ExtensionDeclSyntax.self)
 }
+
+// MARK: - Enum Encodable Extension Generation
+
+/// Capitalizes the first character of a string for use as an enum name
+private func capitalizedCaseName(_ name: String) -> String {
+    guard let first = name.first else { return name }
+    return String(first).uppercased() + name.dropFirst()
+}
+
+func makeEnumEncodableExtension(
+    for typeName: TokenSyntax,
+    with cases: [EnumCaseInfo],
+    expansion: some CodableExpansion
+) -> ExtensionDeclSyntax? {
+    let switchCases: String
+    if cases.isEmpty {
+        // Empty enum - no cases to encode
+        switchCases = ""
+    } else {
+        switchCases = cases.map { enumCase -> String in
+            if enumCase.associatedValues.isEmpty {
+                return "case .\(enumCase.name):\ntry encoder.encodeEnumCase(CodingFields.\(enumCase.name))"
+            } else {
+                let bindings = enumCase.associatedValues.map { "let \($0.encodedName)" }.joined(separator: ", ")
+                let fieldsEnumName = "CodingFields.\(capitalizedCaseName(enumCase.name))Fields"
+
+                let encodeStatements = enumCase.associatedValues.map {
+                    "try valueEncoder.encode(field: \(fieldsEnumName).\($0.encodedName), value: \($0.encodedName))"
+                }.joined(separator: "\n")
+
+                return """
+                case .\(enumCase.name)(\(bindings)):
+                try encoder.encodeEnumCase(CodingFields.\(enumCase.name), associatedValueCount: \(enumCase.associatedValues.count)) { valueEncoder throws(CodingError.Encoding) in
+                \(encodeStatements)
+                }
+                """
+            }
+        }.joined(separator: "\n")
+    }
+
+    let body: String
+    if cases.isEmpty {
+        body = ""
+    } else {
+        body = """
+        switch self {
+        \(switchCases)
+        }
+        """
+    }
+
+    let extensionDecl: DeclSyntax = """
+    extension \(typeName): \(raw: expansion.encodableProtocolName) {
+        func encode(to encoder: inout \(raw: expansion.encoderType)) throws(CodingError.Encoding) {
+            \(raw: body)
+        }
+    }
+    """
+
+    return extensionDecl.as(ExtensionDeclSyntax.self)
+}
+
+// MARK: - Enum Decodable Extension Generation
+
+func makeEnumDecodableExtension(
+    for typeName: TokenSyntax,
+    with cases: [EnumCaseInfo],
+    expansion: some CodableExpansion
+) -> [ExtensionDeclSyntax] {
+    // Generate the main decode method
+    let mainDecl: DeclSyntax
+    if cases.isEmpty {
+        mainDecl = """
+        extension \(typeName): \(raw: expansion.decodableProtocolName) {
+            static func decode(from decoder: inout \(raw: expansion.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
+                throw CodingError.dataCorrupted(debugDescription: "Cannot decode empty enum")
+            }
+        }
+        """
+    } else {
+        // Cases with associated values delegate to per-case decode methods on nested field enums.
+        // Cases without associated values just return the case directly.
+        let caseDecodeStatements = cases.map { enumCase -> String in
+            if enumCase.hasAssociatedValues {
+                let fieldsEnumName = "CodingFields.\(capitalizedCaseName(enumCase.name))Fields"
+                return "case .\(enumCase.name): try \(fieldsEnumName).decode(from: &valuesDecoder)"
+            } else {
+                return "case .\(enumCase.name): .\(enumCase.name)"
+            }
+        }.joined(separator: "\n")
+
+        mainDecl = """
+        extension \(typeName): \(raw: expansion.decodableProtocolName) {
+            static func decode(from decoder: inout \(raw: expansion.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
+                var _codingField: CodingFields?
+                return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                    _codingField = try fieldDecoder.decode(CodingFields.self)
+                } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                    return switch _codingField! {
+                    \(raw: caseDecodeStatements)
+                    }
+                }
+            }
+        }
+        """
+    }
+
+    if let mainExtDecl = mainDecl.as(ExtensionDeclSyntax.self) {
+        return [mainExtDecl]
+    }
+    return []
+}
+
+

--- a/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
@@ -649,8 +649,511 @@ struct CommonCodableMacroTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: "@CommonCodable can only be applied to structs", line: 1, column: 1),
+                DiagnosticSpec(message: "@CommonCodable can only be applied to structs or enums", line: 1, column: 1),
             ],
+            macros: codableTestMacros
+        )
+    }
+
+    // MARK: - Enum Tests
+
+    @Test func enumNoAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonCodable
+            enum Direction {
+                case north
+                case south
+            }
+            """,
+            expandedSource: """
+            enum Direction {
+                case north
+                case south
+            }
+
+            extension Direction {
+                enum CodingFields: StaticStringCodingField {
+                    case north
+                    case south
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .north:
+                            "north"
+                        case .south:
+                            "south"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "north":
+                            .north
+                        case "south":
+                            .south
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Direction: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .north:
+                        try encoder.encodeEnumCase(CodingFields.north)
+                    case .south:
+                        try encoder.encodeEnumCase(CodingFields.south)
+                    }
+                }
+            }
+
+            extension Direction: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Direction {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .north:
+                            .north
+                        case .south:
+                            .south
+                        }
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
+    @Test func enumWithAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonCodable
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+            """,
+            expandedSource: """
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+
+            extension Shape {
+                enum CodingFields: StaticStringCodingField {
+                    case circle
+                    case point
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .circle:
+                            "circle"
+                        case .point:
+                            "point"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "circle":
+                            .circle
+                        case "point":
+                            .point
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum CircleFields: StaticStringCodingField {
+                        case radius
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .radius:
+                                "radius"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "radius":
+                                .radius
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                            var radius: Double?
+                            var _field: CircleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(CircleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .radius:
+                                    radius = try valueDecoder.decode(Double.self)
+                                }
+                            }
+                            guard let radius else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .circle(radius: radius)
+                        }
+                    }
+                }
+            }
+
+            extension Shape: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .circle(let radius):
+                        try encoder.encodeEnumCase(CodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.CircleFields.radius, value: radius)
+                        }
+                    case .point:
+                        try encoder.encodeEnumCase(CodingFields.point)
+                    }
+                }
+            }
+
+            extension Shape: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .circle:
+                            try CodingFields.CircleFields.decode(from: &valuesDecoder)
+                        case .point:
+                            .point
+                        }
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
+    @Test func enumWithUnlabeledAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonCodable
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+            """,
+            expandedSource: """
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+
+            extension Wrapper {
+                enum CodingFields: StaticStringCodingField {
+                    case single
+                    case pair
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .single:
+                            "single"
+                        case .pair:
+                            "pair"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "single":
+                            .single
+                        case "pair":
+                            .pair
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum SingleFields: StaticStringCodingField {
+                        case _0
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> SingleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "_0":
+                                ._0
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                            var _0: Int?
+                            var _field: SingleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(SingleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case ._0:
+                                    _0 = try valueDecoder.decode(Int.self)
+                                }
+                            }
+                            guard let _0 else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .single(_0)
+                        }
+                    }
+
+                    enum PairFields: StaticStringCodingField {
+                        case _0
+                        case _1
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            case ._1:
+                                "_1"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> PairFields {
+                            switch UTF8SpanComparator(key) {
+                            case "_0":
+                                ._0
+                            case "_1":
+                                ._1
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                            var _0: String?
+                            var _1: Int?
+                            var _field: PairFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(PairFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case ._0:
+                                    _0 = try valueDecoder.decode(String.self)
+                                case ._1:
+                                    _1 = try valueDecoder.decode(Int.self)
+                                }
+                            }
+                            guard let _0, let _1 else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .pair(_0, _1)
+                        }
+                    }
+                }
+            }
+
+            extension Wrapper: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .single(let _0):
+                        try encoder.encodeEnumCase(CodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.SingleFields._0, value: _0)
+                        }
+                    case .pair(let _0, let _1):
+                        try encoder.encodeEnumCase(CodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.PairFields._0, value: _0)
+                            try valueEncoder.encode(field: CodingFields.PairFields._1, value: _1)
+                        }
+                    }
+                }
+            }
+
+            extension Wrapper: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .single:
+                            try CodingFields.SingleFields.decode(from: &valuesDecoder)
+                        case .pair:
+                            try CodingFields.PairFields.decode(from: &valuesDecoder)
+                        }
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
+    @Test func enumWithCustomCodingKey() {
+        assertMacroExpansion(
+            """
+            @CommonCodable
+            enum Status {
+                @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: StaticStringCodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "done":
+                            .done
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .inProgress:
+                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                    case .done:
+                        try encoder.encodeEnumCase(CodingFields.done)
+                    }
+                }
+            }
+
+            extension Status: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .done:
+                            .done
+                        }
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
+    @Test func enumWithDecodableAlias() {
+        assertMacroExpansion(
+            """
+            @CommonCodable
+            enum Status {
+                @DecodableAlias("in-progress") @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: StaticStringCodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "in-progress":
+                            .inProgress
+                        case "done":
+                            .done
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .inProgress:
+                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                    case .done:
+                        try encoder.encodeEnumCase(CodingFields.done)
+                    }
+                }
+            }
+
+            extension Status: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .done:
+                            .done
+                        }
+                    }
+                }
+            }
+            """,
             macros: codableTestMacros
         )
     }

--- a/Tests/NewCodableMacrosTests/CommonDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonDecodableMacroTests.swift
@@ -571,7 +571,7 @@ struct CommonDecodableMacroTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: "@CommonDecodable can only be applied to structs", line: 1, column: 1)
+                DiagnosticSpec(message: "@CommonDecodable can only be applied to structs or enums", line: 1, column: 1)
             ],
             macros: decodableTestMacros
         )
@@ -1224,6 +1224,447 @@ struct CommonDecodableMacroTests {
                             throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
                         }
                         return Person(name: name)
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    // MARK: - Enum Tests
+
+    @Test func enumNoAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonDecodable
+            enum Direction {
+                case north
+                case south
+            }
+            """,
+            expandedSource: """
+            enum Direction {
+                case north
+                case south
+            }
+
+            extension Direction {
+                enum CodingFields: StaticStringDecodingField {
+                    case north
+                    case south
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .north:
+                            "north"
+                        case .south:
+                            "south"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "north":
+                            .north
+                        case "south":
+                            .south
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Direction: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Direction {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .north:
+                            .north
+                        case .south:
+                            .south
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumWithAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonDecodable
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+            """,
+            expandedSource: """
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+
+            extension Shape {
+                enum CodingFields: StaticStringDecodingField {
+                    case circle
+                    case point
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .circle:
+                            "circle"
+                        case .point:
+                            "point"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "circle":
+                            .circle
+                        case "point":
+                            .point
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum CircleFields: StaticStringDecodingField {
+                        case radius
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .radius:
+                                "radius"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "radius":
+                                .radius
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                            var radius: Double?
+                            var _field: CircleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(CircleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .radius:
+                                    radius = try valueDecoder.decode(Double.self)
+                                }
+                            }
+                            guard let radius else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .circle(radius: radius)
+                        }
+                    }
+                }
+            }
+
+            extension Shape: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .circle:
+                            try CodingFields.CircleFields.decode(from: &valuesDecoder)
+                        case .point:
+                            .point
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumWithUnlabeledAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonDecodable
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+            """,
+            expandedSource: """
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+
+            extension Wrapper {
+                enum CodingFields: StaticStringDecodingField {
+                    case single
+                    case pair
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .single:
+                            "single"
+                        case .pair:
+                            "pair"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "single":
+                            .single
+                        case "pair":
+                            .pair
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum SingleFields: StaticStringDecodingField {
+                        case _0
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> SingleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "_0":
+                                ._0
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                            var _0: Int?
+                            var _field: SingleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(SingleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case ._0:
+                                    _0 = try valueDecoder.decode(Int.self)
+                                }
+                            }
+                            guard let _0 else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .single(_0)
+                        }
+                    }
+
+                    enum PairFields: StaticStringDecodingField {
+                        case _0
+                        case _1
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            case ._1:
+                                "_1"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> PairFields {
+                            switch UTF8SpanComparator(key) {
+                            case "_0":
+                                ._0
+                            case "_1":
+                                ._1
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                            var _0: String?
+                            var _1: Int?
+                            var _field: PairFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(PairFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case ._0:
+                                    _0 = try valueDecoder.decode(String.self)
+                                case ._1:
+                                    _1 = try valueDecoder.decode(Int.self)
+                                }
+                            }
+                            guard let _0, let _1 else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .pair(_0, _1)
+                        }
+                    }
+                }
+            }
+
+            extension Wrapper: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .single:
+                            try CodingFields.SingleFields.decode(from: &valuesDecoder)
+                        case .pair:
+                            try CodingFields.PairFields.decode(from: &valuesDecoder)
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumWithCustomCodingKey() {
+        assertMacroExpansion(
+            """
+            @CommonDecodable
+            enum Status {
+                @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: StaticStringDecodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "done":
+                            .done
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .done:
+                            .done
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumWithDecodableAlias() {
+        assertMacroExpansion(
+            """
+            @CommonDecodable
+            enum Status {
+                @DecodableAlias("in-progress") @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: StaticStringDecodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "in-progress":
+                            .inProgress
+                        case "done":
+                            .done
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .done:
+                            .done
+                        }
                     }
                 }
             }

--- a/Tests/NewCodableMacrosTests/CommonEncodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonEncodableMacroTests.swift
@@ -260,7 +260,7 @@ struct CommonEncodableMacroTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: "@CommonEncodable can only be applied to structs", line: 1, column: 1)
+                DiagnosticSpec(message: "@CommonEncodable can only be applied to structs or enums", line: 1, column: 1)
             ],
             macros: commonTestMacros
         )
@@ -499,6 +499,242 @@ struct CommonEncodableMacroTests {
                 public func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
                         try structEncoder.encode(field: CodingFields.name, value: self.name)
+                    }
+                }
+            }
+            """,
+            macros: commonTestMacros
+        )
+    }
+
+    // MARK: - Enum Tests
+
+    @Test func enumNoAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonEncodable
+            enum Direction {
+                case north
+                case south
+            }
+            """,
+            expandedSource: """
+            enum Direction {
+                case north
+                case south
+            }
+
+            extension Direction {
+                enum CodingFields: StaticStringEncodingField {
+                    case north
+                    case south
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .north:
+                            "north"
+                        case .south:
+                            "south"
+                        }
+                    }
+                }
+            }
+
+            extension Direction: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .north:
+                        try encoder.encodeEnumCase(CodingFields.north)
+                    case .south:
+                        try encoder.encodeEnumCase(CodingFields.south)
+                    }
+                }
+            }
+            """,
+            macros: commonTestMacros
+        )
+    }
+
+    @Test func enumWithAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonEncodable
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+            """,
+            expandedSource: """
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+
+            extension Shape {
+                enum CodingFields: StaticStringEncodingField {
+                    case circle
+                    case point
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .circle:
+                            "circle"
+                        case .point:
+                            "point"
+                        }
+                    }
+
+                    enum CircleFields: StaticStringEncodingField {
+                        case radius
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .radius:
+                                "radius"
+                            }
+                        }
+                    }
+                }
+            }
+
+            extension Shape: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .circle(let radius):
+                        try encoder.encodeEnumCase(CodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.CircleFields.radius, value: radius)
+                        }
+                    case .point:
+                        try encoder.encodeEnumCase(CodingFields.point)
+                    }
+                }
+            }
+            """,
+            macros: commonTestMacros
+        )
+    }
+
+    @Test func enumWithUnlabeledAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @CommonEncodable
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+            """,
+            expandedSource: """
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+
+            extension Wrapper {
+                enum CodingFields: StaticStringEncodingField {
+                    case single
+                    case pair
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .single:
+                            "single"
+                        case .pair:
+                            "pair"
+                        }
+                    }
+
+                    enum SingleFields: StaticStringEncodingField {
+                        case _0
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            }
+                        }
+                    }
+
+                    enum PairFields: StaticStringEncodingField {
+                        case _0
+                        case _1
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            case ._1:
+                                "_1"
+                            }
+                        }
+                    }
+                }
+            }
+
+            extension Wrapper: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .single(let _0):
+                        try encoder.encodeEnumCase(CodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.SingleFields._0, value: _0)
+                        }
+                    case .pair(let _0, let _1):
+                        try encoder.encodeEnumCase(CodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.PairFields._0, value: _0)
+                            try valueEncoder.encode(field: CodingFields.PairFields._1, value: _1)
+                        }
+                    }
+                }
+            }
+            """,
+            macros: commonTestMacros
+        )
+    }
+
+    @Test func enumWithCustomCodingKey() {
+        assertMacroExpansion(
+            """
+            @CommonEncodable
+            enum Status {
+                @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: StaticStringEncodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+                }
+            }
+
+            extension Status: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .inProgress:
+                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                    case .done:
+                        try encoder.encodeEnumCase(CodingFields.done)
                     }
                 }
             }

--- a/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
@@ -723,8 +723,348 @@ struct JSONCodableMacroTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: "@JSONCodable can only be applied to structs", line: 1, column: 1),
+                DiagnosticSpec(message: "@JSONCodable can only be applied to structs or enums", line: 1, column: 1),
             ],
+            macros: codableTestMacros
+        )
+    }
+
+    // MARK: - Enum Tests
+
+    @Test func enumNoAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @JSONCodable
+            enum Direction {
+                case north
+                case south
+            }
+            """,
+            expandedSource: """
+            enum Direction {
+                case north
+                case south
+            }
+
+            extension Direction {
+                enum CodingFields: JSONOptimizedCodingField {
+                    case north
+                    case south
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .north:
+                            "north"
+                        case .south:
+                            "south"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "north":
+                            .north
+                        case "south":
+                            .south
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Direction: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .north:
+                        try encoder.encodeEnumCase(CodingFields.north)
+                    case .south:
+                        try encoder.encodeEnumCase(CodingFields.south)
+                    }
+                }
+            }
+
+            extension Direction: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Direction {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .north:
+                            .north
+                        case .south:
+                            .south
+                        }
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
+    @Test func enumWithAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @JSONCodable
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+            """,
+            expandedSource: """
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+
+            extension Shape {
+                enum CodingFields: JSONOptimizedCodingField {
+                    case circle
+                    case point
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .circle:
+                            "circle"
+                        case .point:
+                            "point"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "circle":
+                            .circle
+                        case "point":
+                            .point
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum CircleFields: JSONOptimizedCodingField {
+                        case radius
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .radius:
+                                "radius"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "radius":
+                                .radius
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                            var radius: Double?
+                            var _field: CircleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(CircleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .radius:
+                                    radius = try valueDecoder.decode(Double.self)
+                                }
+                            }
+                            guard let radius else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .circle(radius: radius)
+                        }
+                    }
+                }
+            }
+
+            extension Shape: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .circle(let radius):
+                        try encoder.encodeEnumCase(CodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.CircleFields.radius, value: radius)
+                        }
+                    case .point:
+                        try encoder.encodeEnumCase(CodingFields.point)
+                    }
+                }
+            }
+
+            extension Shape: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .circle:
+                            try CodingFields.CircleFields.decode(from: &valuesDecoder)
+                        case .point:
+                            .point
+                        }
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
+    @Test func enumWithCustomCodingKey() {
+        assertMacroExpansion(
+            """
+            @JSONCodable
+            enum Status {
+                @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: JSONOptimizedCodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "done":
+                            .done
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .inProgress:
+                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                    case .done:
+                        try encoder.encodeEnumCase(CodingFields.done)
+                    }
+                }
+            }
+
+            extension Status: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .done:
+                            .done
+                        }
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
+    @Test func enumWithDecodableAlias() {
+        assertMacroExpansion(
+            """
+            @JSONCodable
+            enum Status {
+                @DecodableAlias("in-progress") @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: JSONOptimizedCodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "in-progress":
+                            .inProgress
+                        case "done":
+                            .done
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .inProgress:
+                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                    case .done:
+                        try encoder.encodeEnumCase(CodingFields.done)
+                    }
+                }
+            }
+
+            extension Status: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .done:
+                            .done
+                        }
+                    }
+                }
+            }
+            """,
             macros: codableTestMacros
         )
     }

--- a/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
@@ -571,7 +571,7 @@ struct JSONDecodableMacroTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: "@JSONDecodable can only be applied to structs", line: 1, column: 1)
+                DiagnosticSpec(message: "@JSONDecodable can only be applied to structs or enums", line: 1, column: 1)
             ],
             macros: decodableTestMacros
         )
@@ -1224,6 +1224,612 @@ struct JSONDecodableMacroTests {
                             throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
                         }
                         return Person(name: name)
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    // MARK: - Enum Tests
+
+    @Test func enumNoAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @JSONDecodable
+            enum Direction {
+                case north
+                case south
+                case east
+                case west
+            }
+            """,
+            expandedSource: """
+            enum Direction {
+                case north
+                case south
+                case east
+                case west
+            }
+
+            extension Direction {
+                enum CodingFields: JSONOptimizedDecodingField {
+                    case north
+                    case south
+                    case east
+                    case west
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .north:
+                            "north"
+                        case .south:
+                            "south"
+                        case .east:
+                            "east"
+                        case .west:
+                            "west"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "north":
+                            .north
+                        case "south":
+                            .south
+                        case "east":
+                            .east
+                        case "west":
+                            .west
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Direction: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Direction {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .north:
+                            .north
+                        case .south:
+                            .south
+                        case .east:
+                            .east
+                        case .west:
+                            .west
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumWithLabeledAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @JSONDecodable
+            enum Shape {
+                case circle(radius: Double)
+                case rectangle(width: Int, height: Int)
+            }
+            """,
+            expandedSource: """
+            enum Shape {
+                case circle(radius: Double)
+                case rectangle(width: Int, height: Int)
+            }
+
+            extension Shape {
+                enum CodingFields: JSONOptimizedDecodingField {
+                    case circle
+                    case rectangle
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .circle:
+                            "circle"
+                        case .rectangle:
+                            "rectangle"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "circle":
+                            .circle
+                        case "rectangle":
+                            .rectangle
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum CircleFields: JSONOptimizedDecodingField {
+                        case radius
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .radius:
+                                "radius"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "radius":
+                                .radius
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                            var radius: Double?
+                            var _field: CircleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(CircleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .radius:
+                                    radius = try valueDecoder.decode(Double.self)
+                                }
+                            }
+                            guard let radius else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .circle(radius: radius)
+                        }
+                    }
+
+                    enum RectangleFields: JSONOptimizedDecodingField {
+                        case width
+                        case height
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .width:
+                                "width"
+                            case .height:
+                                "height"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> RectangleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "width":
+                                .width
+                            case "height":
+                                .height
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                            var width: Int?
+                            var height: Int?
+                            var _field: RectangleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(RectangleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .width:
+                                    width = try valueDecoder.decode(Int.self)
+                                case .height:
+                                    height = try valueDecoder.decode(Int.self)
+                                }
+                            }
+                            guard let width, let height else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .rectangle(width: width, height: height)
+                        }
+                    }
+                }
+            }
+
+            extension Shape: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .circle:
+                            try CodingFields.CircleFields.decode(from: &valuesDecoder)
+                        case .rectangle:
+                            try CodingFields.RectangleFields.decode(from: &valuesDecoder)
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumMixedCases() {
+        assertMacroExpansion(
+            """
+            @JSONDecodable
+            enum Result {
+                case success(value: String)
+                case failure
+            }
+            """,
+            expandedSource: """
+            enum Result {
+                case success(value: String)
+                case failure
+            }
+
+            extension Result {
+                enum CodingFields: JSONOptimizedDecodingField {
+                    case success
+                    case failure
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .success:
+                            "success"
+                        case .failure:
+                            "failure"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "success":
+                            .success
+                        case "failure":
+                            .failure
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum SuccessFields: JSONOptimizedDecodingField {
+                        case value
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .value:
+                                "value"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> SuccessFields {
+                            switch UTF8SpanComparator(key) {
+                            case "value":
+                                .value
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Result {
+                            var value: String?
+                            var _field: SuccessFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(SuccessFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .value:
+                                    value = try valueDecoder.decode(String.self)
+                                }
+                            }
+                            guard let value else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .success(value: value)
+                        }
+                    }
+                }
+            }
+
+            extension Result: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Result {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .success:
+                            try CodingFields.SuccessFields.decode(from: &valuesDecoder)
+                        case .failure:
+                            .failure
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumWithUnlabeledAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @JSONDecodable
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+            """,
+            expandedSource: """
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+
+            extension Wrapper {
+                enum CodingFields: JSONOptimizedDecodingField {
+                    case single
+                    case pair
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .single:
+                            "single"
+                        case .pair:
+                            "pair"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "single":
+                            .single
+                        case "pair":
+                            .pair
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum SingleFields: JSONOptimizedDecodingField {
+                        case _0
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> SingleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "_0":
+                                ._0
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                            var _0: Int?
+                            var _field: SingleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(SingleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case ._0:
+                                    _0 = try valueDecoder.decode(Int.self)
+                                }
+                            }
+                            guard let _0 else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .single(_0)
+                        }
+                    }
+
+                    enum PairFields: JSONOptimizedDecodingField {
+                        case _0
+                        case _1
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            case ._1:
+                                "_1"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> PairFields {
+                            switch UTF8SpanComparator(key) {
+                            case "_0":
+                                ._0
+                            case "_1":
+                                ._1
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                            var _0: String?
+                            var _1: Int?
+                            var _field: PairFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(PairFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case ._0:
+                                    _0 = try valueDecoder.decode(String.self)
+                                case ._1:
+                                    _1 = try valueDecoder.decode(Int.self)
+                                }
+                            }
+                            guard let _0, let _1 else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .pair(_0, _1)
+                        }
+                    }
+                }
+            }
+
+            extension Wrapper: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .single:
+                            try CodingFields.SingleFields.decode(from: &valuesDecoder)
+                        case .pair:
+                            try CodingFields.PairFields.decode(from: &valuesDecoder)
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumWithCustomCodingKey() {
+        assertMacroExpansion(
+            """
+            @JSONDecodable
+            enum Status {
+                @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: JSONOptimizedDecodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "done":
+                            .done
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .done:
+                            .done
+                        }
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
+
+    @Test func enumWithDecodableAlias() {
+        assertMacroExpansion(
+            """
+            @JSONDecodable
+            enum Status {
+                @DecodableAlias("in-progress") @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: JSONOptimizedDecodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "in-progress":
+                            .inProgress
+                        case "done":
+                            .done
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: CodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .done:
+                            .done
+                        }
                     }
                 }
             }

--- a/Tests/NewCodableMacrosTests/JSONEncodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONEncodableMacroTests.swift
@@ -260,7 +260,7 @@ struct JSONEncodableMacroTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: "@JSONEncodable can only be applied to structs", line: 1, column: 1)
+                DiagnosticSpec(message: "@JSONEncodable can only be applied to structs or enums", line: 1, column: 1)
             ],
             macros: testMacros
         )
@@ -499,6 +499,335 @@ struct JSONEncodableMacroTests {
                 public func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
                         try structEncoder.encode(field: CodingFields.name, value: self.name)
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    // MARK: - Enum Tests
+
+    @Test func enumNoAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @JSONEncodable
+            enum Direction {
+                case north
+                case south
+                case east
+                case west
+            }
+            """,
+            expandedSource: """
+            enum Direction {
+                case north
+                case south
+                case east
+                case west
+            }
+
+            extension Direction {
+                enum CodingFields: JSONOptimizedEncodingField {
+                    case north
+                    case south
+                    case east
+                    case west
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .north:
+                            "north"
+                        case .south:
+                            "south"
+                        case .east:
+                            "east"
+                        case .west:
+                            "west"
+                        }
+                    }
+                }
+            }
+
+            extension Direction: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .north:
+                        try encoder.encodeEnumCase(CodingFields.north)
+                    case .south:
+                        try encoder.encodeEnumCase(CodingFields.south)
+                    case .east:
+                        try encoder.encodeEnumCase(CodingFields.east)
+                    case .west:
+                        try encoder.encodeEnumCase(CodingFields.west)
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test func enumWithLabeledAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @JSONEncodable
+            enum Shape {
+                case circle(radius: Double)
+                case rectangle(width: Int, height: Int)
+            }
+            """,
+            expandedSource: """
+            enum Shape {
+                case circle(radius: Double)
+                case rectangle(width: Int, height: Int)
+            }
+
+            extension Shape {
+                enum CodingFields: JSONOptimizedEncodingField {
+                    case circle
+                    case rectangle
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .circle:
+                            "circle"
+                        case .rectangle:
+                            "rectangle"
+                        }
+                    }
+
+                    enum CircleFields: JSONOptimizedEncodingField {
+                        case radius
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .radius:
+                                "radius"
+                            }
+                        }
+                    }
+
+                    enum RectangleFields: JSONOptimizedEncodingField {
+                        case width
+                        case height
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .width:
+                                "width"
+                            case .height:
+                                "height"
+                            }
+                        }
+                    }
+                }
+            }
+
+            extension Shape: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .circle(let radius):
+                        try encoder.encodeEnumCase(CodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.CircleFields.radius, value: radius)
+                        }
+                    case .rectangle(let width, let height):
+                        try encoder.encodeEnumCase(CodingFields.rectangle, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.RectangleFields.width, value: width)
+                            try valueEncoder.encode(field: CodingFields.RectangleFields.height, value: height)
+                        }
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test func enumMixedCases() {
+        assertMacroExpansion(
+            """
+            @JSONEncodable
+            enum Result {
+                case success(value: String)
+                case failure
+            }
+            """,
+            expandedSource: """
+            enum Result {
+                case success(value: String)
+                case failure
+            }
+
+            extension Result {
+                enum CodingFields: JSONOptimizedEncodingField {
+                    case success
+                    case failure
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .success:
+                            "success"
+                        case .failure:
+                            "failure"
+                        }
+                    }
+
+                    enum SuccessFields: JSONOptimizedEncodingField {
+                        case value
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .value:
+                                "value"
+                            }
+                        }
+                    }
+                }
+            }
+
+            extension Result: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .success(let value):
+                        try encoder.encodeEnumCase(CodingFields.success, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.SuccessFields.value, value: value)
+                        }
+                    case .failure:
+                        try encoder.encodeEnumCase(CodingFields.failure)
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test func enumWithUnlabeledAssociatedValues() {
+        assertMacroExpansion(
+            """
+            @JSONEncodable
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+            """,
+            expandedSource: """
+            enum Wrapper {
+                case single(Int)
+                case pair(String, Int)
+            }
+
+            extension Wrapper {
+                enum CodingFields: JSONOptimizedEncodingField {
+                    case single
+                    case pair
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .single:
+                            "single"
+                        case .pair:
+                            "pair"
+                        }
+                    }
+
+                    enum SingleFields: JSONOptimizedEncodingField {
+                        case _0
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            }
+                        }
+                    }
+
+                    enum PairFields: JSONOptimizedEncodingField {
+                        case _0
+                        case _1
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case ._0:
+                                "_0"
+                            case ._1:
+                                "_1"
+                            }
+                        }
+                    }
+                }
+            }
+
+            extension Wrapper: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .single(let _0):
+                        try encoder.encodeEnumCase(CodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.SingleFields._0, value: _0)
+                        }
+                    case .pair(let _0, let _1):
+                        try encoder.encodeEnumCase(CodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CodingFields.PairFields._0, value: _0)
+                            try valueEncoder.encode(field: CodingFields.PairFields._1, value: _1)
+                        }
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test func enumWithCustomCodingKey() {
+        assertMacroExpansion(
+            """
+            @JSONEncodable
+            enum Status {
+                @CodingKey("in_progress") case inProgress
+                case done
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case done
+            }
+
+            extension Status {
+                enum CodingFields: JSONOptimizedEncodingField {
+                    case inProgress
+                    case done
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .done:
+                            "done"
+                        }
+                    }
+                }
+            }
+
+            extension Status: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .inProgress:
+                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                    case .done:
+                        try encoder.encodeEnumCase(CodingFields.done)
                     }
                 }
             }

--- a/Tests/NewCodableTests/CodableRevolutionTests.swift
+++ b/Tests/NewCodableTests/CodableRevolutionTests.swift
@@ -2214,7 +2214,7 @@ struct NewCodableTests {
         #expect(result.items.count == 3)
         
         // Verify each item has the correct coding path with array indices
-        Testing.__checkBinaryOperation(result.items[0].capturedCodingPath.count,{ $0 == $1() },2,expression: .__fromBinaryOperation(.__fromSyntaxNode("result.items[0].capturedCodingPath.count"),"==",.__fromSyntaxNode("2")),comments: [.__line("// Verify each item has the correct coding path with array indices")],isRequired: false,sourceLocation: Testing.SourceLocation.__here()).__expected()
+        #expect(result.items[0].capturedCodingPath.count == 2)
         #expect(result.items[0].capturedCodingPath[0].stringValue == "items")
         #expect(result.items[0].capturedCodingPath[1].intValue == 0)
         #expect(result.items[0].id == 100)

--- a/Tests/NewCodableTests/CodableRevolutionTests.swift
+++ b/Tests/NewCodableTests/CodableRevolutionTests.swift
@@ -594,9 +594,11 @@ struct NewCodableTests {
             }
             
             static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Tests {
-                return try decoder.decodeEnumCase { fieldDecoder, valuesDecoder throws(CodingError.Decoding) in
-                    let field = try fieldDecoder.decode(CodingFields.self)
-                    return switch field {
+                var _codingField: CodingFields?
+                return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                    _codingField = try fieldDecoder.decode(CodingFields.self)
+                } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                    return switch _codingField! {
                     case .allUntagged: try decodeAllUntagged(from: &valuesDecoder)
                     case .someTagged: try decodeSomeTagged(from: &valuesDecoder)
                     case .allTagged: try decodeAllTagged(from: &valuesDecoder)
@@ -654,9 +656,11 @@ struct NewCodableTests {
             }
             
             static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> NoAssociatedType {
-                try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                    let field = try fieldDecoder.decode(CodingFields.self)
-                    return switch field {
+                var _codingField: CodingFields?
+                return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                    _codingField = try fieldDecoder.decode(CodingFields.self)
+                } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                    return switch _codingField! {
                     case .one: .one
                     case .two: .two
                     case .three: .three
@@ -798,19 +802,19 @@ struct NewCodableTests {
         let result = try decoder.decode(CodableStructWithAliasedProperty.self, from: qux)
         #expect(result.bar == "hello")
     }
-
+    
     @JSONCodable
     struct Person: Equatable {
-        let name: String
-        let address: Address
-        
-        struct Address: Codable, Equatable {
-            let city: String
-            let state: String
-            let zip: Int
+            let name: String
+            let address: Address
+            
+            struct Address: Codable, Equatable {
+                let city: String
+                let state: String
+                let zip: Int
+            }
         }
-    }
-    
+        
     @Test func testEmbeddedEncodableForJSON() throws {
         let testValue = Person(
             name: "John",

--- a/Tests/NewCodableTests/CommonMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/CommonMacroIntegrationTests.swift
@@ -107,70 +107,10 @@ public struct PublicCommonCodablePerson {
 }
 
 
+@CommonCodable
 struct CommonCodableStructWithAliasedProperty {
     @DecodableAlias("baz", "qux")
     let bar: String
-}
-
-extension CommonCodableStructWithAliasedProperty {
-    enum CodingFields: StaticStringCodingField {
-        case bar
-        case unknown
-        
-        @_transparent
-        var staticString: StaticString {
-            switch self {
-            case .bar:
-                "bar"
-            case .unknown:
-                fatalError()
-            }
-        }
-        
-        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
-            switch UTF8SpanComparator(key) {
-            case "bar":
-                    .bar
-            case "baz":
-                    .bar
-            case "qux":
-                    .bar
-            default:
-                    .unknown
-            }
-        }
-    }
-}
-
-extension CommonCodableStructWithAliasedProperty: CommonEncodable {
-    func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
-        try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-            try structEncoder.encode(field: CodingFields.bar, value: self.bar)
-        }
-    }
-}
-
-extension CommonCodableStructWithAliasedProperty: CommonDecodable {
-    static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> CommonCodableStructWithAliasedProperty {
-        try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
-            var bar: String?
-            var _codingField: CodingFields?
-            try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                _codingField = try fieldDecoder.decode(CodingFields.self)
-            } andValue: { valueDecoder throws(CodingError.Decoding) in
-                switch _codingField! {
-                case .bar:
-                    bar = try valueDecoder.decode(String.self)
-                case .unknown:
-                    break
-                }
-            }
-            guard let bar else {
-                throw CodingError.dataCorrupted(debugDescription: "Missing required field 'bar'")
-            }
-            return CommonCodableStructWithAliasedProperty(bar: bar)
-        }
-    }
 }
 
 
@@ -181,25 +121,21 @@ struct CommonEncodableMacroIntegrationTests {
         let post = CommonSimplePost(title: "Hello", body: "World")
         let data = try NewJSONEncoder().encode(post)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"title\":\"Hello\""))
-        #expect(json.contains("\"body\":\"World\""))
+        #expect(json == #"{"title":"Hello","body":"World"}"#)
     }
 
     @Test func customCodingKey() throws {
         let post = CommonBlogPost(title: "Test", publishDate: "2026-01-01", tags: ["swift"], rating: 4.5)
         let data = try NewJSONEncoder().encode(post)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"date_published\":\"2026-01-01\""))
-        #expect(json.contains("\"title\":\"Test\""))
-        #expect(json.contains("\"tags\":[\"swift\"]"))
-        #expect(json.contains("\"rating\":4.5"))
+        #expect(json == #"{"title":"Test","date_published":"2026-01-01","tags":["swift"],"rating":4.5}"#)
     }
 
     @Test func optionalNilValue() throws {
         let post = CommonBlogPost(title: "Test", publishDate: "2026-01-01", tags: [], rating: nil)
         let data = try NewJSONEncoder().encode(post)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"rating\":null"))
+        #expect(json == #"{"title":"Test","date_published":"2026-01-01","tags":[],"rating":null}"#)
     }
 
     @Test func emptyStruct() throws {
@@ -216,6 +152,8 @@ struct CommonDecodableMacroIntegrationTests {
     @Test func roundTripBasic() throws {
         let original = CommonRoundTripPerson(name: "Alice", age: 30)
         let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"name":"Alice","age":30}"#)
         let decoded = try NewJSONDecoder().decode(CommonRoundTripPerson.self, from: data)
         #expect(decoded.name == "Alice")
         #expect(decoded.age == 30)
@@ -225,7 +163,7 @@ struct CommonDecodableMacroIntegrationTests {
         let original = CommonRoundTripPost(title: "Hello", publishDate: "2026-01-01", rating: 4.5)
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"date_published\":\"2026-01-01\""))
+        #expect(json == #"{"title":"Hello","date_published":"2026-01-01","rating":4.5}"#)
         let decoded = try NewJSONDecoder().decode(CommonRoundTripPost.self, from: data)
         #expect(decoded.title == "Hello")
         #expect(decoded.publishDate == "2026-01-01")
@@ -303,6 +241,8 @@ struct CommonCodableMacroIntegrationTests {
     @Test func roundTrip() throws {
         let original = CommonCodablePerson(name: "Alice", age: 30)
         let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"name":"Alice","age":30}"#)
         let decoded = try NewJSONDecoder().decode(CommonCodablePerson.self, from: data)
         #expect(decoded.name == "Alice")
         #expect(decoded.age == 30)
@@ -312,7 +252,7 @@ struct CommonCodableMacroIntegrationTests {
         let original = CommonCodablePost(title: "Hello", publishDate: "2026-01-01", rating: 4.5)
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"date_published\":\"2026-01-01\""))
+        #expect(json == #"{"title":"Hello","date_published":"2026-01-01","rating":4.5}"#)
         let decoded = try NewJSONDecoder().decode(CommonCodablePost.self, from: data)
         #expect(decoded.title == "Hello")
         #expect(decoded.publishDate == "2026-01-01")
@@ -331,12 +271,14 @@ struct CommonCodableMacroIntegrationTests {
         let original = CommonSimpleStatus.active
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"active\""))
+        #expect(json == #"{"active":{}}"#)
         let decoded = try NewJSONDecoder().decode(CommonSimpleStatus.self, from: data)
         #expect(decoded == original)
 
         let inactive = CommonSimpleStatus.inactive
         let data2 = try NewJSONEncoder().encode(inactive)
+        let json2 = String(data: data2, encoding: .utf8)!
+        #expect(json2 == #"{"inactive":{}}"#)
         let decoded2 = try NewJSONDecoder().decode(CommonSimpleStatus.self, from: data2)
         #expect(decoded2 == inactive)
     }
@@ -345,8 +287,7 @@ struct CommonCodableMacroIntegrationTests {
         let original = CommonTaskStatus.inProgress
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"in_progress\""))
-        #expect(!json.contains("\"inProgress\""))
+        #expect(json == #"{"in_progress":{}}"#)
         let decoded = try NewJSONDecoder().decode(CommonTaskStatus.self, from: data)
         #expect(decoded == original)
     }
@@ -355,7 +296,7 @@ struct CommonCodableMacroIntegrationTests {
         let original = CommonFlexibleStatus.inProgress
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"in_progress\""))
+        #expect(json == #"{"in_progress":{}}"#)
 
         // Decode using the alias key
         let aliasJSON = Data(#"{"in-progress":{}}"#.utf8)
@@ -367,13 +308,14 @@ struct CommonCodableMacroIntegrationTests {
         let circle = CommonShape.circle(radius: 3.14)
         let data = try NewJSONEncoder().encode(circle)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"circle\""))
-        #expect(json.contains("\"radius\""))
+        #expect(json == #"{"circle":{"radius":3.14}}"#)
         let decoded = try NewJSONDecoder().decode(CommonShape.self, from: data)
         #expect(decoded == circle)
 
         let point = CommonShape.point
         let data2 = try NewJSONEncoder().encode(point)
+        let json2 = String(data: data2, encoding: .utf8)!
+        #expect(json2 == #"{"point":{}}"#)
         let decoded2 = try NewJSONDecoder().decode(CommonShape.self, from: data2)
         #expect(decoded2 == point)
     }
@@ -381,11 +323,15 @@ struct CommonCodableMacroIntegrationTests {
     @Test func enumWithUnlabeledAssociatedValues() throws {
         let single = CommonWrapper.single(42)
         let data = try NewJSONEncoder().encode(single)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"single":{"_0":42}}"#)
         let decoded = try NewJSONDecoder().decode(CommonWrapper.self, from: data)
         #expect(decoded == single)
 
         let pair = CommonWrapper.pair("hello", 99)
         let data2 = try NewJSONEncoder().encode(pair)
+        let json2 = String(data: data2, encoding: .utf8)!
+        #expect(json2 == #"{"pair":{"_0":"hello","_1":99}}"#)
         let decoded2 = try NewJSONDecoder().decode(CommonWrapper.self, from: data2)
         #expect(decoded2 == pair)
     }

--- a/Tests/NewCodableTests/CommonMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/CommonMacroIntegrationTests.swift
@@ -267,6 +267,36 @@ struct CommonDecodableMacroIntegrationTests {
     }
 }
 
+@CommonCodable
+enum CommonSimpleStatus: Equatable {
+    case active
+    case inactive
+}
+
+@CommonCodable
+enum CommonTaskStatus: Equatable {
+    @CodingKey("in_progress") case inProgress
+    case done
+}
+
+@CommonCodable
+enum CommonFlexibleStatus: Equatable {
+    @DecodableAlias("in-progress") @CodingKey("in_progress") case inProgress
+    case done
+}
+
+@CommonCodable
+enum CommonShape: Equatable {
+    case circle(radius: Double)
+    case point
+}
+
+@CommonCodable
+enum CommonWrapper: Equatable {
+    case single(Int)
+    case pair(String, Int)
+}
+
 @Suite("@CommonCodable Macro Integration")
 struct CommonCodableMacroIntegrationTests {
 
@@ -295,5 +325,68 @@ struct CommonCodableMacroIntegrationTests {
         let decoded = try NewJSONDecoder().decode(CommonCodablePost.self, from: data)
         #expect(decoded.title == "Test")
         #expect(decoded.rating == nil)
+    }
+
+    @Test func enumWithoutAssociatedValues() throws {
+        let original = CommonSimpleStatus.active
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"active\""))
+        let decoded = try NewJSONDecoder().decode(CommonSimpleStatus.self, from: data)
+        #expect(decoded == original)
+
+        let inactive = CommonSimpleStatus.inactive
+        let data2 = try NewJSONEncoder().encode(inactive)
+        let decoded2 = try NewJSONDecoder().decode(CommonSimpleStatus.self, from: data2)
+        #expect(decoded2 == inactive)
+    }
+
+    @Test func enumWithCodingKey() throws {
+        let original = CommonTaskStatus.inProgress
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"in_progress\""))
+        #expect(!json.contains("\"inProgress\""))
+        let decoded = try NewJSONDecoder().decode(CommonTaskStatus.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func enumWithDecodableAlias() throws {
+        let original = CommonFlexibleStatus.inProgress
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"in_progress\""))
+
+        // Decode using the alias key
+        let aliasJSON = Data(#"{"in-progress":{}}"#.utf8)
+        let decoded = try NewJSONDecoder().decode(CommonFlexibleStatus.self, from: aliasJSON)
+        #expect(decoded == .inProgress)
+    }
+
+    @Test func enumWithLabeledAssociatedValues() throws {
+        let circle = CommonShape.circle(radius: 3.14)
+        let data = try NewJSONEncoder().encode(circle)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"circle\""))
+        #expect(json.contains("\"radius\""))
+        let decoded = try NewJSONDecoder().decode(CommonShape.self, from: data)
+        #expect(decoded == circle)
+
+        let point = CommonShape.point
+        let data2 = try NewJSONEncoder().encode(point)
+        let decoded2 = try NewJSONDecoder().decode(CommonShape.self, from: data2)
+        #expect(decoded2 == point)
+    }
+
+    @Test func enumWithUnlabeledAssociatedValues() throws {
+        let single = CommonWrapper.single(42)
+        let data = try NewJSONEncoder().encode(single)
+        let decoded = try NewJSONDecoder().decode(CommonWrapper.self, from: data)
+        #expect(decoded == single)
+
+        let pair = CommonWrapper.pair("hello", 99)
+        let data2 = try NewJSONEncoder().encode(pair)
+        let decoded2 = try NewJSONDecoder().decode(CommonWrapper.self, from: data2)
+        #expect(decoded2 == pair)
     }
 }

--- a/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
@@ -213,6 +213,36 @@ struct JSONDecodableMacroIntegrationTests {
     }
 }
 
+@JSONCodable
+enum SimpleStatus: Equatable {
+    case active
+    case inactive
+}
+
+@JSONCodable
+enum TaskStatus: Equatable {
+    @CodingKey("in_progress") case inProgress
+    case done
+}
+
+@JSONCodable
+enum FlexibleStatus: Equatable {
+    @DecodableAlias("in-progress") @CodingKey("in_progress") case inProgress
+    case done
+}
+
+@JSONCodable
+enum Shape: Equatable {
+    case circle(radius: Double)
+    case point
+}
+
+@JSONCodable
+enum Wrapper: Equatable {
+    case single(Int)
+    case pair(String, Int)
+}
+
 @Suite("@JSONCodable Macro Integration")
 struct JSONCodableMacroIntegrationTests {
 
@@ -249,5 +279,68 @@ struct JSONCodableMacroIntegrationTests {
         let decoded = try NewJSONDecoder().decode(PublicCodablePerson.self, from: data)
         #expect(decoded.name == "Alice")
         #expect(decoded.age == 30)
+    }
+
+    @Test func enumWithoutAssociatedValues() throws {
+        let original = SimpleStatus.active
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"active\""))
+        let decoded = try NewJSONDecoder().decode(SimpleStatus.self, from: data)
+        #expect(decoded == original)
+
+        let inactive = SimpleStatus.inactive
+        let data2 = try NewJSONEncoder().encode(inactive)
+        let decoded2 = try NewJSONDecoder().decode(SimpleStatus.self, from: data2)
+        #expect(decoded2 == inactive)
+    }
+
+    @Test func enumWithCodingKey() throws {
+        let original = TaskStatus.inProgress
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"in_progress\""))
+        #expect(!json.contains("\"inProgress\""))
+        let decoded = try NewJSONDecoder().decode(TaskStatus.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func enumWithDecodableAlias() throws {
+        let original = FlexibleStatus.inProgress
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"in_progress\""))
+
+        // Decode using the alias key
+        let aliasJSON = Data(#"{"in-progress":{}}"#.utf8)
+        let decoded = try NewJSONDecoder().decode(FlexibleStatus.self, from: aliasJSON)
+        #expect(decoded == .inProgress)
+    }
+
+    @Test func enumWithLabeledAssociatedValues() throws {
+        let circle = Shape.circle(radius: 3.14)
+        let data = try NewJSONEncoder().encode(circle)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"circle\""))
+        #expect(json.contains("\"radius\""))
+        let decoded = try NewJSONDecoder().decode(Shape.self, from: data)
+        #expect(decoded == circle)
+
+        let point = Shape.point
+        let data2 = try NewJSONEncoder().encode(point)
+        let decoded2 = try NewJSONDecoder().decode(Shape.self, from: data2)
+        #expect(decoded2 == point)
+    }
+
+    @Test func enumWithUnlabeledAssociatedValues() throws {
+        let single = Wrapper.single(42)
+        let data = try NewJSONEncoder().encode(single)
+        let decoded = try NewJSONDecoder().decode(Wrapper.self, from: data)
+        #expect(decoded == single)
+
+        let pair = Wrapper.pair("hello", 99)
+        let data2 = try NewJSONEncoder().encode(pair)
+        let decoded2 = try NewJSONDecoder().decode(Wrapper.self, from: data2)
+        #expect(decoded2 == pair)
     }
 }

--- a/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
@@ -127,25 +127,21 @@ struct JSONEncodableMacroIntegrationTests {
         let post = SimplePost(title: "Hello", body: "World")
         let data = try NewJSONEncoder().encode(post)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"title\":\"Hello\""))
-        #expect(json.contains("\"body\":\"World\""))
+        #expect(json == #"{"title":"Hello","body":"World"}"#)
     }
 
     @Test func customCodingKey() throws {
         let post = BlogPost(title: "Test", publishDate: "2026-01-01", tags: ["swift"], rating: 4.5)
         let data = try NewJSONEncoder().encode(post)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"date_published\":\"2026-01-01\""))
-        #expect(json.contains("\"title\":\"Test\""))
-        #expect(json.contains("\"tags\":[\"swift\"]"))
-        #expect(json.contains("\"rating\":4.5"))
+        #expect(json == #"{"title":"Test","date_published":"2026-01-01","tags":["swift"],"rating":4.5}"#)
     }
 
     @Test func optionalNilValue() throws {
         let post = BlogPost(title: "Test", publishDate: "2026-01-01", tags: [], rating: nil)
         let data = try NewJSONEncoder().encode(post)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"rating\":null"))
+        #expect(json == #"{"title":"Test","date_published":"2026-01-01","tags":[],"rating":null}"#)
     }
 
     @Test func emptyStruct() throws {
@@ -162,6 +158,8 @@ struct JSONDecodableMacroIntegrationTests {
     @Test func roundTripBasic() throws {
         let original = RoundTripPerson(name: "Alice", age: 30)
         let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"name":"Alice","age":30}"#)
         let decoded = try NewJSONDecoder().decode(RoundTripPerson.self, from: data)
         #expect(decoded.name == "Alice")
         #expect(decoded.age == 30)
@@ -171,7 +169,7 @@ struct JSONDecodableMacroIntegrationTests {
         let original = RoundTripPost(title: "Hello", publishDate: "2026-01-01", rating: 4.5)
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"date_published\":\"2026-01-01\""))
+        #expect(json == #"{"title":"Hello","date_published":"2026-01-01","rating":4.5}"#)
         let decoded = try NewJSONDecoder().decode(RoundTripPost.self, from: data)
         #expect(decoded.title == "Hello")
         #expect(decoded.publishDate == "2026-01-01")
@@ -249,6 +247,8 @@ struct JSONCodableMacroIntegrationTests {
     @Test func roundTrip() throws {
         let original = CodablePerson(name: "Alice", age: 30)
         let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"name":"Alice","age":30}"#)
         let decoded = try NewJSONDecoder().decode(CodablePerson.self, from: data)
         #expect(decoded.name == "Alice")
         #expect(decoded.age == 30)
@@ -258,7 +258,7 @@ struct JSONCodableMacroIntegrationTests {
         let original = CodablePost(title: "Hello", publishDate: "2026-01-01", rating: 4.5)
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"date_published\":\"2026-01-01\""))
+        #expect(json == #"{"title":"Hello","date_published":"2026-01-01","rating":4.5}"#)
         let decoded = try NewJSONDecoder().decode(CodablePost.self, from: data)
         #expect(decoded.title == "Hello")
         #expect(decoded.publishDate == "2026-01-01")
@@ -285,12 +285,14 @@ struct JSONCodableMacroIntegrationTests {
         let original = SimpleStatus.active
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"active\""))
+        #expect(json == #"{"active":{}}"#)
         let decoded = try NewJSONDecoder().decode(SimpleStatus.self, from: data)
         #expect(decoded == original)
 
         let inactive = SimpleStatus.inactive
         let data2 = try NewJSONEncoder().encode(inactive)
+        let json2 = String(data: data2, encoding: .utf8)!
+        #expect(json2 == #"{"inactive":{}}"#)
         let decoded2 = try NewJSONDecoder().decode(SimpleStatus.self, from: data2)
         #expect(decoded2 == inactive)
     }
@@ -299,8 +301,7 @@ struct JSONCodableMacroIntegrationTests {
         let original = TaskStatus.inProgress
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"in_progress\""))
-        #expect(!json.contains("\"inProgress\""))
+        #expect(json == #"{"in_progress":{}}"#)
         let decoded = try NewJSONDecoder().decode(TaskStatus.self, from: data)
         #expect(decoded == original)
     }
@@ -309,7 +310,7 @@ struct JSONCodableMacroIntegrationTests {
         let original = FlexibleStatus.inProgress
         let data = try NewJSONEncoder().encode(original)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"in_progress\""))
+        #expect(json == #"{"in_progress":{}}"#)
 
         // Decode using the alias key
         let aliasJSON = Data(#"{"in-progress":{}}"#.utf8)
@@ -321,13 +322,14 @@ struct JSONCodableMacroIntegrationTests {
         let circle = Shape.circle(radius: 3.14)
         let data = try NewJSONEncoder().encode(circle)
         let json = String(data: data, encoding: .utf8)!
-        #expect(json.contains("\"circle\""))
-        #expect(json.contains("\"radius\""))
+        #expect(json == #"{"circle":{"radius":3.14}}"#)
         let decoded = try NewJSONDecoder().decode(Shape.self, from: data)
         #expect(decoded == circle)
 
         let point = Shape.point
         let data2 = try NewJSONEncoder().encode(point)
+        let json2 = String(data: data2, encoding: .utf8)!
+        #expect(json2 == #"{"point":{}}"#)
         let decoded2 = try NewJSONDecoder().decode(Shape.self, from: data2)
         #expect(decoded2 == point)
     }
@@ -335,11 +337,15 @@ struct JSONCodableMacroIntegrationTests {
     @Test func enumWithUnlabeledAssociatedValues() throws {
         let single = Wrapper.single(42)
         let data = try NewJSONEncoder().encode(single)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"single":{"_0":42}}"#)
         let decoded = try NewJSONDecoder().decode(Wrapper.self, from: data)
         #expect(decoded == single)
 
         let pair = Wrapper.pair("hello", 99)
         let data2 = try NewJSONEncoder().encode(pair)
+        let json2 = String(data: data2, encoding: .utf8)!
+        #expect(json2 == #"{"pair":{"_0":"hello","_1":99}}"#)
         let decoded2 = try NewJSONDecoder().decode(Wrapper.self, from: data2)
         #expect(decoded2 == pair)
     }


### PR DESCRIPTION
Adds *Codable macro implementation for enums

### Motivation:

The initial version of the *Codable macros only worked for structs. Enums have different structure and a different API surface to call into for encoding and decoding them.

### Modifications:

* More refactoring to support generating code for both structs and enums
* Enum generation implemented

### Result:

* Better factored macro code, for potential future *Codable macro library
* Support for enum cases with and without associated values
* Support for labelled and unlabelled associated values
* Support for CodingKey and DecodableAlias for enum case names

### Testing:

* New macro expansion tests
* New integration tests
