### PR TITLE
Data Collection micro optimizations

### DIFF
--- a/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
@@ -106,12 +106,12 @@ extension Data {
         
         @inlinable // This is @inlinable as trivially computable.
         var startIndex: Int {
-            return Int(slice.lowerBound)
+            return _assumeNonNegative(Int(slice.lowerBound))
         }
         
         @inlinable // This is @inlinable as trivially computable.
         var endIndex: Int {
-            return Int(slice.upperBound)
+            return _assumeNonNegative(Int(slice.upperBound))
         }
         
         @inlinable // This is @inlinable as trivially computable.
@@ -149,7 +149,7 @@ extension Data {
         var count: Int {
             get {
                 // The upper bound is guaranteed to be greater than or equal to the lower bound, and the lower bound must be non-negative so subtraction can never overflow
-                return Int(slice.upperBound &- slice.lowerBound)
+                return _assumeNonNegative(Int(slice.upperBound &- slice.lowerBound))
             }
             set(newValue) {
                 assert(newValue < HalfInt.max)

--- a/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
@@ -34,7 +34,7 @@ extension Data {
         @inlinable @inline(__always) // This is @inlinable as trivially computable.
         var count: Int {
             // The upper bound is guaranteed to be greater than or equal to the lower bound, and the lower bound must be non-negative so subtraction can never overflow
-            return range.upperBound &- range.lowerBound
+            return _assumeNonNegative(range.upperBound &- range.lowerBound)
         }
         
         @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
@@ -105,12 +105,12 @@ extension Data {
         
         @inlinable // This is @inlinable as trivially forwarding.
         var startIndex: Int {
-            return slice.range.lowerBound
+            return _assumeNonNegative(slice.range.lowerBound)
         }
         
         @inlinable // This is @inlinable as trivially forwarding.
         var endIndex: Int {
-            return slice.range.upperBound
+            return _assumeNonNegative(slice.range.upperBound)
         }
         
         @inlinable // This is @inlinable as trivially forwarding.

--- a/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
@@ -110,7 +110,7 @@ extension Data {
         var count: Int {
             @inline(__always)
             get {
-                _slice.count
+                _assumeNonNegative(_slice.upperBound &- _slice.lowerBound)
             }
             set(newValue) {
                 guard newValue != 0 else {
@@ -235,12 +235,12 @@ extension Data {
         
         @_alwaysEmitIntoClient @inline(__always)
         var startIndex: Int {
-            _slice.lowerBound
+            _assumeNonNegative(_slice.lowerBound)
         }
         
         @_alwaysEmitIntoClient @inline(__always)
         var endIndex: Int {
-            _slice.upperBound
+            _assumeNonNegative(_slice.upperBound)
         }
         
         @_alwaysEmitIntoClient

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -119,13 +119,6 @@ internal final class __DataStorage : @unchecked Sendable {
     // The properties below use @exclusivity(unchecked) in release mode to avoid dynamic exclusivity checking. Exclusivity is guaranteed by the copy-on-write implementation of Data itself.
     // Dynamic exclusivity checks are still enabled in debug builds to catch issues with the copy-on-write implementation at-desk and in unit tests.
 
-    /// The size of the prior slice's prefix if the allocation was copied from a slice (to maintain
-    /// stable indexing)
-    #if !DEBUG
-    @exclusivity(unchecked)
-    #endif
-    @usableFromInline var _offset: Int
-    
     /// A pointer to the start of the referenced byte allocation
     #if !DEBUG
     @exclusivity(unchecked)
@@ -143,6 +136,13 @@ internal final class __DataStorage : @unchecked Sendable {
     @exclusivity(unchecked)
     #endif
     @usableFromInline var _capacity: Int
+
+    /// The size of the prior slice's prefix if the allocation was copied from a slice (to maintain
+    /// stable indexing)
+    #if !DEBUG
+    @exclusivity(unchecked)
+    #endif
+    @usableFromInline var _offset: Int
 
     /// The deallocator to use when discarding the byte allocation
     #if !DEBUG

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -168,7 +168,7 @@ internal final class __DataStorage : @unchecked Sendable {
     /// their original allocation, this may point to memory before the actual allocation.
     @inlinable // This is @inlinable as trivially computable.
     var bytes: UnsafeRawPointer? {
-        return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
+        return UnsafeRawPointer(_bytes)?.advanced(by: _offset &* -1)
     }
 
     @inline(__always)
@@ -451,14 +451,14 @@ internal final class __DataStorage : @unchecked Sendable {
     @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
     func get(_ index: Int) -> UInt8 {
         // index must have already been validated by the caller
-        return _bytes!.load(fromByteOffset: index - _offset, as: UInt8.self)
+        return _bytes.unsafelyUnwrapped.load(fromByteOffset: index &- _offset, as: UInt8.self)
     }
     
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
     func set(_ index: Int, to value: UInt8) {
         // index must have already been validated by the caller
         ensureUniqueBufferReference()
-        _bytes!.storeBytes(of: value, toByteOffset: index - _offset, as: UInt8.self)
+        _bytes.unsafelyUnwrapped.storeBytes(of: value, toByteOffset: index &- _offset, as: UInt8.self)
     }
     
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -119,6 +119,13 @@ internal final class __DataStorage : @unchecked Sendable {
     // The properties below use @exclusivity(unchecked) in release mode to avoid dynamic exclusivity checking. Exclusivity is guaranteed by the copy-on-write implementation of Data itself.
     // Dynamic exclusivity checks are still enabled in debug builds to catch issues with the copy-on-write implementation at-desk and in unit tests.
 
+    /// The size of the prior slice's prefix if the allocation was copied from a slice (to maintain
+    /// stable indexing)
+    #if !DEBUG
+    @exclusivity(unchecked)
+    #endif
+    @usableFromInline var _offset: Int
+    
     /// A pointer to the start of the referenced byte allocation
     #if !DEBUG
     @exclusivity(unchecked)
@@ -136,13 +143,6 @@ internal final class __DataStorage : @unchecked Sendable {
     @exclusivity(unchecked)
     #endif
     @usableFromInline var _capacity: Int
-
-    /// The size of the prior slice's prefix if the allocation was copied from a slice (to maintain
-    /// stable indexing)
-    #if !DEBUG
-    @exclusivity(unchecked)
-    #endif
-    @usableFromInline var _offset: Int
 
     /// The deallocator to use when discarding the byte allocation
     #if !DEBUG


### PR DESCRIPTION
Adds some micro optimizations to `Data`'s `Collection` APIs to achieve much smaller instruction counts for simple operations and higher level optimizations.

### Motivation:

In general, when accessing multiple bytes from a `Data`, we expect clients to get the span and read from that (which has low overhead). However, as span APIs are relatively new, there's still code that is in use that repeatedly accesses the subscript of a `Data` repeatedly to read multiple bytes. By adding some micro optimizations to `Data`'s basic `Collection` APIs, we can enable some higher level optimizations by the compiler to significantly reduce the overhead of this operation.

### Modifications:

- Remove overflow and optional checking from `__DataStorage.get`/`__DataStorage.set` (index validation is already performed at a higher level
- Remove overflow checking from `Data.count` (via its representations) since `Range` guarantees that the upper bound is greater than the lower bound
- Add `_assumeNonNegative` (already in use by many stdlib types for these APIs) to guarantee that Data's indices and count are always non-negative

### Result:

Many overflow / bounds checking instructions are no longer present in these APIs. Additionally, higher level optimizations are now enabled. For example, this code:

```swift
extension Data {
    func loadNetworkByteOrderUInt32() -> UInt32 {
        precondition(self.count >= MemoryLayout<UInt32>.size)
        return (
            UInt32(self[self.startIndex]) << 24 |
            UInt32(self[self.startIndex &+ 1]) << 16 |
            UInt32(self[self.startIndex &+ 2]) << 8  |
            UInt32(self[self.startIndex &+ 3])
        )
    }
}
```

is currently 45 instructions on Linux (lots of bounds checking, loading the value byte-by-byte and then combining via bit shifts, etc.). With this change in place, the same code above is now only 10 instructions:

```assembly
// Bounds checking:
	subs	x8, x2, x1
	b.ls	.LBB1_3
	cmp	x8, #4
	b.lo	.LBB1_3
// Loading buffer pointer:
	ldp	x8, x9, [x0, #16]
	sub	x8, x1, x8
// Load 32bit integer from buffer:
	ldr	w8, [x9, x8]
	rev	w0, w8
	ret
.LBB1_3:
	brk	#0x1
```

While the same code could already be achieved via a span, it's also a great benefit for the compiler to optimize the instructions when not using a span when feasible.

### Testing:

Code is exercised by existing unit tests
