### PR TITLE
[NewCodable] fix macros access modifier

### DIFF
--- a/Sources/NewCodableMacros/CommonCodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonCodableMacro.swift
@@ -36,9 +36,10 @@ extension CommonCodableMacro: ExtensionMacro {
             return []
         }
         
+        let access = accessLevel(of: declaration)
         let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: CommonCodingFieldExpansionKind.both)
-        let encodingImpl = makeEncodableExtension(for: typeName, with: properties, kind: CommonEncodableExpansionKind())
-        let decodingImpl = makeDecodableExtension(for: typeName, with: properties, kind: CommonDecodableExpansionKind())
+        let encodingImpl = makeEncodableExtension(for: typeName, with: properties, kind: CommonEncodableExpansionKind(), accessLevel: access)
+        let decodingImpl = makeDecodableExtension(for: typeName, with: properties, kind: CommonDecodableExpansionKind(), accessLevel: access)
         return [codingFields, encodingImpl, decodingImpl].compactMap { $0 }
     }
 }

--- a/Sources/NewCodableMacros/CommonDecodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonDecodableMacro.swift
@@ -37,8 +37,9 @@ extension CommonDecodableMacro: ExtensionMacro {
             return []
         }
         
+        let access = accessLevel(of: declaration)
         let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: CommonCodingFieldExpansionKind.decodingOnly)
-        let impl = makeDecodableExtension(for: typeName, with: properties, kind: CommonDecodableExpansionKind())
+        let impl = makeDecodableExtension(for: typeName, with: properties, kind: CommonDecodableExpansionKind(), accessLevel: access)
         return [codingFields, impl].compactMap { $0 }
     }
 }

--- a/Sources/NewCodableMacros/CommonEncodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonEncodableMacro.swift
@@ -37,8 +37,9 @@ extension CommonEncodableMacro: ExtensionMacro {
             return []
         }
         
+        let access = accessLevel(of: declaration)
         let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: CommonCodingFieldExpansionKind.encodingOnly)
-        let impl = makeEncodableExtension(for: typeName, with: properties, kind: CommonEncodableExpansionKind())
+        let impl = makeEncodableExtension(for: typeName, with: properties, kind: CommonEncodableExpansionKind(), accessLevel: access)
         return [codingFields, impl].compactMap { $0 }
     }
 }

--- a/Sources/NewCodableMacros/JSONCodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONCodableMacro.swift
@@ -36,9 +36,10 @@ extension JSONCodableMacro: ExtensionMacro {
             return []
         }
         
+        let access = accessLevel(of: declaration)
         let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: JSONCodingFieldKind.both)
-        let encodingImpl = makeEncodableExtension(for: typeName, with: properties, kind: JSONEncodableExpansionKind())
-        let decodingImpl = makeDecodableExtension(for: typeName, with: properties, kind: JSONDecodableExpansionKind())
+        let encodingImpl = makeEncodableExtension(for: typeName, with: properties, kind: JSONEncodableExpansionKind(), accessLevel: access)
+        let decodingImpl = makeDecodableExtension(for: typeName, with: properties, kind: JSONDecodableExpansionKind(), accessLevel: access)
         return [codingFields, encodingImpl, decodingImpl].compactMap { $0 }
     }
 }

--- a/Sources/NewCodableMacros/JSONDecodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONDecodableMacro.swift
@@ -37,8 +37,9 @@ extension JSONDecodableMacro: ExtensionMacro {
             return []
         }
         
+        let access = accessLevel(of: declaration)
         let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: JSONCodingFieldKind.decodingOnly)
-        let impl = makeDecodableExtension(for: typeName, with: properties, kind: JSONDecodableExpansionKind())
+        let impl = makeDecodableExtension(for: typeName, with: properties, kind: JSONDecodableExpansionKind(), accessLevel: access)
         return [codingFields, impl].compactMap { $0 }
     }
 }

--- a/Sources/NewCodableMacros/JSONEncodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONEncodableMacro.swift
@@ -37,8 +37,9 @@ extension JSONEncodableMacro: ExtensionMacro {
             return []
         }
         
+        let access = accessLevel(of: declaration)
         let codingFields = makeCodingFieldsExtension(for: typeName, from: properties, kind: JSONCodingFieldKind.encodingOnly)
-        let impl = makeEncodableExtension(for: typeName, with: properties, kind: JSONEncodableExpansionKind())
+        let impl = makeEncodableExtension(for: typeName, with: properties, kind: JSONEncodableExpansionKind(), accessLevel: access)
         return [codingFields, impl].compactMap { $0 }
     }
 }

--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -176,10 +176,6 @@ func extractDetailedStoredProperties(
 
 /// Returns the access-level modifier (with trailing space) that should be applied to
 /// members generated inside an extension of `declaration`, or `""` when no modifier is needed.
-///
-/// Mirrors Swift's synthesized Codable behavior: when the attached type is `public` or `open`,
-/// generated members must be `public` to satisfy protocol requirements; `package` types
-/// need `package`; `internal`/`fileprivate`/`private` can use the default (empty string).
 func accessLevel(of declaration: some DeclGroupSyntax) -> String {
     for modifier in declaration.modifiers {
         switch modifier.name.tokenKind {

--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -248,12 +248,6 @@ func defaultValueExpression(from attributes: AttributeListSyntax) -> String? {
 // MARK: - Coding Fields Generation
 
 /// Unified function for generating coding fields with any expansion kind.
-///
-/// The generated `CodingFields` enum and its members are intentionally kept at the
-/// default access level — they are only referenced inside the bodies of the
-/// synthesized `encode(to:)` / `decode(from:)` methods in a sibling extension, so an
-/// internal conformance to a public protocol is sufficient (matching Swift's
-/// synthesized `CodingKeys` behavior for `Codable`).
 func makeCodingFieldsExtension<T: CodingFieldExpansionKind>(
     for typeName: TokenSyntax,
     from properties: [DetailedStoredProperty],

--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -172,6 +172,28 @@ func extractDetailedStoredProperties(
     return properties
 }
 
+// MARK: - Access Level
+
+/// Returns the access-level modifier (with trailing space) that should be applied to
+/// members generated inside an extension of `declaration`, or `""` when no modifier is needed.
+///
+/// Mirrors Swift's synthesized Codable behavior: when the attached type is `public` or `open`,
+/// generated members must be `public` to satisfy protocol requirements; `package` types
+/// need `package`; `internal`/`fileprivate`/`private` can use the default (empty string).
+func accessLevel(of declaration: some DeclGroupSyntax) -> String {
+    for modifier in declaration.modifiers {
+        switch modifier.name.tokenKind {
+        case .keyword(.public), .keyword(.open):
+            return "public "
+        case .keyword(.package):
+            return "package "
+        default:
+            continue
+        }
+    }
+    return ""
+}
+
 // MARK: - Attribute Parsing Utilities
 
 func customCodingKey(from attributes: AttributeListSyntax) -> String? {
@@ -225,7 +247,13 @@ func defaultValueExpression(from attributes: AttributeListSyntax) -> String? {
 
 // MARK: - Coding Fields Generation
 
-/// Unified function for generating coding fields with any expansion kind
+/// Unified function for generating coding fields with any expansion kind.
+///
+/// The generated `CodingFields` enum and its members are intentionally kept at the
+/// default access level — they are only referenced inside the bodies of the
+/// synthesized `encode(to:)` / `decode(from:)` methods in a sibling extension, so an
+/// internal conformance to a public protocol is sufficient (matching Swift's
+/// synthesized `CodingKeys` behavior for `Codable`).
 func makeCodingFieldsExtension<T: CodingFieldExpansionKind>(
     for typeName: TokenSyntax,
     from properties: [DetailedStoredProperty],
@@ -354,13 +382,14 @@ protocol EncodableExpansionKind {
 func makeEncodableExtension(
     for typeName: TokenSyntax,
     with properties: [DetailedStoredProperty],
-    kind: some EncodableExpansionKind
+    kind: some EncodableExpansionKind,
+    accessLevel: String = ""
 ) -> ExtensionDeclSyntax? {
     let extensionDecl: DeclSyntax
     if properties.isEmpty {
         extensionDecl = """
         extension \(typeName): \(raw: kind.protocolName) {
-            func encode(to encoder: \(raw: kind.encoderType)) throws(CodingError.Encoding) {
+            \(raw: accessLevel)func encode(to encoder: \(raw: kind.encoderType)) throws(CodingError.Encoding) {
                 try encoder.encodeStructFields(count: 0) { _ throws(CodingError.Encoding) in
                 }
             }
@@ -375,7 +404,7 @@ func makeEncodableExtension(
 
         extensionDecl = """
         extension \(typeName): \(raw: kind.protocolName) {
-            func encode(to encoder: \(raw: kind.encoderType)) throws(CodingError.Encoding) {
+            \(raw: accessLevel)func encode(to encoder: \(raw: kind.encoderType)) throws(CodingError.Encoding) {
                 try encoder.encodeStructFields(count: \(raw: fieldCount)) { structEncoder throws(CodingError.Encoding) in
                     \(raw: encodeStatements)
                 }
@@ -401,13 +430,14 @@ protocol DecodableExpansionKind {
 func makeDecodableExtension(
     for typeName: TokenSyntax,
     with properties: [DetailedStoredProperty],
-    kind: some DecodableExpansionKind
+    kind: some DecodableExpansionKind,
+    accessLevel: String = ""
 ) -> ExtensionDeclSyntax? {
     let decl: DeclSyntax
     if properties.isEmpty {
         decl = """
         extension \(typeName): \(raw: kind.protocolName) {
-            static func decode(from decoder: \(raw: kind.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
+            \(raw: accessLevel)static func decode(from decoder: \(raw: kind.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
                 try decoder.decodeStruct { _ throws(CodingError.Decoding) in
                     \(typeName)()
                 }
@@ -460,7 +490,7 @@ func makeDecodableExtension(
 
         decl = """
         extension \(typeName): \(raw: kind.protocolName) {
-            static func decode(from decoder: \(raw: kind.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
+            \(raw: accessLevel)static func decode(from decoder: \(raw: kind.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     \(raw: varDeclarations)
                     var _codingField: CodingFields?

--- a/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
@@ -547,6 +547,94 @@ struct CommonCodableMacroTests {
         )
     }
 
+    @Test func publicStructEmitsPublicMembers() {
+        assertMacroExpansion(
+            """
+            @CommonCodable
+            public struct Person {
+                public let name: String
+                public let age: Int
+            }
+            """,
+            expandedSource: """
+            public struct Person {
+                public let name: String
+                public let age: Int
+            }
+
+            extension Person {
+                enum CodingFields: StaticStringCodingField {
+                    case name
+                    case age
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .age:
+                            "age"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "age":
+                            .age
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: CommonEncodable {
+                public func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                    }
+                }
+            }
+
+            extension Person: CommonDecodable {
+                public static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var age: Int?
+                        var _codingField: CodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .age:
+                                age = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let age else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'age'")
+                        }
+                        return Person(name: name, age: age)
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
     @Test func errorOnNonStruct() {
         assertMacroExpansion(
             """

--- a/Tests/NewCodableMacrosTests/CommonDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonDecodableMacroTests.swift
@@ -1165,6 +1165,72 @@ struct CommonDecodableMacroTests {
             macros: decodableTestMacros
         )
     }
+
+    @Test func publicStructEmitsPublicMembers() {
+        assertMacroExpansion(
+            """
+            @CommonDecodable
+            public struct Person {
+                public let name: String
+            }
+            """,
+            expandedSource: """
+            public struct Person {
+                public let name: String
+            }
+
+            extension Person {
+                enum CodingFields: StaticStringDecodingField {
+                    case name
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: CommonDecodable {
+                public static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var _codingField: CodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        return Person(name: name)
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
 }
 
 private let decodableTestMacros: [String: Macro.Type] = [

--- a/Tests/NewCodableMacrosTests/CommonEncodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonEncodableMacroTests.swift
@@ -467,4 +467,43 @@ struct CommonEncodableMacroTests {
             macros: commonTestMacros
         )
     }
+
+    @Test func publicStructEmitsPublicMembers() {
+        assertMacroExpansion(
+            """
+            @CommonEncodable
+            public struct Person {
+                public let name: String
+            }
+            """,
+            expandedSource: """
+            public struct Person {
+                public let name: String
+            }
+
+            extension Person {
+                enum CodingFields: StaticStringEncodingField {
+                    case name
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        }
+                    }
+                }
+            }
+
+            extension Person: CommonEncodable {
+                public func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                    }
+                }
+            }
+            """,
+            macros: commonTestMacros
+        )
+    }
 }

--- a/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
@@ -547,6 +547,168 @@ struct JSONCodableMacroTests {
         )
     }
 
+    @Test func publicStructEmitsPublicMembers() {
+        assertMacroExpansion(
+            """
+            @JSONCodable
+            public struct Person {
+                public let name: String
+                public let age: Int
+            }
+            """,
+            expandedSource: """
+            public struct Person {
+                public let name: String
+                public let age: Int
+            }
+
+            extension Person {
+                enum CodingFields: JSONOptimizedCodingField {
+                    case name
+                    case age
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .age:
+                            "age"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "age":
+                            .age
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: JSONEncodable {
+                public func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                    }
+                }
+            }
+
+            extension Person: JSONDecodable {
+                public static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var age: Int?
+                        var _codingField: CodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .age:
+                                age = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let age else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'age'")
+                        }
+                        return Person(name: name, age: age)
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
+    @Test func packageStructEmitsPackageMembers() {
+        assertMacroExpansion(
+            """
+            @JSONCodable
+            package struct Person {
+                package let name: String
+            }
+            """,
+            expandedSource: """
+            package struct Person {
+                package let name: String
+            }
+
+            extension Person {
+                enum CodingFields: JSONOptimizedCodingField {
+                    case name
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: JSONEncodable {
+                package func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                    }
+                }
+            }
+
+            extension Person: JSONDecodable {
+                package static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var _codingField: CodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        return Person(name: name)
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
+
     @Test func errorOnNonStruct() {
         assertMacroExpansion(
             """

--- a/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
@@ -1165,6 +1165,72 @@ struct JSONDecodableMacroTests {
             macros: decodableTestMacros
         )
     }
+
+    @Test func publicStructEmitsPublicMembers() {
+        assertMacroExpansion(
+            """
+            @JSONDecodable
+            public struct Person {
+                public let name: String
+            }
+            """,
+            expandedSource: """
+            public struct Person {
+                public let name: String
+            }
+
+            extension Person {
+                enum CodingFields: JSONOptimizedDecodingField {
+                    case name
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: JSONDecodable {
+                public static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var _codingField: CodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        return Person(name: name)
+                    }
+                }
+            }
+            """,
+            macros: decodableTestMacros
+        )
+    }
 }
 
 private let decodableTestMacros: [String: Macro.Type] = [

--- a/Tests/NewCodableMacrosTests/JSONEncodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONEncodableMacroTests.swift
@@ -467,4 +467,43 @@ struct JSONEncodableMacroTests {
             macros: testMacros
         )
     }
+
+    @Test func publicStructEmitsPublicMembers() {
+        assertMacroExpansion(
+            """
+            @JSONEncodable
+            public struct Person {
+                public let name: String
+            }
+            """,
+            expandedSource: """
+            public struct Person {
+                public let name: String
+            }
+
+            extension Person {
+                enum CodingFields: JSONOptimizedEncodingField {
+                    case name
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        }
+                    }
+                }
+            }
+
+            extension Person: JSONEncodable {
+                public func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
 }

--- a/Tests/NewCodableTests/CommonMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/CommonMacroIntegrationTests.swift
@@ -81,6 +81,31 @@ struct CommonCodableStructWithDefaultedProperty {
     let bar: String
 }
 
+// Public types exercise access-level propagation in the generated extensions.
+
+@CommonEncodable
+public struct PublicCommonEncodablePerson {
+    public var name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}
+
+@CommonDecodable
+public struct PublicCommonDecodablePerson {
+    public var name: String
+}
+
+@CommonCodable
+public struct PublicCommonCodablePerson {
+    public var name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}
+
 
 struct CommonCodableStructWithAliasedProperty {
     @DecodableAlias("baz", "qux")

--- a/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
@@ -87,6 +87,39 @@ struct CodableStructWithAliasedProperty {
     let bar: String
 }
 
+// Public types exercise access-level propagation in the generated extensions.
+// Without correct `public` modifiers on the synthesized members, these would
+// fail to compile with "method must be declared public because it matches a
+// requirement in public protocol".
+
+@JSONEncodable
+public struct PublicEncodablePerson {
+    public var name: String
+    public var age: Int
+
+    public init(name: String, age: Int) {
+        self.name = name
+        self.age = age
+    }
+}
+
+@JSONDecodable
+public struct PublicDecodablePerson {
+    public var name: String
+    public var age: Int
+}
+
+@JSONCodable
+public struct PublicCodablePerson {
+    public var name: String
+    public var age: Int
+
+    public init(name: String, age: Int) {
+        self.name = name
+        self.age = age
+    }
+}
+
 @Suite("@JSONEncodable Macro Integration")
 struct JSONEncodableMacroIntegrationTests {
 
@@ -208,5 +241,13 @@ struct JSONCodableMacroIntegrationTests {
         let decoded = try NewJSONDecoder().decode(CodablePost.self, from: data)
         #expect(decoded.title == "Test")
         #expect(decoded.rating == nil)
+    }
+
+    @Test func publicTypeRoundTrip() throws {
+        let original = PublicCodablePerson(name: "Alice", age: 30)
+        let data = try NewJSONEncoder().encode(original)
+        let decoded = try NewJSONDecoder().decode(PublicCodablePerson.self, from: data)
+        #expect(decoded.name == "Alice")
+        #expect(decoded.age == 30)
     }
 }


### PR DESCRIPTION
The `@JSONCodable` / `@JSONEncodable` / `@JSONDecodable` and `@CommonCodable` / `@CommonEncodable` / `@CommonDecodable` macros currently produce an extension whose `encode(to:)` / `decode(from:)` methods have no access modifier. When the attached type is `public` (or `package`), the Swift compiler rejects the generated code:

```
error: method 'encode(to:)' must be declared public because it matches a
requirement in public protocol 'JSONEncodable'
```

Reproducer — this fails to compile today:

```swift
import NewCodable

@JSONCodable
public struct Person {
    public var name: String
    public var age: Int
}
```

## Fix

Inspect the access modifier of the attached declaration and prefix the `encode(to:)` / `decode(from:)` methods accordingly, mirroring Swift's synthesized `Codable` behavior:

- `public` / `open` → `public `
- `package` → `package `
- `internal` / `fileprivate` / `private` / (none) → `` (empty)

Added `accessLevel(of:)` helper in `SharedMacroInfrastructure.swift`; threaded an `accessLevel: String` parameter (defaulting to `""`, preserving existing test expectations for internal types) through `makeEncodableExtension` and `makeDecodableExtension`. All six macro implementations (`JSONCodableMacro`, `JSONEncodableMacro`, `JSONDecodableMacro`, `CommonCodableMacro`, `CommonEncodableMacro`, `CommonDecodableMacro`) now compute the access level once via `accessLevel(of: declaration)` and forward it to the shared generators.