### PR TITLE
Add DocC inline docs for Foundation

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
@@ -10,11 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A container for attribute keys and values.
+///
+/// ``AttributeContainer`` provides a way to store attributes and their values outside of an attributed string. You
+/// use this type to initialize an instance of ``AttributedString`` with preset attributes, and to set, merge, or
+/// replace attributes in existing attributed strings.
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct AttributeContainer : Sendable {
     internal var storage : AttributedString._AttributeStorage
     
+    /// Creates an empty attribute container.
     public init() {
         storage = .init()
     }
@@ -26,12 +32,14 @@ public struct AttributeContainer : Sendable {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeContainer {
+    /// Returns the attribute that corresponds to a specified key.
     @preconcurrency
     public subscript<T: AttributedStringKey>(_: T.Type) -> T.Value? where T.Value : Sendable {
         get { storage[T.self] }
         set { storage[T.self] = newValue }
     }
 
+    /// Returns the attribute that corresponds to a specified key path.
     @preconcurrency
     @inlinable // Trivial implementation, allows callers to optimize away the keypath allocation
     public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? where K.Value : Sendable {
@@ -39,6 +47,13 @@ extension AttributeContainer {
         set { self[K.self] = newValue }
     }
 
+    /// Returns the attribute container that corresponds to a specified key path.
+    ///
+    /// Use this subscript when you need to work with an explicit attribute scope. For example,
+    /// the SwiftUI `foregroundColor` attribute overrides the attribute in the AppKit and UIKit
+    /// scopes with the same name. If you work with both the SwiftUI and UIKit scopes, you can
+    /// use the syntax `myAttributeContainer.uiKit.foregroundColor` to disambiguate and explicitly
+    /// use the UIKit attribute.
     public subscript<S: AttributeScope>(dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>) -> ScopedAttributeContainer<S> {
         get {
             return ScopedAttributeContainer(storage)
@@ -56,15 +71,48 @@ extension AttributeContainer {
         }
     }
 
+    /// Returns a modified attribute container as part of building a chain of attributes, for use as a static method.
+    ///
+    /// This method returns an ``AttributeContainer/Builder``, which allows you to chain multiple
+    /// attributes in a single call, like this:
+    ///
+    /// ```swift
+    /// // An attribute container with the link and backgroundColor attributes.
+    /// let myContainer = AttributeContainer.link(myURL).backgroundColor(.yellow)
+    /// ```
     public static subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> Builder<K> {
         return Builder(container: AttributeContainer())
     }
 
+    /// Returns a modified attribute container as part of building a chain of attributes.
+    ///
+    /// This method returns an ``AttributeContainer/Builder``, which allows you to chain multiple
+    /// attributes in a single call, like this:
+    ///
+    /// ```swift
+    /// // An attribute container with the link and backgroundColor attributes.
+    /// let myContainer = AttributeContainer().link(myURL).backgroundColor(.yellow)
+    /// ```
     @_disfavoredOverload
     public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> Builder<K> {
         return Builder(container: self)
     }
 
+    /// A type that iteratively builds attribute containers by setting attribute values.
+    ///
+    /// The ``AttributeContainer/Builder`` type lets you build ``AttributeContainer`` instances by chaining together
+    /// several attributes in one expression. The following example shows this approach:
+    ///
+    /// ```swift
+    /// // An attribute container with the link and backgroundColor attributes.
+    /// let myContainer = AttributeContainer().link(myURL).backgroundColor(.yellow)
+    /// ```
+    ///
+    /// The first part of this expression, `AttributeContainer().link(URL(myURL))`, creates a builder to apply
+    /// the `link` attribute to the empty ``AttributeContainer``. The builder's ``Builder/callAsFunction(_:)``
+    /// returns a new ``AttributeContainer`` with this attribute set. Then the `backgroundColor(.yellow)` creates
+    /// a second builder to modify the just-returned ``AttributeContainer`` by adding the `backgroundColor`
+    /// attribute. The result is an ``AttributeContainer`` with both attributes set.
     public struct Builder<T: AttributedStringKey> : Sendable {
         var container : AttributeContainer
 
@@ -76,10 +124,21 @@ extension AttributeContainer {
         }
     }
 
+    /// Merges the container's attributes with those in another attribute container.
+    ///
+    /// - Parameters:
+    ///   - other: The attribute container with the attributes to merge.
+    ///   - mergePolicy: A policy to use when resolving conflicts between this string's attributes and those in `other`.
     public mutating func merge(_ other: AttributeContainer, mergePolicy: AttributedString.AttributeMergePolicy = .keepNew) {
         self.storage.mergeIn(other.storage, mergePolicy: mergePolicy)
     }
 
+    /// Returns an attribute container by merging the container's attributes with those in another attribute container.
+    ///
+    /// - Parameters:
+    ///   - other: The attribute container with the attributes to merge.
+    ///   - mergePolicy: A policy to use when resolving conflicts between this string's attributes and those in `other`.
+    /// - Returns: An attribute container created by merging the source container's attributes with those in another attribute container.
     public func merging(_ other: AttributeContainer, mergePolicy:  AttributedString.AttributeMergePolicy = .keepNew) -> AttributeContainer {
         var copy = self
         copy.merge(other, mergePolicy:  mergePolicy)

--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -18,12 +18,40 @@ internal import Synchronization
 //     var foregroundColor : ForegroundColor
 // }
 // An AttributeScope can contain other scopes as well.
+
+/// A type that organizes attributes into a grouping, and supports dynamic member lookup and serialization of attribute keys.
+///
+/// Attribute owners — typically frameworks — define attributes with ``AttributedStringKey`` types. To allow access to attributes with dynamic member lookup, owners create one or more structures that conform to ``AttributeScope``. The scopes provide short names for their attributes that map to the ``AttributedStringKey`` type. The following example shows how to do this:
+///
+/// ```swift
+/// struct TextStyleAttributes : AttributeScope {
+/// let foregroundColor : ForegroundColorAttribute // ForegroundColorAttribute.Value == Color
+/// let backgroundColor : BackgroundColorAttribute // BackgroundColorAttribute.Value == Color
+/// let underlineStyle : UnderlineStyleAttribute // UnderlineStyleAttribute.Value == UnderlineStyle
+/// // etc.
+/// }
+/// ```
+///
+///
+/// This allows callers to use a syntax like `myAttributedString.foregroundColor = .red`.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol AttributeScope : DecodingConfigurationProviding, EncodingConfigurationProviding, SendableMetatype {
+    /// The configuration for decoding the attribute scope.
     static var decodingConfiguration: AttributeScopeCodableConfiguration { get }
+    /// The configuration for encoding the attribute scope.
     static var encodingConfiguration: AttributeScopeCodableConfiguration { get }
 }
 
+/// Collections of attributes that system frameworks define.
+///
+/// Attribute scopes define groups of attributes appropriate for use with attributed strings in a certain domain. Attribute definitions contain a name, value type, and encode/decode methods to support serialization.
+///
+/// For example, the ``FoundationAttributes`` scope provides an attribute type for a link to a URL, ``FoundationAttributes/LinkAttribute``, along with a property to access this type, ``FoundationAttributes/link``. Because ``FoundationAttributes`` implements ``AttributeDynamicLookup``, you can access the link attribute by name, as this example shows:
+///
+/// ```swift
+/// var attrStr = AttributedString("Example site")
+/// attrStr.link = URL(string: "http://example.com")
+/// ```
 @frozen
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public enum AttributeScopes { }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
@@ -20,13 +20,23 @@ internal import _FoundationCollections
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// A type that transforms an attribute by altering its range or value, or by replacing it entirely.
+    ///
+    /// For simple transformations, the closure you provide to the `transformingAttributes(…)` methods of ``AttributedString`` can use this instance to change the attribute's value. You can also use this instance to change the range of the string that the attribute applies to. To completely replace the attribute with an attribute of a different type, use ``replace(with:value:)-6bn0e``.
     @preconcurrency
     public struct SingleAttributeTransformer<T: AttributedStringKey> : Sendable where T.Value : Sendable {
+        /// The range of the attribute in the attributed string.
+        ///
+        /// Use this property to examine or alter the range that the attribute
+        /// applies to.
         public var range: Range<Index>
 
         internal var attrName = T.name
         internal var attr : _AttributeValue?
 
+        /// The value of the attribute.
+        ///
+        /// Use this property to examine or alter the attribute value.
         public var value: T.Value? {
             get { attr?.rawValue(as: T.self) }
             set { attr = .wrapIfPresent(newValue, for: T.self) }
@@ -80,12 +90,18 @@ extension AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// Returns an attributed string by calling a closure that transforms one attribute of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The ``AttributedStringKey`` that identifies the attribute to transform.
+    ///   - c: The closure that receives an ``AttributedString/SingleAttributeTransformer`` that you use to access and alter the attribute's range and value.
+    /// - Returns: An attributed string with the applied transformation to the specified attribute.
     @preconcurrency
     public func transformingAttributes<K>(
         _ k:  K.Type,
         _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void
-    ) -> AttributedString 
-    where 
+    ) -> AttributedString
+    where
         K.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
@@ -100,14 +116,21 @@ extension AttributedString {
         return copy
     }
 
+    /// Returns an attributed string by calling a closure that transforms two attributes of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The ``AttributedStringKey`` that identifies an attribute to transform.
+    ///   - k2: The ``AttributedStringKey`` that identifies a second attribute to transform.
+    ///   - c: A closure that receives two ``AttributedString/SingleAttributeTransformer`` instances that you use to access and alter the attributes' ranges and values.
+    /// - Returns: An attributed string with the applied transformations to the specified attributes.
     @preconcurrency
     public func transformingAttributes<K1, K2>(
         _ k:  K1.Type,
         _ k2: K2.Type,
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>) -> Void
-    ) -> AttributedString 
-    where 
+    ) -> AttributedString
+    where
         K1.Value : Sendable,
         K2.Value : Sendable {
         let orig = AttributedString(_guts)
@@ -127,6 +150,14 @@ extension AttributedString {
         return copy
     }
 
+    /// Returns an attributed string by calling a closure that transforms three attributes of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The ``AttributedStringKey`` that identifies an attribute to transform.
+    ///   - k2: The ``AttributedStringKey`` that identifies a second attribute to transform.
+    ///   - k3: The ``AttributedStringKey`` that identifies a third attribute to transform.
+    ///   - c: A closure that receives three ``AttributedString/SingleAttributeTransformer`` instances that you use to access and alter the attributes' ranges and values.
+    /// - Returns: An attributed string with the applied transformations to the specified attributes.
     @preconcurrency
     public func transformingAttributes<K1, K2, K3>(
         _ k:  K1.Type,
@@ -135,7 +166,7 @@ extension AttributedString {
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>) -> Void
-    ) -> AttributedString 
+    ) -> AttributedString
     where
         K1.Value : Sendable,
         K2.Value : Sendable,
@@ -161,6 +192,15 @@ extension AttributedString {
         return copy
     }
 
+    /// Returns an attributed string by calling a closure that transforms four attributes of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The ``AttributedStringKey`` that identifies an attribute to transform.
+    ///   - k2: The ``AttributedStringKey`` that identifies a second attribute to transform.
+    ///   - k3: The ``AttributedStringKey`` that identifies a third attribute to transform.
+    ///   - k4: The ``AttributedStringKey`` that identifies a fourth attribute to transform.
+    ///   - c: A closure that receives four ``AttributedString/SingleAttributeTransformer`` instances that you use to access and alter the attributes' ranges and values.
+    /// - Returns: An attributed string with the applied transformations to the specified attributes.
     @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4>(
         _ k:  K1.Type,
@@ -202,6 +242,16 @@ extension AttributedString {
         return copy
     }
 
+    /// Returns an attributed string created by calling a closure that transforms five attributes of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The ``AttributedStringKey`` that identifies an attribute to transform.
+    ///   - k2: The ``AttributedStringKey`` that identifies a second attribute to transform.
+    ///   - k3: The ``AttributedStringKey`` that identifies a third attribute to transform.
+    ///   - k4: The ``AttributedStringKey`` that identifies a fourth attribute to transform.
+    ///   - k5: The ``AttributedStringKey`` that identifies a fifth attribute to transform.
+    ///   - c: A closure that receives five ``AttributedString/SingleAttributeTransformer`` instances that you use to access and alter the attributes' ranges and values.
+    /// - Returns: An attributed string with the applied transformations to the specified attributes.
     @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4, K5>(
         _ k:  K1.Type,
@@ -253,6 +303,12 @@ extension AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// Returns an attributed string by calling a closure that transforms one attribute, which a key path identifies, of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The key path to the ``AttributedStringKey`` that identifies the attribute to transform.
+    ///   - c: The closure that receives an ``AttributedString/SingleAttributeTransformer`` that you use to access and alter the attribute's range and value.
+    /// - Returns: An attributed string with the applied transformation to the specified attribute.
     @preconcurrency
     public func transformingAttributes<K>(
         _ k: KeyPath<AttributeDynamicLookup, K>,
@@ -263,6 +319,13 @@ extension AttributedString {
         self.transformingAttributes(K.self, c)
     }
 
+    /// Returns an attributed string created by calling a closure that transforms two attributes, which key paths identify, of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The key path to an ``AttributedStringKey`` that identifies an attribute to transform.
+    ///   - k2: The key path to an ``AttributedStringKey`` that identifies a second attribute to transform.
+    ///   - c: A closure that receives two ``AttributedString/SingleAttributeTransformer`` instances that you use to access and alter the attributes' ranges and values.
+    /// - Returns: An attributed string with the applied transformations to the specified attributes.
     @preconcurrency
     public func transformingAttributes<K1, K2>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
@@ -276,6 +339,14 @@ extension AttributedString {
         self.transformingAttributes(K1.self, K2.self, c)
     }
 
+    /// Returns an attributed string by calling a closure that transforms three attributes, which key paths identify, of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The key path to an ``AttributedStringKey`` that identifies an attribute to transform.
+    ///   - k2: The key path to an ``AttributedStringKey`` that identifies a second attribute to transform.
+    ///   - k3: The key path to an ``AttributedStringKey`` that identifies a third attribute to transform.
+    ///   - c: A closure that receives three ``AttributedString/SingleAttributeTransformer`` instances that you use to access and alter the attributes' ranges and values.
+    /// - Returns: An attributed string with the applied transformations to the specified attributes.
     @preconcurrency
     public func transformingAttributes<K1, K2, K3>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
@@ -292,6 +363,15 @@ extension AttributedString {
         self.transformingAttributes(K1.self, K2.self, K3.self, c)
     }
 
+    /// Returns an attributed string created by calling a closure that transforms four attributes, which key paths identify, of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The key path to an ``AttributedStringKey`` that identifies an attribute to transform.
+    ///   - k2: The key path to an ``AttributedStringKey`` that identifies a second attribute to transform.
+    ///   - k3: The key path to an ``AttributedStringKey`` that identifies a third attribute to transform.
+    ///   - k4: The key path to an ``AttributedStringKey`` that identifies a fourth attribute to transform.
+    ///   - c: A closure that receives four ``AttributedString/SingleAttributeTransformer`` instances that you use to access and alter the attributes' ranges and values.
+    /// - Returns: An attributed string with the applied transformations to the specified attributes.
     @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
@@ -311,6 +391,16 @@ extension AttributedString {
         self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, c)
     }
 
+    /// Returns an attributed string created by calling a closure that transforms five attributes, which key paths identify, of a source attributed string.
+    ///
+    /// - Parameters:
+    ///   - k: The key path to an ``AttributedStringKey`` that identifies an attribute to transform.
+    ///   - k2: The key path to an ``AttributedStringKey`` that identifies a second attribute to transform.
+    ///   - k3: The key path to an ``AttributedStringKey`` that identifies a third attribute to transform.
+    ///   - k4: The key path to an ``AttributedStringKey`` that identifies a fourth attribute to transform.
+    ///   - k5: The key path to an ``AttributedStringKey`` that identifies a fifth attribute to transform.
+    ///   - c: A closure that receives five ``AttributedString/SingleAttributeTransformer`` instances that you use to access and alter the attributes' ranges and values.
+    /// - Returns: An attributed string, with the applied transformations to the given attributes.
     @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4, K5>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -20,6 +20,7 @@ internal import _FoundationCollections
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// A view into the underlying storage of the attributed string, as Unicode characters.
     public struct CharacterView : Sendable {
         /// The guts of the base attributed string.
         internal var _guts: Guts
@@ -55,6 +56,15 @@ extension AttributedString {
         }
     }
 
+    /// The characters of the attributed string, as a view into the underlying string.
+    ///
+    /// Use the ``AttributedString/characters`` view when you want to look for specific string
+    /// content. You can then use the resulting ranges to set attributes for specific parts of
+    /// the ``AttributedString``.
+    ///
+    /// You can also use this property to mutate the attributed string, using
+    /// `RangeReplaceableCollection` methods, such as `insert(_:at:)` and `append(_:)`.
+    /// Inserted characters inherit any attributes present at the insertion point.
     public var characters: CharacterView {
         get {
             return CharacterView(_guts)
@@ -113,6 +123,14 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         .init(_range.upperBound, version: _guts.version)
     }
 
+    /// The number of characters in the collection.
+    ///
+    /// To check whether a collection is empty, use its `isEmpty` property
+    /// instead of comparing `count` to zero. Unless the collection guarantees
+    /// random-access performance, calculating `count` can be an O(*n*)
+    /// operation.
+    ///
+    /// - Complexity: O(*n*)
     @_alwaysEmitIntoClient
     public var count: Int {
     #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -20,6 +20,7 @@ internal import _FoundationCollections
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// An iterable view into segments of the attributed string, each of which indicates where a run of identical attributes begins or ends.
     public struct Runs: Sendable {
         internal typealias _InternalRun = AttributedString._InternalRun
         internal typealias _AttributeStorage = AttributedString._AttributeStorage
@@ -103,6 +104,10 @@ extension AttributedString {
         }
     }
 
+    /// The attributed runs of the attributed string, as a view into the underlying string.
+    ///
+    /// Runs begin and end when the attributes for the characters change. Use this property to
+    /// iterate over the runs with `for`-`in` syntax.
     public var runs: Runs {
         Runs(_guts)
     }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -20,6 +20,7 @@ internal import _FoundationCollections
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// A view into the underlying storage of the attributed string, as Unicode scalars.
     public struct UnicodeScalarView: Sendable {
         internal var _guts: Guts
 
@@ -48,6 +49,15 @@ extension AttributedString {
         }
     }
 
+    /// The Unicode scalars of the attributed string, as a view into the underlying string.
+    ///
+    /// Use this property when you want to split the attributed string by Unicode scalar instead
+    /// of grapheme cluster. This is useful when you need to carefully control insertion points
+    /// or render the content.
+    ///
+    /// You can also use this property to mutate the attributed string, using
+    /// `RangeReplaceableCollection` methods, such as `insert(_:at:)` and `append(_:)`.
+    /// Inserted characters inherit any attributes present at the insertion point.
     public var unicodeScalars: UnicodeScalarView {
         get {
             UnicodeScalarView(_guts)
@@ -114,6 +124,16 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
         .init(_range.upperBound, version: _guts.version)
     }
 
+    /// The number of elements in the collection.
+    ///
+    /// To check whether a collection is empty, use its `isEmpty` property
+    /// instead of comparing `count` to zero. Unless the collection guarantees
+    /// random-access performance, calculating `count` can be an O(*n*)
+    /// operation.
+    ///
+    /// - Complexity: O(1) if the collection conforms to
+    ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
+    ///   of the collection.
     @_alwaysEmitIntoClient
     public var count: Int {
     #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -20,6 +20,102 @@ internal import _FoundationCollections
 
 internal import Synchronization
 
+/// A value type for a string with associated attributes for portions of its text.
+///
+/// Attributed strings are character strings that have attributes for individual characters or
+/// ranges of characters. Attributes provide traits like visual styles for display, accessibility
+/// for guided access, and hyperlink data for linking between data sources. Attribute keys provide
+/// the name and value type of each attribute. System frameworks like Foundation and SwiftUI define
+/// common keys, and you can define your own in custom extensions.
+///
+/// ## String Attributes
+///
+/// You can apply an attribute to an entire string, or to a range within the string. The string
+/// represents each range with consistent attributes as a *run*. ``AttributedString`` uses
+/// subscripts and dynamic member lookup to simplify working with attributes from your call points.
+///
+/// In its most verbose form, you set an attribute by creating an ``AttributeContainer`` and
+/// merging it into an existing attributed string, like this:
+///
+/// ```swift
+/// var attributedString = AttributedString("This is a string with empty attributes.")
+/// var container = AttributeContainer()
+/// container[AttributeScopes.AppKitAttributes.ForegroundColorAttribute.self] = .red
+/// attributedString.mergeAttributes(container, mergePolicy: .keepNew)
+/// ```
+///
+/// Using the attributed string's ``subscript(_:)-6gvcp`` method, you can omit the explicit use of
+/// an ``AttributeContainer`` and just set the attribute by its type:
+///
+/// ```swift
+/// attributedString[AttributeScopes.AppKitAttributes.ForegroundColorAttribute.self] = .yellow
+/// ```
+///
+/// Because an ``AttributedString`` supports dynamic member lookup — as described under
+/// [Attributes](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes)
+/// in *The Swift Programming Language* — you can access its subscripts with dot syntax instead.
+/// When combined with properties like `foregroundColor` that return the attribute key type, this
+/// final form offers a natural way to set an attribute that applies to an entire string:
+///
+/// ```swift
+/// attributedString.foregroundColor = .green
+/// ```
+///
+/// You can also set an attribute to apply only to part of an attributed string, by applying the
+/// attribute to a range, as seen here:
+///
+/// ```swift
+/// var attributedString = AttributedString("The first month of your subscription is free.")
+/// guard let range = attributedString.range(of: "free") else { return }
+/// attributedString[range].foregroundColor = .green
+/// ```
+///
+/// You can access portions of the string with unique combinations of attributes by iterating over
+/// the string's ``runs`` property.
+///
+/// You can define your own custom attributes by creating types that conform to
+/// ``AttributedStringKey``, and collecting them in an ``AttributeScope``. Custom keys should also
+/// extend ``AttributeDynamicLookup``, so callers can use dot-syntax to access the attribute.
+///
+/// ## Creating Attributed Strings with Markdown
+///
+/// You can create an attributed string by passing a standard `String` or `Data` instance that
+/// contains Markdown to initializers like ``init(markdown:options:baseURL:)-52n3u``. The attributed
+/// string creates attributes by parsing the markup in the string.
+///
+/// ```swift
+/// do {
+///     let thankYouString = try AttributedString(
+///         markdown: "**Thank you!** Please visit our [website](https://example.com)")
+/// } catch {
+///     print("Couldn't parse the string. \(error.localizedDescription)")
+/// }
+/// ```
+///
+/// Localized strings that you load from strings files with initializers like
+/// ``init(localized:options:table:bundle:locale:comment:)-8dlnl`` can also contain Markdown to add
+/// styling. In addition, these localized attributed string initializers can apply the
+/// ``AttributeScopes/FoundationAttributes/ReplacementIndexAttribute`` attribute, which allows you
+/// to determine the range of replacement strings, whose order may vary between languages.
+///
+/// By declaring new attributes that conform to ``MarkdownDecodableAttributedStringKey``, you can
+/// add attributes that you invoke by using Apple's Markdown extension syntax:
+/// `^[text](name: value, name: value, …)`.
+///
+/// Localized attributed strings can also use the extension syntax to indicate parts of the string
+/// where the system can apply automatic grammar agreement. See the initializers that take a
+/// `localized:` parameter for examples of this extension syntax, as used with automatic grammar
+/// agreement.
+///
+/// ## Attribute Scopes
+///
+/// The ``AttributedString`` API defines keys for common uses, such as text styling, semantically
+/// marking up formattable types like dates and numbers, and hyperlinking. You can find these in the
+/// ``AttributeScopes`` enumeration, which contains attributes for AppKit, Foundation, SwiftUI, and
+/// UIKit.
+///
+/// You can define your own attributes by implementing ``AttributedStringKey``, and reference them
+/// by name by collecting them in an ``AttributeScope``.
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct AttributedString : Sendable {
@@ -41,6 +137,7 @@ extension AttributedString {
 // MARK: Initialization
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// Creates an empty attributed string.
     public init() {
         self._guts = Guts()
     }
@@ -73,16 +170,29 @@ extension AttributedString {
 
     /// Creates a new attributed string with the given `String` value associated with the given
     /// attributes.
+    ///
+    /// - Parameters:
+    ///   - string: A string to add attributes to.
+    ///   - attributes: Attributes to apply to `string`.
     public init(_ string: String, attributes: AttributeContainer = .init()) {
         self.init(BigString(string), attributes: attributes.storage)
     }
 
     /// Creates a new attributed string with the given `Substring` value associated with the given
     /// attributes.
+    ///
+    /// - Parameters:
+    ///   - substring: A substring to add attributes to.
+    ///   - attributes: Attributes to apply to `substring`.
     public init(_ substring: Substring, attributes: AttributeContainer = .init()) {
         self.init(BigString(substring), attributes: attributes.storage)
     }
 
+    /// Creates an attributed string from a character sequence and an attribute container.
+    ///
+    /// - Parameters:
+    ///   - elements: A character sequence that provides the textual content for the attributed string.
+    ///   - attributes: Attributes to apply to the textual content.
     public init<S : Sequence>(
         _ elements: S,
         attributes: AttributeContainer = .init()
@@ -91,6 +201,9 @@ extension AttributedString {
         self.init(str, attributes: attributes.storage)
     }
 
+    /// Creates an attributed string from an attributed substring.
+    ///
+    /// - Parameter substring: An attributed substring to create the new attributed string from.
     public init(_ substring: AttributedSubstring) {
         let str = BigString(substring._unicodeScalars)
         let runs = substring._guts.runs.extract(utf8Offsets: substring._range._utf8OffsetRange)
@@ -103,10 +216,20 @@ extension AttributedString {
 
 #if FOUNDATION_FRAMEWORK
     // TODO: Support scope-specific initialization in FoundationPreview
+    /// Creates an attributed string from another attributed string, including an attribute scope that a key path identifies.
+    ///
+    /// - Parameters:
+    ///   - other: An attributed string or attributed substring.
+    ///   - scope: An ``AttributeScopes`` key path that identifies an attribute scope to associate with the attributed string.
     public init<S : AttributeScope, T : AttributedStringProtocol>(_ other: T, including scope: KeyPath<AttributeScopes, S.Type>) {
         self.init(other, including: S.self)
     }
 
+    /// Creates an attributed string from another attributed string, including an attribute scope.
+    ///
+    /// - Parameters:
+    ///   - other: An attributed string or attributed substring.
+    ///   - scope: An attribute scope to associate with the attributed string.
     public init<S : AttributeScope, T : AttributedStringProtocol>(_ other: T, including scope: S.Type) {
         // FIXME: This `copy(in:)` call does too much work, potentially unexpectedly removing attributes.
         self.init(other.__guts.copy(in: other._stringBounds))
@@ -160,6 +283,9 @@ extension AttributedString { // Equatable
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString: ExpressibleByStringLiteral {
+    /// Creates an attributed string from the specified string literal, with no attributes.
+    ///
+    /// - Parameter value: The string literal that provides the attributed string's initial content.
     public init(stringLiteral value: String) {
         self.init(value)
     }
@@ -167,16 +293,29 @@ extension AttributedString: ExpressibleByStringLiteral {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString { // AttributedStringAttributeMutation
+    /// Sets the attributed string's attributes to those in a specified attribute container.
+    ///
+    /// - Parameter attributes: The attribute container with the attributes to apply.
     public mutating func setAttributes(_ attributes: AttributeContainer) {
         ensureUniqueReference()
         _guts.setAttributes(attributes.storage, in: _stringBounds)
     }
 
+    /// Merges the attributed string's attributes with those in a specified attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The attribute container with the attributes to merge.
+    ///   - mergePolicy: A policy to use when resolving conflicts between this string's attributes and those in `attributes`.
     public mutating func mergeAttributes(_ attributes: AttributeContainer, mergePolicy:  AttributeMergePolicy = .keepNew) {
         ensureUniqueReference()
         _guts.mergeAttributes(attributes, in: _stringBounds, mergePolicy:  mergePolicy)
     }
 
+    /// Replaces occurrences of attributes in one attribute container with those in another attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The existing attributes to replace.
+    ///   - others: The new attributes to apply.
     public mutating func replaceAttributes(_ attributes: AttributeContainer, with others: AttributeContainer) {
         guard attributes != others else { return }
         ensureUniqueReference()
@@ -203,6 +342,7 @@ extension AttributedString { // AttributedStringAttributeMutation
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString: AttributedStringProtocol {
+    /// A type that represents the position of a character or code unit within an attributed string.
     public struct Index : Comparable, Sendable {
         internal var _value: BigString.Index
         internal var _version: AttributedString.Guts.Version
@@ -221,10 +361,16 @@ extension AttributedString: AttributedStringProtocol {
         }
     }
     
+    /// The position of the first character in a nonempty attributed string.
+    ///
+    /// In an empty string, `startIndex` is equal to `endIndex`.
     public var startIndex : Index {
         Index(_guts.string.startIndex, version: _guts.version)
     }
     
+    /// The string's past-the-end position — the position one greater than the last valid subscript argument.
+    ///
+    /// In an empty string, `endIndex` is equal to `startIndex`.
     public var endIndex : Index {
         Index(_guts.string.endIndex, version: _guts.version)
     }
@@ -244,6 +390,14 @@ extension AttributedString: AttributedStringProtocol {
         }
     }
     
+    /// Returns an attribute value that a key path indicates.
+    ///
+    /// This subscript returns `nil` unless the specified attribute exists, and is present and
+    /// identical for the entire attributed string or substring. To find portions of the string
+    /// with consistent attributes, use the ``AttributedString/runs`` property.
+    ///
+    /// Getting or setting stringwide attributes with this subscript has `O(n)` behavior in
+    /// the worst case, where `n` is the number of runs.
     @preconcurrency
     @inlinable // Trivial implementation, allows callers to optimize away the keypath allocation
     public subscript<K: AttributedStringKey>(
@@ -253,6 +407,20 @@ extension AttributedString: AttributedStringProtocol {
         set { self[K.self] = newValue }
     }
     
+    /// Returns a scoped attribute container that a key path indicates.
+    ///
+    /// Use this subscript when you need to work with an explicit attribute scope. For example,
+    /// the SwiftUI `foregroundColor` attribute overrides the attribute in the AppKit and UIKit
+    /// scopes with the same name. If you work with both the SwiftUI and UIKit scopes, you can
+    /// use the syntax `myAttributedString.uiKit.foregroundColor` to disambiguate and explicitly
+    /// use the UIKit attribute.
+    ///
+    /// The attribute container that this method returns contains only attributes that exist,
+    /// and are present and identical for the entire attributed string. To find portions of the
+    /// string with consistent attributes, use the ``AttributedString/runs`` property.
+    ///
+    /// Getting or setting stringwide attributes with this subscript has `O(n)` behavior in
+    /// the worst case, where `n` is the number of runs.
     public subscript<S: AttributeScope>(
         dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>
     ) -> ScopedAttributeContainer<S> {
@@ -284,18 +452,34 @@ extension AttributedString {
         _guts.incrementVersion()
     }
 
+    /// Appends a string to the attributed string.
+    ///
+    /// - Parameter s: The string to append.
     public mutating func append(_ s: some AttributedStringProtocol) {
         replaceSubrange(endIndex ..< endIndex, with: s)
     }
 
+    /// Inserts the specified string at a specific index in the attributed string.
+    ///
+    /// - Parameters:
+    ///   - s: The string to insert.
+    ///   - index: The index that indicates where to insert the string.
     public mutating func insert(_ s: some AttributedStringProtocol, at index: AttributedString.Index) {
         replaceSubrange(index ..< index, with: s)
     }
 
+    /// Removes a range of characters from the attributed string.
+    ///
+    /// - Parameter range: The range to remove.
     public mutating func removeSubrange(_ range: some RangeExpression<Index>) {
         replaceSubrange(range, with: AttributedString())
     }
 
+    /// Replaces the contents in a range of the attributed string.
+    ///
+    /// - Parameters:
+    ///   - range: The range of the attributed string to replace.
+    ///   - s: The string to insert in place of the replaced range.
     public mutating func replaceSubrange(_ range: some RangeExpression<Index>, with s: some AttributedStringProtocol) {
         ensureUniqueReference()
         // Note: slicing generally allows sub-Character ranges, but we need to resolve range
@@ -308,22 +492,44 @@ extension AttributedString {
 // MARK: Concatenation operators
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// Concatenates two attributed strings or substrings.
+    ///
+    /// - Parameters:
+    ///   - lhs: An attributed string or substring to concatenate.
+    ///   - rhs: Another attributed string or substring to concatenate.
+    /// - Returns: The result of concatenating `rhs` to the end of `lhs`.
     public static func +(lhs: AttributedString, rhs: some AttributedStringProtocol) -> AttributedString {
         var result = lhs
         result.append(rhs)
         return result
     }
-    
+
+    /// Appends an attributed string or substring to another attributed string.
+    ///
+    /// - Parameters:
+    ///   - lhs: An attributed string. After the operation, the value of this string is the original `lhs` string with `rhs` appended to it.
+    ///   - rhs: An attributed string or substring to append to `lhs`.
     public static func +=(lhs: inout AttributedString, rhs: some AttributedStringProtocol) {
         lhs.append(rhs)
     }
-    
+
+    /// Concatenates two attributed strings.
+    ///
+    /// - Parameters:
+    ///   - lhs: An attributed string to concatenate.
+    ///   - rhs: Another attributed string to concatenate.
+    /// - Returns: The result of concatenating `rhs` to the end of `lhs`.
     public static func + (lhs: AttributedString, rhs: AttributedString) -> AttributedString {
         var result = lhs
         result.append(rhs)
         return result
     }
-    
+
+    /// Appends an attributed string to another attributed string.
+    ///
+    /// - Parameters:
+    ///   - lhs: An attributed string. After the operation, the value of this string is the original `lhs` string with `rhs` appended to it.
+    ///   - rhs: An attributed string to append to `lhs`.
     public static func += (lhs: inout Self, rhs: AttributedString) {
         lhs.append(rhs)
     }
@@ -332,6 +538,7 @@ extension AttributedString {
 // MARK: Substring access
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// Returns a substring of the attributed string using a range to indicate the substring bounds.
     public subscript(bounds: some RangeExpression<Index>) -> AttributedSubstring {
         get {
             // Note: slicing generally allows sub-Character ranges, but we need to resolve range

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -94,9 +94,37 @@ extension AttributedString {
 }
 
 // Developers define new attributes by implementing AttributeKey.
+/// A type that defines an attribute's name and type.
+///
+/// You don't instantiate types that conform to this protocol. Rather, dynamic member lookup uses this type as the basis for looking up key paths on ``AttributedString`` subtypes when using an ``AttributeScope`` type parameter. When it also conforms to ``CodableAttributedStringKey``, (or ``DecodableAttributedStringKey``/``EncodableAttributedStringKey`` if the type isn't fully codable), the ``AttributedStringKey`` describes which attributes of an ``AttributedString`` support encoding or decoding.
+///
+/// Attribute owners — typically frameworks — declare a key like the following:
+///
+/// ```swift
+/// enum OutlineColorAttribute : AttributedStringKey {
+/// typealias Value = Color
+/// static let name = "OutlineColor"
+/// }
+/// ```
+///
+///
+/// Callers can use these types to get attribute values from attributed strings, but typically you want to reference them by name. Attribute owners enable this by creating one or more structures that conform to ``AttributeScope``, in which they provide short names for their attributes that map to the ``AttributedStringKey`` type. The following example shows how to do this:
+///
+/// ```swift
+/// struct MyTextStyleAttributes : AttributeScope {
+/// let outlineColor : OutlineColorAttribute // OutlineColorAttribute.Value == Color
+/// let shadowColor : ShadowColorAttribute // ShadowColorAttribute.Value == Color
+/// // etc.
+/// }
+/// ```
+///
+///
+/// After you extend ``AttributeScope`` like this, extend ``AttributeDynamicLookup`` to allow callers to use dynamic member lookup syntax, like `myAttributedString.outlineColor = .red`.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol AttributedStringKey : SendableMetatype {
+    /// The type of the key's value.
     associatedtype Value : Hashable
+    /// The name of the key.
     static var name : String { get }
     
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
@@ -125,9 +153,23 @@ extension AttributedStringKey {
 
 // MARK: Attribute Scopes
 
+/// A type to support dynamic member lookup of attributes and containers.
+///
+/// This type allows attribute owners to add extensions that enable dynamic member lookup access to attributes. Supporting types — including ``AttributedString``, ``AttributedSubstring``, and ``AttributeContainer`` — gain dynamic lookup support by extending this type.
+///
+/// You can enable dynamic member lookup for your own ``AttributedStringKey`` attributes by defining them as implementations, collecting them into an ``AttributeScope`` and extending ``AttributeDynamicLookup``, like in the following example:
+///
+/// ```swift
+/// public extension AttributeDynamicLookup {
+/// subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.MyFrameworkAttributes, T>) -> T {
+/// return self[T.self]
+/// }
+/// }
+/// ```
 @dynamicMemberLookup @frozen
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public enum AttributeDynamicLookup {
+    /// Returns an attributed string key that corresponds to a specified type.
     public subscript<T: AttributedStringKey>(_: T.Type) -> T {
         get { fatalError("Called outside of a dynamicMemberLookup subscript overload") }
     }
@@ -140,6 +182,9 @@ public enum AttributeDynamicLookup {
 @available(*, unavailable)
 extension AttributeDynamicLookup : Sendable {}
 
+/// An attribute container that allows dynamic member lookup of its contents within the specified attribute scope.
+///
+/// Use a ``ScopedAttributeContainer`` when you need to disambiguate between attributes that exist in several attribute scopes that your app uses.
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct ScopedAttributeContainer<S: AttributeScope> : Sendable {
@@ -149,6 +194,7 @@ public struct ScopedAttributeContainer<S: AttributeScope> : Sendable {
     // Note: if ScopedAttributeContainer ever adds a mutating function that can mutate multiple attributes, this will need to record multiple removed keys
     internal var removedKey : String?
 
+    /// Returns the value of the attribute that the specified key path indicates.
     @preconcurrency
     public subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<S, T>) -> T.Value? where T.Value : Sendable {
         get { storage[T.self] }

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
@@ -30,21 +30,51 @@ extension Decoder {
     }
 }
 
+/// A protocol that defines how an attribute key encodes its value.
+///
+/// Implement this protocol to make an attribute encodable. Encoding an ``AttributedString`` or ``AttributeContainer`` drops any attributes whose types don't conform to this protocol.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol EncodableAttributedStringKey : AttributedStringKey {
+    /// Encodes a value to the provided encoder.
+    ///
+    /// This method throws an error if writing to the encoder fails.
+    ///
+    /// - Parameters:
+    ///   - value: The value to encode.
+    ///   - encoder: The encoder to write data to.
     static func encode(_ value: Value, to encoder: Encoder) throws
 }
 
+/// A protocol that defines how an attribute key decodes its value.
+///
+/// Implement this protocol to make an attribute decodable. Decoding an ``AttributedString`` or ``AttributeContainer`` drops any attributes whose types don't conform to this protocol.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol DecodableAttributedStringKey : AttributedStringKey {
+    /// Decodes a value from the provided decoder.
+    ///
+    /// This method throws an error if reading from the decoder fails, or if the data read is
+    /// corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    /// - Returns: The decoded value.
     static func decode(from decoder: Decoder) throws -> Value
 }
 
+/// A type alias for attribute keys that are both encodable and decodable.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public typealias CodableAttributedStringKey = EncodableAttributedStringKey & DecodableAttributedStringKey
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension EncodableAttributedStringKey where Value : Encodable {
+    /// Encodes a Swift value to the provided encoder, using a default implementation.
+    ///
+    /// The default implementation calls down to the value's `Encodable.encode(to:)` method.
+    ///
+    /// This method throws an error if writing the encoder fails.
+    ///
+    /// - Parameters:
+    ///   - value: The value to encode.
+    ///   - encoder: The encoder to write data to.
     public static func encode(_ value: Value, to encoder: Encoder) throws {
         try value.encode(to: encoder)
     }
@@ -52,25 +82,68 @@ extension EncodableAttributedStringKey where Value : Encodable {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension DecodableAttributedStringKey where Value : Decodable {
+    /// Decodes a Swift value from the provided decoder, using a default implementation.
+    ///
+    /// The default implementation calls down to the value's `Decodable.init(from:)` method.
+    ///
+    /// This method throws an error if reading from the decoder fails, or if the data read is
+    /// corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    /// - Returns: The decoded value.
     public static func decode(from decoder: Decoder) throws -> Value {
         return try Value.init(from: decoder)
     }
 }
 
 
+/// A protocol that defines how an attribute key decodes a value that corresponds to Markdown syntax.
+///
+/// This protocol is separate from ``DecodableAttributedStringKey`` to separate explicit attributes defined by the SDK from Markdown's semantic styling attributes. You use these attributes with Apple's extended syntax for markdown: `^[text](attribute: value)`.
+///
+/// Using this protocol allows your markup names to differ from the names of your attributes. For example, the automatic grammar agreement feature uses markup like `^[text to inflect](inflect: true)`. This feature defines an ``AttributeScopes/FoundationAttributes/InflectionRuleAttribute`` that conforms to ``MarkdownDecodableAttributedStringKey``. The value of its ``AttributeScopes/FoundationAttributes/InflectionRuleAttribute/name`` proprerty is `NSInflect`, while its ``AttributeScopes/FoundationAttributes/InflectionRuleAttribute/markdownName-aom1``, used in actual Markdown strings like the one shown here, is `inflect`.
+///
+/// To define your own attributes for use with Markdown syntax, make sure your attributes conform to this protocol. The markdown parser ignores attributes that don't conform, even if you use the extended Markdown syntax.
+///
+/// > Tip:
+/// > When creating attributed strings from Markdown-based initializers like ``AttributedString/init(markdown:options:baseURL:)-52n3u``, be sure to set the ``AttributedString/MarkdownParsingOptions/allowsExtendedAttributes`` option. If you don't include this option, the string won't parse ``MarkdownDecodableAttributedStringKey``-based attributes.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol MarkdownDecodableAttributedStringKey : AttributedStringKey {
+    /// Decodes a value from the provided decoder.
+    ///
+    /// This method throws an error if reading from the decoder fails, or if the data read is
+    /// corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    /// - Returns: The decoded value.
     static func decodeMarkdown(from decoder: Decoder) throws -> Value
+    /// The Markdown name associated with an attributed string key.
     static var markdownName: String { get }
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension MarkdownDecodableAttributedStringKey {
+    /// The Markdown name associated with an attributed string key, as provided by a default
+    /// implementation.
+    ///
+    /// The default value of this property is the value of the ``AttributedStringKey``'s
+    /// ``AttributedStringKey/name``.
     public static var markdownName: String { name }
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension MarkdownDecodableAttributedStringKey where Self : DecodableAttributedStringKey {
+    /// Decodes a value from the provided decoder, using a default implementation.
+    ///
+    /// The default implementation calls ``DecodableAttributedStringKey/decode(from:)-9mpts``,
+    /// inherited from ``DecodableAttributedStringKey``, meaning it uses the same decoding as
+    /// non-Markdown encoding.
+    ///
+    /// This method throws an error if reading from the decoder fails, or if the data read is
+    /// corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    /// - Returns: The decoded value.
     public static func decodeMarkdown(from decoder: Decoder) throws -> Value {
         try Self.decode(from: decoder)
     }
@@ -79,6 +152,16 @@ extension MarkdownDecodableAttributedStringKey where Self : DecodableAttributedS
 #if FOUNDATION_FRAMEWORK
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension EncodableAttributedStringKey where Value : NSSecureCoding & NSObject {
+    /// Encodes an Objective-C value to the provided encoder, using a default implementation.
+    ///
+    /// The default implementation uses an ``NSKeyedArchiver`` on the object, then calls
+    /// `Encodable.encode(to:)` on the resulting data.
+    ///
+    /// This method throws an error if writing to the encoder fails.
+    ///
+    /// - Parameters:
+    ///   - value: The value to encode.
+    ///   - encoder: The encoder to write data to.
     public static func encode(_ value: Value, to encoder: Encoder) throws {
         let data = try NSKeyedArchiver.archivedData(withRootObject: value, requiringSecureCoding: true)
         var container = encoder.singleValueContainer()
@@ -88,6 +171,16 @@ extension EncodableAttributedStringKey where Value : NSSecureCoding & NSObject {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension DecodableAttributedStringKey where Value : NSSecureCoding & NSObject {
+    /// Decodes an Objective-C value from the provided decoder, using a default implementation.
+    ///
+    /// The default implementation decodes the object as a ``Data`` instance, then uses an
+    /// ``NSKeyedUnarchiver`` to unarchive the object.
+    ///
+    /// This method throws an error if reading from the decoder fails, or if the data read is
+    /// corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    /// - Returns: The decoded object.
     public static func decode(from decoder: Decoder) throws -> Value {
         let container = try decoder.singleValueContainer()
         let data = try container.decode(Data.self)
@@ -103,6 +196,7 @@ extension DecodableAttributedStringKey where Value : NSSecureCoding & NSObject {
 
 // MARK: AttributedString CodableWithConfiguration Conformance
 
+/// A configuration type for encoding and decoding attributed strings.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct AttributeScopeCodableConfiguration : Sendable {
     internal let attributesTable : [String : any AttributedStringKey.Type]
@@ -126,7 +220,9 @@ public struct AttributeScopeCodableConfiguration : Sendable {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeScope {
+    /// The configuration for encoding the attribute scope.
     public static var encodingConfiguration: AttributeScopeCodableConfiguration { AttributeScopeCodableConfiguration(Self.self) }
+    /// The configuration for decoding the attribute scope.
     public static var decodingConfiguration: AttributeScopeCodableConfiguration { AttributeScopeCodableConfiguration(Self.self) }
 }
 
@@ -363,6 +459,11 @@ extension AttributeContainer : CodableWithConfiguration {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension CodableConfiguration where ConfigurationProvider : AttributeScope {
+    /// Creates a codable configuration wrapper for the given value, using given configuration provider type identified by key path.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: The underlying value to make codable, using data from the configuration provider.
+    ///   - keyPath: A key path that identifies the type of the configuration provider, which provides additional information to encode `wrappedValue`.
     public init(wrappedValue: T, from keyPath: KeyPath<AttributeScopes, ConfigurationProvider.Type>) {
         self.wrappedValue = wrappedValue
     }

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -20,8 +20,11 @@ internal import _FoundationCollections
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// A type that defines the behavior when merging attributes.
     public enum AttributeMergePolicy : Sendable {
+        /// The new value for this attribute takes precedence.
         case keepNew
+        /// The existing value for this attribute takes precedence.
         case keepCurrent
         
         internal var combinerClosure: (_AttributeValue, _AttributeValue) -> _AttributeValue {
@@ -33,23 +36,52 @@ extension AttributedString {
     }
 }
 
+/// A protocol that defines in-place mutations for attributes in an attributed string.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol AttributedStringAttributeMutation {
+    /// Sets the attributed string's attributes to those in a specified attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The attribute container with the attributes to apply.
     mutating func setAttributes(_ attributes: AttributeContainer)
+    /// Merges the attributed string's attributes with those in a specified attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The attribute container with the attributes to merge.
+    ///   - mergePolicy: A policy to use when resolving conflicts between this string's attributes and those in `attributes`.
     mutating func mergeAttributes(_ attributes: AttributeContainer, mergePolicy: AttributedString.AttributeMergePolicy)
+    /// Replaces the attributed string's attributes with those in a specified attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The existing attributes to replace.
+    ///   - others: The new attributes to apply.
     mutating func replaceAttributes(_ attributes: AttributeContainer, with others: AttributeContainer)
 }
 
+/// A protocol that provides common functionality to attributed strings and attributed substrings.
+///
+/// Don't declare new conformances to ``AttributedStringProtocol``. Only the ``AttributedString`` and ``AttributedSubstring`` types in the standard library are valid conforming types.
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol AttributedStringProtocol
     : AttributedStringAttributeMutation, Hashable, CustomStringConvertible, Sendable
 {
+    /// The position of the first character in a nonempty attributed string.
     var startIndex : AttributedString.Index { get }
+    /// A string's past-the-end position — the position one greater than the last valid subscript argument.
     var endIndex : AttributedString.Index { get }
 
+    /// The attributed runs of the attributed string, as a view into the underlying string.
+    ///
+    /// Runs begin and end when the attributes for the characters change. Use this property to iterate over the runs with `for`-`in` syntax.
     var runs : AttributedString.Runs { get }
+    /// The characters of the attributed string, as a view into the underlying string.
+    ///
+    /// Use the ``AttributedStringProtocol/characters`` view when you want to look for specific string content. You can then use the resulting ranges to set attributes for specific parts of the ``AttributedString`` or ``AttributedSubstring``.
     var characters : AttributedString.CharacterView { get }
+    /// The Unicode scalars of the attributed string, as a view into the underlying string.
+    ///
+    /// Use this property when you want to split the attributed string by Unicode scalar instead of grapheme cluster. This is useful when you need to carefully control insertion points or render the content.
     var unicodeScalars : AttributedString.UnicodeScalarView { get }
     
     @available(FoundationPreview 6.2, *)
@@ -58,10 +90,20 @@ public protocol AttributedStringProtocol
     @available(FoundationPreview 6.2, *)
     var utf16 : AttributedString.UTF16View { get }
 
+    /// Returns an attribute value that corresponds to an attributed string key.
+    ///
+    /// This subscript returns `nil` unless the specified attribute exists, and is present and identical for the entire attributed string or substring. To find portions of an attributed string with consistent attributes, use the ``AttributedString/runs`` property.
     @preconcurrency subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? where K.Value : Sendable { get set }
+    /// Returns an attribute value that a key path indicates.
+    ///
+    /// This subscript returns `nil` unless the specified attribute exists, and is present and identical for the entire attributed string or substring. To find portions of an attributed string with consistent attributes, use the ``AttributedStringProtocol/runs`` property.
     @preconcurrency subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? where K.Value : Sendable { get set }
+    /// Returns a scoped attribute container that a key path indicates.
+    ///
+    /// Use this subscript when you need to work with an explicit attribute scope. For example, the SwiftUI ``AttributeScopes/SwiftUIAttributes/foregroundColor`` attribute overrides the attribute in the AppKit and UIKit scopes with the same name. If you work with both the SwiftUI and UIKit scopes, you can use the syntax `myAttributedString.uiKit.foregroundColor` to disambiguate and explicitly use the UIKit attribute.
     subscript<S: AttributeScope>(dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>) -> ScopedAttributeContainer<S> { get set }
 
+    /// Returns a substring of the attributed string using a range to indicate the substring bounds.
     subscript<R: RangeExpression>(bounds: R) -> AttributedSubstring where R.Bound == AttributedString.Index { get }
 }
 
@@ -79,12 +121,21 @@ extension AttributedStringProtocol {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedStringProtocol {
+    /// Returns an attributed string by setting the attributed string's attributes to those in a specified attribute container.
+    ///
+    /// - Parameter attributes: The attribute container with the attributes to apply.
+    /// - Returns: An attributed string from setting the attributed string's attributes to those in a specified attribute container.
     public func settingAttributes(_ attributes: AttributeContainer) -> AttributedString {
         var new = AttributedString(self)
         new.setAttributes(attributes)
         return new
     }
 
+    /// Returns an attributed string by merging the attributed string's attributes with those in a specified attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The attribute container with the attributes to merge.
+    ///   - mergePolicy: A policy to use when resolving conflicts between this string's attributes and those in `attributes`.
     public func mergingAttributes(
         _ attributes: AttributeContainer,
         mergePolicy:  AttributedString.AttributeMergePolicy = .keepNew
@@ -94,6 +145,11 @@ extension AttributedStringProtocol {
         return new
     }
 
+    /// Returns an attributed string by replacing occurrences of attributes in one attribute container with those in another attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The existing attributes to replace.
+    ///   - others: The new attributes to apply.
     public func replacingAttributes(
         _ attributes: AttributeContainer, with others: AttributeContainer
     ) -> AttributedString {
@@ -186,26 +242,56 @@ extension AttributedStringProtocol { // Equatable, Hashable
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedStringProtocol {
+    /// Returns the position of the character immediately after another charcter indicated by an index.
+    ///
+    /// - Parameter i: The index of a character in the attributed string.
+    /// - Returns: The position of the character immediately after the character at index `i`.
     public func index(afterCharacter i: AttributedString.Index) -> AttributedString.Index {
         self.characters.index(after: i)
     }
+    /// Returns the position of the character immediately before another charcter indicated by an index.
+    ///
+    /// - Parameter i: The index of a character in the attributed string.
+    /// - Returns: The position of the character immediately before the character at index `i`.
     public func index(beforeCharacter i: AttributedString.Index) -> AttributedString.Index {
         self.characters.index(before: i)
     }
+    /// Returns the position of the character offset a given distance, measured in characters, from a given string index.
+    ///
+    /// - Parameters:
+    ///   - i: The index of a position in the string.
+    ///   - distance: The number of charcters to advance by.
     public func index(_ i: AttributedString.Index, offsetByCharacters distance: Int) -> AttributedString.Index {
         self.characters.index(i, offsetBy: distance)
     }
 
+    /// Returns the position of the Unicode scalar immediately after a Unicode scalar indicated by an index.
+    ///
+    /// - Parameter i: The index of a Unicode scalar in the attributed string.
+    /// - Returns: The position of the Unicode scalar immediately after the Unicode scalar at index `i`.
     public func index(afterUnicodeScalar i: AttributedString.Index) -> AttributedString.Index {
         self.unicodeScalars.index(after: i)
     }
+    /// Returns the position of the Unicode scalar immediately before a Unicode scalar indicated by an index.
+    ///
+    /// - Parameter i: The index of a Unicode scalar in the attributed string.
+    /// - Returns: The position of the Unicode scalar immediately before the Unicode scalar at index `i`.
     public func index(beforeUnicodeScalar i: AttributedString.Index) -> AttributedString.Index {
         self.unicodeScalars.index(before: i)
     }
+    /// Returns the position of the Unicode scalar offset a given distance, measured in Unicode scalars, from a given string index.
+    ///
+    /// - Parameters:
+    ///   - i: The index of a position in the string.
+    ///   - distance: The number of Unicode scalars to advance by.
     public func index(_ i: AttributedString.Index, offsetByUnicodeScalars distance: Int) -> AttributedString.Index {
         self.unicodeScalars.index(i, offsetBy: distance)
     }
 
+    /// Returns the position of the run immediately after a run indicated by an index.
+    ///
+    /// - Parameter i: The index of a run in the attributed string.
+    /// - Returns: The position of first run immediately after the end of `i`-th run.
     public func index(afterRun i: AttributedString.Index) -> AttributedString.Index {
         // Expected semantics: Result is the end of the run that contains `i`.
         let guts = self.__guts
@@ -217,6 +303,10 @@ extension AttributedStringProtocol {
         return AttributedString.Index(Swift.min(next, bounds.upperBound), version: guts.version)
     }
 
+    /// Returns the position of the run immediately before a run indicated by an index.
+    ///
+    /// - Parameter i: The index of a run in the attributed string.
+    /// - Returns: The position of the first run immediately before the beginning of the `i`-th run.
     public func index(beforeRun i: AttributedString.Index) -> AttributedString.Index {
         // Expected semantics: result is the start of the run preceding the one that contains `i`.
         // (I.e., `i` needs to get implicitly rounded down to the nearest run boundary before we
@@ -230,6 +320,11 @@ extension AttributedStringProtocol {
         return AttributedString.Index(Swift.max(prev, bounds.lowerBound), version: guts.version)
     }
 
+    /// Returns the position of the run offset a given number of runs from a given string index.
+    ///
+    /// - Parameters:
+    ///   - i: The index of a position in the string.
+    ///   - distance: The number of runs to advance by.
     public func index(_ i: AttributedString.Index, offsetByRuns distance: Int) -> AttributedString.Index {
         let guts = self.__guts
         let bounds = self._stringBounds
@@ -276,6 +371,12 @@ extension AttributedStringProtocol {
         return self._utf8Index(at: startOffset) ..< self._utf8Index(at: endOffset) // O(log(n))
     }
 
+    /// Returns the range of a substring in the attributed string, if it exists.
+    ///
+    /// - Parameters:
+    ///   - stringToFind: The string to find.
+    ///   - options: Options that affect the search behavior, such as case-insensivity, search direction, and regular expression matching.
+    ///   - locale: The locale to use when searching, or `nil` to use the current locale. The default is `nil`.
     public func range<T: StringProtocol>(of stringToFind: T, options: String.CompareOptions = [], locale: Locale? = nil) -> Range<AttributedString.Index>? {
         if locale == nil {
             return _range(of: stringToFind, options: options)

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -18,6 +18,23 @@ internal import _RopeModule
 internal import _FoundationCollections
 #endif
 
+/// A portion of an attributed string.
+///
+/// ``AttributedSubstring`` provides no-copy access to the contents of the string within the relevant range. The distinction between an ``AttributedString`` and an ``AttributedSubstring`` lets you distinguish between whether you're in possession of an entire string or just a slice of it.
+///
+/// Because ``AttributedSubstring`` and ``AttributedString`` both conform to ``AttributedStringProtocol``, working with ranges of ``AttributedString`` is natural. Modifying attributes by range works the same as it does on the base string.
+///
+/// If you use an ``AttributedSubstring`` to mutate its base ``AttributedString``, you must perform your mutation inline, as the following example shows:
+///
+/// ```swift
+/// // Correct use of copying.
+/// attrStr[range].link = url
+///
+/// // Incorrect use of AttributedString copy. Copies the referenced range of the base
+/// // AttributedString and mutates that.
+/// var substr = attrStr[range]
+/// substr.link = url
+/// ```
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct AttributedSubstring: Sendable {
@@ -43,6 +60,7 @@ public struct AttributedSubstring: Sendable {
         self._range = Range(uncheckedBounds: (slice.startIndex, slice.endIndex))
     }
 
+    /// Creates an empty attributed substring.
     public init() {
         let str = AttributedString()
         self.init(str._guts, in: str._stringBounds)
@@ -51,6 +69,8 @@ public struct AttributedSubstring: Sendable {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedSubstring {
+    /// Returns the underlying attributed string that the attributed substring
+    /// derives from.
     public var base: AttributedString {
         return AttributedString(_guts)
     }
@@ -87,10 +107,13 @@ extension AttributedSubstring { // Equatable
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedSubstring : AttributedStringProtocol {
+    /// The position of the first character in a nonempty attributed substring.
     public var startIndex: AttributedString.Index {
         .init(_range.lowerBound, version: _guts.version)
     }
 
+    /// A substring's past-the-end position -- the position one greater than
+    /// the last valid subscript argument.
     public var endIndex: AttributedString.Index {
         .init(_range.upperBound, version: _guts.version)
     }
@@ -107,16 +130,33 @@ extension AttributedSubstring : AttributedStringProtocol {
         }
     }
 
+    /// Sets the attributed substring's attributes to those in a specified
+    /// attribute container.
+    ///
+    /// - Parameter attributes: The attribute container with the attributes to
+    ///   apply.
     public mutating func setAttributes(_ attributes: AttributeContainer) {
         ensureUniqueReference()
         _guts.setAttributes(attributes.storage, in: _range)
     }
 
+    /// Merges the attributed string's attributes with those in a specified
+    /// attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The attribute container with the attributes to merge.
+    ///   - mergePolicy: A policy to use when resolving conflicts.
     public mutating func mergeAttributes(_ attributes: AttributeContainer, mergePolicy:  AttributedString.AttributeMergePolicy = .keepNew) {
         ensureUniqueReference()
         _guts.mergeAttributes(attributes, in: _range, mergePolicy:  mergePolicy)
     }
 
+    /// Replaces the attributed substring's attributes with those in a specified
+    /// attribute container.
+    ///
+    /// - Parameters:
+    ///   - attributes: The existing attributes to replace.
+    ///   - others: The new attributes to apply.
     public mutating func replaceAttributes(_ attributes: AttributeContainer, with others: AttributeContainer) {
         guard attributes != others else {
             return
@@ -141,18 +181,25 @@ extension AttributedSubstring : AttributedStringProtocol {
         }
     }
 
+    /// The attributed runs of the attributed string, as a view into the
+    /// underlying string.
     public var runs: AttributedString.Runs {
         get { .init(_guts, in: _range) }
     }
 
+    /// The characters of the attributed string, as a view into the underlying
+    /// string.
     public var characters: AttributedString.CharacterView {
         return AttributedString.CharacterView(_guts, in: _range)
     }
 
+    /// The Unicode scalars of the attributed string, as a view into the
+    /// underlying string.
     public var unicodeScalars: AttributedString.UnicodeScalarView {
         return AttributedString.UnicodeScalarView(_guts, in: _range)
     }
 
+    /// Returns a substring of the attributed substring that a range indicates.
     public subscript(bounds: some RangeExpression<AttributedString.Index>) -> AttributedSubstring {
         let bounds = bounds.relative(to: characters)
         return AttributedSubstring(_guts, in: bounds._bstringRange)
@@ -161,6 +208,11 @@ extension AttributedSubstring : AttributedStringProtocol {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedSubstring {
+    /// Returns an attribute value that corresponds to an attributed string key.
+    ///
+    /// Returns `nil` unless the specified attribute exists and is present and
+    /// identical for the entire string or substring. Use ``runs`` to find
+    /// portions with consistent attributes.
     @preconcurrency
     public subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? where K.Value : Sendable {
         get {
@@ -176,6 +228,11 @@ extension AttributedSubstring {
         }
     }
 
+    /// Returns an attribute value that a key path indicates.
+    ///
+    /// Returns `nil` unless the specified attribute exists and is present and
+    /// identical for the entire string or substring. Use ``runs`` to find
+    /// portions with consistent attributes.
     @preconcurrency
     @inlinable // Trivial implementation, allows callers to optimize away the keypath allocation
     public subscript<K: AttributedStringKey>(
@@ -185,6 +242,11 @@ extension AttributedSubstring {
         set { self[K.self] = newValue }
     }
 
+    /// Returns a scoped attribute container that a key path indicates.
+    ///
+    /// Use explicit attribute scopes to disambiguate attributes that exist in
+    /// more than one scope. The container contains only attributes present and
+    /// identical for the entire string or substring.
     public subscript<S: AttributeScope>(
         dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>
     ) -> ScopedAttributeContainer<S> {

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -50,11 +50,26 @@ extension String {
 
 #if FOUNDATION_FRAMEWORK
 
+/// A protocol that defines Objective-C interoperability with an attribute key's value type.
+///
+/// Conform to this protocol to allow your attributed string key to customize its Objective-C conversion behavior. This allows you to define an Objective-C value type and provide methods to convert to and from this type.
+///
+/// Attributed string keys that don't conform to this protocol cast the value to <doc://com.apple.documentation/documentation/swift/anyobject> before converting to Objective-C. When converting from Objective-C, the value casts to the key's ``AttributedStringKey/Value`` type. In cases where Swift types bridge automatically to Objective-C types, like <doc://com.apple.documentation/documentation/swift/string> to ``NSString``, this default behavior is adequate. But for unbridged value types, you need to conform to this protocol and provide the conversion methods.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol ObjectiveCConvertibleAttributedStringKey : AttributedStringKey {
+    /// The Objective-C type that corresponds to this key's value type.
     associatedtype ObjectiveCValue : NSObject
 
+    /// Returns an Objective-C typed value for a given value of this key's type.
+    ///
+    /// - Parameter value: The value to convert.
+    /// - Returns: `value`, expressed as the Objective-C type defined by
+    ///   ``ObjectiveCConvertibleAttributedStringKey/ObjectiveCValue``.
     static func objectiveCValue(for value: Value) throws -> ObjectiveCValue
+    /// Returns a value of this key's type for a given Objective-C value.
+    ///
+    /// - Parameter object: The Objective-C value to convert.
+    /// - Returns: `object`, expressed as this key's type.
     static func value(for object: ObjectiveCValue) throws -> Value
 }
 
@@ -93,15 +108,39 @@ internal struct _AttributeConversionOptions : OptionSet {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeContainer {
+    /// Creates an attribute container from a dictionary, using default attribute scopes.
+    ///
+    /// - Parameter dictionary: A dictionary of attribute keys and their values.
+    ///
+    /// This initializer includes all attribute scopes defined by the SDK, such as
+    /// `FoundationAttributes`, `SwiftUIAttributes`, and `AccessibilityAttributes`. To use
+    /// third-party attribute scopes, use the initializers ``AttributeContainer/init(_:including:)-2mw0o``
+    /// and ``AttributeContainer/init(_:including:)-28n0g``.
     public init(_ dictionary: [NSAttributedString.Key : Any]) {
         // Passing .dropThrowingAttributes causes attributes that throw during conversion to be dropped, so it is safe to do try! here
         try! self.init(dictionary, attributeTable: _loadDefaultAttributes(), options: .dropThrowingAttributes)
     }
 
+    /// Creates an attribute container from a dictionary and an attribute scope that a key path identifies.
+    ///
+    /// - Parameters:
+    ///   - dictionary: A dictionary of attribute keys and their values.
+    ///   - scope: A key path that identifies the attribute scope of the dictionary keys. This can be a nested scope that contains several scopes.
+    ///
+    /// This initializer only collects attributes from `dictionary` that exist in the provided scope.
+    /// The resulting attribute container omits any keys in `dictionary` that don't exist in `scope`.
     public init<S: AttributeScope>(_ dictionary: [NSAttributedString.Key : Any], including scope: KeyPath<AttributeScopes, S.Type>) throws {
         try self.init(dictionary, including: S.self)
     }
     
+    /// Creates an attribute container from a dictionary and an attribute scope.
+    ///
+    /// - Parameters:
+    ///   - dictionary: A dictionary of attribute keys and their values.
+    ///   - scope: The attribute scope of the dictionary keys. This can be a nested scope that contains several scopes.
+    ///
+    /// This initializer only collects attributes from `dictionary` that exist in the provided scope.
+    /// The resulting attribute container omits any keys in `dictionary` that don't exist in `scope`.
     public init<S: AttributeScope>(_ dictionary: [NSAttributedString.Key : Any], including scope: S.Type) throws {
         try self.init(dictionary, attributeTable: S.attributeKeyTypes())
     }
@@ -163,15 +202,33 @@ extension Dictionary where Key == NSAttributedString.Key, Value == Any {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension NSAttributedString {
+    /// Creates a reference-type attributed string from the specified value-type attributed string.
+    ///
+    /// This initializer includes all attribute scopes defined by the SDK, such as
+    /// `FoundationAttributes`, `SwiftUIAttributes`, and `AccessibilityAttributes`.
+    /// To use third-party attribute scopes, use the initializers that accept an `including` parameter.
+    ///
+    /// - Parameters:
+    ///   - attrStr: The value type attributed string that provides the text and attributes of the new object.
     public convenience init(_ attrStr: AttributedString) {
         // Passing .dropThrowingAttributes causes attributes that throw during conversion to be dropped, so it is safe to do try! here
         try! self.init(attrStr, attributeTable: _loadDefaultAttributes(), options: .dropThrowingAttributes)
     }
-    
+
+    /// Creates a reference-type attributed string from the specified value-type attributed string, including an attribute scope that a key path identifies.
+    ///
+    /// - Parameters:
+    ///   - attrStr: The value-type attributed string that provides the text and attributes of the new object.
+    ///   - scope: A key path that identifies the attribute scope of the attributes in `attrStr`. This can be a nested scope that contains several scopes.
     public convenience init<S: AttributeScope>(_ attrStr: AttributedString, including scope: KeyPath<AttributeScopes, S.Type>) throws {
         try self.init(attrStr, including: S.self)
     }
-    
+
+    /// Creates a reference-type attributed string from the specified value-type attributed string, including an attribute scope.
+    ///
+    /// - Parameters:
+    ///   - attrStr: The value-type attributed string that provides the text and attributes of the new object.
+    ///   - scope: The attribute scope of the attributes in `attrStr`. This can be a nested scope that contains several scopes.
     public convenience init<S: AttributeScope>(_ attrStr: AttributedString, including scope: S.Type) throws {
         try self.init(attrStr, attributeTable: scope.attributeKeyTypes())
     }
@@ -205,15 +262,39 @@ extension NSAttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    /// Creates a value-type attributed string from a reference type.
+    ///
+    /// - Parameter nsStr: The ``NSAttributedString`` to convert.
+    ///
+    /// This initializer includes all attribute scopes defined by the SDK, such as
+    /// `FoundationAttributes`, `SwiftUIAttributes`, and `AccessibilityAttributes`. To use
+    /// third-party attribute scopes, use the initializers ``AttributedString/init(_:including:)-9no47``
+    /// or ``AttributedString/init(_:including:)-puv0``.
     public init(_ nsStr: NSAttributedString) {
         // Passing .dropThrowingAttributes causes attributes that throw during conversion to be dropped, so it is safe to do try! here
         try! self.init(nsStr, attributeTable: _loadDefaultAttributes(), options: .dropThrowingAttributes)
     }
     
+    /// Creates a value-type attributed string from a reference type, including an attribute scope that a key path identifies.
+    ///
+    /// - Parameters:
+    ///   - nsStr: The ``NSAttributedString`` to convert.
+    ///   - scope: A key path that identifies the attribute scope of the attributes in `nsStr`. This can be a nested scope that contains several scopes.
+    ///
+    /// This initializer only collects attributes from `nsStr` that exist in the provided scope.
+    /// The resulting attributed string omits any keys in `nsStr` that don't exist in `scope`.
     public init<S: AttributeScope>(_ nsStr: NSAttributedString, including scope: KeyPath<AttributeScopes, S.Type>) throws {
         try self.init(nsStr, including: S.self)
     }
     
+    /// Creates a value-type attributed string from a reference type, including an attribute scope.
+    ///
+    /// - Parameters:
+    ///   - nsStr: The ``NSAttributedString`` to convert.
+    ///   - scope: The attribute scope of the attributes in `nsStr`. This can be a nested scope that contains several scopes.
+    ///
+    /// This initializer only collects attributes from `nsStr` that exist in the provided scope.
+    /// The resulting attributed string omits any keys in `nsStr` that don't exist in `scope`.
     public init<S: AttributeScope>(_ nsStr: NSAttributedString, including scope: S.Type) throws {
         try self.init(nsStr, attributeTable: S.attributeKeyTypes())
     }

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -18,20 +18,30 @@ internal import Foundation_Private.NSAttributedString
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeScopes {
+    /// A property for accessing the attribute scopes that Foundation defines.
     public var foundation: FoundationAttributes.Type { FoundationAttributes.self }
     
+    /// Attribute scopes that Foundation defines.
     public struct FoundationAttributes : AttributeScope {
+        /// A property for accessing the link attribute.
         public let link: LinkAttribute
+        /// A property for accessing a language identifier attribute.
         public let languageIdentifier: LanguageIdentifierAttribute
+        /// A property for accessing a person name component attribute.
         public let personNameComponent: PersonNameComponentAttribute
+        /// A property for accessing a number format attribute.
         public let numberFormat: NumberFormatAttributes
+        /// A property for accessing a date field attribute.
         public let dateField: DateFieldAttribute
+        /// A property for accessing an alternative presentation attribute.
         public let alternateDescription: AlternateDescriptionAttribute
+        /// A property for accessing an image URL attribute.
         public let imageURL: ImageURLAttribute
+        /// A property for accessing a replacement index attribute.
         public let replacementIndex : ReplacementIndexAttribute
         public let measurement: MeasurementAttribute
         public let byteCount: ByteCountAttribute
-        
+
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public let durationField: DurationFieldAttribute
 
@@ -40,28 +50,53 @@ extension AttributeScopes {
         public let writingDirection: WritingDirectionAttribute
 
 #if FOUNDATION_FRAMEWORK
+        /// A scope for accessing an agreement concept attribute.
         @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public let agreementConcept: AgreementConceptAttribute
+        /// A scope for accessing an agreement argument attribute.
         @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public let agreementArgument: AgreementArgumentAttribute
+        /// A scope for accessing a referent concept attribute.
         @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         public let referentConcept: ReferentConceptAttribute
         @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public let localizedNumberFormat: LocalizedNumberFormatAttribute
-        
+
         // TODO: Support AttributedString markdown in FoundationPreview: https://github.com/apple/swift-foundation/issues/44
+        /// A property for accessing an inline presentation intent attribute.
         public let inlinePresentationIntent: InlinePresentationIntentAttribute
+        /// A property for accessing a presentation intent attribute.
         public let presentationIntent: PresentationIntentAttribute
+        /// A property for accessing a Markdown source position attribute.
+        ///
+        /// This attribute indicates the position in the Markdown source where a run
+        /// of attributed text begins and ends, omitting markup characters in the source.
+        /// For example, after parsing the source string `"This is *emphasized*."`, the
+        /// text `emphasized` has a Markdown source position that starts at column `10`.
+        /// This index is the `"e"` character, not the `"*"` formatting character.
+        ///
+        /// > Tip: ``AttributedString/MarkdownSourcePosition`` uses `1`-based counting for
+        /// > its row and column properties. For columns, the value represents a UTF-8 index.
+        /// > With multi-byte characters, the column is therefore the first byte of the character.
+        ///
+        /// An attributed string parsed from Markdown text includes this attribute only if
+        /// the ``AttributedString/MarkdownParsingOptions/appliesSourcePositionAttributes``
+        /// value in the ``AttributedString/MarkdownParsingOptions`` provided to the
+        /// ``AttributedString`` initializer is `true`.
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public let markdownSourcePosition: MarkdownSourcePositionAttribute
         @available(FoundationPreview 6.2, *)
         public let listItemDelimiter: ListItemDelimiterAttribute
-        
+
+        /// A property for accessing a localized string argument attribute.
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public let localizedStringArgumentAttributes: LocalizedStringArgumentAttributes
-        
+
+        /// A scope for accessing an inflection alternative attribute.
         public let inflectionAlternative: InflectionAlternativeAttribute
+        /// A scope for accessing a morphology attribute.
         public let morphology: MorphologyAttribute
+        /// A scope for accessing an inflection rule attribute.
         public let inflect: InflectionRuleAttribute
         @_spi(AutomaticGrammaticalAgreement)
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
@@ -80,10 +115,13 @@ extension AttributeScopes.FoundationAttributes : Sendable {}
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeDynamicLookup {
+    /// Returns the attributed string key for a specified Foundation key path.
     public subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.FoundationAttributes, T>) -> T {
         return self[T.self]
     }
 
+    /// Returns the attributed string key for a specified Foundation number
+    /// format key path.
     public subscript<T: AttributedStringKey>(
         dynamicMember keyPath: KeyPath<AttributeScopes.FoundationAttributes.NumberFormatAttributes, T>
     ) -> T {
@@ -104,11 +142,14 @@ extension AttributeDynamicLookup {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeScopes.FoundationAttributes {
+    /// A type for using a link as an attribute.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum LinkAttribute : CodableAttributedStringKey {
+        /// The type of the link attribute's value.
         public typealias Value = URL
         
+        /// The name of the link attribute.
         public static var name: String {
             // Used to be: public static var name = "NSLink", but changed for Sendability and ABI compatibility
             get { "NSLink" }
@@ -118,6 +159,13 @@ extension AttributeScopes.FoundationAttributes {
     
 #if FOUNDATION_FRAMEWORK
     
+    /// An attribute that specifies a grammatical agreement concept for substituting pronouns in localized text.
+    ///
+    /// Use the ``AttributeScopes/FoundationAttributes/referentConcept`` formatting
+    /// attribute for cases where you need to refer to a person using their preferred
+    /// pronoun in a string.
+    ///
+    /// For an example of how to use a `referentConcept`, see ``TermOfAddress``.
     @frozen
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public enum ReferentConceptAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
@@ -126,6 +174,14 @@ extension AttributeScopes.FoundationAttributes {
         public static let markdownName = "referentConcept"
     }
 
+    /// An attribute that represents grammatical agreement for objects that aren't part of the inflected text.
+    ///
+    /// Use this formatting attribute for cases where you need to inflect text based
+    /// on a term of address or phrase that isn't part of the inflected text. For
+    /// example, you can use an ``InflectionConcept/termsOfAddress(_:)`` concept to
+    /// make a word agree with a person's preferred term of address, or a
+    /// ``InflectionConcept/localizedPhrase(_:)`` concept to agree with a noun that
+    /// doesn't appear in the sentence.
     @frozen
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public enum AgreementConceptAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
@@ -134,6 +190,22 @@ extension AttributeScopes.FoundationAttributes {
         public static let markdownName = "agreeWithConcept"
     }
     
+    /// An attribute that represents grammatical agreement with an argument in a localized string.
+    ///
+    /// Many languages require grammatical agreement in their sentences. In Spanish,
+    /// for example, adjectives and verbs need to agree with the gender of the subject
+    /// they refer to. Use the `agreeWithArgument` attribute to make a word at one
+    /// position in a sentence inflect to agree with a word at another position,
+    /// eliminating the need to include multiple gendered forms in localization files.
+    ///
+    /// In a localization file, wrap the word needing inflection in an
+    /// `agreeWithArgument` attribute and point it to the replacement index of the
+    /// word it needs to agree with:
+    ///
+    /// ```
+    /// // In the Spanish localization file:
+    /// "Your %1@ %2@ is ready." = "Tu ^[%2$@ %1$@](inflect: true) está ^[listo](agreeWithArgument: 2)."
+    /// ```
     @frozen
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public enum AgreementArgumentAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
@@ -142,6 +214,7 @@ extension AttributeScopes.FoundationAttributes {
         public static let markdownName = "agreeWithArgument"
     }
     
+    /// A type for using a morphology as an attribute.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum MorphologyAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
@@ -150,6 +223,21 @@ extension AttributeScopes.FoundationAttributes {
         public static let markdownName = "morphology"
     }
     
+    /// A rule that affects how an attributed string performs automatic grammatical agreement.
+    ///
+    /// Most apps can rely on loading localized strings to perform automatic grammar agreement. Typically, strings in your app's strings files use the Markdown extension syntax to indicate portions of the string that may require inflection to agree grammatically. This transformation occurs when you load the attributed string with methods like `init(localized:options:table:bundle:locale:comment:)`.
+    ///
+    /// However, if the system lacks information about the words in the string, you may need to apply an inflection rule programmatically. For example, a social networking app may have gender information about other users that you want to apply at runtime. When performing manual inflection at runtime, you use an inflection rule to indicate to the system what portions of a string should be automatically edited, and what to match. Apply the ``AttributeScopes/FoundationAttributes/inflect`` attribute to set an ``InflectionRule`` on an ``AttributedString``, then call ``AttributedString/inflected()`` to perform the grammar agreement and produce an edited string.
+    ///
+    /// ```swift
+    /// var string = AttributedString(localized: "They liked your post.")
+    /// // The user who liked the post uses feminine pronouns.
+    /// var morphology = Morphology()
+    /// morphology.grammaticalGender = .feminine
+    /// string.inflect = InflectionRule(morphology: morphology)
+    /// let result = string.inflected()
+    /// // result == "She liked your post."
+    /// ```
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum InflectionRuleAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
@@ -201,6 +289,7 @@ extension AttributeScopes.FoundationAttributes {
 
 #endif // FOUNDATION_FRAMEWORK
     
+    /// A type for using a language identifier as an attribute.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum LanguageIdentifierAttribute : CodableAttributedStringKey {
@@ -208,6 +297,7 @@ extension AttributeScopes.FoundationAttributes {
         public static let name = "NSLanguage"
     }
     
+    /// A type for using a person name component as an attribute.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum PersonNameComponentAttribute : CodableAttributedStringKey {
@@ -219,6 +309,7 @@ extension AttributeScopes.FoundationAttributes {
         }
     }
     
+    /// A type for using a number format as an attribute.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public struct NumberFormatAttributes: AttributeScope {
         public let numberSymbol: SymbolAttribute
@@ -250,6 +341,10 @@ extension AttributeScopes.FoundationAttributes {
         }
     }
     
+    /// A type for using a date field as an attribute.
+    ///
+    /// A date field indicates a portion of a formatted date, such as its year,
+    /// month, day, hour, or minute.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum DateFieldAttribute : CodableAttributedStringKey {
@@ -382,6 +477,19 @@ extension AttributeScopes.FoundationAttributes {
     
 #if FOUNDATION_FRAMEWORK
     
+    /// An attribute that provides an alternative inflection phrase when the system can't achieve grammatical agreement.
+    ///
+    /// Use this attribute to provide an alternative phrase for cases where the system
+    /// can't achieve unambiguous grammatical agreement. For example, when inflecting
+    /// a gendered word without knowing the person's preferred terms of address, you
+    /// can set an `inflectionAlternative` to supply a gender-neutral fallback:
+    ///
+    /// ```swift
+    /// let resource = LocalizedStringResource(
+    ///     "^[Bienvenido](inflect: true, inflectionAlternative: 'Te damos la bienvenida').")
+    /// let result = AttributedString(localized: resource)
+    /// // result == "Te damos la bienvenida."
+    /// ```
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum InflectionAlternativeAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey, ObjectiveCConvertibleAttributedStringKey {
@@ -409,7 +517,11 @@ extension AttributeScopes.FoundationAttributes {
         }
     }
     
-	@frozen
+    /// A type for using an inline presentation intent as an attribute.
+    ///
+    /// An inline presentation intent applies to a run of characters inside a larger
+    /// block, and covers traits like emphasis, strikethrough, and code voice.
+    @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum InlinePresentationIntentAttribute : CodableAttributedStringKey, ObjectiveCConvertibleAttributedStringKey {
         public typealias Value = InlinePresentationIntent
@@ -425,6 +537,10 @@ extension AttributeScopes.FoundationAttributes {
         }
     }
     
+    /// A type for using a presentation intent as an attribute.
+    ///
+    /// A presentation intent applies to a block of characters, and covers traits
+    /// like list, block quote, or table presentation.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum PresentationIntentAttribute : CodableAttributedStringKey {
@@ -432,10 +548,13 @@ extension AttributeScopes.FoundationAttributes {
         public static let name = NSAttributedString.Key.presentationIntentAttributeName.rawValue
     }
     
+    /// A type for using a markdown source position as an attribute.
     @frozen
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public enum MarkdownSourcePositionAttribute: CodableAttributedStringKey {
+        /// The name of the attribute, for use in encoding and decoding.
         public static let name = NSAttributedString.Key.markdownSourcePosition.rawValue
+        /// The value type of a Markdown source position attribute.
         public typealias Value = AttributedString.MarkdownSourcePosition
     }
     
@@ -479,6 +598,7 @@ extension AttributeScopes.FoundationAttributes {
     
 #endif // FOUNDATION_FRAMEWORK
     
+    /// A type for using an alternative description as an attribute.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum AlternateDescriptionAttribute : CodableAttributedStringKey {
@@ -486,13 +606,22 @@ extension AttributeScopes.FoundationAttributes {
         public static let name = "NSAlternateDescription"
     }
     
+    /// A type for using an image URL as an attribute.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum ImageURLAttribute : CodableAttributedStringKey {
+        /// The type of the image URL attribute.
         public typealias Value = URL
+        /// The name of the image URL attribute.
         public static let name = "NSImageURL"
     }
     
+    /// A type for using a replacement index as an attribute.
+    ///
+    /// When you use the ``AttributedString/FormattingOptions/applyReplacementIndexAttribute``
+    /// formatting option, the resulting formatted string uses this attribute to mark
+    /// the location of replacement strings. This allows you to relate ranges to
+    /// replacements even if localizers change the word order in format strings.
     @frozen
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum ReplacementIndexAttribute : CodableAttributedStringKey {
@@ -579,24 +708,47 @@ extension AttributeScopes.FoundationAttributes {
     }
 
 #if FOUNDATION_FRAMEWORK
+    /// A type for using a localized string argument as an attribute.
+    ///
+    /// You use the this scope's attributes when creating an attributed string from a ``LocalizedStringResource``. The process creating the attributed string may not have access to the original arguments passed to the interpolation. Instead, the attributed string marks formatted runs with this type, allowing you to retrieve the original values.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct LocalizedStringArgumentAttributes {
-    
-        // Represents all numeric arguments (i.e. those that use format specifiers such as %d, %f, etc.)
+
+        /// The value of a numeric argument used to format the run with this attribute.
         public let localizedNumericArgument: LocalizedNumericArgumentAttribute
-        
+
+        /// The date value used to format the run with this attribute.
         public let localizedDateArgument: LocalizedDateArgumentAttribute
+        /// The date interval value used to format the run with this attribute.
         public let localizedDateIntervalArgument: LocalizedDateIntervalArgumentAttribute
+        /// The URL value used to format the run with this attribute.
         public let localizedURLArgument: LocalizedURLArgumentAttribute
         
+        /// A type for a numeric argument used to format the run with this attribute.
         @frozen
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public enum LocalizedNumericArgumentAttribute : CodableAttributedStringKey {
+            /// The name of the attribute.
             public static let name = "Foundation.LocalizedNumericArgumentAttribute"
+            /// The value type represented by this attribute.
+            ///
+            /// Each case of this enumeration provides the value type and the value itself, as an associated value.
             public enum Value : Hashable, Codable, Sendable {
+                /// An unsigned integer value.
+                ///
+                /// - Parameter uint: The attribute value, as a `UInt64`.
                 case uint(UInt64)
+                /// A signed integer value.
+                ///
+                /// - Parameter int: The attribute value, as an `Int64`.
                 case int(Int64)
+                /// A double-precision floating point value.
+                ///
+                /// - Parameter double: The attribute value, as a `Double`.
                 case double(Double)
+                /// A decimal value.
+                ///
+                /// - Parameter decimal: The attribute value, as a `Decimal`.
                 case decimal(Decimal)
                 
                 private typealias UintCodingKeys = DefaultAssociatedValueCodingKeys1
@@ -606,24 +758,30 @@ extension AttributeScopes.FoundationAttributes {
             }
         }
         
+        /// A type for a date argument used to format the run with this attribute.
         @frozen
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public enum LocalizedDateArgumentAttribute : CodableAttributedStringKey {
             public typealias Value = Date
+            /// The name of the attribute.
             public static let name = "Foundation.LocalizedDateArgumentAttribute"
         }
         
+        /// A type for a date interval argument used to format the run with this attribute.
         @frozen
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public enum LocalizedDateIntervalArgumentAttribute : CodableAttributedStringKey {
             public typealias Value = Range<Date>
+            /// The name of the attribute.
             public static let name = "Foundation.LocalizedDateIntervalArgumentAttribute"
         }
         
+        /// A type for a URL argument used to format the run with this attribute.
         @frozen
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public enum LocalizedURLArgumentAttribute : CodableAttributedStringKey {
             public typealias Value = URL
+            /// The name of the attribute.
             public static let name = "Foundation.LocalizedURLArgumentAttribute"
         }
     }
@@ -842,12 +1000,21 @@ extension AttributeScopes.FoundationAttributes.LocalizedStringArgumentAttributes
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeScopes.FoundationAttributes.LinkAttribute : ObjectiveCConvertibleAttributedStringKey {
+    /// The type of the link attribute's value when calling it from Objective-C.
     public typealias ObjectiveCValue = NSObject // NSURL or NSString
     
+    /// Returns an object for a specified URL value.
+    ///
+    /// - Parameter value: A URL to produce an `NSObject` from.
+    /// - Returns: The object for the specified URL.
     public static func objectiveCValue(for value: URL) throws -> NSObject {
         value as NSURL
     }
-    
+
+    /// Returns the URL value of the specified object.
+    ///
+    /// - Parameter object: An `NSObject` to retrieve a URL value from.
+    /// - Returns: A URL value.
     public static func value(for object: NSObject) throws -> URL {
         if let object = object as? NSURL {
             return object as URL

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -29,29 +29,42 @@ import CRT
 internal import _ForSwiftFoundation
 #endif
 
-/**
- `Calendar` encapsulates information about systems of reckoning time in which the beginning, length, and divisions of a year are defined. It provides information about the calendar and support for calendrical computations such as determining the range of a given calendrical unit and adding units to a given absolute time.
-*/
+/// A definition of the relationships between calendar units and absolute points in time, providing features for calculation and comparison of dates.
+///
+/// `Calendar` encapsulates information about systems of reckoning time in which the beginning, length, and divisions of a year are defined. It provides information about the calendar and support for calendrical computations such as determining the range of a given calendrical unit and adding units to a given absolute time.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct Calendar : Hashable, Equatable, Sendable {
     private var _calendar: any _CalendarProtocol & AnyObject
 
-    /// Calendar supports many different kinds of calendars. Each is identified by an identifier here.
+    /// An enumeration for the available calendars.
     public enum Identifier : Sendable, CustomDebugStringConvertible {
         /// The common calendar in Europe, the Western Hemisphere, and elsewhere.
         case gregorian
+        /// Identifier for the Buddhist calendar.
         case buddhist
+        /// Identifier for the Chinese calendar.
         case chinese
+        /// Identifier for the Coptic calendar.
         case coptic
+        /// Identifier for the Ethiopic (Amete Mihret) calendar.
         case ethiopicAmeteMihret
+        /// Identifier for the Ethiopic (Amete Alem) calendar.
         case ethiopicAmeteAlem
+        /// Identifier for the Hebrew calendar.
         case hebrew
+        /// Identifier for the ISO8601 calendar.
         case iso8601
+        /// Identifier for the Indian calendar.
         case indian
+        /// Identifier for the Islamic calendar.
         case islamic
+        /// Identifier for the Islamic civil calendar.
         case islamicCivil
+        /// Identifier for the Japanese calendar.
         case japanese
+        /// Identifier for the Persian calendar.
         case persian
+        /// Identifier for the Republic of China calendar.
         case republicOfChina
 
         /// A simple tabular Islamic calendar using the astronomical/Thursday epoch of CE 622 July 15
@@ -342,21 +355,37 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - seealso: `DateComponents`
     public enum Component : Sendable {
+        /// Identifier for the era unit.
         case era
+        /// Identifier for the year unit.
         case year
+        /// Identifier for the month unit.
         case month
+        /// Identifier for the day unit.
         case day
+        /// Identifier for the hour unit.
         case hour
+        /// Identifier for the minute unit.
         case minute
+        /// Identifier for the second unit.
         case second
+        /// Identifier for the weekday unit.
         case weekday
+        /// Identifier for the weekday ordinal unit.
         case weekdayOrdinal
+        /// Identifier for the quarter of the calendar.
         case quarter
+        /// Identifier for the week of the month calendar unit.
         case weekOfMonth
+        /// Identifier for the week of the year unit.
         case weekOfYear
+        /// Identifier for the week-counting year unit.
         case yearForWeekOfYear
+        /// Identifier for the nanosecond unit.
         case nanosecond
+        /// Identifier for the calendar unit.
         case calendar
+        /// Identifier for the time zone unit.
         case timeZone
         @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
         case isLeapMonth
@@ -414,14 +443,14 @@ public struct Calendar : Hashable, Equatable, Sendable {
         }
     }
 
-    /// Returns the user's current calendar.
+    /// The user's current calendar.
     ///
     /// This calendar does not track changes that the user makes to their preferences.
     public static var current : Calendar {
         Calendar(inner: CalendarCache.cache.current)
     }
 
-    /// A Calendar that tracks changes to user's preferred calendar.
+    /// A calendar that tracks changes to user's preferred calendar.
     ///
     /// If mutated, this calendar will no longer track the user's preferred calendar.
     ///
@@ -507,7 +536,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         isKnownUniquelyReferenced(&x)
     }
     
-    /// The first weekday of the calendar.
+    /// The first day of the week for the calendar.
     public var firstWeekday : Int {
         get {
             _calendar.firstWeekday
@@ -542,7 +571,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     // MARK: -
     //
 
-    /// Returns the minimum range limits of the values that a given component can take on in the receiver.
+    /// Returns the minimum range limits of the values that a given component can take on.
     ///
     /// As an example, in the Gregorian calendar the minimum range of values for the Day component is 1-28.
     /// - parameter component: A component to calculate a range for.
@@ -551,7 +580,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         _calendar.minimumRange(of: component)
     }
 
-    /// The maximum range limits of the values that a given component can take on in the receive
+    /// The maximum range limits of the values that a given component can take on.
     ///
     /// As an example, in the Gregorian calendar the maximum range of values for the Day component is 1-31.
     /// - parameter component: A component to calculate a range for.
@@ -616,7 +645,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
 
     // MARK: - Addition
     
-    /// Returns a new `Date` representing the date calculated by adding components to a given date.
+    /// Returns a new Date representing the date calculated by adding components to a given date.
     ///
     /// - parameter components: A set of values to add to the date.
     /// - parameter date: The starting date.
@@ -626,7 +655,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         _calendar.date(byAdding: components, to: date.capped, wrappingComponents: wrappingComponents)
     }
 
-    /// Returns a new `Date` representing the date calculated by adding an amount of a specific component to a given date.
+    /// Returns a new Date representing the date calculated by adding an amount of a specific component to a given date.
     ///
     /// - parameter component: A single component to add.
     /// - parameter value: The value of the specified component to add.
@@ -836,7 +865,9 @@ public struct Calendar : Hashable, Equatable, Sendable {
         return interval.start
     }
 
-    /// Compares the given dates down to the given component, reporting them `orderedSame` if they are the same in the given component and all larger components, otherwise either `orderedAscending` or `orderedDescending`.
+    /// Compares two dates down to the specified component.
+    ///
+    /// The result is `orderedSame` if they are the same in the given component and all larger components. Otherwise, the result is either `orderedAscending` or `orderedDescending`.
     ///
     /// - parameter date1: A date to compare.
     /// - parameter date2: A date to compare.
@@ -989,7 +1020,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         return .orderedSame
     }
 
-    /// Compares the given dates down to the given component, reporting them equal if they are the same in the given component and all larger components.
+    /// Returns a Boolean value indicating whether two dates are equal in the given component and all larger components.
     ///
     /// - parameter date1: A date to compare.
     /// - parameter date2: A date to compare.
@@ -1001,7 +1032,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
 
-    /// Returns `true` if the given date is within the same day as another date, as defined by the calendar and calendar's locale.
+    /// Returns a Boolean value indicating whether a date is within the same day as another date, as defined by the calendar and calendar's locale.
     ///
     /// - parameter date1: A date to check for containment.
     /// - parameter date2: A date to check for containment.
@@ -1012,7 +1043,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
 
-    /// Returns `true` if the given date is within today, as defined by the calendar and calendar's locale.
+    /// Returns a Boolean value indicating whether the given date is within today, as defined by the calendar and calendar's locale.
     ///
     /// - parameter date: The specified date.
     /// - returns: `true` if the given date is within today.
@@ -1022,7 +1053,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
 
-    /// Returns `true` if the given date is within yesterday, as defined by the calendar and calendar's locale.
+    /// Returns a Boolean value indicating whether the given date is within yesterday, as defined by the calendar and calendar's locale.
     ///
     /// - parameter date: The specified date.
     /// - returns: `true` if the given date is within yesterday.
@@ -1037,7 +1068,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
 
-    /// Returns `true` if the given date is within tomorrow, as defined by the calendar and calendar's locale.
+    /// Returns a Boolean value indicating whether the given date is within tomorrow, as defined by the calendar and calendar's locale.
     ///
     /// - parameter date: The specified date.
     /// - returns: `true` if the given date is within tomorrow.
@@ -1052,7 +1083,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
 
-    /// Returns `true` if the given date is within a weekend period, as defined by the calendar and calendar's locale.
+    /// Returns a Boolean value indicating whether the given date is within a weekend period, as defined by the calendar and calendar's locale.
     ///
     /// - parameter date: The specified date.
     /// - returns: `true` if the given date is within a weekend.
@@ -1061,7 +1092,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         _calendar.isDateInWeekend(date.capped)
     }
 
-    /// Finds the range of the weekend around the given date, and returns the starting date and duration of the weekend via two inout parameters.
+    /// Find the range of the weekend around the given date, returned via two by-reference parameters.
     ///
     /// Note that a given entire day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
     /// - seealso: `dateIntervalOfWeekend(containing:)`
@@ -1080,7 +1111,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         return true
     }
 
-    /// Returns a `DateInterval` of the weekend contained by the given date, or nil if the date is not in a weekend.
+    /// Returns a DateInterval of the weekend contained by the given date, or nil if the date is not in a weekend.
     ///
     /// - parameter date: The date contained in the weekend.
     /// - returns: A `DateInterval`, or nil if the date is not in a weekend.
@@ -1129,7 +1160,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         return true
     }
 
-    /// Returns a `DateInterval` of the next weekend, which starts strictly after the given date.
+    /// Returns a DateInterval of the next weekend, which starts strictly after the given date.
     ///
     /// If `direction` is `.backward`, then finds the previous weekend range strictly before the given date.
     ///
@@ -1297,7 +1328,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         DatesByMatching(calendar: self, start: start, range: range, matchingComponents: components, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, direction: direction)
     }
                 
-    /// Computes the next date which matches (or most closely matches) a given set of components.
+    /// Computes the next date which matches (or most closely match) a given set of components.
     ///
     /// The general semantics follow those of the `enumerateDates` function.
     /// To compute a sequence of results, use the `enumerateDates` function, rather than looping and calling this method with the previous loop iteration's result.
@@ -1320,7 +1351,9 @@ public struct Calendar : Hashable, Equatable, Sendable {
     // MARK: -
     //
 
-    /// Returns a new `Date` representing the date calculated by setting a specific component to a given time, and trying to keep lower components the same.  If the component already has that value, this may result in a date which is the same as the given date.
+    /// Returns a new Date representing the date calculated by setting a specific component to a given time, and trying to keep lower components the same.
+    ///
+    /// If the component already has the value, the result may be a date equal to the given date.
     ///
     /// Changing a component's value often will require higher or coupled components to change as well.  For example, setting the Weekday to Thursday usually will require the Day component to change its value, and possibly the Month and Year as well.
     /// If no such time exists, the next available time is returned (which could, for example, be in a different day, week, month, ... than the nominal target date).  Setting a component to something which would be inconsistent forces other components to change; for example, setting the Weekday to Thursday probably shifts the Day and possibly Month and Year.
@@ -1344,7 +1377,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         return result
     }
 
-    /// Returns a new `Date` representing the date calculated by setting hour, minute, and second to a given time on a specified `Date`.
+    /// Returns a new Date representing the date calculated by setting hour, minute, and second to a given time on a specified Date.
     ///
     /// If no such time exists, the next available time is returned (which could, for example, be in a different day than the nominal target date).
     /// The intent is to return a date on the same day as the original date argument.  This may result in a date which is backward than the given date, of course.
@@ -1383,7 +1416,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         }
     }
 
-    /// Determine if the `Date` has all of the specified `DateComponents`.
+    /// Determines if the date has all of the specified date components.
     ///
     /// It may be useful to test the return value of `nextDate(after:matching:matchingPolicy:behavior:direction:)` to find out if the components were obeyed or if the method had to fudge the result value due to missing time (for example, a daylight saving time transition).
     ///

--- a/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
+++ b/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
@@ -14,7 +14,35 @@
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
-    /// Converts `self` to its textual representation.
+    /// Generates a locale-aware string representation of a date using the specified date format style.
+    ///
+    /// For full customization of the string representation of a date, use the `formatted(_:)` instance method of `Date` and provide a ``Date/FormatStyle`` object.
+    ///
+    /// You can achieve any customization of date and time representation your app requires by applying a series of convenience modifiers to your format style. This example applies a series of modifiers to the format style to precisely define the formatting of the year, month, day, hour, minute, and timezone components of the resulting string.
+    ///
+    /// ```swift
+    /// let birthday = Date()
+    ///
+    /// birthday.formatted(
+    ///     Date.FormatStyle()
+    ///         .year(.defaultDigits)
+    ///         .month(.abbreviated)
+    ///         .day(.twoDigits)
+    ///         .hour(.defaultDigits(amPM: .abbreviated))
+    ///         .minute(.twoDigits)
+    ///         .timeZone(.identifier(.long))
+    ///         .era(.wide)
+    ///         .dayOfYear(.defaultDigits)
+    ///         .weekday(.abbreviated)
+    ///         .week(.defaultDigits)
+    /// )
+    /// // Sun, Jan 17, 2021 Anno Domini (week: 4), 11:18 AM America/Chicago
+    /// ```
+    ///
+    /// For the default date formatting, use the ``Date/formatted()`` method. For basic customization of the formatted date string, use the ``Date/formatted(date:time:)`` and include a date and time style.
+    ///
+    /// For more information about formatting dates, see ``Date/FormatStyle``.
+    ///
     /// - Parameter format: The format for formatting `self`.
     /// - Returns: A representation of `self` using the given `format`. The type of the representation is specified by `FormatStyle.FormatOutput`.
 #if FOUNDATION_FRAMEWORK
@@ -67,7 +95,6 @@ extension DateComponents {
     
     // Parsing
     /// Creates a new `DateComponents` by parsing the given representation.
-    /// - Parameter value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
     /// - Parameters:
     ///   - value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
     ///   - strategy: The parse strategy to parse `value` whose `ParseOutput` is `DateComponents`.

--- a/Sources/FoundationEssentials/Calendar/DateComponents.swift
+++ b/Sources/FoundationEssentials/Calendar/DateComponents.swift
@@ -10,13 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-/**
- `DateComponents` encapsulates the components of a date in an extendable, structured manner.
-
- It is used to specify a date by providing the temporal components that make up a date and time in a particular calendar: hour, minutes, seconds, day, month, year, and so on. It can also be used to specify a duration of time, for example, 5 hours and 16 minutes. A `DateComponents` is not required to define all the component fields.
-
- When a new instance of `DateComponents` is created, the date components are set to `nil`.
-*/
+/// A date or time specified in terms of units (such as year, month, day, hour, minute) to be evaluated in a calendar system and time zone.
+///
+/// `DateComponents` encapsulates the components of a date in an extendable, structured manner.
+///
+/// It is used to specify a date by providing the temporal components that make up a date and time in a particular calendar: hour, minutes, seconds, day, month, year, and so on. It can also be used to specify a duration of time, for example, 5 hours and 16 minutes. A `DateComponents` is not required to define all the component fields.
+///
+/// When a new instance of `DateComponents` is created, the date components are set to `nil`.
 @available(macOS 10.9, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct DateComponents : Hashable, Equatable, Sendable {
     internal var _calendar: Calendar?
@@ -40,7 +40,7 @@ public struct DateComponents : Hashable, Equatable, Sendable {
     internal var _isLeapMonth: Bool?
     internal var _isRepeatedDay: Bool?
 
-    /// Initialize a `DateComponents`, optionally specifying values for its fields.
+    /// Initializes a date components value, optionally specifying values for its fields.
     public init(calendar: Calendar? = nil,
          timeZone: TimeZone? = nil,
          era: Int? = nil,
@@ -150,7 +150,7 @@ public struct DateComponents : Hashable, Equatable, Sendable {
         }
     }
 
-    /// The `Calendar` used to interpret the other values in this structure.
+    /// The calendar used to interpret the other values in this structure.
     ///
     /// - note: API which uses `DateComponents` may have different behavior if this value is `nil`. For example, assuming the current calendar or ignoring certain values.
     public var calendar: Calendar? {
@@ -286,7 +286,7 @@ public struct DateComponents : Hashable, Equatable, Sendable {
         set { _week = converted(newValue) }
     }
 
-    /// The ISO 8601 week-numbering year of the receiver.
+    /// The year corresponding to a week-counting week.
     ///
     /// The Gregorian calendar defines a week to have 7 days, and a year to have 365 days, or 366 in a leap year. However, neither 365 or 366 divide evenly into a 7 day week, so it is often the case that the last week of a year ends on a day in the next year, and the first week of a year begins in the preceding year. To reconcile this, ISO 8601 defines a week-numbering year, consisting of either 52 or 53 full weeks (364 or 371 days), such that the first week of a year is designated to be the week containing the first Thursday of the year.
     ///
@@ -310,7 +310,7 @@ public struct DateComponents : Hashable, Equatable, Sendable {
         set { _isRepeatedDay = newValue }
     }
 
-    /// Returns a `Date` calculated from the current components using the `calendar` property.
+    /// The date calculated from the current components using the stored calendar.
     public var date: Date? {
         guard let calendar = _calendar else { return nil }
 
@@ -380,7 +380,7 @@ public struct DateComponents : Hashable, Equatable, Sendable {
 
     // MARK: -
 
-    /// Returns true if the combination of properties which have been set in the receiver is a date which exists in the `calendar` property.
+    /// Indicates whether the current combination of properties represents a date which exists in the current calendar.
     ///
     /// This method is not appropriate for use on `DateComponents` values which are specifying relative quantities of calendar components.
     ///
@@ -395,7 +395,7 @@ public struct DateComponents : Hashable, Equatable, Sendable {
         return isValidDate(in: calendar)
     }
 
-    /// Returns true if the combination of properties which have been set in the receiver is a date which exists in the specified `Calendar`.
+    /// Indicates whether the current combination of properties represents a date which exists in the specified calendar.
     ///
     /// This method is not appropriate for use on `DateComponents` values which are specifying relative quantities of calendar components.
     ///

--- a/Sources/FoundationEssentials/Calendar/RecurrenceRule.swift
+++ b/Sources/FoundationEssentials/Calendar/RecurrenceRule.swift
@@ -107,7 +107,7 @@ extension Calendar {
         ///
         /// Default value is `1`
         public var interval: Int
-        /// When a recurring event stops recurring
+        /// When a recurring event stops recurring.
         public struct End: Sendable, Equatable {
             private enum _End: Equatable, Hashable {
                 case never
@@ -171,8 +171,8 @@ extension Calendar {
             /// If n is negative, repeat on the n-to-last of the given weekday.
             case nth(Int, Locale.Weekday)
         }
-        
-        /// Uniquely identifies a month in any calendar system
+
+        /// Uniquely identifies a month in any calendar system.
         public struct Month: Sendable, ExpressibleByIntegerLiteral, Equatable {
             public typealias IntegerLiteralType = Int
             

--- a/Sources/FoundationEssentials/CodableWithConfiguration.swift
+++ b/Sources/FoundationEssentials/CodableWithConfiguration.swift
@@ -10,30 +10,49 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A protocol whose conformers provide a configuration instance to help encode types that don't support encoding by themselves.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol EncodingConfigurationProviding {
     associatedtype EncodingConfiguration
+    /// The configuration instance that assists in encoding another type.
     static var encodingConfiguration: EncodingConfiguration { get }
 }
 
+/// A protocol for types that support encoding when supplied with an additional configuration type.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol EncodableWithConfiguration {
+    /// The type of the encoding configuration.
     associatedtype EncodingConfiguration
+    /// Encodes the value into the specified encoder with help from the provided configuration.
+    ///
+    /// - Parameters:
+    ///   - encoder: The encoder to write data to.
+    ///   - configuration: An encoding configuration instance that provides additional information necessary for encoding.
     func encode(to encoder: Encoder, configuration: EncodingConfiguration) throws
 }
 
+/// A protocol whose conformers provide a configuration instance to help decode types that don't support encoding by themselves.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol DecodingConfigurationProviding {
     associatedtype DecodingConfiguration
+    /// The configuration instance that assists in decoding another type.
     static var decodingConfiguration: DecodingConfiguration { get }
 }
 
+/// A protocol for types that support decoding when supplied with an additional configuration type.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol DecodableWithConfiguration {
+    /// The configuration type that assists in decoding.
     associatedtype DecodingConfiguration
+    /// Creates a new instance by retrieving the instance's data from the specified decoder with help from the provided configuration.
+    ///
+    /// - Parameters:
+    ///   - decoder: The decoder to read data from.
+    ///   - configuration: A decoding configuration instance that provides additional information necessary for decoding.
     init(from decoder: Decoder, configuration: DecodingConfiguration) throws
 }
 
+/// A type that can convert itself into and out of an external representation with the help of a configuration that handles encoding contained types.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public typealias CodableWithConfiguration = EncodableWithConfiguration & DecodableWithConfiguration
 
@@ -171,6 +190,21 @@ public extension UnkeyedDecodingContainer {
 
 }
 
+/// A property wrapper that makes a type codable, by supplying a configuration that provides additional information for serialization.
+///
+/// ``CodableConfiguration`` allows you to create <doc://com.apple.documentation/documentation/swift/codable> types whose members don't all conform to <doc://com.apple.documentation/documentation/swift/codable>. For types that can't support encoding and decoding by themselves but could become encodable and decodable with some statically-defined information, use the `@CodableConfiguration` wrapper. This lets you assign a configuration provider — a type that conforms to both ``EncodingConfigurationProviding`` and ``DecodingConfigurationProviding`` — to supply this data.
+///
+/// Limiting the ``CodableConfiguration`` to statically-defined information protects clients from loading unexpected data, similar to the protection provided by ``NSSecureCoding``.
+///
+/// In the following example, the `Message` type uses `@CodableConfiguration` for an ``AttributedString`` property called `content`. While ``AttributedString`` does conform to <doc://com.apple.documentation/documentation/swift/codable>, it can only encode its known attributes — those declared by the platform SDK — as part of this conformance. By adding a ``CodableConfiguration`` for the custom `MyAttributes` type, `Message` uses ``EncodableWithConfiguration/encode(to:configuration:)`` when encoding `content`, which preserves the custom attributes.
+///
+/// ```swift
+/// struct Message: Codable {
+/// let date: Date
+/// let sender: Person
+/// @CodableConfiguration(from: MyAttributes.self) var content = AttributedString()
+/// }
+/// ```
 @propertyWrapper
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct CodableConfiguration<T, ConfigurationProvider> : Codable
@@ -179,12 +213,30 @@ where T: CodableWithConfiguration,
       ConfigurationProvider.EncodingConfiguration == T.EncodingConfiguration,
       ConfigurationProvider.DecodingConfiguration == T.DecodingConfiguration
 {
+    /// The underlying value to make codable, using data from the configuration provider.
     public var wrappedValue: T
 
+    /// Creates a codable configuration wrapper for the given value.
+    ///
+    /// This initializer doesn't take a `ConfigurationProvider.Type` parameter.
+    /// As a result, it won't compile unless the compiler can imply the provider
+    /// type through other means, such as a generic expression like
+    /// `@CodableConfiguration<AttributedString, FoundationAttributes>`.
+    ///
+    /// For clarity, use this type's other initializers, which take the
+    /// configuration provider type as an explicit parameter.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: The underlying value to make codable.
     public init(wrappedValue: T) {
         self.wrappedValue = wrappedValue
     }
 
+    /// Creates a codable configuration wrapper for the given value, using the given configuration provider type.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: The underlying value to make codable, using data from the configuration provider.
+    ///   - configurationProvider: The type of the configuration provider, which provides additional information to encode `wrappedValue`.
     public init(wrappedValue: T, from configurationProvider: ConfigurationProvider.Type) {
         self.wrappedValue = wrappedValue
     }

--- a/Sources/FoundationEssentials/ComparisonResult.swift
+++ b/Sources/FoundationEssentials/ComparisonResult.swift
@@ -12,7 +12,10 @@
 
 #if !FOUNDATION_FRAMEWORK
 
-/// Used to indicate how items in a request are ordered, from the first one given in a method invocation or function call to the last (that is, left to right in code).
+/// Constants that indicate sort order.
+///
+/// These constants are used to indicate how items in a request are ordered, from the first one given in a method invocation or function call to the last (that is, left to right in code).
+///
 /// Given the function:
 /// ```
 /// func f(a: Int, b: Int) -> ComparisonResult
@@ -23,8 +26,11 @@
 ///   `a == b`  then return `.orderedSame`. The operands are equal.
 @frozen @available(macOS 10.0, iOS 2.0, tvOS 9.0, watchOS 2.0, *)
 public enum ComparisonResult : Int, Sendable {
+    /// The left operand is smaller than the right operand.
     case orderedAscending   = -1
+    /// The two operands are equal.
     case orderedSame        = 0
+    /// The left operand is greater than the right operand.
     case orderedDescending  = 1
 }
 

--- a/Sources/FoundationEssentials/Data/ContiguousBytes.swift
+++ b/Sources/FoundationEssentials/Data/ContiguousBytes.swift
@@ -12,8 +12,7 @@
 
 //===--- ContiguousBytes --------------------------------------------------===//
 
-/// Indicates that the conforming type is a contiguous collection of raw bytes
-/// whose underlying storage is directly accessible by calling withBytes.
+/// A protocol that declares the type offers direct access to the underlying raw bytes in a contiguous manner.
 ///
 /// This protocol predates the introduction of the `RawSpan` type in the
 /// standard library. Types that conform to this protocol will generally provide

--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -62,7 +62,9 @@ extension Data {
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
     // These types are typealiased to the `NSData` options for framework builds only.
+    /// Options to use when encoding data.
     public typealias Base64EncodingOptions = NSData.Base64EncodingOptions
+    /// Options to use when decoding data.
     public typealias Base64DecodingOptions = NSData.Base64DecodingOptions
 }
 #endif //!FOUNDATION_FRAMEWORK
@@ -117,7 +119,7 @@ extension Data {
         Base64.encodeToString(bytes: self, options: options)
     }
 
-    /// Returns a Base-64 encoded `Data`.
+    /// Returns Base-64 encoded data.
     ///
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded data.

--- a/Sources/FoundationEssentials/Data/Data+Deprecated.swift
+++ b/Sources/FoundationEssentials/Data/Data+Deprecated.swift
@@ -49,7 +49,7 @@ extension Data {
         }
     }
     
-    /// Enumerate the contents of the data.
+    /// Enumerates the contents of the data's buffer.
     ///
     /// In some cases, (for example, a `Data` backed by a `dispatch_data_t`, the bytes may be stored discontinuously. In those cases, this function invokes the closure for each contiguous region of bytes.
     /// - parameter block: The closure to invoke for each region of data. You may stop the enumeration by setting the `stop` parameter to `true`.

--- a/Sources/FoundationEssentials/Data/Data+Iterator.swift
+++ b/Sources/FoundationEssentials/Data/Data+Iterator.swift
@@ -12,7 +12,7 @@
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
-    /// An iterator over the contents of the data.
+    /// Returns an iterator over the contents of the data.
     ///
     /// The iterator will increment byte-by-byte.
     @inlinable // This is @inlinable as trivially computable.
@@ -20,6 +20,9 @@ extension Data {
         return Iterator(self, at: startIndex)
     }
     
+    /// An iterator that operates over the contents of data.
+    ///
+    /// The iterator will increment byte-by-byte.
     public struct Iterator : IteratorProtocol, Sendable {
         @usableFromInline
         internal typealias Buffer = (

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -519,8 +519,10 @@ private func readBytesFromFileDescriptor(_ fd: Int32, path: borrowing some FileS
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
 #if FOUNDATION_FRAMEWORK
+    /// Options to control the reading of data from a URL.
     public typealias ReadingOptions = NSData.ReadingOptions
 #else
+    /// Options to control the reading of data from a URL.
     public struct ReadingOptions : OptionSet, Sendable {
         public let rawValue: UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
@@ -539,7 +541,7 @@ extension Data {
     }
 #endif
     
-    /// Initialize a `Data` with the contents of a `URL`.
+    /// Creates data by reading from the specified URL.
     ///
     /// - parameter url: The `URL` to read.
     /// - parameter options: Options for the read operation. Default value is `[]`.

--- a/Sources/FoundationEssentials/Data/Data+Searching.swift
+++ b/Sources/FoundationEssentials/Data/Data+Searching.swift
@@ -13,9 +13,10 @@
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
 #if FOUNDATION_FRAMEWORK
+    /// Options that control a data search operation.
     public typealias SearchOptions = NSData.SearchOptions
     
-    /// Find the given `Data` in the content of this `Data`.
+    /// Finds the range of the specified data as a subsequence of this data, if it exists.
     ///
     /// - parameter dataToFind: The data to be searched for.
     /// - parameter options: Options for the search. Default value is `[]`.
@@ -40,6 +41,7 @@ extension Data {
 #else
     // TODO: Implement range(of:options:in:) for Foundation package.
     
+    /// Options that control a data search operation.
     public struct SearchOptions : OptionSet, Sendable {
         public let rawValue: UInt
         

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -716,10 +716,12 @@ private func writeExtendedAttributes(fd: Int32, attributes: [String : Data]) {
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
 #if FOUNDATION_FRAMEWORK
+    /// Options to control the writing of data to a URL.
     public typealias WritingOptions = NSData.WritingOptions
 #else
     
     // This is imported from the ObjC 'option set', which is actually a combination of an option and an enumeration (file protection).
+    /// Options to control the writing of data to a URL.
     public struct WritingOptions : OptionSet, Sendable {
         public let rawValue: UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
@@ -750,7 +752,7 @@ extension Data {
     }
 #endif
     
-    /// Write the contents of the `Data` to a location.
+    /// Writes the contents of the data buffer to a location.
     ///
     /// - parameter url: The location to write the data into.
     /// - parameter options: Options for writing the data. Default value is `[]`.

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -123,18 +123,29 @@ internal func _withStackOrHeapBuffer(capacity: Int, _ body: (UnsafeMutableBuffer
     body(buffer)
 }
 
+/// A byte buffer in memory.
+///
+/// The `Data` value type allows simple byte buffers to take on the behavior of Foundation objects.
+/// You can create empty or pre-populated buffers from a variety of sources and later add or remove bytes.
+/// You can filter and sort the content, or compare against other buffers. You can manipulate subranges
+/// of bytes and iterate over some or all of them.
+///
+/// `Data` bridges to the `NSData` class and its mutable subclass, `NSMutableData`. You can use these
+/// interchangeably in code that interacts with Objective-C APIs.
 @frozen
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 #if compiler(>=6.2)
 @_addressableForDependencies
 #endif
 public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceableCollection, Sendable, Hashable {
+    /// A type used to indicate a position in a data's buffer.
     public typealias Index = Int
+    /// A type used to indicate a range of positions in a data's buffer.
     public typealias Indices = Range<Int>
 
     @usableFromInline internal var _representation: _Representation
 
-    // A standard or custom deallocator for `Data`.
+    /// A deallocator you use to customize how the backing store is deallocated for data created with the no-copy initializer.
     ///
     /// When creating a `Data` with the no-copy initializer, you may specify a `Data.Deallocator` to customize the behavior of how the backing store is deallocated.
     public enum Deallocator {
@@ -176,7 +187,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     // MARK: -
     // MARK: Init methods
 
-    /// Initialize a `Data` with copied memory content.
+    /// Creates data with copied memory content.
     ///
     /// - parameter bytes: A pointer to the memory. It will be copied.
     /// - parameter count: The number of bytes to copy.
@@ -185,7 +196,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _representation = _Representation(UnsafeRawBufferPointer(start: bytes, count: count))
     }
 
-    /// Initialize a `Data` with copied memory content.
+    /// Creates a data buffer with copied memory content using a buffer pointer.
     ///
     /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
     @inlinable // This is @inlinable as a trivial, generic initializer.
@@ -193,7 +204,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _representation = _Representation(UnsafeRawBufferPointer(buffer))
     }
 
-    /// Initialize a `Data` with copied memory content.
+    /// Creates a data buffer with copied memory content using a mutable buffer pointer.
     ///
     /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
     @inlinable // This is @inlinable as a trivial, generic initializer.
@@ -213,7 +224,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
-    /// Initialize a `Data` with the specified size.
+    /// Creates an empty data buffer of a specified size.
     ///
     /// This initializer doesn't necessarily allocate the requested memory right away. `Data` allocates additional memory as needed, so `capacity` simply establishes the initial capacity. When it does allocate the initial memory, though, it allocates the specified amount.
     ///
@@ -227,7 +238,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _representation = _Representation(capacity: capacity)
     }
 
-    /// Initialize a `Data` with the specified count of zeroed bytes.
+    /// Creates a new data buffer with the specified count of zeroed bytes.
     ///
     /// - parameter count: The number of bytes the data initially contains.
     @inlinable // This is @inlinable as a trivial initializer.
@@ -235,7 +246,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _representation = _Representation(count: count)
     }
 
-    /// Initialize an empty `Data`.
+    /// Creates an empty data buffer.
     @inlinable // This is @inlinable as a trivial initializer.
     public init() {
         _representation = .empty
@@ -304,7 +315,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
-    /// Initialize a `Data` without copying the bytes.
+    /// Creates a data buffer with memory content without copying the bytes.
     ///
     /// If the result is mutated and is not a unique reference, then the `Data` will still follow copy-on-write semantics. In this case, the copy will use its own deallocator. Therefore, it is usually best to only use this initializer when you either enforce immutability with `let` or ensure that no other references to the underlying data are formed.
     /// - parameter bytes: A pointer to the bytes.
@@ -472,6 +483,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     // -----------------------------------
     // MARK: - Properties and Functions
 
+    /// Prepares the collection to store the specified number of elements, when doing so is appropriate for the underlying type.
     @inlinable // This is @inlinable as trivially forwarding.
     public mutating func reserveCapacity(_ minimumCapacity: Int) {
         _representation.reserveCapacity(minimumCapacity)
@@ -590,12 +602,14 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _representation.append(contentsOf: UnsafeRawBufferPointer(buffer))
     }
 
+    /// Appends the specified bytes from memory to the end of the data.
     @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public mutating func append(_ bytes: UnsafePointer<UInt8>, count: Int) {
         if count == 0 { return }
         _append(UnsafeBufferPointer(start: bytes, count: count))
     }
 
+    /// Appends the specified data to the end of this data.
     public mutating func append(_ other: Data) {
         guard !other.isEmpty else { return }
         other.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
@@ -692,6 +706,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
     #endif
 
+    /// Appends the bytes in the specified sequence to the end of the data.
     @inline(__always)
     @_alwaysEmitIntoClient
     public mutating func append(contentsOf elements: some Sequence<UInt8> & ContiguousBytes) {
@@ -702,6 +717,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
+    /// Appends the bytes in the specified sequence to the end of the data.
     @inline(__always)
     @_alwaysEmitIntoClient
     @abi(mutating func append(fastContentsof elements: some Sequence<UInt8>))
@@ -779,7 +795,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
 
     // MARK: -
 
-    /// Set a region of the data to `0`.
+    /// Sets a region of the data buffer to 0.
     ///
     /// If `range` exceeds the bounds of the data, then the data is resized to fit.
     /// - parameter range: The range in the data to set to `0`.
@@ -811,7 +827,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
     #endif
 
-    /// Replace a region of bytes in the data with new bytes from a buffer.
+    /// Replaces a region of bytes in the data with new bytes from a buffer.
     ///
     /// This will resize the data if required, to fit the entire contents of `buffer`.
     ///
@@ -823,6 +839,14 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         replaceSubrange(subrange, with: UnsafeRawBufferPointer(buffer))
     }
 
+    /// Replaces a region of bytes in the data with new bytes from a collection.
+    ///
+    /// This will resize the data if required, to fit the entire contents of `newElements`.
+    ///
+    /// - Precondition: The bounds of `subrange` must be valid indices of the collection.
+    /// - Parameters:
+    ///   - subrange: The range in the data to replace.
+    ///   - newElements: The replacement bytes.
     @inline(__always)
     @_alwaysEmitIntoClient
     public mutating func replaceSubrange(_ subrange: Range<Index>, with newElements: some Collection<UInt8> & ContiguousBytes) {
@@ -831,6 +855,14 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
+    /// Replaces a region of bytes in the data with new bytes from a collection.
+    ///
+    /// This will resize the data if required, to fit the entire contents of `newElements`.
+    ///
+    /// - Precondition: The bounds of `subrange` must be valid indices of the collection.
+    /// - Parameters:
+    ///   - subrange: The range in the data to replace.
+    ///   - newElements: The replacement bytes.
     @inline(__always)
     @_alwaysEmitIntoClient
     @abi(mutating func repalceSubrangeFast(_ subrange: Range<Index>, with newElements: some Collection<UInt8>))
@@ -879,12 +911,13 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
+    /// Replaces a region of bytes in the data with bytes from memory.
     @inlinable // This is @inlinable as trivially forwarding.
     public mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer, count cnt: Int) {
         _representation.replaceSubrange(subrange, with: bytes, count: cnt)
     }
 
-    /// Return a new copy of the data in a specified range.
+    /// Returns a new copy of the data in a specified range.
     ///
     /// - parameter range: The range to copy.
     public func subdata(in range: Range<Index>) -> Data {
@@ -901,6 +934,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     // MARK: -
     //
 
+    /// Returns a new data buffer created by removing the given number of bytes from the front of the original data.
     public func advanced(by amount: Int) -> Data {
         precondition(amount >= 0)
         let start = self.index(self.startIndex, offsetBy: amount)
@@ -911,7 +945,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     // MARK: -
     // MARK: Index and Subscript
 
-    /// Sets or returns the byte at the specified index.
+    /// Accesses the byte at the specified index.
     @inlinable // This is @inlinable as trivially forwarding.
     public subscript(index: Index) -> UInt8 {
         get {
@@ -922,6 +956,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
+    /// Accesses the bytes at the specified range of indexes.
     @inlinable // This is @inlinable as trivially forwarding.
     public subscript(bounds: Range<Index>) -> Data {
         get {
@@ -956,7 +991,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
 
     }
 
-    /// The start `Index` in the data.
+    /// The beginning index into the data.
     @inlinable // This is @inlinable as trivially forwarding.
     public var startIndex: Index {
         get {
@@ -974,11 +1009,13 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
+    /// Returns the index that immediately precedes the specified index.
     @inlinable // This is @inlinable as trivially computable.
     public func index(before i: Index) -> Index {
         return i - 1
     }
 
+    /// Returns the index that immediately follows the specified index.
     @inlinable // This is @inlinable as trivially computable.
     public func index(after i: Index) -> Index {
         return i + 1

--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -26,34 +26,45 @@ import stdlib_h
 
 //===--- DataProtocol -----------------------------------------------------===//
 
+/// A protocol that provides consistent data access to the bytes underlying contiguous and noncontiguous data buffers.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public protocol DataProtocol : RandomAccessCollection where Element == UInt8, SubSequence : DataProtocol {
     // FIXME: Remove in favor of opaque type on `regions`.
+    /// A type that represents a collection of contiguous parts that make up the type conforming to a data protocol.
     associatedtype Regions: BidirectionalCollection where Regions.Element : DataProtocol & ContiguousBytes, Regions.Element.SubSequence : ContiguousBytes
 
-    /// A `BidirectionalCollection` of `DataProtocol` elements which compose a
-    /// discontiguous buffer of memory.  Each region is a contiguous buffer of
-    /// bytes.
-    ///
-    /// The sum of the lengths of the associated regions must equal `self.count`
-    /// (such that iterating `regions` and iterating `self` produces the same
-    /// sequence of indices in the same number of index advancements).
+    /// A collection of buffers that make up the whole of the type conforming to a data protocol.
     var regions: Regions { get }
 
     /// Returns the first found range of the given data buffer.
     ///
     /// A default implementation is given in terms of `self.regions`.
+    ///
+    /// - Parameters:
+    ///   - of: The data sequence to find.
+    ///   - in: A range to limit the scope of the search.
+    /// - Returns: The range, if found, of the first match of the provided data sequence.
     func firstRange<D: DataProtocol, R: RangeExpression>(of: D, in: R) -> Range<Index>? where R.Bound == Index
 
     /// Returns the last found range of the given data buffer.
     ///
     /// A default implementation is given in terms of `self.regions`.
+    ///
+    /// - Parameters:
+    ///   - of: The data sequence to find.
+    ///   - in: A range to limit the scope of the search.
+    /// - Returns: The range, if found, of the last match of the provided data sequence.
     func lastRange<D: DataProtocol, R: RangeExpression>(of: D, in: R) -> Range<Index>? where R.Bound == Index
 
     /// Copies `count` bytes from the start of the buffer to the destination
     /// buffer.
     ///
     /// A default implementation is given in terms of `copyBytes(to:from:)`.
+    ///
+    /// - Parameters:
+    ///   - to: A pointer to the raw memory buffer you want to copy the bytes into.
+    ///   - count: The number of bytes to copy.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     func copyBytes(to: UnsafeMutableRawBufferPointer, count: Int) -> Int
 
@@ -61,30 +72,57 @@ public protocol DataProtocol : RandomAccessCollection where Element == UInt8, Su
     /// buffer.
     ///
     /// A default implementation is given in terms of `copyBytes(to:from:)`.
+    ///
+    /// - Parameters:
+    ///   - to: A typed pointer to the buffer you want to copy the bytes into.
+    ///   - count: The number of bytes to copy.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     func copyBytes<DestinationType>(to: UnsafeMutableBufferPointer<DestinationType>, count: Int) -> Int
 
     /// Copies the bytes from the given range to the destination buffer.
     ///
     /// A default implementation is given in terms of `self.regions`.
+    ///
+    /// - Parameters:
+    ///   - to: A pointer to the raw memory buffer you want to copy the bytes into.
+    ///   - from: The range of bytes to copy.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     func copyBytes<R: RangeExpression>(to: UnsafeMutableRawBufferPointer, from: R) -> Int where R.Bound == Index
 
     /// Copies the bytes from the given range to the destination buffer.
     ///
     /// A default implementation is given in terms of `self.regions`.
+    ///
+    /// - Parameters:
+    ///   - to: A typed pointer to the buffer you want to copy the bytes into.
+    ///   - from: The range of bytes to copy.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     func copyBytes<DestinationType, R: RangeExpression>(to: UnsafeMutableBufferPointer<DestinationType>, from: R) -> Int where R.Bound == Index
 }
 
 //===--- MutableDataProtocol ----------------------------------------------===//
 
+/// A protocol that provides consistent data access to the bytes underlying contiguous and noncontiguous mutable data buffers.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public protocol MutableDataProtocol : DataProtocol, MutableCollection, RangeReplaceableCollection {
-    /// Replaces the contents of the buffer at the given range with zeroes.
+    /// Replaces the contents of the data buffer with zeros for the provided range.
+    ///
+    /// The following example sets the bytes to zero for the bytes identified by
+    /// the provided range:
+    ///
+    /// ```swift
+    /// var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+    /// dest.resetBytes(in: 1...3)
+    /// // dest = [0xFF, 0x00, 0x00, 0x00, 0xFF, 0xFF]
+    /// ```
     ///
     /// A default implementation is given in terms of
     /// `replaceSubrange(_:with:)`.
+    ///
+    /// - Parameter range: The range of bytes to replace with zeros.
     mutating func resetBytes<R: RangeExpression>(in range: R) where R.Bound == Index
 }
 
@@ -92,34 +130,127 @@ public protocol MutableDataProtocol : DataProtocol, MutableCollection, RangeRepl
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension DataProtocol {
+    /// Returns the first found range of the type's data buffer.
+    ///
+    /// - Parameter data: The data sequence to find.
+    /// - Returns: The range, if found, of the first match of the provided data sequence.
+    ///
+    /// An example of searching a data buffer converted from a string:
+    ///
+    /// ```swift
+    /// let data = "0123456789".data(using: .utf8)!
+    /// let pattern = "456".data(using: .utf8)!
+    /// let foundRange = data.firstRange(of: pattern)
+    ///
+    /// // foundRange == Range(4..<7)
+    /// ```
     public func firstRange<D: DataProtocol>(of data: D) -> Range<Index>? {
         return self.firstRange(of: data, in: self.startIndex ..< self.endIndex)
     }
 
+    /// Returns the last found range of the type's data buffer.
+    ///
+    /// - Parameter data: The data sequence to find.
+    /// - Returns: The range, if found, of the last match of the provided data sequence.
+    ///
+    /// An example of searching a data buffer for the last match:
+    ///
+    /// ```swift
+    /// let data: [UInt8] = [0, 1, 2, 3, 0, 1, 2, 3]
+    /// let pattern: [UInt8] = [2, 3]
+    ///
+    /// let match = data.lastRange(of: pattern)
+    /// // match == 6..<8
+    /// ```
     public func lastRange<D: DataProtocol>(of data: D) -> Range<Index>? {
         return self.lastRange(of: data, in: self.startIndex ..< self.endIndex)
     }
 
+    /// Copies the bytes of data from the type into a raw memory buffer.
+    ///
+    /// The following example copies the bytes from the raw memory buffer into the provided
+    /// raw memory buffer:
+    ///
+    /// ```swift
+    /// let source: [UInt8] = [0, 1, 2]
+    /// var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+    /// dest.withUnsafeMutableBytes { destBufferPtr in
+    ///     let count = source.copyBytes(to: destBufferPtr)
+    ///     // count == 3
+    /// }
+    /// // dest = [0x00, 0x01, 0x02, 0xFF, 0xFF, 0xFF]
+    /// ```
+    ///
+    /// - Parameter ptr: A pointer to the raw memory buffer you want to copy the bytes into.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     public func copyBytes(to ptr: UnsafeMutableRawBufferPointer) -> Int {
         return copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
     }
 
+    /// Copies the bytes of data from the type into a typed memory buffer.
+    ///
+    /// The following example copies the bytes from a typed memory buffer into the provided
+    /// typed memory buffer:
+    ///
+    /// ```swift
+    /// let source: [UInt8] = [0, 1, 2]
+    /// var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+    /// dest.withUnsafeMutableBufferPointer { typedMemBuffer in
+    ///     let count = source.copyBytes(to: typedMemBuffer)
+    ///     // count == 3
+    /// }
+    /// // dest = [0x00, 0x01, 0x02, 0xFF, 0xFF, 0xFF]
+    /// ```
+    ///
+    /// - Parameter ptr: A typed pointer to the buffer you want to copy the bytes into.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     public func copyBytes<DestinationType>(to ptr: UnsafeMutableBufferPointer<DestinationType>) -> Int {
         return copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
     }
 
+    /// Copies the provided number of bytes from the start of the type into a raw memory buffer.
+    ///
+    /// The following example copies the number of bytes that `count` identified from the
+    /// beginning of the raw memory buffer into the provided raw memory buffer:
+    ///
+    /// ```swift
+    /// let source: [UInt8] = [0, 1, 2]
+    /// var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+    /// dest.withUnsafeMutableBytes { destBufferPtr in
+    ///     let count = source.copyBytes(to: destBufferPtr, count: 2)
+    ///     // count == 2
+    /// }
+    /// // dest = [0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF]
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - ptr: A pointer to the raw memory buffer you want to copy the bytes into.
+    ///   - count: The number of bytes to copy.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     public func copyBytes(to ptr: UnsafeMutableRawBufferPointer, count: Int) -> Int {
         return copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
     }
 
+    /// Copies the provided number of bytes from the start of the type into a typed memory buffer.
+    ///
+    /// - Parameters:
+    ///   - ptr: A typed pointer to the buffer you want to copy the bytes into.
+    ///   - count: The number of bytes to copy.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     public func copyBytes<DestinationType>(to ptr: UnsafeMutableBufferPointer<DestinationType>, count: Int) -> Int {
         return copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
     }
 
+    /// Copies a range of the bytes from the type into a raw memory buffer.
+    ///
+    /// - Parameters:
+    ///   - ptr: A pointer to the raw memory buffer you want to copy the bytes into.
+    ///   - range: The range of bytes to copy.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     public func copyBytes<R: RangeExpression>(to ptr: UnsafeMutableRawBufferPointer, from range: R) -> Int where R.Bound == Index {
         precondition(ptr.baseAddress != nil)
@@ -148,6 +279,12 @@ extension DataProtocol {
         return offset
     }
 
+    /// Copies a range of the bytes from the type into a typed memory buffer.
+    ///
+    /// - Parameters:
+    ///   - ptr: A typed pointer to the buffer you want to copy the bytes into.
+    ///   - range: The range of bytes to copy.
+    /// - Returns: The number of bytes copied.
     @discardableResult
     public func copyBytes<DestinationType, R: RangeExpression>(to ptr: UnsafeMutableBufferPointer<DestinationType>, from range: R) -> Int where R.Bound == Index {
         return self.copyBytes(to: UnsafeMutableRawBufferPointer(start: ptr.baseAddress, count: ptr.count * MemoryLayout<DestinationType>.stride), from: range)
@@ -171,6 +308,25 @@ extension DataProtocol {
         }
     }
 
+    /// Returns the first found range of the type's data buffer within the specified range.
+    ///
+    /// - Parameters:
+    ///   - data: The data sequence to find.
+    ///   - range: A range to limit the scope of the search.
+    /// - Returns: The range, if found, of the first match of the provided data sequence.
+    ///
+    /// An example of searching a constrained range within a data buffer for the first match:
+    ///
+    /// ```swift
+    /// let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    /// let pattern: [UInt8] = [2, 3, 4]
+    ///
+    /// let possibleMatch = data.firstRange(of: pattern, in: 5...9)
+    /// // possibleMatch == nil
+    ///
+    /// let match = data.firstRange(of: pattern, in: 2...9)
+    /// // match == 2..<5
+    /// ```
     public func firstRange<D: DataProtocol, R: RangeExpression>(of data: D, in range: R) -> Range<Index>? where R.Bound == Index {
         let r = range.relative(to: self)
         let length = data.count
@@ -189,6 +345,12 @@ extension DataProtocol {
         return nil
     }
 
+    /// Returns the last found range of the type's data buffer within the specified range.
+    ///
+    /// - Parameters:
+    ///   - data: The data sequence to find.
+    ///   - range: A range to limit the scope of the search.
+    /// - Returns: The range, if found, of the last match of the provided data sequence.
     public func lastRange<D: DataProtocol, R: RangeExpression>(of data: D, in range: R) -> Range<Index>? where R.Bound == Index {
         let r = range.relative(to: self)
         let length = data.count
@@ -210,6 +372,14 @@ extension DataProtocol {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension DataProtocol where Self : ContiguousBytes {
+    /// Copies a range of the bytes from the type into a typed memory buffer.
+    ///
+    /// This specialization is available when the conforming type also conforms to
+    /// `ContiguousBytes`, and copies bytes directly using `memcpy` for better performance.
+    ///
+    /// - Parameters:
+    ///   - ptr: A typed pointer to the buffer you want to copy the bytes into.
+    ///   - range: The range of bytes to copy.
     public func copyBytes<DestinationType, R: RangeExpression>(to ptr: UnsafeMutableBufferPointer<DestinationType>, from range: R) where R.Bound == Index {
         precondition(ptr.baseAddress != nil)
         
@@ -226,6 +396,9 @@ extension DataProtocol where Self : ContiguousBytes {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension MutableDataProtocol {
+    /// Replaces the contents of the data buffer with zeros for the provided range.
+    ///
+    /// - Parameter range: The range of bytes to replace with zeros.
     public mutating func resetBytes<R: RangeExpression>(in range: R) where R.Bound == Index {
         let r = range.relative(to: self)
         let count = distance(from: r.lowerBound, to: r.upperBound)
@@ -245,7 +418,7 @@ extension Data : MutableDataProtocol {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
-    /// Copy the contents of the data to a pointer.
+    /// Copies the contents of the data to memory.
     ///
     /// - parameter pointer: A pointer to the buffer you wish to copy the bytes into.
     /// - parameter count: The number of bytes to copy.
@@ -263,7 +436,7 @@ extension Data {
         _representation.copyBytes(to: pointer, from: range)
     }
     
-    /// Copy a subset of the contents of the data to a pointer.
+    /// Copies a subset of the contents of the data to memory.
     ///
     /// - parameter pointer: A pointer to the buffer you wish to copy the bytes into.
     /// - parameter range: The range in the `Data` to copy.
@@ -273,7 +446,7 @@ extension Data {
         _copyBytesHelper(to: pointer, from: range)
     }
     
-    // Copy the contents of the data into a buffer.
+    /// Copies the bytes in a range from the data into a buffer.
     ///
     /// This function copies the bytes in `range` from the data into the buffer. If the count of the `range` is greater than `MemoryLayout<DestinationType>.stride * buffer.count` then the first N bytes will be copied into the buffer.
     /// - precondition: The range must be within the bounds of the data. Otherwise `fatalError` is called.

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -25,14 +25,17 @@ import WinSDK
 #endif
 
 #if !FOUNDATION_FRAMEWORK
+/// A number of seconds.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public typealias TimeInterval = Double
 #endif // !FOUNDATION_FRAMEWORK
-/**
- `Date` represents a single point in time.
-
- A `Date` is independent of a particular calendar or time zone. To represent a `Date` to a user, you must interpret it in the context of a `Calendar`.
-*/
+/// A specific point in time, independent of any calendar or time zone.
+///
+/// A `Date` value encapsulates a single point in time, independent of any particular calendrical system or time zone. Date values represent a time interval relative to an absolute reference date.
+///
+/// The `Date` structure provides methods for comparing dates, calculating the time interval between two dates, and creating a new date from a time interval relative to another date. Use date values in conjunction with `DateFormatter` instances to create localized representations of dates and times and with `Calendar` instances to perform calendar arithmetic.
+///
+/// `Date` bridges to the `NSDate` class. You can use these interchangeably in code that interacts with Objective-C APIs.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct Date : Comparable, Hashable, Equatable, Sendable {
 
@@ -49,82 +52,73 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
         return Self.getCurrentAbsoluteTime()
     }
 
-    /// Returns a `Date` initialized to the current date and time.
+    /// Creates a date value initialized to the current date and time.
     public init() {
         _time = Self.getCurrentAbsoluteTime()
     }
 
-    /// Returns a `Date` initialized relative to the current date and time by a given number of seconds.
+    /// Creates a date value initialized relative to the current date and time by a given number of seconds.
     public init(timeIntervalSinceNow: TimeInterval) {
         self.init(timeIntervalSinceReferenceDate: timeIntervalSinceNow + Self.getCurrentAbsoluteTime())
     }
 
-    /// Returns a `Date` initialized relative to 00:00:00 UTC on 1 January 1970 by a given number of seconds.
+    /// Creates a date value initialized relative to 00:00:00 UTC on 1 January 1970 by a given number of seconds.
     public init(timeIntervalSince1970: TimeInterval) {
         self.init(timeIntervalSinceReferenceDate: timeIntervalSince1970 - Date.timeIntervalBetween1970AndReferenceDate)
     }
 
-    /**
-    Returns a `Date` initialized relative to another given date by a given number of seconds.
-
-    - Parameter timeInterval: The number of seconds to add to `date`. A negative value means the receiver will be earlier than `date`.
-    - Parameter date: The reference date.
-    */
+    /// Creates a date value initialized relative to another given date by a given number of seconds.
+    ///
+    /// - Parameters:
+    ///   - timeInterval: The number of seconds to add to `date`. A negative value means the receiver will be earlier than `date`.
+    ///   - date: The reference date.
     public init(timeInterval: TimeInterval, since date: Date) {
         self.init(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate + timeInterval)
     }
 
-    /// Returns a `Date` initialized relative to 00:00:00 UTC on 1 January 2001 by a given number of seconds.
+    /// Creates a date value initialized relative to 00:00:00 UTC on 1 January 2001 by a given number of seconds.
     public init(timeIntervalSinceReferenceDate ti: TimeInterval) {
         _time = ti
     }
 
-    /**
-    Returns the interval between the date object and 00:00:00 UTC on 1 January 2001.
-
-    This property's value is negative if the date object is earlier than the system's absolute reference date (00:00:00 UTC on 1 January 2001).
-    */
+    /// The interval between the date value and 00:00:00 UTC on 1 January 2001.
+    ///
+    /// This property's value is negative if the date object is earlier than the system's absolute reference date (00:00:00 UTC on 1 January 2001).
     public var timeIntervalSinceReferenceDate: TimeInterval {
         return _time
     }
 
-    /**
-    Returns the interval between the receiver and another given date.
-
-    - Parameter another: The date with which to compare the receiver.
-
-    - Returns: The interval between the receiver and the `another` parameter. If the receiver is earlier than `anotherDate`, the return value is negative. If `anotherDate` is `nil`, the results are undefined.
-
-    - SeeAlso: `timeIntervalSince1970`
-    - SeeAlso: `timeIntervalSinceNow`
-    - SeeAlso: `timeIntervalSinceReferenceDate`
-    */
+    /// Returns the interval between this date and another given date.
+    ///
+    /// - Parameter date: The date with which to compare this one.
+    ///
+    /// - Returns: The interval between the receiver and the `another` parameter. If the receiver is earlier than `anotherDate`, the return value is negative. If `anotherDate` is `nil`, the results are undefined.
+    ///
+    /// - SeeAlso: `timeIntervalSince1970`
+    /// - SeeAlso: `timeIntervalSinceNow`
+    /// - SeeAlso: `timeIntervalSinceReferenceDate`
     public func timeIntervalSince(_ date: Date) -> TimeInterval {
         return self.timeIntervalSinceReferenceDate - date.timeIntervalSinceReferenceDate
     }
 
-    /**
-    The time interval between the date and the current date and time.
-
-    If the date is earlier than the current date and time, this property's value is negative.
-
-    - SeeAlso: `timeIntervalSince(_:)`
-    - SeeAlso: `timeIntervalSince1970`
-    - SeeAlso: `timeIntervalSinceReferenceDate`
-    */
+    /// The time interval between the date value and the current date and time.
+    ///
+    /// If the date is earlier than the current date and time, this property's value is negative.
+    ///
+    /// - SeeAlso: `timeIntervalSince(_:)`
+    /// - SeeAlso: `timeIntervalSince1970`
+    /// - SeeAlso: `timeIntervalSinceReferenceDate`
     public var timeIntervalSinceNow: TimeInterval {
         return self.timeIntervalSinceReferenceDate - Self.getCurrentAbsoluteTime()
     }
 
-    /**
-    The interval between the date object and 00:00:00 UTC on 1 January 1970.
-
-    This property's value is negative if the date object is earlier than 00:00:00 UTC on 1 January 1970.
-
-    - SeeAlso: `timeIntervalSince(_:)`
-    - SeeAlso: `timeIntervalSinceNow`
-    - SeeAlso: `timeIntervalSinceReferenceDate`
-    */
+    /// The interval between the date value and 00:00:00 UTC on 1 January 1970.
+    ///
+    /// This property's value is negative if the date object is earlier than 00:00:00 UTC on 1 January 1970.
+    ///
+    /// - SeeAlso: `timeIntervalSince(_:)`
+    /// - SeeAlso: `timeIntervalSinceNow`
+    /// - SeeAlso: `timeIntervalSinceReferenceDate`
     public var timeIntervalSince1970: TimeInterval {
         return self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1970AndReferenceDate
     }
@@ -133,37 +127,40 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
         return self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1601AndReferenceDate
     }
 
-    /// Return a new `Date` by adding a `TimeInterval` to this `Date`.
+    /// Creates a new date value by adding a time interval to this date.
     ///
-    /// - parameter timeInterval: The value to add, in seconds.
-    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    /// - Parameter timeInterval: The value to add, in seconds.
+    /// - Returns: A new date value calculated by adding a time interval to this date.
+    ///
+    /// > Warning:
+    /// > This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
     public func addingTimeInterval(_ timeInterval: TimeInterval) -> Date {
         return self + timeInterval
     }
 
-    /// Add a `TimeInterval` to this `Date`.
+    /// Adds a time interval to this date.
     ///
-    /// - parameter timeInterval: The value to add, in seconds.
-    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    /// - Parameter timeInterval: The value to add, in seconds.
+    ///
+    /// > Warning:
+    /// > This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
     public mutating func addTimeInterval(_ timeInterval: TimeInterval) {
         self += timeInterval
     }
 
-    /**
-    Creates and returns a Date value representing a date in the distant future.
-
-    The distant future is in terms of centuries.
-    */
+    /// A date value representing a date in the distant future.
+    ///
+    /// The distant future is in terms of centuries.
     public static let distantFuture = Date(timeIntervalSinceReferenceDate: 63113904000.0)
 
-    /**
-    Creates and returns a Date value representing a date in the distant past.
-
-    The distant past is in terms of centuries.
-    */
+    /// A date value representing a date in the distant past.
+    ///
+    /// The distant past is in terms of centuries.
     public static let distantPast = Date(timeIntervalSinceReferenceDate: -63114076800.0)
 
-    /// Returns a `Date` initialized to the current date and time.
+    /// Returns a date instance that represents the current date and time, at the moment of access.
+    ///
+    /// This property is equivalent to calling ``Date/init()``. If you assign this value to a variable or property, the assigned value doesn't automatically update as time passes.
     @backDeployed(before: macOS 12, iOS 15, tvOS 15, watchOS 8)
     public static var now : Date { Date() }
 
@@ -171,7 +168,9 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
         hasher.combine(_time)
     }
 
-    /// Compare two `Date` values.
+    /// Compares another date to this one.
+    ///
+    /// - Parameter other: Another date.
     public func compare(_ other: Date) -> ComparisonResult {
         if _time < other.timeIntervalSinceReferenceDate {
             return .orderedAscending
@@ -197,7 +196,12 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
         return lhs.timeIntervalSinceReferenceDate > rhs.timeIntervalSinceReferenceDate
     }
 
-    /// Returns a `Date` with a specified amount of time added to it.
+    /// Returns a date with a specified amount of time added to it.
+    ///
+    /// - Parameters:
+    ///   - lhs: A date.
+    ///   - rhs: A ``TimeInterval`` to add to the date.
+    /// - Returns: A date with a specified amount of time added to it.
     public static func +(lhs: Date, rhs: TimeInterval) -> Date {
         return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate + rhs)
     }
@@ -207,9 +211,14 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
         return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate - rhs)
     }
 
-    /// Add a `TimeInterval` to a `Date`.
+    /// Adds a time interval to a date.
     ///
-    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    /// - Parameters:
+    ///   - lhs: A date.
+    ///   - rhs: A ``TimeInterval`` to add to the date.
+    ///
+    /// > Warning:
+    /// > This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. This takes into account complexities like daylight saving time, months with different numbers of days, and more.
     public static func +=(lhs: inout Date, rhs: TimeInterval) {
         lhs = lhs + rhs
     }
@@ -404,12 +413,23 @@ extension Date {
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Date {
+    /// A type alias to define the stride of a date.
+    ///
+    /// The stride of a Date is a ``TimeInterval``.
     public typealias Stride = TimeInterval
-    
+
+    /// Returns the distance from this date to another date, specified as a time interval.
+    ///
+    /// - Parameter other: Another date.
+    /// - Returns: The distance from this date to the other date, as a ``TimeInterval``.
     public func distance(to other: Date) -> TimeInterval {
         return other.timeIntervalSinceReferenceDate - self.timeIntervalSinceReferenceDate
     }
     
+    /// Returns a date offset the specified time interval from this date.
+    ///
+    /// - Parameter n: The time interval offset.
+    /// - Returns: A date offset the specified time interval from this date.
     public func advanced(by n: TimeInterval) -> Date {
         return self + n
     }

--- a/Sources/FoundationEssentials/DateInterval.swift
+++ b/Sources/FoundationEssentials/DateInterval.swift
@@ -10,7 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// DateInterval represents a closed date interval in the form of [startDate, endDate].  It is possible for the start and end dates to be the same with a duration of 0.  DateInterval does not support reverse intervals i.e. intervals where the duration is less than 0 and the end date occurs earlier in time than the start date.
+/// The span of time between a specific start date and end date.
+///
+/// `DateInterval` represents a closed date interval in the form of [startDate, endDate]. It is
+/// possible for the start and end dates to be the same with a duration of 0. `DateInterval` does
+/// not support reverse intervals i.e. intervals where the duration is less than 0 and the end date
+/// occurs earlier in time than the start date.
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 public struct DateInterval : Comparable, Hashable, Codable, Sendable {
 
@@ -19,7 +24,7 @@ public struct DateInterval : Comparable, Hashable, Codable, Sendable {
 
     /// The end date.
     ///
-    /// - precondition: `end >= start`
+    /// - Precondition: `end >= start`
     public var end : Date {
         get {
             return start + duration
@@ -32,60 +37,58 @@ public struct DateInterval : Comparable, Hashable, Codable, Sendable {
 
     /// The duration.
     ///
-    /// - precondition: `duration >= 0`
+    /// - Precondition: `duration >= 0`
     public var duration : TimeInterval {
         willSet {
             precondition(newValue >= 0, "Negative durations are not allowed")
         }
     }
 
-    /// Initializes a `DateInterval` with start and end dates set to the current date and the duration set to `0`.
+    /// Initializes an interval with start and end dates set to the current date and the duration set to `0`.
     public init() {
         let d = Date()
         start = d
         duration = 0
     }
 
-    /// Initialize a `DateInterval` with the specified start and end date.
+    /// Initializes an interval with the specified start and end date.
     ///
-    /// - precondition: `end >= start`
+    /// - Precondition: `end >= start`
     public init(start: Date, end: Date) {
         precondition(end >= start, "Reverse intervals are not allowed")
         self.start = start
         duration = end.timeIntervalSince(start)
     }
 
-    /// Initialize a `DateInterval` with the specified start date and duration.
+    /// Initializes an interval with the specified start date and duration.
     ///
-    /// - precondition: `duration >= 0`
+    /// - Precondition: `duration >= 0`
     public init(start: Date, duration: TimeInterval) {
         precondition(duration >= 0, "Negative durations are not allowed")
         self.start = start
         self.duration = duration
     }
 
-    /**
-     Compare two DateIntervals.
-
-     This method prioritizes ordering by start date. If the start dates are equal, then it will order by duration.
-     e.g. Given intervals a and b
-     ```
-     a.   |-----|
-     b.      |-----|
-     ```
-
-     `a.compare(b)` would return `.OrderedAscending` because a's start date is earlier in time than b's start date.
-
-     In the event that the start dates are equal, the compare method will attempt to order by duration.
-     e.g. Given intervals c and d
-     ```
-     c.  |-----|
-     d.  |---|
-     ```
-     `c.compare(d)` would result in `.OrderedDescending` because c is longer than d.
-
-     If both the start dates and the durations are equal, then the intervals are considered equal and `.OrderedSame` is returned as the result.
-    */
+    /// Compares two intervals.
+    ///
+    /// This method prioritizes ordering by start date. If the start dates are equal, then it will order by duration.
+    /// e.g. Given intervals a and b
+    /// ```
+    /// a.   |-----|
+    /// b.      |-----|
+    /// ```
+    ///
+    /// `a.compare(b)` would return `.orderedAscending` because a's start date is earlier in time than b's start date.
+    ///
+    /// In the event that the start dates are equal, the compare method will attempt to order by duration.
+    /// e.g. Given intervals c and d
+    /// ```
+    /// c.  |-----|
+    /// d.  |---|
+    /// ```
+    /// `c.compare(d)` would result in `.orderedDescending` because c is longer than d.
+    ///
+    /// If both the start dates and the durations are equal, then the intervals are considered equal and `.orderedSame` is returned as the result.
     public func compare(_ dateInterval: DateInterval) -> ComparisonResult {
         let result = start.compare(dateInterval.start)
         if result == .orderedSame {
@@ -96,14 +99,14 @@ public struct DateInterval : Comparable, Hashable, Codable, Sendable {
         return result
     }
 
-    /// Returns `true` if `self` intersects the `dateInterval`.
+    /// Indicates whether this interval intersects the specified interval.
     public func intersects(_ dateInterval: DateInterval) -> Bool {
         return contains(dateInterval.start) || contains(dateInterval.end) || dateInterval.contains(start) || dateInterval.contains(end)
     }
 
-    /// Returns a DateInterval that represents the interval where the given date interval and the current instance intersect.
+    /// Returns an interval that represents the interval where the given date interval and the current instance intersect.
     ///
-    /// In the event that there is no intersection, the method returns nil.
+    /// In the event that there is no intersection, the method returns `nil`.
     public func intersection(with dateInterval: DateInterval) -> DateInterval? {
         if !intersects(dateInterval) {
             return nil
@@ -137,7 +140,7 @@ public struct DateInterval : Comparable, Hashable, Codable, Sendable {
         return DateInterval(start: resultStartDate, end: resultEndDate)
     }
 
-    /// Returns `true` if `self` contains `date`.
+    /// Indicates whether this interval contains the given date.
     public func contains(_ date: Date) -> Bool {
         let timeIntervalForGivenDate = date.timeIntervalSinceReferenceDate
         let timeIntervalForSelfStart = start.timeIntervalSinceReferenceDate

--- a/Sources/FoundationEssentials/Decimal/Decimal+Compatibility.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Compatibility.swift
@@ -20,7 +20,9 @@ internal import _ForSwiftFoundation
 #if FOUNDATION_FRAMEWORK
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal {
+    /// An alias for a type that specifies possible rounding modes.
     public typealias RoundingMode = NSDecimalNumber.RoundingMode
+    /// An alias for a type that specifies possible calculation errors.
     public typealias CalculationError = NSDecimalNumber.CalculationError
 }
 
@@ -80,6 +82,12 @@ extension Decimal : _ObjectiveCBridgeable {
 // MARK: - Bridging code to C functions
 // We have one implementation function for each, and an entry point for both Darwin (cdecl, exported from the framework), and swift-corelibs-foundation (SPI here and available via that package as API)
 
+/// Returns a decimal number raised to a given power.
+///
+/// - Parameters:
+///   - x: The decimal number to raise to the power of `y`.
+///   - y: The power to raise `x` to.
+/// - Returns: The result of raising `x` to the power `y`. Returns `NaN` if the operation fails.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public func pow(_ x: Decimal, _ y: Int) -> Decimal {
     let result = try? x._power(

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -16,6 +16,11 @@ internal import _ForSwiftFoundation
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal : CustomStringConvertible {
+    /// Creates and initializes a decimal by parsing a string according to the provided locale's conventions.
+    ///
+    /// - Parameters:
+    ///   - string: A string containing a formatted decimal value.
+    ///   - locale: A locale that indicates the formatting conventions used by `string`.
     public init?(string: __shared String, locale: __shared Locale? = nil) {
         let decimalSeparator = locale?.decimalSeparator ?? "."
         guard case let .success(value, _) = Decimal._decimal(
@@ -37,6 +42,7 @@ extension Decimal : CustomStringConvertible {
 // FloatingPoint, even if we can't conform directly.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal /* : FloatingPoint */ {
+    /// The decimal that contains the smallest possible non-infinite magnitude for the underlying representation.
     public static let leastFiniteMagnitude = Decimal(
         _exponent: 127,
         _length: 8,
@@ -46,6 +52,7 @@ extension Decimal /* : FloatingPoint */ {
         _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
     )
 
+    /// The decimal that contains the largest possible non-infinite magnitude for the underlying representation.
     public static let greatestFiniteMagnitude = Decimal(
         _exponent: 127,
         _length: 8,
@@ -55,6 +62,7 @@ extension Decimal /* : FloatingPoint */ {
         _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
     )
 
+    /// The decimal value that represents the smallest possible normal magnitude for the underlying representation.
     public static let leastNormalMagnitude = Decimal(
         _exponent: -127,
         _length: 1,
@@ -64,6 +72,7 @@ extension Decimal /* : FloatingPoint */ {
         _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
     )
 
+    /// The decimal value that represents the smallest possible non-zero value for the underlying representation.
     public static let leastNonzeroMagnitude = Decimal(
         _exponent: -127,
         _length: 1,
@@ -73,6 +82,7 @@ extension Decimal /* : FloatingPoint */ {
         _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
     )
 
+    /// The mathematical constant pi.
     public static let pi = Decimal(
         _exponent: -38,
         _length: 8,
@@ -88,40 +98,50 @@ extension Decimal /* : FloatingPoint */ {
     @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
     public static var signalingNaN: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
 
+    /// A quiet representation of not-a-number.
     public static var quietNaN: Decimal {
         return Decimal(
             _exponent: 0, _length: 0, _isNegative: 1, _isCompact: 0,
             _reserved: 0, _mantissa: (0, 0, 0, 0, 0, 0, 0, 0))
     }
 
+    /// The value that represents "not a number."
     public static var nan: Decimal { quietNaN }
 
+    /// The radix used by decimal numbers.
     public static var radix: Int { 10 }
 
+    /// Creates and initializes a decimal with the provided unsigned integer value.
     public init(_ value: UInt8) {
         self.init(UInt64(value))
     }
 
+    /// Creates and initializes a decimal with the provided integer value.
     public init(_ value: Int8) {
         self.init(Int64(value))
     }
 
+    /// Creates and initializes a decimal with the provided unsigned integer value.
     public init(_ value: UInt16) {
         self.init(UInt64(value))
     }
 
+    /// Creates and initializes a decimal with the provided integer value.
     public init(_ value: Int16) {
         self.init(Int64(value))
     }
 
+    /// Creates and initializes a decimal with the provided unsigned integer value.
     public init(_ value: UInt32) {
         self.init(UInt64(value))
     }
 
+    /// Creates and initializes a decimal with the provided integer value.
     public init(_ value: Int32) {
         self.init(Int64(value))
     }
 
+    /// Creates and initializes a decimal with the provided unsigned integer value.
     public init(_ value: UInt64) {
         self = Decimal()
         if value == 0 {
@@ -145,6 +165,7 @@ extension Decimal /* : FloatingPoint */ {
         _mantissa.3 = UInt16(truncatingIfNeeded: compactValue >> 48)
     }
 
+    /// Creates and initializes a decimal with the provided integer value.
     public init(_ value: Int64) {
         self = .init(value.magnitude)
         if value < 0 {
@@ -152,14 +173,17 @@ extension Decimal /* : FloatingPoint */ {
         }
     }
 
+    /// Creates and initializes a decimal with the provided unsigned integer value.
     public init(_ value: UInt) {
         self.init(UInt64(value))
     }
 
+    /// Creates and initializes a decimal with the provided integer value.
     public init(_ value: Int) {
         self.init(Int64(value))
     }
 
+    /// Creates and initializes a decimal with the provided floating point value.
     public init(_ value: Double) {
         precondition(!value.isInfinite, "Decimal does not yet fully adopt FloatingPoint")
         if value.isNaN {
@@ -235,6 +259,7 @@ extension Decimal /* : FloatingPoint */ {
         }
     }
 
+    /// Creates a decimal initialized with the given sign, exponent, and significand.
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
 #if FOUNDATION_FRAMEWORK
         // Compatibility path
@@ -271,6 +296,11 @@ extension Decimal /* : FloatingPoint */ {
         }
     }
 
+    /// Creates and initializes a decimal with the sign and magnitude of the given decimals.
+    ///
+    /// - Parameters:
+    ///   - signOf: A `Decimal` to use for the sign of the newly-created `Decimal`.
+    ///   - magnitude: A `Decimal` to use for the magnitude of the newly-created `Decimal`.
     public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {
         self.init(
             _exponent: magnitude._exponent,
@@ -281,20 +311,24 @@ extension Decimal /* : FloatingPoint */ {
             _mantissa: magnitude._mantissa)
     }
 
+    /// The exponent of the decimal.
     public var exponent: Int {
         return Int(_exponent)
     }
 
+    /// The significand of the decimal.
     public var significand: Decimal {
         return Decimal(
             _exponent: 0, _length: _length, _isNegative: 0, _isCompact: _isCompact,
             _reserved: 0, _mantissa: _mantissa)
     }
 
+    /// The sign of the decimal.
     public var sign: FloatingPointSign {
         return _isNegative == 0 ? FloatingPointSign.plus : FloatingPointSign.minus
     }
 
+    /// The unit in the last place of the decimal.
     public var ulp: Decimal {
         guard isFinite else { return .nan }
 
@@ -313,7 +347,7 @@ extension Decimal /* : FloatingPoint */ {
             _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
 
-    /// The IEEE 754 "class" of this type.
+    /// The IEEE 754 class of this type.
     public var floatingPointClass: FloatingPointClassification {
         if _length == 0 && _isNegative == 1 {
             return .quietNaN
@@ -330,40 +364,44 @@ extension Decimal /* : FloatingPoint */ {
         }
     }
 
+    /// A Boolean value indicating whether the representation of this decimal is canonical.
     public var isCanonical: Bool { true }
 
-    /// `true` if `self` is negative, `false` otherwise.
+    /// A Boolean value indicating whether this decimal has a negative sign.
+    ///
+    /// This property is `true` when the value is negative or `-0.0`; otherwise, `false`.
     public var isSignMinus: Bool { _isNegative != 0 }
 
-    /// `true` if `self` is +0.0 or -0.0, `false` otherwise.
+    /// A Boolean value indicating whether this value is zero.
+    ///
+    /// This property is `true` for `-0.0` and `+0.0` and `false` for all other values.
     public var isZero: Bool { _length == 0 && _isNegative == 0 }
 
-    /// `true` if `self` is subnormal, `false` otherwise.
+    /// A Boolean value indicating whether this decimal is subnormal.
     public var isSubnormal: Bool { false }
 
-    /// `true` if `self` is normal (not zero, subnormal, infinity, or NaN),
-    /// `false` otherwise.
+    /// A Boolean value indicating whether this decimal is normal (not zero, subnormal, infinity, or NaN).
     public var isNormal: Bool { !isZero && !isInfinite && !isNaN }
 
-    /// `true` if `self` is zero, subnormal, or normal (not infinity or NaN),
-    /// `false` otherwise.
+    /// A Boolean value indicating whether this decimal is zero, subnormal, or normal (not infinity or NaN).
     public var isFinite: Bool { !isNaN }
 
-    /// `true` if `self` is infinity, `false` otherwise.
+    /// A Boolean value indicating whether this decimal is infinity.
     public var isInfinite: Bool { false }
 
-    /// `true` if `self` is NaN, `false` otherwise.
+    /// A Boolean value indicating whether this decimal is NaN.
     public var isNaN: Bool { _length == 0 && _isNegative == 1 }
 
-    /// `true` if `self` is a signaling NaN, `false` otherwise.
+    /// A Boolean value indicating whether this decimal is a signaling NaN.
     public var isSignaling: Bool { false }
 
-    /// `true` if `self` is a signaling NaN, `false` otherwise.
+    /// A Boolean value indicating whether this decimal is a signaling NaN.
     public var isSignalingNaN: Bool { false }
 
     @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
     public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not yet fully adopt FloatingPoint") }
 
+    /// The least representable value that is greater than this decimal.
     public var nextUp: Decimal {
         if _isNegative == 1 {
             if _exponent > -128 &&
@@ -395,23 +433,28 @@ extension Decimal /* : FloatingPoint */ {
         return self + ulp
     }
 
+    /// The greatest representable value that is less than this decimal.
     public var nextDown: Decimal {
         return -(-self).nextUp
     }
 
+    /// Indicates whether this decimal is equal to the specified one.
     public func isEqual(to other: Decimal) -> Bool {
         return self == other
     }
 
+    /// Indicates whether this decimal is less than the specified one.
     public func isLess(than other: Decimal) -> Bool {
         return Decimal._compare(lhs: self, rhs: other) == .orderedAscending
     }
 
+    /// Indicates whether this decimal is less than or equal to the specified one.
     public func isLessThanOrEqualTo(_ other: Decimal) -> Bool {
         let order = Decimal._compare(lhs: self, rhs: other)
         return order == .orderedAscending || order == .orderedSame
     }
 
+    /// Returns a Boolean value indicating whether this instance should precede the given value in an ascending sort.
     public func isTotallyOrdered(belowOrEqualTo other: Decimal) -> Bool {
         // Note: Decimal does not have -0 or infinities to worry about
         if self.isNaN {
@@ -430,6 +473,7 @@ extension Decimal /* : FloatingPoint */ {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal : ExpressibleByFloatLiteral {
+    /// Creates and initializes a decimal with the provided floating point value.
     public init(floatLiteral value: Double) {
         self.init(value)
     }
@@ -437,6 +481,7 @@ extension Decimal : ExpressibleByFloatLiteral {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal : ExpressibleByIntegerLiteral {
+    /// Creates and initializes a decimal with the provided integer value.
     public init(integerLiteral value: Int) {
         self.init(value)
     }
@@ -587,6 +632,7 @@ extension Decimal : Codable {
 // MARK: - SignedNumeric
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal : SignedNumeric {
+    /// The magnitude of this decimal.
     public var magnitude: Decimal {
         guard _length != 0 else { return self }
         return Decimal(
@@ -595,6 +641,11 @@ extension Decimal : SignedNumeric {
             _reserved: 0, _mantissa: self._mantissa)
     }
 
+    /// Creates a new decimal value exactly representing the provided integer.
+    ///
+    /// If `source` isn't representable as a `Decimal` instance, the result is `nil`.
+    ///
+    /// - Parameter source: The integer to convert.
     public init?<T : BinaryInteger>(exactly source: T) {
         let zero = 0 as T
 
@@ -650,6 +701,16 @@ extension Decimal : SignedNumeric {
     }
 #endif
 
+    /// Adds two decimal numbers, storing the result in the first number.
+    ///
+    /// If the result of this operation requires more precision than the `Decimal`
+    /// type can provide, the result is rounded using the
+    /// ``NSDecimalNumber/RoundingMode/plain`` rounding mode. To specify a different
+    /// rounding mode, use the ``NSDecimalAdd(_:_:_:_:)`` function instead.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to add.
+    ///   - rhs: Another value to add.
     public static func +=(lhs: inout Decimal, rhs: Decimal) {
         do {
             let result = try lhs._add(rhs: rhs, roundingMode: .plain)
@@ -659,6 +720,16 @@ extension Decimal : SignedNumeric {
         }
     }
 
+    /// Subtracts one decimal number from another, storing the result in the first number.
+    ///
+    /// If the result of this operation requires more precision than the `Decimal`
+    /// type can provide, the result is rounded using the
+    /// ``NSDecimalNumber/RoundingMode/plain`` rounding mode. To specify a different
+    /// rounding mode, use the ``NSDecimalSubtract(_:_:_:_:)`` function instead.
+    ///
+    /// - Parameters:
+    ///   - lhs: The value to subtract from.
+    ///   - rhs: The value to subtract.
     public static func -=(lhs: inout Decimal, rhs: Decimal) {
         do {
             let result = try lhs._subtract(rhs: rhs, roundingMode: .plain)
@@ -668,6 +739,16 @@ extension Decimal : SignedNumeric {
         }
     }
 
+    /// Multiplies two decimal numbers, storing the result in the first number.
+    ///
+    /// If the result of this operation requires more precision than the `Decimal`
+    /// type can provide, the result is rounded using the
+    /// ``NSDecimalNumber/RoundingMode/plain`` rounding mode. To specify a different
+    /// rounding mode, use the ``NSDecimalMultiply(_:_:_:_:)`` function instead.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to multiply.
+    ///   - rhs: Another value to multiply.
     public static func *=(lhs: inout Decimal, rhs: Decimal) {
         do {
             let result = try lhs._multiply(by: rhs, roundingMode: .plain)
@@ -677,6 +758,16 @@ extension Decimal : SignedNumeric {
         }
     }
 
+    /// Divides one decimal number by another, storing the result in the first number.
+    ///
+    /// If the result of this operation requires more precision than the `Decimal`
+    /// type can provide, the result is rounded using the
+    /// ``NSDecimalNumber/RoundingMode/plain`` rounding mode. To specify a different
+    /// rounding mode, use the ``NSDecimalDivide(_:_:_:_:)`` function instead.
+    ///
+    /// - Parameters:
+    ///   - lhs: The value to divide.
+    ///   - rhs: The value to divide `lhs` by.
     public static func /=(lhs: inout Decimal, rhs: Decimal) {
         do {
             let result = try lhs._divide(by: rhs, roundingMode: .plain)
@@ -686,30 +777,75 @@ extension Decimal : SignedNumeric {
         }
     }
 
+    /// Adds two decimal numbers.
+    ///
+    /// If the result of this operation requires more precision than the `Decimal`
+    /// type can provide, the result is rounded using the
+    /// ``NSDecimalNumber/RoundingMode/plain`` rounding mode. To specify a different
+    /// rounding mode, use the ``NSDecimalAdd(_:_:_:_:)`` function instead.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to add.
+    ///   - rhs: Another value to add.
+    /// - Returns: The result of adding `lhs` and `rhs`.
     public static func +(lhs: Decimal, rhs: Decimal) -> Decimal {
         var answer = lhs
         answer += rhs
         return answer
     }
 
+    /// Subtracts one decimal number from another.
+    ///
+    /// If the result of this operation requires more precision than the `Decimal`
+    /// type can provide, the result is rounded using the
+    /// ``NSDecimalNumber/RoundingMode/plain`` rounding mode. To specify a different
+    /// rounding mode, use the ``NSDecimalSubtract(_:_:_:_:)`` function instead.
+    ///
+    /// - Parameters:
+    ///   - lhs: The value to subtract from.
+    ///   - rhs: The value to subtract.
+    /// - Returns: The result of subtracting `rhs` from `lhs`.
     public static func -(lhs: Decimal, rhs: Decimal) -> Decimal {
         var answer = lhs
         answer -= rhs
         return answer
     }
 
+    /// Multiplies two decimal numbers.
+    ///
+    /// If the result of this operation requires more precision than the `Decimal`
+    /// type can provide, the result is rounded using the
+    /// ``NSDecimalNumber/RoundingMode/plain`` rounding mode. To specify a different
+    /// rounding mode, use the ``NSDecimalMultiply(_:_:_:_:)`` function instead.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to multiply.
+    ///   - rhs: Another value to multiply.
+    /// - Returns: The result of multiplying `lhs` by `rhs`.
     public static func *(lhs: Decimal, rhs: Decimal) -> Decimal {
         var answer = lhs
         answer *= rhs
         return answer
     }
 
+    /// Divides one decimal number by another.
+    ///
+    /// If the result of this operation requires more precision than the `Decimal`
+    /// type can provide, the result is rounded using the
+    /// ``NSDecimalNumber/RoundingMode/plain`` rounding mode. To specify a different
+    /// rounding mode, use the ``NSDecimalDivide(_:_:_:_:)`` function instead.
+    ///
+    /// - Parameters:
+    ///   - lhs: The value to divide.
+    ///   - rhs: The value to divide `lhs` by.
+    /// - Returns: The result of dividing `lhs` by `rhs`.
     public static func /(lhs: Decimal, rhs: Decimal) -> Decimal {
         var answer = lhs
         answer /= rhs
         return answer
     }
 
+    /// Negates this decimal.
     public mutating func negate() {
         guard self._length != 0 else { return }
         self._isNegative = self._isNegative == 0 ? 1 : 0
@@ -718,10 +854,12 @@ extension Decimal : SignedNumeric {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal : Strideable {
+    /// Returns the distance from this value to the specified value.
     public func distance(to other: Decimal) -> Decimal {
         return other - self
     }
 
+    /// Returns a new value advanced by the given distance.
     public func advanced(by n: Decimal) -> Decimal {
         return self + n
     }

--- a/Sources/FoundationEssentials/Decimal/Decimal.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal.swift
@@ -20,6 +20,7 @@ import ucrt
 
 #if !FOUNDATION_FRAMEWORK
 
+/// A structure representing a base-10 number.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct Decimal: Sendable {
     @_spi(SwiftCorelibsFoundation)
@@ -150,6 +151,7 @@ public struct Decimal: Sendable {
         self = d
     }
 
+    /// Creates a decimal initialized to `0`.
     public init() {
         self.storage = .init(
             exponent: 0,
@@ -161,6 +163,7 @@ public struct Decimal: Sendable {
 }
 
 extension Decimal {
+    /// An enumeration that specifies possible rounding modes.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public enum RoundingMode: UInt, Sendable {
         case plain
@@ -169,6 +172,7 @@ extension Decimal {
         case bankers
     }
 
+    /// An enumeration that specifies possible calculation errors.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public enum CalculationError: UInt, Sendable {
         case noError

--- a/Sources/FoundationEssentials/Error/CocoaError.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError.swift
@@ -184,8 +184,7 @@ extension CocoaError {
 #endif
 }
 
-/// Describes an error that provides localized messages describing why
-/// an error occurred and provides more information about the error.
+/// A specialized error that provides localized messages describing the error and why it occurred.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public protocol LocalizedError : Error {
     /// A localized message describing what error occurred.
@@ -211,8 +210,7 @@ public extension LocalizedError {
 
 #if FOUNDATION_FRAMEWORK
 
-/// Describes an error type that specifically provides a domain, code,
-/// and user-info dictionary.
+/// A specialized error that provides a domain, error code, and user-info dictionary.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public protocol CustomNSError : Error {
     /// The domain of the error.

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
@@ -14,73 +14,127 @@
 
 internal import Synchronization
 
+    /// Values representing a file's type attribute.
+    ///
+    /// ## Discussion
+    ///
+    /// These strings are the possible values for the ``FileAttributeKey/type`` attribute key contained in the dictionary object returned by ``FileManager/attributesOfItem(atPath:)``.
 public struct FileAttributeType : Hashable, RawRepresentable, Sendable {
     public let rawValue: String
+    /// Creates a file attribute type value.
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    
+
     public init(_ rawValue: String) {
         self.rawValue = rawValue
     }
-    
+
+    /// A block special file.
     public static let typeBlockSpecial: Self = Self("NSFileTypeBlockSpecial")
+    /// A character special file.
     public static let typeCharacterSpecial: Self = Self("NSFileTypeCharacterSpecial")
+    /// A directory.
     public static let typeDirectory: Self = Self("NSFileTypeDirectory")
+    /// A regular file.
     public static let typeRegular: Self = Self("NSFileTypeRegular")
+    /// A socket.
     public static let typeSocket: Self = Self("NSFileTypeSocket")
+    /// A symbolic link.
     public static let typeSymbolicLink: Self = Self("NSFileTypeSymbolicLink")
+    /// A file whose type is unknown.
     public static let typeUnknown: Self = Self("NSFileTypeUnknown")
 }
 
+/// Keys in dictionaries used to get and set file attributes.
+///
+/// ## Discussion
+///
+/// These keys are used with the methods listed in the Getting and Setting Attributes topic of ``FileManager``.
 public struct FileAttributeKey: Hashable, RawRepresentable, Sendable {
     public typealias RawValue = String
     public let rawValue: String
-    
+
+    /// Creates a file attribute key.
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    
+
+    /// Creates a file attribute key.
     public init(_ rawValue: String) {
         self.rawValue = rawValue
     }
-    
+
+    /// The key in a file attribute dictionary whose value indicates the file's type.
     public static let type = Self(rawValue: "NSFileType")
+    /// The key in a file attribute dictionary whose value indicates the file's size in bytes.
     public static let size = Self(rawValue: "NSFileSize")
+    /// The key in a file attribute dictionary whose value indicates the file's last modified date.
     public static let modificationDate = Self(rawValue: "NSFileModificationDate")
+    /// The key in a file attribute dictionary whose value indicates the file's reference count.
     public static let referenceCount = Self(rawValue: "NSFileCount")
+    /// The key in a file attribute dictionary whose value indicates the identifier for the device on which the file resides.
     public static let deviceIdentifier = Self(rawValue: "NSFileDeviceIdentifier")
+    /// The key in a file attribute dictionary whose value indicates the name of the file's owner.
     public static let ownerAccountName = Self(rawValue: "NSFileOwnerAccountName")
+    /// The key in a file attribute dictionary whose value indicates the group name of the file's owner.
     public static let groupOwnerAccountName = Self(rawValue: "NSFileGroupOwnerAccountName")
+    /// The key in a file attribute dictionary whose value indicates the file's Posix permissions.
     public static let posixPermissions = Self(rawValue: "NSFilePosixPermissions")
+    /// The key in a file attribute dictionary whose value indicates the filesystem number of the file system.
     public static let systemNumber = Self(rawValue: "NSFileSystemNumber")
+    /// The key in a file attribute dictionary whose value indicates the file's filesystem file number.
     public static let systemFileNumber = Self(rawValue: "NSFileSystemFileNumber")
+    /// The key in a file attribute dictionary whose value indicates whether the file's extension is hidden.
     public static let extensionHidden = Self(rawValue: "NSFileExtensionHidden")
+    /// The key in a file attribute dictionary whose value indicates the file's HFS creator code.
     public static let hfsCreatorCode = Self(rawValue: "NSFileHFSCreatorCode")
+    /// The key in a file attribute dictionary whose value indicates the file's HFS type code.
     public static let hfsTypeCode = Self(rawValue: "NSFileHFSTypeCode")
+    /// The key in a file attribute dictionary whose value indicates whether the file is mutable.
     public static let immutable = Self(rawValue: "NSFileImmutable")
+    /// The key in a file attribute dictionary whose value indicates whether the file is read-only.
     public static let appendOnly = Self(rawValue: "NSFileAppendOnly")
+    /// The key in a file attribute dictionary whose value indicates the file's creation date.
     public static let creationDate = Self(rawValue: "NSFileCreationDate")
+    /// The key in a file attribute dictionary whose value indicates the file's owner's account ID.
     public static let ownerAccountID = Self(rawValue: "NSFileOwnerAccountID")
+    /// The key in a file attribute dictionary whose value indicates the file's group ID.
     public static let groupOwnerAccountID = Self(rawValue: "NSFileGroupOwnerAccountID")
+    /// The key in a file attribute dictionary whose value indicates whether the file is busy.
     public static let busy = Self(rawValue: "NSFileBusy")
+    /// The key in a file attribute dictionary whose value identifies the protection level for this file.
     public static let protectionKey = Self(rawValue: "NSFileProtectionKey")
+    /// The key in a file attribute dictionary whose value indicates the size of the file system.
     public static let systemSize = Self(rawValue: "NSFileSystemSize")
+    /// The key in a file attribute dictionary whose value indicates the amount of free space on the file system.
     public static let systemFreeSize = Self(rawValue: "NSFileSystemFreeSize")
+    /// The key in a file attribute dictionary whose value indicates the number of nodes in the file system.
     public static let systemNodes = Self(rawValue: "NSFileSystemNodes")
+    /// The key in a file attribute dictionary whose value indicates the number of free nodes in the file system.
     public static let systemFreeNodes = Self(rawValue: "NSFileSystemFreeNodes")
 }
 
+/// Protection level values that can be associated with a file attribute key.
+///
+/// These values are associated with the ``FileAttributeKey/protectionKey`` key.
 public struct FileProtectionType : RawRepresentable, Sendable {
     public let rawValue: String
-    
+
+    /// Creates a file protection type value.
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    
+
+    /// The file has no special protections associated with it.
     public static let none = Self(rawValue: "NSFileProtectionNone")
+    /// The file is stored in an encrypted format on disk and cannot be read
+    /// from or written to while the device is locked or booting.
     public static let complete = Self(rawValue: "NSFileProtectionComplete")
+    /// The file is stored in an encrypted format on disk after it is closed.
     public static let completeUnlessOpen = Self(rawValue: "NSFileProtectionCompleteUnlessOpen")
+    /// The file is stored in an encrypted format on disk and cannot be
+    /// accessed until after the device has booted.
     public static let completeUntilFirstUserAuthentication = Self(rawValue: "NSFileProtectionCompleteUntilFirstUserAuthentication")
     public static let inactive = Self(rawValue: "NSFileProtectionCompleteWhenUserInactive")
 }

--- a/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
@@ -12,6 +12,12 @@
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
+    /// Generates a locale-aware string representation of a date using the ISO 8601 date format.
+    ///
+    /// Calling this method is equivalent to passing a ``Date/ISO8601FormatStyle`` to a date's ``Date/formatted()`` method.
+    ///
+    /// - Parameter style: A customized ``Date/ISO8601FormatStyle`` to apply. By default, the method applies an unmodified ISO 8601 format style.
+    /// - Returns: A string, formatted according to the specified style.
     public func ISO8601Format(_ style: ISO8601FormatStyle = .init()) -> String {
         return style.format(self)
     }
@@ -19,25 +25,63 @@ extension Date {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
-    /// Options for generating and parsing string representations of dates following the ISO 8601 standard.
+    /// A type that converts between dates and their ISO-8601 string representations.
+    ///
+    /// The ``Date/ISO8601FormatStyle`` type generates and parses string representations of dates following the [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) standard, like `2024-04-01T12:34:56.789Z`. Use this type to create ISO-8601 representations of dates and create dates from text strings in ISO 8601 format. For other formatting conventions, like human-readable, localized date formats, use ``Date/FormatStyle``.
+    ///
+    /// Instance modifier methods applied to an ISO-8601 format style customize the formatted output, as the following example illustrates.
+    ///
+    /// ```swift
+    /// let now = Date()
+    /// print(now.formatted(Date.ISO8601FormatStyle().dateSeparator(.dash)))
+    /// // 2021-06-21T211015Z
+    /// ```
+    ///
+    ///
+    /// Use the static factory property ``FormatStyle/iso8601`` to create an instance of ``Date/ISO8601FormatStyle``. Then apply instance modifier methods to customize the format, as in the example below.
+    ///
+    /// ```swift
+    /// let meetNow = Date()
+    /// let formatted = meetNow.formatted(.iso8601
+    /// .year()
+    /// .month()
+    /// .day()
+    /// .timeZone(separator: .omitted)
+    /// .time(includingFractionalSeconds: true)
+    /// .timeSeparator(.colon)
+    /// ) // "2022-06-10T12:34:56.789Z"
+    ///
+    /// ```
     public struct ISO8601FormatStyle : Sendable {
+        /// A type describing the character separating the time and time zone of a date in an ISO 8601 date format.
         public enum TimeZoneSeparator : String, Codable, Sendable {
+            /// Use a colon (`:`) to separate the time zone components.
             case colon = ":"
+            /// Omit the time zone separator.
             case omitted = ""
         }
 
+        /// A type describing the character separating year, month, and day components of a date in an ISO 8601 date format.
         public enum DateSeparator : String, Codable, Sendable {
+            /// Use a dash (`-`) to separate date components.
             case dash = "-"
+            /// Omit the date separator.
             case omitted = ""
         }
 
+        /// Type describing the character separating the time components of a date in an ISO 8601 date format.
         public enum TimeSeparator : String, Codable, Sendable {
+            /// Use a colon (`:`) to separate time components.
             case colon = ":"
+            /// Omit the time separator.
             case omitted = ""
         }
 
+        /// Type describing the character separating the date and time components of a date in an ISO 8601 date format.
         public enum DateTimeSeparator : String, Codable, Sendable {
+            /// Use a space to separate the date and time components.
             case space = " "
+            /// Use the standard `T` separator between date and time components.
             case standard = "'T'"
         }
         
@@ -70,6 +114,7 @@ extension Date {
                 componentsFormatStyle.timeZoneSeparator = newValue
             }
         }
+        /// The character used to separate the components of a date.
         public private(set) var dateSeparator: DateSeparator  {
             get {
                 componentsFormatStyle.dateSeparator
@@ -79,6 +124,7 @@ extension Date {
             }
         }
         
+        /// The character used to separate the date and time components of an ISO 8601 string representation of a date.
         public private(set) var dateTimeSeparator: DateTimeSeparator {
             get {
                 componentsFormatStyle.dateTimeSeparator
@@ -130,6 +176,26 @@ extension Date {
         
         // MARK: -
 
+        /// Creates an instance using the provided date separator, date and time components separator, and time zone.
+        ///
+        /// Possible values of `dateSeparator` are `dash` and `omitted`.
+        /// Possible values of `dateTimeSeparator` are `space` and `standard`.
+        ///
+        /// ```swift
+        /// let aDate = Date()
+        /// print(aDate.formatted(Date.ISO8601FormatStyle(dateSeparator: .omitted, dateTimeSeparator: .standard)))
+        /// // 20210622T172132Z
+        ///
+        /// if let centralStandardTimeZone = TimeZone(identifier: "CST") {
+        ///    print(aDate.formatted(Date.ISO8601FormatStyle(dateSeparator: .dash, dateTimeSeparator: .space, timeZone: centralStandardTimeZone)))
+        /// }
+        /// // 2021-06-22 122132-0500
+        /// ```
+        ///
+        /// - Parameters:
+        ///   - dateSeparator: The separator character used between the year, month, and day.
+        ///   - dateTimeSeparator: The separator character used between the date and time components.
+        ///   - timeZone: The time zone used to create the string representation of the date.
         @_disfavoredOverload
         public init(dateSeparator: DateSeparator = .dash, dateTimeSeparator: DateTimeSeparator = .standard, timeZone: TimeZone = TimeZone(secondsFromGMT: 0)!) {
             componentsFormatStyle = DateComponents.ISO8601FormatStyle(dateSeparator: dateSeparator, dateTimeSeparator: dateTimeSeparator, timeZone: timeZone)
@@ -144,42 +210,104 @@ extension Date {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.ISO8601FormatStyle {
+    /// Modifies the ISO 8601 date format style to include the year in the formatted output.
+    ///
+    /// The default ``Date/ISO8601FormatStyle`` includes the year.
+    ///
+    /// - Returns: An ISO 8601 date format style modified to include the year.
     public func year() -> Self {
         .init(componentsFormatStyle.year())
     }
 
+    /// Modifies the ISO 8601 date format style to include the week of the year in the formatted output.
+    ///
+    /// When the format style includes the week of year, the output represents the day
+    /// as the ordinal day of the week.
+    ///
+    /// - Returns: An ISO 8601 date format style modified to include the week of the year.
     public func weekOfYear() -> Self {
         .init(componentsFormatStyle.weekOfYear())
     }
 
+    /// Modifies the ISO 8601 date format style to include the month in the formatted output.
+    ///
+    /// If `month()` isn't included in the format but `day()` is, the format represents
+    /// the day as the ordinal date. The default ``Date/ISO8601FormatStyle`` includes the month.
+    ///
+    /// - Returns: An ISO 8601 date format style modified to include the month.
     public func month() -> Self {
         .init(componentsFormatStyle.month())
     }
 
+    /// Modifies the ISO 8601 date format style to include the day in the formatted output.
+    ///
+    /// If `month()` isn't included in the format and `day()` is, the format represents
+    /// the day as the ordinal date. The default ``Date/ISO8601FormatStyle`` includes the day.
+    ///
+    /// - Returns: An ISO 8601 date format style modified to include the day.
     public func day() -> Self {
         .init(componentsFormatStyle.day())
     }
 
+    /// Modifies the ISO 8601 date format style to include the time in the formatted output.
+    ///
+    /// The default ``Date/ISO8601FormatStyle`` includes the time but not the fractional seconds.
+    ///
+    /// - Parameter includingFractionalSeconds: Specifies whether the format style includes the fractional component of the seconds.
+    /// - Returns: An ISO 8601 date format style modified to include the time.
     public func time(includingFractionalSeconds: Bool) -> Self {
         .init(componentsFormatStyle.time(includingFractionalSeconds: includingFractionalSeconds))
     }
 
+    /// Modifies the ISO 8601 date format style to include the time zone in the formatted output.
+    ///
+    /// The default ``Date/ISO8601FormatStyle`` doesn't include the time zone.
+    ///
+    /// - Parameter separator: The character used to separate the time and time zone in a date.
+    /// - Returns: An ISO 8601 date format style modified to include the time zone.
     public func timeZone(separator: TimeZoneSeparator) -> Self {
         .init(componentsFormatStyle.timeZone(separator: separator))
     }
 
+    /// Modifies the ISO 8601 date format style to use the specified date separator.
+    ///
+    /// Possible values are ``DateSeparator/dash`` and ``DateSeparator/omitted``.
+    /// The default is ``DateSeparator/omitted``.
+    ///
+    /// - Parameter separator: The character used to separate the year, month, and day in a date.
+    /// - Returns: An ISO 8601 date format style modified to include the specified date separator style.
     public func dateSeparator(_ separator: DateSeparator) -> Self {
         .init(componentsFormatStyle.dateSeparator(separator))
     }
 
+    /// Sets the character that separates the date and time components.
+    ///
+    /// Possible values are ``DateTimeSeparator/space`` and ``DateTimeSeparator/standard``.
+    /// The default is ``DateTimeSeparator/standard``.
+    ///
+    /// - Parameter separator: The character used to separate the date and time components.
+    /// - Returns: An ISO 8601 date format style with the provided date and time component separator.
     public func dateTimeSeparator(_ separator: DateTimeSeparator) -> Self {
         .init(componentsFormatStyle.dateTimeSeparator(separator))
     }
 
+    /// Modifies the ISO 8601 date format style to use the specified time separator.
+    ///
+    /// Possible values are ``TimeSeparator/colon`` and ``TimeSeparator/omitted``.
+    /// The default is ``TimeSeparator/omitted``.
+    ///
+    /// - Parameter separator: The character used to separate the hour and minute in a date.
+    /// - Returns: An ISO 8601 date format style modified to include the specified time separator style.
     public func timeSeparator(_ separator: TimeSeparator) -> Self {
         .init(componentsFormatStyle.timeSeparator(separator))
     }
 
+    /// Modifies the ISO 8601 date format style to use the specified time zone separator.
+    ///
+    /// Possible values are ``TimeZoneSeparator/colon`` and ``TimeZoneSeparator/omitted``.
+    ///
+    /// - Parameter separator: The character used to separate the time and time zone in a date.
+    /// - Returns: An ISO 8601 date format style modified to include the specified time zone separator style.
     public func timeZoneSeparator(_ separator: TimeZoneSeparator) -> Self {
         .init(componentsFormatStyle.timeZoneSeparator(separator))
     }    
@@ -188,6 +316,12 @@ extension Date.ISO8601FormatStyle {
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.ISO8601FormatStyle : FormatStyle {
 
+    /// Creates a locale-aware ISO 8601 string representation from a date value.
+    ///
+    /// Once you create a style, you can use it to format dates multiple times.
+    ///
+    /// - Parameter value: The date to format.
+    /// - Returns: A string ISO 8601 representation of the date.
     public func format(_ value: Date) -> String {
         var whichComponents = Calendar.ComponentSet()
         let fields = componentsFormatStyle.formatFields
@@ -258,6 +392,11 @@ public extension ParseableFormatStyle where Self == Date.ISO8601FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension ParseStrategy where Self == Date.ISO8601FormatStyle {
+    /// A style for formatting a date in accordance with the ISO-8601 standard.
+    ///
+    /// Use the dot-notation form of this type property when the call point allows the use of
+    /// ``Date/ISO8601FormatStyle``; in other words, when the value type is `Date`. Typically, you
+    /// use this with the ``Date/formatted(_:)`` method of `Date`.
     @_disfavoredOverload
     static var iso8601: Self { .init() }
 }
@@ -265,6 +404,28 @@ public extension ParseStrategy where Self == Date.ISO8601FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.ISO8601FormatStyle : ParseStrategy {
+    /// Parses a string into a date.
+    ///
+    /// This method attempts to parse a provided string into an instance of
+    /// date using the source date format style. The function throws an error
+    /// if it can't parse the input string into a date instance.
+    ///
+    /// ```swift
+    /// let birthdayFormatStyle = Date.ISO8601FormatStyle()
+    ///     .dateSeparator(.dash)
+    ///     .timeSeparator(.colon)
+    ///     .year()
+    ///     .month()
+    ///     .day()
+    ///     .time(includingFractionalSeconds: false)
+    ///
+    /// let yourBirthdayString = "2021-02-17T14:33:25"
+    /// let yourBirthday = try? birthdayFormatStyle.parse(yourBirthdayString)
+    /// // Feb 17, 2021 at 8:33 AM
+    /// ```
+    ///
+    /// - Parameter value: The string to parse.
+    /// - Returns: An instance of `Date` parsed from the input string.
     public func parse(_ value: String) throws -> Date {
         guard let (_, date) = parse(value, in: value.startIndex..<value.endIndex) else {
             throw parseError(value, exampleFormattedString: self.format(Date.now))
@@ -293,6 +454,7 @@ extension Date.ISO8601FormatStyle : ParseStrategy {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.ISO8601FormatStyle: ParseableFormatStyle {
+    /// The strategy used to parse a string into a date.
     public var parseStrategy: Self {
         return self
     }
@@ -302,7 +464,18 @@ extension Date.ISO8601FormatStyle: ParseableFormatStyle {
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension Date.ISO8601FormatStyle : CustomConsumingRegexComponent {
+    /// The type returned when capturing matching substrings with this strategy.
     public typealias RegexOutput = Date
+    /// Processes the input string within the specified bounds, beginning at the given index, and returns the end position of the match and the produced output.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture
+    /// calls it automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Date)? {
         guard index < bounds.upperBound else {
             return nil

--- a/Sources/FoundationEssentials/Formatting/FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/FormatStyle.swift
@@ -10,20 +10,136 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type that can convert a given data type into a representation.
+/// A type that converts a given data type into a representation in another type, such as a string.
+///
+/// Types conforming to the `FormatStyle` protocol take their input type and produce formatted
+/// instances of their output type. The formatting process accounts for locale-specific conventions,
+/// like grouping and separators for numbers, and presentation of units for measurements. The format
+/// styles Foundation provides produce their output as `String` or `AttributedString` instances. You
+/// can also create custom styles that format their output as any type, like XML or JSON `Data` or
+/// an image.
+///
+/// There are two basic approaches to using a `FormatStyle`:
+///
+/// - Create an instance of a type that conforms to `FormatStyle` and apply it to one or more
+///   instances of the input type, by calling the style's ``format(_:)`` method. Use this when you
+///   want to customize a style once and apply it repeatedly to many instances.
+/// - Pass an instance of a type that conforms to `FormatStyle` to the data type's `formatted(_:)`
+///   method, which takes the style as a parameter. Use this for one-off formatting scenarios, or
+///   when you want to apply different format styles to the same data value. For the simplest cases,
+///   most types that support formatting also have a no-argument `formatted()` method that applies a
+///   locale-appropriate default format style.
+///
+/// Foundation provides format styles for integers (`IntegerFormatStyle`), floating-point numbers
+/// (`FloatingPointFormatStyle`), decimals (`Decimal.FormatStyle`), measurements
+/// (`Measurement.FormatStyle`), arrays (`ListFormatStyle`), and more. The numeric format styles
+/// also provide supporting format styles to format currency and percent values, like
+/// `IntegerFormatStyle.Currency` and `Decimal.FormatStyle.Percent`.
+///
+/// ### Modifying a format style
+///
+/// Format styles include modifier methods that return a new format style with an adjusted behavior.
+/// The following example creates an `IntegerFormatStyle`, then applies modifiers to round values
+/// down to the nearest 1,000 and applies formatting appropriate to the `fr_FR` locale:
+///
+/// ```swift
+/// let style = IntegerFormatStyle<Int>()
+///     .rounded(rule: .down, increment: 1000)
+///     .locale(Locale(identifier: "fr_FR"))
+/// let rounded = 123456789.formatted(style) // "123 456 000"
+/// ```
+///
+/// Foundation caches identical instances of a customized format style, so you don't need to pass
+/// format style instances around unrelated parts of your app's source code.
+///
+/// ### Accessing static instances
+///
+/// Types that conform to `FormatStyle` typically extend the base protocol with type properties or
+/// type methods to provide convenience instances. These are available for use in a data type's
+/// `formatted(_:)` method when the format style's input type matches the data type. For example,
+/// the various numeric format styles define `number` properties with generic constraints to match
+/// the different numeric types (`Double`, `Int`, `Float16`, and so on).
+///
+/// To see how this works, consider this example of a default formatter for an `Int` value. Because
+/// `123456789` is a `BinaryInteger`, its `formatted(_:)` method accepts an `IntegerFormatStyle`
+/// parameter. The following example shows the style's default behavior in the `en_US` locale.
+///
+/// ```swift
+/// let formatted = 123456789.formatted(IntegerFormatStyle()) // "123,456,789"
+/// ```
+///
+/// `IntegerFormatStyle` extends `FormatStyle` with multiple type properties called `number`, each
+/// of which is an `IntegerFormatStyle` instance; these properties differ by which
+/// `BinaryInteger`-conforming type they take as input. Since one of these statically-defined
+/// properties takes `Int` as its input, you can use this type property instead of instantiating a
+/// new format style instance. Using dot notation to access this property on the inferred
+/// `FormatStyle` makes the call point much easier to read, as seen here:
+///
+/// ```swift
+/// let formatted = 123456789.formatted(.number) // "123,456,789"
+/// ```
+///
+/// Furthermore, since you can customize these statically-accessed format style instances, you can
+/// rewrite the example from the previous section without instantiating a new `IntegerFormatStyle`,
+/// like this:
+///
+/// ```swift
+/// let rounded = 123456789.formatted(.number
+///     .rounded(rule: .down, increment: 1000)
+///     .locale(Locale(identifier: "fr_FR"))) // "123 456 000"
+/// ```
+///
+/// ### Parsing with a format style
+///
+/// To perform the opposite conversion — from formatted output type to input data type — some
+/// format styles provide a corresponding `ParseStrategy` type. These format styles typically expose
+/// an instance of this type as a variable, called `parseStrategy`.
+///
+/// You can use a `ParseStrategy` one of two ways:
+///
+/// - Initialize the data type by calling an initializer of that type that takes a formatted
+///   instance and a parse strategy as parameters. For example, you can create a `Decimal` from a
+///   formatted string with the initializer `Decimal.init(_:format:lenient:)`.
+/// - Create a parse strategy and call its `parse(_:)` method on one or more formatted instances.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public protocol FormatStyle<FormatInput, FormatOutput> : Codable, Hashable {
 
-    /// The type of data to format.
+    /// The type this format style accepts as input.
+    ///
+    /// Swift type inference uses this value to determine which static accessors are available at a
+    /// given call point. For example, when you format an `Int32`, you can use the static `number`
+    /// property that provides a `IntegerFormatStyle<Int32>`, as seen in the following example. This
+    /// works because the style's input type `IntegerFormatStyle.FormatInput` is a `BinaryInteger`
+    /// generically constrained to the `Int32` type.
+    ///
+    /// ```swift
+    /// let perihelionDistanceToSunInKm: Int32 = 147098291
+    /// perihelionDistanceToSunInKm.formatted(.number
+    ///     .notation(.scientific)) // "1.470983E8"
+    /// ```
     associatedtype FormatInput
 
-    /// The type of the formatted data.
+    /// The type this format style produces as output.
+    ///
+    /// Conforming types in Foundation define this type as either `String` or `AttributedString`.
     associatedtype FormatOutput
 
-    /// Creates a `FormatOutput` instance from `value`.
+    /// Formats a value, using this style.
+    ///
+    /// Use this method when you want to create a single style instance, and then use it to format
+    /// multiple values.
+    ///
+    /// - Parameter value: The value to format.
+    /// - Returns: A representation of `value`, in the ``FormatOutput`` type, formatted according to
+    ///   the style's configuration.
     func format(_ value: FormatInput) -> FormatOutput
 
-    /// If the format allows selecting a locale, returns a copy of this format with the new locale set. Default implementation returns an unmodified self.
+    /// Modifies the format style to use the specified locale.
+    ///
+    /// Use this format style to change the locale used by an existing format style.
+    ///
+    /// - Parameter locale: The locale to apply to the format style.
+    /// - Returns: A format style modified to use the provided locale.
     func locale(_ locale: Locale) -> Self
 }
 

--- a/Sources/FoundationEssentials/Formatting/ParseStrategy.swift
+++ b/Sources/FoundationEssentials/Formatting/ParseStrategy.swift
@@ -10,16 +10,41 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type that can parse a representation of a given data type.
+/// A type that parses an input representation, such as a formatted string, into a provided data type.
+///
+/// A ``ParseStrategy`` allows you to convert a formatted representation into a data type, using one of two approaches:
+///
+/// - Initialize the data type by calling an initializer of that type that takes a formatted instance and a parse strategy as parameters. For example, you can create a ``Decimal`` from a formatted string with the initializer ``Decimal/init(_:format:lenient:)-6fk71``.
+/// - Create a parse strategy and call its ``parse(_:)`` method on one or more formatted instances.
+///
+/// ``ParseStrategy`` is closely related to ``FormatStyle``, which provides the opposite conversion: from data type to formatted representation. To use a parse strategy, you create a ``FormatStyle`` to define the representation you expect, then access the style's `parseStrategy` property to get a strategy instance.
+///
+/// The following example creates a ``Decimal/FormatStyle/Currency`` format style that uses US dollars and US English number-formatting conventions. It then creates a ``Decimal`` instance by providing a formatted string to parse and the format style's ``Decimal/FormatStyle/Currency/parseStrategy``.
+///
+/// ```swift
+/// let style = Decimal.FormatStyle.Currency(code: "USD",
+/// locale: Locale(identifier: "en_US"))
+/// let parsed = try? Decimal("$12,345.67",
+/// strategy: style.parseStrategy) // 12345.67
+/// ```
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public protocol ParseStrategy : Codable, Hashable {
 
-    /// The type of the representation describing the data.
+    /// The input type parsed by this strategy.
+    ///
+    /// Conforming types provide a value for this associated type to declare the type of values they parse.
     associatedtype ParseInput
 
-    /// The type of the data type.
+    /// The output type returned by this strategy.
+    ///
+    /// Conforming types provide a value for this associated type to declare the type of values they return.
     associatedtype ParseOutput
 
-    /// Creates an instance of the `ParseOutput` type from `value`.
+    /// Parses a value, using this strategy.
+    ///
+    /// This method throws an error if the parse strategy can't parse `value`.
+    ///
+    /// - Parameter value: A value whose type matches the strategy's ``ParseStrategy/ParseInput`` type.
+    /// - Returns: A parsed value of the type declared by ``ParseStrategy/ParseOutput``.
     func parse(_ value: ParseInput) throws -> ParseOutput
 }

--- a/Sources/FoundationEssentials/Formatting/ParseableFormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/ParseableFormatStyle.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type that can convert a given data type into a representation.
+/// A type that can convert a given input data type into a representation in an output type.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public protocol ParseableFormatStyle: FormatStyle {
     associatedtype Strategy: ParseStrategy where Strategy.ParseInput == FormatOutput, Strategy.ParseOutput == FormatInput

--- a/Sources/FoundationEssentials/FoundationEssentials.docc/FoundationEssentials.md
+++ b/Sources/FoundationEssentials/FoundationEssentials.docc/FoundationEssentials.md
@@ -1,0 +1,6 @@
+# ``FoundationEssentials``
+
+
+Access essential data types, collections, and operating-system services to define the base layer of functionality for your app.
+
+The FoundationEssentials library provides a base layer of functionality for apps and frameworks, including data storage and persistence, text processing, basic date and time calculations, and sorting and filtering.

--- a/Sources/FoundationEssentials/IndexPath.swift
+++ b/Sources/FoundationEssentials/IndexPath.swift
@@ -14,15 +14,16 @@
 internal import _ForSwiftFoundation
 #endif
 
-/**
- `IndexPath` represents the path to a specific node in a tree of nested array collections.
- 
- Each index in an index path represents the index into an array of children from one node in the tree to another, deeper, node.
- */
+/// A list of indexes that together represent the path to a specific location in a tree of nested arrays.
+///
+/// Each index in an index path represents the index into an array of children from one node in the tree to another, deeper, node.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCollection, Comparable, ExpressibleByArrayLiteral, Sendable {
+    /// A type that represents one node of an index path.
     public typealias Element = Int
+    /// A type that points to a particular node in an index path, similar to an array index.
     public typealias Index = Array<Int>.Index
+    /// A type that represents a group of nodes in an index path.
     public typealias Indices = DefaultIndices<IndexPath>
     
     fileprivate enum Storage : ExpressibleByArrayLiteral {
@@ -458,23 +459,23 @@ public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCo
     
     fileprivate var _indexes : Storage
     
-    /// Initialize an empty index path.
+    /// Creates an empty index path.
     public init() {
         _indexes = []
     }
     
-    /// Initialize with a sequence of integers.
+    /// Creates an index path from a sequence of integers.
     public init<ElementSequence : Sequence>(indexes: ElementSequence)
         where ElementSequence.Iterator.Element == Element {
             _indexes = Storage(indexes.map { $0 })
     }
     
-    /// Initialize with an array literal.
+    /// Creates an index path from an array literal.
     public init(arrayLiteral indexes: Element...) {
         _indexes = Storage(indexes)
     }
     
-    /// Initialize with an array of elements.
+    /// Creates an index path from an array of elements.
     public init(indexes: Array<Element>) {
         _indexes = Storage(indexes)
     }
@@ -483,48 +484,49 @@ public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCo
         _indexes = storage
     }
     
-    /// Initialize with a single element.
+    /// Creates an index path with a single element.
     public init(index: Element) {
         _indexes = [index]
     }
     
-    /// Return a new `IndexPath` containing all but the last element.
+    /// Returns a new index path containing all but the last element.
     public func dropLast() -> IndexPath {
         return IndexPath(storage: _indexes.dropLast())
     }
     
-    /// Append an `IndexPath` to `self`.
+    /// Appends the nodes of another index path to this one.
     public mutating func append(_ other: IndexPath) {
         _indexes.append(contentsOf: other._indexes)
     }
     
-    /// Append a single element to `self`.
+    /// Appends a single element to this index path as a new node.
     public mutating func append(_ other: Element) {
         _indexes.append(other)
     }
     
-    /// Append an array of elements to `self`.
+    /// Appends an array of elements to this index path as additional nodes.
     public mutating func append(_ other: Array<Element>) {
         _indexes.append(contentsOf: other)
     }
     
-    /// Return a new `IndexPath` containing the elements in self and the elements in `other`.
+    /// Returns a new index path containing the elements of this one plus the given element.
     public func appending(_ other: Element) -> IndexPath {
         var result = _indexes
         result.append(other)
         return IndexPath(storage: result)
     }
     
-    /// Return a new `IndexPath` containing the elements in self and the elements in `other`.
+    /// Returns a new index path containing the elements of this one plus those of another index path.
     public func appending(_ other: IndexPath) -> IndexPath {
         return IndexPath(storage: _indexes + other._indexes)
     }
     
-    /// Return a new `IndexPath` containing the elements in self and the elements in `other`.
+    /// Returns a new index path containing the elements of this one plus an array of additional elements.
     public func appending(_ other: Array<Element>) -> IndexPath {
         return IndexPath(storage: _indexes + other)
     }
     
+    /// Accesses one of the index path's nodes.
     public subscript(index: Index) -> Element {
         get {
             return _indexes[index]
@@ -534,6 +536,7 @@ public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCo
         }
     }
     
+    /// Accesses a contiguous subrange of the index path's nodes.
     public subscript(range: Range<Index>) -> IndexPath {
         get {
             return IndexPath(storage: _indexes[range])
@@ -543,6 +546,7 @@ public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCo
         }
     }
     
+    /// Returns an iterator over the nodes of the index path.
     public func makeIterator() -> IndexingIterator<IndexPath> {
         return IndexingIterator(_elements: self)
     }
@@ -551,23 +555,27 @@ public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCo
         return _indexes.count
     }
     
+    /// The index of the first node in the index path.
     public var startIndex: Index {
         return _indexes.startIndex
     }
     
+    /// One past the index of the last node in the index path.
     public var endIndex: Index {
         return _indexes.endIndex
     }
     
+    /// Returns the index that precedes the given index.
     public func index(before i: Index) -> Index {
         return _indexes.index(before: i)
     }
     
+    /// Returns the index that follows the given index.
     public func index(after i: Index) -> Index {
         return _indexes.index(after: i)
     }
     
-    /// Sorting an array of `IndexPath` using this comparison results in an array representing nodes in depth-first traversal order.
+    /// Compares this index path to another in depth-first traversal order.
     public func compare(_ other: IndexPath) -> ComparisonResult  {
         let thisLength = count
         let otherLength = other.count
@@ -618,10 +626,12 @@ public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCo
         return lhs._indexes == rhs._indexes
     }
     
+    /// Combines the elements of two index paths into a single index path.
     public static func +(lhs: IndexPath, rhs: IndexPath) -> IndexPath {
         return lhs.appending(rhs)
     }
     
+    /// Appends the elements of another index path to this index path.
     public static func +=(lhs: inout IndexPath, rhs: IndexPath) {
         lhs.append(rhs)
     }

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -63,7 +63,7 @@ private struct _DictionaryCodingKey: CodingKey {
 // JSON Decoder
 //===----------------------------------------------------------------------===//
 
-/// `JSONDecoder` facilitates the decoding of JSON into semantic `Decodable` types.
+/// An object that decodes instances of a data type from JSON objects.
 // NOTE: older overlays had Foundation.JSONDecoder as the ObjC name.
 // The two must coexist, so it was renamed. The old name must not be
 // used in the new runtime. _TtC10Foundation13__JSONDecoder is the
@@ -71,11 +71,35 @@ private struct _DictionaryCodingKey: CodingKey {
 #if FOUNDATION_FRAMEWORK
 @_objcRuntimeName(_TtC10Foundation13__JSONDecoder)
 #endif
+/// An object that decodes instances of a data type from JSON objects.
+///
+/// The example below shows how to decode an instance of a simple `GroceryProduct` type from a JSON object. The type adopts <doc://com.apple.documentation/documentation/swift/codable> so that it's decodable using a ``JSONDecoder`` instance.
+///
+/// ```swift
+/// struct GroceryProduct: Codable {
+/// var name: String
+/// var points: Int
+/// var description: String?
+/// }
+///
+/// let json = """
+/// {
+/// "name": "Durian",
+/// "points": 600,
+/// "description": "A fruit with a distinctive scent."
+/// }
+/// """.data(using: .utf8)!
+///
+/// let decoder = JSONDecoder()
+/// let product = try decoder.decode(GroceryProduct.self, from: json)
+///
+/// print(product.name) // Prints "Durian"
+/// ```
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 open class JSONDecoder {
     // MARK: Options
 
-    /// The strategy to use for decoding `Date` values.
+    /// The strategies available for formatting dates when decoding them from JSON.
     public enum DateDecodingStrategy : Sendable {
         /// Defer to `Date` for decoding. This is the default strategy.
         case deferredToDate
@@ -100,7 +124,7 @@ open class JSONDecoder {
         case custom(@Sendable (_ decoder: Decoder) throws -> Date)
     }
 
-    /// The strategy to use for decoding `Data` values.
+    /// The strategies for decoding raw data.
     public enum DataDecodingStrategy : Sendable {
         /// Defer to `Data` for decoding.
         case deferredToData
@@ -113,7 +137,9 @@ open class JSONDecoder {
         case custom(@Sendable (_ decoder: Decoder) throws -> Data)
     }
 
-    /// The strategy to use for non-JSON-conforming floating-point values (IEEE 754 infinity and NaN).
+    /// The strategies for encoding nonconforming floating-point numbers, also known as IEEE 754 exceptional values.
+    ///
+    /// The IEEE 754 floating-point specification defines exceptional values, which include <doc://com.apple.documentation/documentation/swift/floatingpoint/infinity> and <doc://com.apple.documentation/documentation/swift/floatingpoint/nan>.
     public enum NonConformingFloatDecodingStrategy : Sendable {
         /// Throw upon encountering non-conforming values. This is the default strategy.
         case `throw`
@@ -122,7 +148,10 @@ open class JSONDecoder {
         case convertFromString(positiveInfinity: String, negativeInfinity: String, nan: String)
     }
 
-    /// The strategy to use for automatically changing the value of keys before decoding.
+    /// The values that determine how to decode a type's coding keys from JSON keys.
+    ///
+    /// > Note:
+    /// > Key decoding strategies other than ``useDefaultKeys`` may have a noticeable performance cost because those strategies may inspect and transform each key.
     public enum KeyDecodingStrategy : Sendable {
         /// Use the keys specified by each type. This is the default strategy.
         case useDefaultKeys
@@ -192,7 +221,7 @@ open class JSONDecoder {
         }
     }
 
-    /// The strategy to use in decoding dates. Defaults to `.deferredToDate`.
+    /// The strategy used when decoding dates from part of a JSON object.
     open var dateDecodingStrategy: DateDecodingStrategy {
         get {
             optionsLock._unsafeLock()
@@ -215,7 +244,9 @@ open class JSONDecoder {
         }
     }
 
-    /// The strategy to use in decoding binary data. Defaults to `.base64`.
+    /// The strategy that a decoder uses to decode raw data.
+    ///
+    /// Defaults to `.base64`.
     open var dataDecodingStrategy: DataDecodingStrategy {
         get {
             optionsLock._unsafeLock()
@@ -238,7 +269,9 @@ open class JSONDecoder {
         }
     }
 
-    /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
+    /// The strategy used by a decoder when it encounters exceptional floating-point values.
+    ///
+    /// Defaults to `.throw`.
     open var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy {
         get {
             optionsLock._unsafeLock()
@@ -261,7 +294,9 @@ open class JSONDecoder {
         }
     }
 
-    /// The strategy to use for decoding keys. Defaults to `.useDefaultKeys`.
+    /// A value that determines how to decode a type's coding keys from JSON keys.
+    ///
+    /// Defaults to `.useDefaultKeys`.
     open var keyDecodingStrategy: KeyDecodingStrategy {
         get {
             optionsLock._unsafeLock()
@@ -284,7 +319,7 @@ open class JSONDecoder {
         }
     }
 
-    /// Contextual user-provided information for use during decoding.
+    /// A dictionary you use to customize the decoding process by providing contextual information.
     @preconcurrency
     open var userInfo: [CodingUserInfoKey : any Sendable] {
         get {
@@ -308,7 +343,9 @@ open class JSONDecoder {
         }
     }
 
-    /// Set to `true` to allow parsing of JSON5. Defaults to `false`.
+    /// Specifies that decoding supports the JSON5 syntax.
+    ///
+    /// Defaults to `false`.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     open var allowsJSON5: Bool {
         get {
@@ -321,7 +358,9 @@ open class JSONDecoder {
 
     private let assumesTopLevelDictionaryKey = CodingUserInfoKey(rawValue: "_NSAssumesTopLevelDictionaryJSON5")!
 
-    /// Set to `true` to assume the data is a top level Dictionary (no surrounding "{ }" required). Defaults to `false`. Compatible with both JSON5 and non-JSON5 mode.
+    /// Specifies that decoding assumes the top level of the JSON data is a dictionary, even if it doesn't begin and end with braces.
+    ///
+    /// Defaults to `false`. Compatible with both JSON5 and non-JSON5 mode.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     open var assumesTopLevelDictionary: Bool {
         get {
@@ -348,7 +387,7 @@ open class JSONDecoder {
 
     // MARK: - Constructing a JSON Decoder
 
-    /// Initializes `self` with default strategies.
+    /// Creates a new, reusable JSON decoder with the default formatting settings and decoding strategies.
     public init() {}
 
     private var scannerOptions : JSONScanner.Options {
@@ -361,7 +400,7 @@ open class JSONDecoder {
 
     // MARK: - Decoding Values
 
-    /// Decodes a top-level value of the given type from the given JSON representation.
+    /// Returns a value of the type you specify, decoded from a JSON object.
     ///
     /// - parameter type: The type of the value to decode.
     /// - parameter data: The data to decode from.

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -16,11 +16,38 @@ internal import Synchronization
 // JSON Encoder
 //===----------------------------------------------------------------------===//
 
-/// `JSONEncoder` facilitates the encoding of `Encodable` values into JSON.
 // NOTE: older overlays had Foundation.JSONEncoder as the ObjC name.
 // The two must coexist, so it was renamed. The old name must not be
 // used in the new runtime. _TtC10Foundation13__JSONEncoder is the
 // mangled name for Foundation.__JSONEncoder.
+
+/// An object that encodes instances of a data type as JSON objects.
+///
+/// The example below shows how to encode an instance of a simple `GroceryProduct` type from a JSON object. The type adopts <doc://com.apple.documentation/documentation/swift/codable> so that it's encodable as JSON using a ``JSONEncoder`` instance.
+///
+/// ```swift
+/// struct GroceryProduct: Codable {
+/// var name: String
+/// var points: Int
+/// var description: String?
+/// }
+///
+/// let pear = GroceryProduct(name: "Pear", points: 250, description: "A ripe pear.")
+///
+/// let encoder = JSONEncoder()
+/// encoder.outputFormatting = .prettyPrinted
+///
+/// let data = try encoder.encode(pear)
+/// print(String(data: data, encoding: .utf8)!)
+///
+/// /* Prints:
+/// {
+/// "name" : "Pear",
+/// "points" : 250,
+/// "description" : "A ripe pear."
+/// }
+/// */
+/// ```
 #if FOUNDATION_FRAMEWORK
 @_objcRuntimeName(_TtC10Foundation13__JSONEncoder)
 #endif
@@ -28,7 +55,7 @@ internal import Synchronization
 open class JSONEncoder {
     // MARK: Options
 
-    /// The formatting of the output JSON data.
+    /// The output formatting options that determine the readability, size, and element order of an encoded JSON object.
     public struct OutputFormatting : OptionSet, Sendable {
         /// The format's default value.
         public let rawValue: UInt
@@ -38,14 +65,16 @@ open class JSONEncoder {
             self.rawValue = rawValue
         }
 
-        /// Produce human-readable JSON with indented output.
+        /// The output formatting option that uses ample white space and indentation to make output easy to read.
         public static let prettyPrinted = OutputFormatting(rawValue: 1 << 0)
 
-        /// Produce JSON with dictionary keys sorted in lexicographic order.
+        /// The output formatting option that sorts keys in lexicographic order.
         @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
         public static let sortedKeys    = OutputFormatting(rawValue: 1 << 1)
 
-        /// By default slashes get escaped ("/" → "\/", "http://apple.com/" → "http:\/\/apple.com\/")
+        /// The output formatting option specifies that the output doesn't prefix slash characters with escape characters.
+        ///
+        /// By default slashes get escaped ("/" -> "\/", "http://apple.com/" -> "http:\/\/apple.com\/")
         /// for security reasons, allowing outputted JSON to be safely embedded within HTML/XML.
         /// In contexts where this escaping is unnecessary, the JSON is known to not be embedded,
         /// or is intended only for display, this option avoids this escaping.
@@ -53,58 +82,63 @@ open class JSONEncoder {
         public static let withoutEscapingSlashes = OutputFormatting(rawValue: 1 << 3)
     }
 
-    /// The strategy to use for encoding `Date` values.
+    /// The formatting strategies available for formatting dates when encoding a date as JSON.
     public enum DateEncodingStrategy : Sendable {
-        /// Defer to `Date` for choosing an encoding. This is the default strategy.
+        /// The strategy that uses formatting from the Date structure.
         case deferredToDate
 
-        /// Encode the `Date` as a UNIX timestamp (as a JSON number).
+        /// The strategy that encodes dates in terms of seconds since midnight UTC on January 1, 1970.
         case secondsSince1970
 
-        /// Encode the `Date` as UNIX millisecond timestamp (as a JSON number).
+        /// The strategy that encodes dates in terms of milliseconds since midnight UTC on January 1, 1970.
         case millisecondsSince1970
 
-        /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+        /// The strategy that formats dates according to the ISO 8601 and RFC 3339 standards.
         @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
 #if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
-        /// Encode the `Date` as a string formatted by the given formatter.
+        /// The strategy that defers formatting settings to a supplied date formatter.
         case formatted(DateFormatter)
 #endif // FOUNDATION_FRAMEWORK
-        
-        /// Encode the `Date` as a custom value encoded by the given closure.
+
+        /// The strategy that formats custom dates by calling a user-defined function.
         ///
         /// If the closure fails to encode a value into the given encoder, the encoder will encode an empty automatic container in its place.
         @preconcurrency
         case custom(@Sendable (Date, Encoder) throws -> Void)
     }
     
-    /// The strategy to use for encoding `Data` values.
+    /// The strategies for encoding raw data.
     public enum DataEncodingStrategy : Sendable {
-        /// Defer to `Data` for choosing an encoding.
+        /// The strategy that encodes data using the encoding specified by the data instance itself.
         case deferredToData
 
-        /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
+        /// The strategy that encodes data using Base 64 encoding. This is the default strategy.
         case base64
 
-        /// Encode the `Data` as a custom value encoded by the given closure.
+        /// The strategy that encodes data using a user-defined function.
         ///
         /// If the closure fails to encode a value into the given encoder, the encoder will encode an empty automatic container in its place.
         @preconcurrency
         case custom(@Sendable (Data, Encoder) throws -> Void)
     }
 
-    /// The strategy to use for non-JSON-conforming floating-point values (IEEE 754 infinity and NaN).
+    /// The strategies for encoding nonconforming floating-point numbers, also known as IEEE 754 exceptional values.
+    ///
+    /// The IEEE 754 floating-point specification defines exceptional values, which include <doc://com.apple.documentation/documentation/swift/floatingpoint/infinity> and <doc://com.apple.documentation/documentation/swift/floatingpoint/nan>.
     public enum NonConformingFloatEncodingStrategy : Sendable {
-        /// Throw upon encountering non-conforming values. This is the default strategy.
+        /// The strategy that throws an error upon encoding an exceptional floating-point value. This is the default strategy.
         case `throw`
 
-        /// Encode the values using the given representation strings.
+        /// The strategy that encodes exceptional floating-point values from a specified string representation.
         case convertToString(positiveInfinity: String, negativeInfinity: String, nan: String)
     }
 
-    /// The strategy to use for automatically changing the value of keys before encoding.
+    /// The values that determine how to encode a type's coding keys as JSON keys.
+    ///
+    /// > Note:
+    /// > Key encoding strategies other than ``useDefaultKeys`` may have a noticeable performance cost because those strategies may inspect and transform each key.
     public enum KeyEncodingStrategy : Sendable {
         /// Use the keys specified by each type. This is the default strategy.
         case useDefaultKeys
@@ -181,7 +215,9 @@ open class JSONEncoder {
         }
     }
 
-    /// The output format to produce. Defaults to `[]`.
+    /// A value that determines the readability, size, and element order of the encoded JSON object.
+    ///
+    /// Defaults to `[]`.
     open var outputFormatting: OutputFormatting {
         get {
             optionsLock._unsafeLock()
@@ -204,7 +240,9 @@ open class JSONEncoder {
         }
     }
 
-    /// The strategy to use in encoding dates. Defaults to `.deferredToDate`.
+    /// The strategy used when encoding dates as part of a JSON object.
+    ///
+    /// Defaults to `.deferredToDate`.
     open var dateEncodingStrategy: DateEncodingStrategy {
         get {
             optionsLock._unsafeLock()
@@ -227,7 +265,9 @@ open class JSONEncoder {
         }
     }
 
-    /// The strategy to use in encoding binary data. Defaults to `.base64`.
+    /// The strategy that an encoder uses to encode raw data.
+    ///
+    /// Defaults to `.base64`.
     open var dataEncodingStrategy: DataEncodingStrategy {
         get {
             optionsLock._unsafeLock()
@@ -250,7 +290,9 @@ open class JSONEncoder {
         }
     }
 
-    /// The strategy to use in encoding non-conforming numbers. Defaults to `.throw`.
+    /// The strategy used by an encoder when it encounters exceptional floating-point values.
+    ///
+    /// Defaults to `.throw`.
     open var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy {
         get {
             optionsLock._unsafeLock()
@@ -273,7 +315,9 @@ open class JSONEncoder {
         }
     }
 
-    /// The strategy to use for encoding keys. Defaults to `.useDefaultKeys`.
+    /// A value that determines how to encode a type's coding keys as JSON keys.
+    ///
+    /// Defaults to `.useDefaultKeys`.
     open var keyEncodingStrategy: KeyEncodingStrategy {
         get {
             optionsLock._unsafeLock()
@@ -296,7 +340,7 @@ open class JSONEncoder {
         }
     }
 
-    /// Contextual user-provided information for use during encoding.
+    /// A dictionary you use to customize the encoding process by providing contextual information.
     @preconcurrency
     open var userInfo: [CodingUserInfoKey : any Sendable] {
         get {
@@ -336,13 +380,13 @@ open class JSONEncoder {
 
     // MARK: - Constructing a JSON Encoder
 
-    /// Initializes `self` with default strategies.
+    /// Creates a new, reusable JSON encoder with the default formatting settings and encoding strategies.
     public init() {}
 
 
     // MARK: - Encoding Values
 
-    /// Encodes the given top-level value and returns its JSON representation.
+    /// Returns a JSON-encoded representation of the value you supply.
     ///
     /// - parameter value: The value to encode.
     /// - returns: A new `Data` value containing the encoded JSON data.

--- a/Sources/FoundationEssentials/Locale/Locale+Components.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Components.swift
@@ -16,7 +16,7 @@
 
 extension Locale {
 
-    /// Represents locale-related attributes. You can use `Locale.Components` to create a `Locale` with specific overrides.
+    /// A type that represents the components of a locale, for use when creating a locale with specific overrides.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct Components : Hashable, Codable, Sendable {
 
@@ -59,9 +59,13 @@ extension Locale {
         /// Corresponds to the "ms" key of the Unicode BCP 47 extension
         public var measurementSystem: Locale.MeasurementSystem?
 
-        /// Set this to override the region for region-related preferences, such as measuring system, calendar, and first day of the week. If unset, the region of the language component is used
+        /// The region used by the locale.
         ///
-        /// Corresponds to the "rg" key of the Unicode BCP 47 extension
+        /// Set this property to override the region for region-related preferences,
+        /// such as measuring system, calendar, and first day of the week. If unset,
+        /// the locale uses the region of the language component.
+        ///
+        /// This property corresponds to the `rg` key of the Unicode BCP 47 extension.
         public var region: Locale.Region?
 
         /// Set this to override the regional subdivision of `region`
@@ -153,13 +157,17 @@ extension Locale.MeasurementSystem : CustomDebugStringConvertible { }
 
 extension Locale {
 
+    /// An alphabetical code associated with a language.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct LanguageCode : Hashable, Codable, Sendable, ExpressibleByStringLiteral {
+        /// Creates a language code from an identifier as a string literal.
+        ///
+        /// - Parameter value: A two-letter ISO 639-1 or three-letter ISO 639-2 code, such as `en` for English. You can also use a code of your own choice for a custom language.
         public init(stringLiteral value: String) {
             self.init(value)
         }
 
-        /// Creates a `LanguageCode` type
+        /// Creates a `LanguageCode` type.
         /// - Parameter identifier: A two-letter or three-letter ISO 639 code, or a language code of your choice if using a custom language, such as "en" for English. Case-insensitive.
         public init(_ identifier: String) {
             _identifier = identifier
@@ -238,8 +246,10 @@ extension Locale {
         }
     }
 
+    /// The written script used with a given language.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct Script : Hashable, Codable, Sendable, ExpressibleByStringLiteral {
+        /// Creates a script from a BCP 47 identifier as a string literal.
         public init(stringLiteral value: String) {
             self.init(value)
         }
@@ -303,12 +313,16 @@ extension Locale {
         }
     }
 
+    /// A type that represents a geographic region, for use in specifying a locale or language.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct Region : Hashable, Codable, Sendable, ExpressibleByStringLiteral {
 
         package static let cldrKeywordKey = ICUCLDRKey("rg")
         package static let legacyKeywordKey = ICULegacyKey("rg")
 
+        /// Creates a region from a BCP 47 identifier as a string literal.
+        ///
+        /// - Parameter value: A BCP 47 identifier, such as `US` for the United States. This parameter is case-insensitive.
         public init(stringLiteral value: String) {
             self.init(value)
         }
@@ -321,6 +335,7 @@ extension Locale {
             _normalizedIdentifier
         }
 
+        /// The BCP 47 identifier of the region.
         public var identifier: String {
             get {
                 _identifier
@@ -331,14 +346,14 @@ extension Locale {
             }
         }
 
-        /// Creates a `Region` with the specified region code
+        /// Creates a region from a BCP 47 identifier.
         /// - Parameter identifier: A two-letter BCP 47 region subtag such as "US" for the United States. Case-insensitive.
         public init(_ identifier: String) {
             _identifier = identifier
             _normalizedIdentifier = identifier.uppercased()
         }
 
-        /// Represents an unknown or invalid region
+        /// A pre-defined unknown or invalid region.
         public static let unknown = Region("ZZ")
 
         public func hash(into hasher: inout Hasher) {
@@ -373,18 +388,23 @@ extension Locale {
         }
     }
 
+    /// A type that represents the string sort order used by the locale.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct Collation : Hashable, Codable, Sendable, ExpressibleByStringLiteral {
 
         package static let cldrKeywordKey = ICUCLDRKey("co")
         package static let legacyKeywordKey = ICULegacyKey("collation")
 
+        /// Creates a collation from a BCP 47 identifier as a string literal.
+        ///
+        /// - Parameter value: The BCP 47 collation identifier, like `standard` for a language's standard ordering, or `phonetic` for phonetic ordering.
         public init(stringLiteral value: String) {
             self.init(value)
         }
 
         package var _identifier: String
         package var _normalizedIdentifier: String
+        /// The collation's BCP 47 identifier.
         public var identifier: String {
             get {
                 _identifier
@@ -400,15 +420,21 @@ extension Locale {
             _normalizedIdentifier
         }
 
-        /// The complete list of collation identifiers can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/collation.xml), under the key named "co"
+        /// Creates a collation from a BCP 47 identifier.
+        ///
+        /// - Parameter identifier: The BCP 47 collation identifier, like `standard` for a language's standard ordering, or `phonetic` for phonetic ordering. The complete list of collation identifiers can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/collation.xml), under the key named "co".
         public init(_ identifier: String) {
             _identifier = identifier
             _normalizedIdentifier = identifier.lowercased()
         }
 
-        /// Dedicated for string search. This is only appropriate for determining whether two strings should be considered equivalent. Using this may ignore or modify the string for searching purpose. For example, the contractions in Thai and Lao are suppressed. It should not be used to determine the relative order of the two strings.
+        /// A collation used for string search.
+        ///
+        /// Use this collation only for determining whether to consider two strings as equivalent. Using this collation may modify the string for search purposes. For example, this collation suppresses the contractions in Thai and Lao.
+        ///
+        /// Don't use this collation to determine the relative order of two strings.
         public static let searchRules = Collation("search")
-        /// The default ordering for each language
+        /// A collation that provides the default ordering for each language.
         public static let standard = Collation("standard")
 
         public func hash(into hasher: inout Hasher) {
@@ -443,13 +469,17 @@ extension Locale {
         }
     }
 
+    /// A type that represents the currency system used by a locale, like dollars or euros.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    /// The complete list of currency codes can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/currency.xml), under the key with the name "cu"
     public struct Currency : Hashable, Codable, Sendable, ExpressibleByStringLiteral {
-
+        // The complete list of currency codes can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/currency.xml), under the key with the name "cu"
+        
         package static let cldrKeywordKey = ICUCLDRKey("cu")
         package static let legacyKeywordKey = ICULegacyKey("currency")
 
+        /// Creates a currency instance from a BCP 47 identifier as a string literal.
+        ///
+        /// - Parameter value: The currency's BCP 47 identifier, like `usd` for US dollars, or `jpy` for Japanese yen.
         public init(stringLiteral value: String) {
             self.init(value)
         }
@@ -457,6 +487,7 @@ extension Locale {
         package var _identifier: String
         package var _normalizedIdentifier: String
 
+        /// The currency's identifier.
         public var identifier: String {
             get {
                 _identifier
@@ -472,6 +503,9 @@ extension Locale {
             _normalizedIdentifier
         }
 
+        /// Creates a currency instance from a BCP 47 identifier.
+        ///
+        /// - Parameter identifier: The currency's BCP 47 identifier, like `usd` for US dollars, or `jpy` for Japanese yen.
         public init(_ identifier: String) {
             _identifier = identifier
             _normalizedIdentifier = identifier.lowercased()
@@ -509,13 +543,14 @@ extension Locale {
         }
     }
 
+    /// A type that represents the numbering system used in a locale.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    /// Defines representations for numeric values. Also known as numeral system
     public struct NumberingSystem : Hashable, Codable, Sendable, ExpressibleByStringLiteral {
 
         package static let cldrKeywordKey = ICUCLDRKey("nu")
         package static let legacyKeywordKey = ICULegacyKey("numbers")
 
+        /// Creates a numbering system instance from a BCP 47 identifier as a string literal.
         public init(stringLiteral value: String) {
             self.init(value)
         }
@@ -523,6 +558,7 @@ extension Locale {
         package var _identifier: String
         package var _normalizedIdentifier: String
 
+        /// The numbering system's identifier.
         public var identifier: String {
             get {
                 _identifier
@@ -538,7 +574,9 @@ extension Locale {
             _normalizedIdentifier
         }
 
-        /// The complete list of valid numbering systems can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/number.xml), under the key with the name "nu"
+        /// Creates a numbering system from a BCP 47 identifier.
+        ///
+        /// The complete list of valid numbering systems can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/number.xml), under the key with the name "nu".
         public init(_ identifier: String) {
             _identifier = identifier
             _normalizedIdentifier = identifier.lowercased()
@@ -578,14 +616,22 @@ extension Locale {
         }
     }
 
+    /// A type that represents weekdays, used for indicating a locale's first day of the week.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public enum Weekday: String, Codable, Hashable, Sendable {
+        /// The weekday enumeration value for Sunday.
         case sunday = "sun"
+        /// The weekday enumeration value for Monday.
         case monday = "mon"
+        /// The weekday enumeration value for Tuesday.
         case tuesday = "tue"
+        /// The weekday enumeration value for Wednesday.
         case wednesday = "wed"
+        /// The weekday enumeration value for Thursday.
         case thursday = "thu"
+        /// The weekday enumeration value for Friday.
         case friday = "fri"
+        /// The weekday enumeration value for Saturday.
         case saturday = "sat"
 
         package static let cldrKeywordKey = ICUCLDRKey("fw")
@@ -614,6 +660,7 @@ extension Locale {
         }
     }
 
+    /// A type that represents the hour cycle used in a locale, like one-to-twelve or zero-to-twenty-three.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public enum HourCycle : String, Codable, Hashable, Sendable {
         /// 12-hour clock. Hour ranges from 0 to 11
@@ -632,12 +679,16 @@ extension Locale {
         package static let legacyKeywordKey = ICULegacyKey("hours")
     }
 
+    /// A type that represents the measurement system used by a locale, like metric or the US system.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct MeasurementSystem: Codable, Hashable, Sendable, ExpressibleByStringLiteral {
 
         package static let cldrKeywordKey = ICUCLDRKey("ms")
         package static let legacyKeywordKey = ICULegacyKey("measure")
 
+        /// Creates a measurement system instance from a BCP 47 identifier as a string literal.
+        ///
+        /// - Parameter value: The measurement system's BCP 47 identifier, like `metric` or `ussystem`.
         public init(stringLiteral value: String) {
             self.init(value)
         }
@@ -645,6 +696,7 @@ extension Locale {
         package var _identifier: String
         package var _normalizedIdentifier: String
 
+        /// The measurement system's identifier.
         public var identifier: String {
             get {
                 _identifier
@@ -660,20 +712,22 @@ extension Locale {
             _normalizedIdentifier
         }
 
-        /// The complete list of valid measurement systems can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/measure.xml), under the key with the name "ms"
+        /// Creates a measurement system from a BCP 47 identifier.
+        ///
+        /// The complete list of valid measurement systems can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/measure.xml), under the key with the name "ms".
         public init(_ identifier: String) {
             _identifier = identifier
             _normalizedIdentifier = identifier.lowercased()
         }
 
-        /// Metric system
+        /// The metric system.
         public static let metric = MeasurementSystem("metric")
-        /// US System of measurement: feet, pints, etc.; pints are 16oz
+        /// The US system of measurement: feet, pints, etc.; pints are 16oz.
         public static let us = MeasurementSystem("ussystem")
-        /// UK System of measurement: feet, pints, etc.; pints are 20oz
+        /// The UK system of measurement: feet, pints, etc.; pints are 20oz.
         public static let uk = MeasurementSystem("uksystem")
 
-        /// Returns a list of measurement systems
+        /// An array containing all available measurement systems.
         public static var measurementSystems: [MeasurementSystem] {
             [ metric, us, uk ]
         }
@@ -710,13 +764,16 @@ extension Locale {
         }
     }
 
+    /// A type that represents a subdivision of a region, such as a state in the US or a province in Canada.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    /// A subdivision of a country or region, such as a state in the United States, or a province in Canada.
     public struct Subdivision : Hashable, Codable, Sendable, ExpressibleByStringLiteral {
 
         package static let cldrKeywordKey = ICUCLDRKey("sd")
         package static let legacyKeywordKey = ICULegacyKey("sd")
 
+        /// Creates a subdivision from a Unicode identifier as a string literal.
+        ///
+        /// - Parameter value: The subdivision's identifier.
         public init(stringLiteral value: String) {
             self.init(value)
         }
@@ -724,6 +781,7 @@ extension Locale {
         package var _identifier: String
         package var _normalizedIdentifier: String
 
+        /// The subdivision's identifier.
         public var identifier: String {
             get {
                 _identifier
@@ -739,14 +797,16 @@ extension Locale {
             _normalizedIdentifier
         }
 
-        /// Creates a subdivision with the given identifier
-        /// - Parameter identifier: A unicode subdivision identifier, such as "usca" for California, US. Case-insensitive. The complete list of subdivision identifier can be found [here](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/validity/subdivision.xml), under the "subdivision" type
+        /// Creates a subdivision with the given identifier.
+        /// - Parameter identifier: A unicode subdivision identifier, such as "usca" for California, US. Case-insensitive. The complete list of subdivision identifiers can be found [here](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/validity/subdivision.xml), under the "subdivision" type.
         public init(_ identifier: String) {
             _identifier = identifier
             _normalizedIdentifier = identifier.lowercased()
         }
 
-        /// Returns the subdivision representing the given region as a whole. For example, returns a subdivision with the "uszzzz" identifier for the entire US region
+        /// Returns the subdivision representing the given region as a whole.
+        ///
+        /// For example, returns a subdivision with the "uszzzz" identifier for the entire US region.
         public static func subdivision(for region: Region) -> Subdivision {
             return .init(region.identifier + "zzzz")
         }
@@ -783,12 +843,16 @@ extension Locale {
         }
     }
 
+    /// A type that represents a locale's language variant.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct Variant: Codable, Hashable, Sendable, ExpressibleByStringLiteral {
 
         package static let cldrKeywordKey = ICUCLDRKey("va")
         package static let legacyKeywordKey = ICULegacyKey("va")
 
+        /// Creates a variant from a BCP 47 identifier as a string literal.
+        ///
+        /// - Parameter value: The variant's BCP 47 identifier.
         public init(stringLiteral value: String) {
             self.init(value)
         }
@@ -796,6 +860,7 @@ extension Locale {
         package var _identifier: String
         package var _normalizedIdentifier: String
 
+        /// The variant's identifier.
         public var identifier: String {
             get {
                 _identifier
@@ -811,7 +876,9 @@ extension Locale {
             _normalizedIdentifier
         }
 
-        /// The complete list of valid variants can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/variant.xml), under the key named "va"
+        /// Creates a variant from a BCP 47 identifier.
+        ///
+        /// The complete list of valid variants can be found [here](https://github.com/unicode-org/cldr/blob/latest/common/bcp47/variant.xml), under the key named "va".
         public init(_ identifier: String) {
             _identifier = identifier
             _normalizedIdentifier = identifier.lowercased()

--- a/Sources/FoundationEssentials/Locale/Locale+Language.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Language.swift
@@ -16,16 +16,26 @@ internal import Foundation_Private
 
 extension Locale {
 
+    /// A type that represents a language, as used in a locale.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct Language : Hashable, Codable, Sendable {
 
+        /// A type that identifies a language by its various components.
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-        /// Represents a language identifier
         public struct Components : Hashable, Codable, Sendable {
+            /// The language code that identifies this language.
             public var languageCode: Locale.LanguageCode?
+            /// The written script used by this language.
             public var script: Locale.Script?
+            /// The region used with this language.
             public var region: Locale.Region?
 
+            /// Creates a language components instance from a given language code, script, and region.
+            ///
+            /// - Parameters:
+            ///   - languageCode: The language code to use for the new components instance.
+            ///   - script: The script to use for the new components instance.
+            ///   - region: The region to use for the new components instance.
             public init(languageCode: Locale.LanguageCode? = nil, script: Locale.Script? = nil, region: Locale.Region? = nil) {
                 self.languageCode = languageCode
                 self.script = script
@@ -63,15 +73,26 @@ extension Locale {
         }
 #endif
         
+        /// Creates a language from its component values.
+        ///
+        /// - Parameter components: A `Language.Components` instance that provides a custom language code, region, and script for the new `Language` instance.
         public init(components: Language.Components) {
             self.components = components
         }
 
+        /// Creates a language from a given language code, script, and region.
+        ///
+        /// - Parameters:
+        ///   - languageCode: A language code, typically created from a two- or three-letter language code specified by ISO 639.
+        ///   - script: The script to use for the new locale components instance.
+        ///   - region: The region to use for the new components instance.
         public init(languageCode: Locale.LanguageCode? = nil, script: Locale.Script? = nil, region: Locale.Region? = nil) {
             self.components = Components(languageCode: languageCode, script: script, region: region)
         }
 
-        /// Returns a list of system languages, includes the languages of all product localization for the current platform
+        /// An array of the system's supported languages.
+        ///
+        /// The returned array includes the languages of all product localizations for the current platform.
         public static var systemLanguages: [Language] {
 #if FOUNDATION_FRAMEWORK && canImport(_FoundationICU)
             NSLocale.systemLanguages().map {

--- a/Sources/FoundationEssentials/Locale/Locale.swift
+++ b/Sources/FoundationEssentials/Locale/Locale.swift
@@ -10,15 +10,46 @@
 //
 //===----------------------------------------------------------------------===//
 
-/**
- `Locale` encapsulates information about linguistic, cultural, and technological conventions and standards. Examples of information encapsulated by a locale include the symbol used for the decimal separator in numbers and the way dates are formatted.
-
- Locales are typically used to provide, format, and interpret information about and according to the user's customs and preferences. They are frequently used in conjunction with formatters. Although you can use many locales, you usually use the one associated with the current user.
-*/
+/// Information about linguistic, cultural, and technological conventions for use in formatting data for presentation.
+///
+/// `Locale` encapsulates information about linguistic, cultural, and technological conventions and standards. Examples of information encapsulated by a locale include the symbol used for the decimal separator in numbers and the formatting conventions for dates and times.
+///
+/// Apps use locales to provide, format, and interpret information about and according to the user's customs and preferences. Data formatting APIs commonly make use of locales to present data in a locale-appropriate way.
+///
+/// You can create a `Locale` from a common identifier like `en-US`, or by specifying its components. More commonly, you access the current system locale with the ``current`` or ``autoupdatingCurrent`` static variables.
+///
+/// ### Working with locale components
+///
+/// A `Locale` exposes its various traits — the appropriate measurement system, currency symbols, date and time conventions, and more — as strongly-typed properties like ``currency``, `numberingSystem`, and `firstDayOfWeek`.
+///
+/// In addition, the ``language`` property allows you examine traits of languages, through the ``Language`` type, in contast with `NSLocale`, where `NSLocale.languageCode` is just a string identifier. You can use a locale's language to compare whether two locales use the same language, or if one language is a parent of another.
+///
+/// The following example creates a `Locale` from the identifier `zh-CN`, for Chinese. It then accesses this locale's ``language`` to get the language's ``Language/script``, and uses a US English locale to get a localized string describing the script: "Simplified Han". With the locale `zh-Hant-CN`, for Traditional Chinese, the script would be "Traditional Han" instead.
+///
+/// ```swift
+/// let zhCN = Locale(identifier: "zh-CN")
+/// if let script = zhCN.language.script {
+///     let enUS = Locale(identifier: "en-US")
+///     let localizedScript = enUS.localizedString(forScript: script) // "Simplified Han"
+/// }
+/// ```
+///
+/// ### Creating custom locales from components
+///
+/// You can create a custom locale by creating a `Locale` instance from a customized ``Components``. Do this when you want to tweak specific aspects of a locale. The following example creates a locale that uses language conventions of British English (language region `GB`), but otherwise uses US conventions for things like currency and measurement.
+///
+/// ```swift
+/// var components = Locale.Components(languageCode: "en", languageRegion: "GB")
+/// components.region = Locale.Region("US")
+/// let en_GB_US = Locale(components: components)
+/// ```
+///
+/// Creating a custom locale like this isn't necessarily common in apps, but can be useful in unit testing your app's localizations.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct Locale : Hashable, Equatable, Sendable {
 
 #if FOUNDATION_FRAMEWORK
+    /// An alias for the standard set of language directions.
     public typealias LanguageDirection = NSLocale.LanguageDirection
 #else
     public enum LanguageDirection : UInt, Sendable {
@@ -39,36 +70,59 @@ public struct Locale : Hashable, Equatable, Sendable {
     }
 #endif
 
-    // Identifier canonicalization
+    /// A type that indicates the standard that defines a locale's identifier.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public enum IdentifierType : Sendable {
         /* This canonicalizes the identifier */
-        /// Identifier following ICU (International Components for Unicode) convention. Unlike the `posix` type, does not include character set
-        /// For example: "th_TH@calendar=gregorian;numbers=thai"
+        /// The type of identifiers that follow ICU (International Components for Unicode) conventions.
+        ///
+        /// An example of this type is `th_TH@calendar=gregorian;numbers=thai`.
         case icu
 
         /* This would be a canonicalized "Unicode BCP 47 locale identifier", not a "BCP 47 language tag", per https://www.unicode.org/reports/tr35/#BCP_47_Language_Tag_Conversion */
-        /// The identifier is also a valid BCP47 language tag
-        /// For example: "th-TH-u-ca-gregory-nu-thai"
+        /// The type of BCP 47 language identifiers.
+        ///
+        /// An example of this type is `th-TH-u-ca-gregory-nu-thai`.
         case bcp47
 
-        /// The components are the same as `icu`, but does not use the key-value type keyword list
-        /// For example: "th_TH_u_ca_gregory_nu_thai"
+        /// The type of identifiers that follow CLDR (Common Locale Data Repository) conventions.
+        ///
+        /// The components in this type of identifier use the same components as in ``Locale/IdentifierType/icu``, but don't use the key-value type keyword list. An example of this type is `th_TH_u_ca_gregory_nu_thai`.
         case cldr
     }
 
     internal var _locale: any _LocaleProtocol
 
-    /// Returns a locale which tracks the user's current preferences.
+    /// A locale which tracks the user's current preferences.
     ///
-    /// If mutated, this Locale will no longer track the user's preferences.
+    /// This value represents the locale currently used by the app, based on the following:
     ///
-    /// - note: The autoupdating Locale will only compare equal to another autoupdating Locale.
+    /// * The current system locale.
+    /// * Any app-specific locale choice made in the Settings app.
+    /// * The availability of the preferred locale in the app. For example, if the person using an app has set their device to use a Spanish-language locale, but the app only supports English, this value returns an English locale.
+    ///
+    /// Use this property when you want a locale that always reflects the latest configuration settings. When the person using the app changes settings, reading properties from a locale instance obtained from this property provides the latest values. If you need to rely on a locale that does not change, use the locale given by the ``Locale/current`` property instead.
+    ///
+    /// Although the locale obtained here automatically follows the latest language and region settings, it provides no indication when the settings change. To receive notification of locale changes in Swift, add an observer for ``Locale/CurrentLocaleDidChangeMessage``. In Objective-C, you can add your object as an observer of `NSCurrentLocaleDidChangeNotification`.
+    ///
+    /// If mutated, this `Locale` no longer tracks the user's preferences.
+    ///
+    /// - Note: The autoupdating `Locale` only compares as equal to another autoupdating `Locale`.
     public static var autoupdatingCurrent : Locale {
         Locale(inner: LocaleCache.autoupdatingCurrent)
     }
 
-    /// Returns the user's current locale.
+    /// A locale representing the user's region settings at the time the property is read.
+    ///
+    /// This value represents the locale currently used by the app, based on the following:
+    ///
+    /// * The current system locale.
+    /// * Any app-specific locale choice made in the Settings app.
+    /// * The availability of the preferred locale in the app. For example, if the person using an app has set their device to use a Spanish-language locale, but the app only supports English, this value returns an English locale.
+    ///
+    /// Use this property when you need to rely on a consistent locale. A locale instance obtained this way does not change even when the person using the device changes language or region settings. If you want a locale instance that always reflects the current configuration, use the one provided by the ``Locale/autoupdatingCurrent`` property instead.
+    ///
+    /// To receive notification of locale changes in Swift, add an observer for ``Locale/CurrentLocaleDidChangeMessage``. In Objective-C, you can add your object as an observer of ``NSLocale/currentLocaleDidChangeNotification``.
     public static var current : Locale {
         Locale(inner: LocaleCache.cache.current)
     }
@@ -106,23 +160,45 @@ public struct Locale : Hashable, Equatable, Sendable {
     // MARK: -
     //
 
-    /// Return a locale with the specified identifier.
+    /// Creates a locale with the specified identifier.
+    ///
+    /// - Parameter identifier: A BCP-47 language identifier such as `en_US` or `en-u-nu-thai-ca-buddhist`, or an ICU-style identifier such as `en@calendar=buddhist;numbers=thai`.
     public init(identifier: String) {
         _locale = LocaleCache.cache.fixed(identifier)
     }
 
-    /// Creates a `Locale` with the specified locale components
+    /// Creates a locale from the given components.
+    ///
+    /// Use this initializer to create a locale with a unique combination of components, beyond the defaults provided by a language and country code.
+    ///
+    /// For example, you can create a ``Locale/Components`` instance that uses UK language conventions, but US regional conventions for traits like currency and measurement. You then use the components to create a new `Locale` instance, like this:
+    ///
+    /// ```swift
+    /// var components = Locale.Components(languageCode: "en", languageRegion: "GB")
+    /// components.region = Locale.Region("US")
+    /// let en_GB_US = Locale(components: components)
+    /// ```
+    ///
+    /// - Parameter components: A ``Locale/Components`` instance that provides the components to create a customized locale.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public init(components: Locale.Components) {
         _locale = LocaleCache.cache.fixedComponents(components)
     }
 
-    /// Creates a `Locale` with the specified language components
+    /// Creates a locale from the given language components.
+    ///
+    /// - Parameter languageComponents: A ``Locale/Language/Components`` instance that provides language components that identify a locale.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public init(languageComponents: Locale.Language.Components) {
         self = Locale(identifier: languageComponents.identifier)
     }
 
+    /// Creates a locale with the specified language code, script, and region identifier.
+    ///
+    /// - Parameters:
+    ///   - languageCode: A language code, typically created from a two- or three-letter language code specified by ISO 639.
+    ///   - script: The script to use for the new locale components instance.
+    ///   - languageRegion: A language region, typically created from a two-letter BCP 47 region subtag like `US`.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public init(languageCode: LanguageCode? = nil, script: Script? = nil, languageRegion: Region? = nil) {
         let comps = Components(languageCode: languageCode, script: script, languageRegion: languageRegion)
@@ -158,7 +234,7 @@ public struct Locale : Hashable, Equatable, Sendable {
     // MARK: -
     //
 
-    /// Returns a localized string for a specified identifier.
+    /// Returns a localized string for a specified locale identifier.
     ///
     /// For example, in the "en" locale, the result for `"es"` is `"Spanish"`.
     public func localizedString(forIdentifier identifier: String) -> String? {
@@ -193,7 +269,7 @@ public struct Locale : Hashable, Equatable, Sendable {
         _locale.variantCodeDisplayName(for: variantCode)
     }
 
-    /// Returns a localized string for a specified `Calendar.Identifier`.
+    /// Returns a localized string for a specified calendar.
     ///
     /// For example, in the "en" locale, the result for `.buddhist` is `"Buddhist Calendar"`.
     public func localizedString(for calendarIdentifier: Calendar.Identifier) -> String? {
@@ -203,7 +279,7 @@ public struct Locale : Hashable, Equatable, Sendable {
     /// Returns a localized string for a specified ISO 4217 currency code.
     ///
     /// For example, in the "en" locale, the result for `"USD"` is `"US Dollar"`.
-    /// - seealso: `Locale.isoCurrencyCodes`
+    /// - SeeAlso: `Locale.isoCurrencyCodes`
     public func localizedString(forCurrencyCode currencyCode: String) -> String? {
         _locale.currencyCodeDisplayName(for: currencyCode)
     }
@@ -234,7 +310,7 @@ public struct Locale : Hashable, Equatable, Sendable {
     // MARK: -
     //
 
-    /// Returns the identifier of the locale.
+    /// The identifier of the locale.
     public var identifier: String {
         @_effects(releasenone)
         get {
@@ -242,7 +318,7 @@ public struct Locale : Hashable, Equatable, Sendable {
         }
     }
 
-    /// Returns the language code of the locale, or nil if has none.
+    /// The language code of the locale, or `nil` if has none.
     ///
     /// For example, for the locale "zh-Hant-HK", returns "zh".
     @available(macOS, deprecated: 13, renamed: "language.languageCode.identifier")
@@ -253,7 +329,7 @@ public struct Locale : Hashable, Equatable, Sendable {
         _locale.languageCode
     }
 
-    /// Returns the region code of the locale, or nil if it has none.
+    /// The region code of the locale, or `nil` if it has none.
     ///
     /// For example, for the locale "zh-Hant-HK", returns "HK".
     @available(macOS, deprecated: 13, renamed: "region.identifier")
@@ -269,7 +345,7 @@ public struct Locale : Hashable, Equatable, Sendable {
         return result
     }
 
-    /// Returns the script code of the locale, or nil if has none.
+    /// The script code of the locale, or `nil` if has none.
     ///
     /// For example, for the locale "zh-Hant-HK", returns "Hant".
     @available(macOS, deprecated: 13, renamed: "language.script.identifier")
@@ -280,7 +356,7 @@ public struct Locale : Hashable, Equatable, Sendable {
         _locale.scriptCode
     }
 
-    /// Returns the variant code for the locale, or nil if it has none.
+    /// The variant code for the locale, or `nil` if it has none.
     ///
     /// For example, for the locale "en_POSIX", returns "POSIX".
     @available(macOS, deprecated: 13, renamed: "variant.identifier")
@@ -296,13 +372,13 @@ public struct Locale : Hashable, Equatable, Sendable {
     }
 
 #if FOUNDATION_FRAMEWORK
-    /// Returns the exemplar character set for the locale, or nil if has none.
+    /// The exemplar character set for the locale, or `nil` if has none.
     public var exemplarCharacterSet: CharacterSet? {
         _locale.exemplarCharacterSet
     }
 #endif
 
-    /// Returns the calendar for the locale, or the Gregorian calendar as a fallback.
+    /// The calendar for the locale, or the Gregorian calendar as a fallback.
     public var calendar: Calendar {
         var cal = _locale.calendar
         // This is a fairly expensive operation, because it recreates the Calendar's backing ICU object.
@@ -325,7 +401,7 @@ public struct Locale : Hashable, Equatable, Sendable {
     }
 #endif
 
-    /// Returns the collation identifier for the locale, or nil if it has none.
+    /// The collation identifier for the locale, or `nil` if it has none.
     ///
     /// For example, for the locale "en_US@collation=phonebook", returns "phonebook".
     @available(macOS, deprecated: 13, renamed: "collation.identifier")
@@ -336,9 +412,9 @@ public struct Locale : Hashable, Equatable, Sendable {
         _locale.collationIdentifier
     }
 
-    /// Returns true if the locale uses the metric system.
+    /// A Boolean that is true if the locale uses the metric system.
     ///
-    /// -seealso: MeasurementFormatter
+    /// - SeeAlso: `MeasurementFormatter`
     @available(macOS, deprecated: 13, message: "Use `measurementSystem` instead")
     @available(iOS, deprecated: 16, message: "Use `measurementSystem` instead")
     @available(tvOS, deprecated: 16, message: "Use `measurementSystem` instead")
@@ -347,28 +423,28 @@ public struct Locale : Hashable, Equatable, Sendable {
         _locale.usesMetricSystem
     }
 
-    /// Returns the decimal separator of the locale.
+    /// The decimal separator of the locale.
     ///
     /// For example, for "en_US", returns ".".
     public var decimalSeparator: String? {
         _locale.decimalSeparator
     }
 
-    /// Returns the grouping separator of the locale.
+    /// The grouping separator of the locale.
     ///
     /// For example, for "en_US", returns ",".
     public var groupingSeparator: String? {
         _locale.groupingSeparator
     }
 
-    /// Returns the currency symbol of the locale.
+    /// The currency symbol of the locale.
     ///
     /// For example, for "zh-Hant-HK", returns "HK$".
     public var currencySymbol: String? {
         _locale.currencySymbol
     }
 
-    /// Returns the currency code of the locale.
+    /// The currency code of the locale.
     ///
     /// For example, for "zh-Hant-HK", returns "HKD".
     @available(macOS, deprecated: 13, renamed: "currency.identifier")
@@ -379,116 +455,165 @@ public struct Locale : Hashable, Equatable, Sendable {
         _locale.currencyCode
     }
 
-    /// Returns the collator identifier of the locale.
+    /// The collator identifier of the locale.
     public var collatorIdentifier: String? {
         _locale.collatorIdentifier
     }
 
-    /// Returns the quotation begin delimiter of the locale.
+    /// The quotation begin delimiter of the locale.
     ///
-    /// For example, returns `“` for "en_US", and `「` for "zh-Hant-HK".
+    /// For example, returns `\u{201C}` for “en_US”, and `\u{300C}` for “zh-Hant-HK”.
     public var quotationBeginDelimiter: String? {
         _locale.quotationBeginDelimiter
     }
 
-    /// Returns the quotation end delimiter of the locale.
+    /// The quotation end delimiter of the locale.
     ///
-    /// For example, returns `”` for "en_US", and `」` for "zh-Hant-HK".
+    /// For example, returns `\u{201D}` for “en_US”, and `\u{300D}` for “zh-Hant-HK”.
     public var quotationEndDelimiter: String? {
         _locale.quotationEndDelimiter
     }
 
-    /// Returns the alternate quotation begin delimiter of the locale.
+    /// The alternate quotation begin delimiter of the locale.
     ///
-    /// For example, returns `‘` for "en_US", and `『` for "zh-Hant-HK".
+    /// For example, returns `\u{2018}` for "en_US", and `\u{300E}` for "zh-Hant-HK".
     public var alternateQuotationBeginDelimiter: String? {
         _locale.alternateQuotationBeginDelimiter
     }
 
-    /// Returns the alternate quotation end delimiter of the locale.
+    /// The alternate quotation end delimiter of the locale.
     ///
-    /// For example, returns `’` for "en_US", and `』` for "zh-Hant-HK".
+    /// For example, returns `\u{2019}` for "en_US", and `\u{300F}` for "zh-Hant-HK".
     public var alternateQuotationEndDelimiter: String? {
         _locale.alternateQuotationEndDelimiter
     }
 
     // MARK: - Components
 
+    /// The measurement system used by the locale, like metric or the US system.
+    ///
+    /// When called on the special `Locale` instances ``current`` or ``autoupdatingCurrent``, if the user overrode the default measurement system, this property provides the user's preference.
+    ///
+    /// This property corresponds to the `ms` key of the Unicode BCP 47 extension.
+    ///
+    /// For locale instances created with the `ms` specifier (such as `en-US@ms=metric`), or with a custom ``Locale/Components``, this property represents the custom measurement system. Otherwise, it represents the locale's default measurement system.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    /// Returns the measurement system of the locale. Returns `metric` as the default value if the data isn't available.
     public var measurementSystem: MeasurementSystem {
         _locale.measurementSystem
     }
 
-    /// Returns the currency of the locale. Returns nil if the data isn't available.
+    /// The currency used by the locale.
+    ///
+    /// This property corresponds to the `cu` key of the Unicode BCP 47 extension.
+    ///
+    /// For locale instances created with the `cu` specifier (such as `en-US@cu=cad`), or with a custom ``Locale/Components``, this property represents the custom currency. Otherwise, it represents the locale's default currency.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var currency: Currency? {
         _locale.currency
     }
 
-    /// Returns the numbering system of the locale. If the locale has an explicitly specified numbering system in the identifier (e.g. `bn_BD@numbers=latn`) or in the associated `Locale.Components`, that numbering system is returned. Otherwise, returns the default numbering system of the locale. Returns `"latn"` as the default value if the data isn't available.
+    /// The numbering system used by the locale.
+    ///
+    /// This property corresponds to the `nu` key of the Unicode BCP 47 extension.
+    ///
+    /// For locale instances created with the `nu` specifier (such as `en-US@nu=jpanfin`), or with a custom ``Locale/Components``, this property represents the custom numbering system. Otherwise, it represents the locale's default numbering system.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var numberingSystem: NumberingSystem {
         _locale.numberingSystem
     }
 
-    /// Returns all the valid numbering systems for the locale. For example, `"ar-AE (Arabic (United Arab Emirates)"` has both `"latn" (Latin digits)` and `"arab" (Arabic-Indic digits)` numbering system.
+    /// An array containing all the valid numbering systems for the locale.
+    ///
+    /// The following snippet creates a locale for Arabic as used in United Arab Emirates. For this locale, there are two numbering systems available: `latn` (Latin digits) and `arab` (Arabic-Indic digits).
+    ///
+    /// ```swift
+    /// let uae = Locale(identifier: "ar-AE") // Arabic / U.A.E.
+    /// let numberingSystems = uae.availableNumberingSystems
+    /// print("\(numberingSystems.map{$0.identifier})") // ["latn","arab"]
+    /// ```
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var availableNumberingSystems: [NumberingSystem] {
         _locale.availableNumberingSystems
     }
 
-    /// Returns the first day of the week of the locale. Returns `.sunday` as the default value if the data isn't available to the requested locale.
+    /// The first day of the week as represented by this locale.
+    ///
+    /// This value is the preferred first day of the week to show in a calendar view. It isn't necessarily the same as the first day after the weekend; don't try to determine a first-day-of-week value from weekend information.
+    ///
+    /// This property corresponds to the `fw` key of the Unicode BCP 47 extension.
+    ///
+    /// For locale instances created with the `fw` specifier (such as `en-US@fw=mon`), or with a custom ``Locale/Components``, this property represents the custom day. Otherwise, it represents the locale's default first day of the week.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var firstDayOfWeek: Weekday {
         _locale.firstDayOfWeek
     }
 
+    /// The language of the locale.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var language: Language {
         _locale.language
     }
 
+    /// Returns the locale identifier, in the specified standard format.
+    ///
+    /// - Parameter type: The standard locale identifier format to use for the returned string.
+    /// - Returns: The locale identifier, formatted in accordance with the specified identifier type.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-    /// Returns the identifier conforming to the specified standard
     public func identifier(_ type: IdentifierType) -> String {
         _locale.identifier(type)
     }
 
-    /// Returns the hour cycle such as whether it uses 12-hour clock or 24-hour clock. Default is `.zeroToTwentyThree` if the data isn't available.
-    /// Calling this on `.current` or `.autoupdatingCurrent` returns user's preference values as set in the system settings if available, overriding the default value of the user's locale.
+    /// The hour cycle used by the locale, like one-to-twelve or zero-to-twenty-three.
+    ///
+    /// When called on the special `Locale` instances ``current`` or ``autoupdatingCurrent``, if the user overrode the default hour cycle, this property provides the user's preference.
+    ///
+    /// This property corresponds to the `hc` key of the Unicode BCP 47 extension.
+    ///
+    /// For locale instances created with the `hc` specifier (such as `en-US@hc=h23`), or with a custom ``Locale/Components``, this property represents the custom hour cycle. Otherwise, it represents the locale's default hour cycle.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var hourCycle: HourCycle {
         _locale.hourCycle
     }
 
-    /// Returns the default collation used by the locale. Default is `.standard`.
+    /// The string sort order of the locale.
+    ///
+    /// This property corresponds to the `co` key of the Unicode BCP 47 extension.
+    ///
+    /// For locale instances created with the `co` specifier (such as `en-US@co=phonetic`), or with a custom ``Locale/Components``, this property represents the custom collation. Otherwise, it represents the locale's default sort order.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var collation: Collation {
         _locale.collation
     }
 
-    /// Returns the region of the locale. For example, "US" for "en_US", "GB" for "en_GB", "PT" for "pt_PT".
+    /// The region used by the locale.
     ///
+    /// This property corresponds to the `rg` key of the Unicode BCP 47 extension.
     ///
-    /// note: Typically this is equivalent to the language region, unless there's an `rg` override in the locale identifier. For example, for "en_GB@rg=USzzzz", the language region is "GB", while the locale region is "US". `Language.region` represents the region variant of the language, such as "British English" in this example, while `Locale.region` controls the region-specific default values, such as measuring system and first day of the week.
+    /// For locale instances created with the `rg` specifier (such as `en-GB@rg=US`), or with a custom ``Locale/Components``, this property represents the custom region. Otherwise, it represents the language's region.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var region: Region? {
         _locale.region
     }
 
+    /// The time zone associated with the locale, if any.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var timeZone: TimeZone? {
         _locale.timeZone
     }
 
-    /// Returns the regional subdivision for the locale, or nil if there is none.
+    /// The optional subdivision of the region used by this locale.
+    ///
+    /// This property corresponds to the `sd` key of the Unicode BCP 47 extension.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var subdivision: Subdivision? {
         _locale.subdivision
     }
 
-    /// Returns the variant for the locale, or nil if it has none. For example, for the locale "en_POSIX", returns "POSIX".
+    /// An optional variant used by the locale.
+    ///
+    /// This property corresponds to the `va` key of the Unicode BCP 47 extension.
+    ///
+    /// For locale instances created with the `va` specifier (such as `en-US@va=posix`), or with a custom ``Locale/Components``, this property represents the custom variant. Otherwise, it represents the locale's default variant.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public var variant: Variant? {
         _locale.variant
@@ -558,12 +683,14 @@ public struct Locale : Hashable, Equatable, Sendable {
     // MARK: -
     //
 
+    /// A list of the user's preferred languages.
+    ///
     /// Returns a list of the user's preferred languages, as specified in Language & Region settings, taking into account any per-app language overrides.
     ///
-    /// - note: `Bundle` is responsible for determining the language that your application will run in, based on the result of this API and combined with the languages your application supports.
-    /// - seealso: `Bundle.preferredLocalizations(from:)`
-    /// - seealso: `Bundle.preferredLocalizations(from:forPreferences:)`
-    /// - seealso: `Locale.preferredLocales`
+    /// - Note: `Bundle` is responsible for determining the language that your application will run in, based on the result of this API and combined with the languages your application supports.
+    /// - SeeAlso: `Bundle.preferredLocalizations(from:)`
+    /// - SeeAlso: `Bundle.preferredLocalizations(from:forPreferences:)`
+    /// - SeeAlso: `Locale.preferredLocales`
     public static var preferredLanguages: [String] {
         LocaleCache.cache.preferredLanguages(forCurrentUser: false)
     }

--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -15,12 +15,40 @@
 #if canImport(ReflectionInternal)
 internal import ReflectionInternal
 
+/// A type that provides the expected key paths found in an archived predicate.
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public protocol PredicateCodableKeyPathProviding {
+    /// The allowed key paths.
     @preconcurrency
     static var predicateCodableKeyPaths : [String : PartialKeyPath<Self> & Sendable] { get }
 }
 
+/// A specification of the expected types and key paths found in an archived predicate.
+///
+/// Use this configuration when encoding and decoding a predicate to restrict what that predicate can contain.  If a predicate contains data types or keypaths that aren't allowed by the configuration, the encoding or decoding process throws an error.
+///
+/// ```swift
+/// var configuration = PredicateCodableConfiguration.standardConfiguration
+/// configuration.allowType(Message.self, identifier: "MyApp.Message")
+/// configuration.allowType(Person.self, identifier: "MyApp.Person")
+/// configuration.allowKeyPath(\Message.sender, identifier: "MyApp.Message.sender")
+/// configuration.allowKeyPath(\Person.firstName, identifier: "MyApp.Person.firstName")
+/// configuration.allowKeyPath(\Person.lastName, identifier: "MyApp.Person.lastName")
+///
+/// struct MyRequest: Codable {
+/// let predicate: Predicate<Message>
+///
+/// func encode(to encoder: Encoder) throws {
+/// var container = encoder.container(keyedBy: CodingKeys.self)
+/// try container.encode(predicate, forKey: .predicate, configuration: configuration)
+/// }
+///
+/// init(from decoder: Decoder) throws {
+/// let container = try decoder.container(keyedBy: CodingKeys.self)
+/// predicate = try container.decode(Predicate<Message>.self, forKey: .predicate, configuration: configuration)
+/// }
+/// }
+/// ```
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConvertible {
     enum AllowListType : Equatable, Sendable {

--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -564,6 +564,18 @@ extension NSExpression : OverwritingInitializable {}
 
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension NSPredicate {
+    /// Creates a predicate by converting an existing predicate.
+    ///
+    /// Only a subset of predicates that can be expressed by `Predicate` are convertible to `NSPredicate`.
+    /// Predicates that include operations like the following can't be converted:
+    ///
+    /// - Accessing key paths for properties that aren't exposed to the Objective-C runtime.
+    /// - Capturing values of types that aren't supported by `NSPredicate`, like custom Swift structures.
+    /// - Using some functions or operators, like performing collection operations on a nonstring value.
+    ///
+    /// - Parameters:
+    ///   - predicate: The predicate to convert.
+    /// - Returns: The converted predicate, or `nil` if conversion fails.
     public convenience init?<Input>(_ predicate: Predicate<Input>) where Input : NSObject {
         let variable = predicate.variable
         var state = NSPredicateConversionState(object: variable.key)

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -10,8 +10,55 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A logical condition used to test a set of input values for searching or filtering.
+///
+/// A predicate is a logical condition that evaluates to a Boolean value (true or false). You use predicates for operations like filtering a collection or searching for matching elements.
+///
+/// To create a predicate, use the `Predicate(_:)` macro. For example:
+///
+/// ```swift
+/// let messagePredicate = #Predicate<Message> { message in
+///     message.length < 100 && message.sender == "Jeremy"
+/// }
+/// ```
+///
+/// In the example above, the closure that contains the predicate's conditions takes one argument — the value being tested. Even though you write the predicate using a closure, the macro transforms that closure into a predicate when you compile. The code in the closure isn't run as part of your program.
+///
+/// In the predicate's definition, you can use the following operations:
+///
+/// - Arithmetic (`+`, `-`, `*`, `/`, `%`)
+/// - Unary minus (`-`)
+/// - Range (`...`, `..<`)
+/// - Comparison (`<`, `<=`, `>`, `>=`, `==`, `!=`)
+/// - Ternary conditional (`?:`)
+/// - Conditional expressions
+/// - Boolean logic (`&&`, `||`, `!`)
+/// - Swift optionals (`?`, `??`, `!`, `flatMap(_:)`, `if`-`let` expressions)
+/// - Types (`as`, `as?`, `as!`, `is`)
+/// - Sequence operations (`allSatisfy()`, `filter()`, `contains()`, `contains(where:)`, `starts(with:)`, `max()`, `min()`)
+/// - Subscript and member access (`[]`, `.`)
+/// - String comparisons (`contains(_:)`, `localizedStandardContains(_:)`, `caseInsensitiveCompare(_:)`, `localizedCompare(_:)`)
+///
+/// A predicate can't contain any nested declarations, use any flow control such as `for` loops,
+/// or modify variables from its enclosing scope. However, it can refer to constants that are in
+/// scope.
+///
+/// To express more complex queries, you can nest expressions in the predicate:
+///
+/// ```swift
+/// let messagePredicate = #Predicate<Message> { message in
+///     message.recipients.contains {
+///         $0.firstName == message.sender.firstName
+///     }
+/// }
+/// ```
+///
+/// You can safely encode and decode predicates, pass predicates across concurrency boundaries, and load a predicate from a file. To define a list of types and key paths that are allowed when reading an archived predicate, use ``PredicateCodableConfiguration``.
+///
+/// You can transform a predicate into another representation — for example, to express a predicate in another query language, or to create a modified predicate — using the ``expression`` property.
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public struct Predicate<each Input> : Sendable {
+    /// The component expressions of the predicate.
     public let expression : any StandardPredicateExpression<Bool>
     public let variable: (repeat PredicateExpressions.Variable<each Input>)
     
@@ -51,6 +98,10 @@ extension Predicate {
 
 
 // Namespace for operator expressions
+/// The expressions that make up a predicate.
+///
+/// Don't use this type directly. When you call the `Predicate(_:)` macro in
+/// your code, the expansion of that macro produces these values.
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 @frozen public enum PredicateExpressions {}
 

--- a/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
@@ -10,6 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A mapping from a predicates's input variables to their values.
+///
+/// If you define a custom predicate expression type, you must propagate the predicate's bindings to its subexpressions.
+///
+/// If you define a custom predicate type, you must create an instance of this structure, populate it with the predicate's variables, and propagate it throughout the expression tree.
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public struct PredicateBindings {
     // Store as a values as an array instead of a dictionary (since it is almost always very few elements, this reduces heap allocation and hashing overhead)

--- a/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
@@ -12,6 +12,31 @@
 
 internal import Synchronization
 
+/// A component expression that makes up part of a predicate.
+///
+/// To transform a predicate, define a protocol for the result and add conformance on each predicate expression type that you support. For example:
+///
+/// ```swift
+/// protocol ProsePredicateExpression {
+/// func proseQuery() -> String
+/// }
+///
+/// // Repeated for each supported operator.
+/// extension PredicateExpressions.Equal: ProsePredicateExpression
+/// where LHS: ProsePredicateExpression,
+/// RHS: ProsePredicateExpression {
+/// func proseQuery() -> String {
+/// return lhs.proseQuery() + " is equal to " + rhs.proseQuery()
+/// }
+/// }
+///
+/// extension Predicate  {
+/// func proseQuery() -> String? {
+/// guard let expression = expression as? ProsePredicateExpression else { return nil }
+/// return expression.proseQuery()
+/// }
+/// }
+/// ```
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public protocol PredicateExpression<Output> {
     associatedtype Output
@@ -19,10 +44,13 @@ public protocol PredicateExpression<Output> {
     func evaluate(_ bindings: PredicateBindings) throws -> Output
 }
 
-// Only Foundation should add conformances to this protocol
+/// A component expression that makes up part of a predicate, and that's supported by the standard predicate type.
+///
+/// Don't declare new types that conform to the `StandardPredicateExpression` protocol.  Only the types provided by Foundation are valid conforming types.
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public protocol StandardPredicateExpression<Output> : PredicateExpression, Codable, Sendable {}
 
+/// An error thrown while evaluating a predicate.
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
     internal enum _Error: Hashable, Sendable {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo+API.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo+API.swift
@@ -14,6 +14,10 @@
 
 /// A collection of information about the current process.
 public final class ProcessInfo: Sendable {
+    /// Returns the process information agent for the process.
+    ///
+    /// An `ProcessInfo` object is created the first time this property is
+    /// accessed, and that same object is returned on each subsequent access.
     public static let processInfo: ProcessInfo = ProcessInfo()
 
     private let _processInfo: _ProcessInfo = _ProcessInfo.processInfo
@@ -22,18 +26,34 @@ public final class ProcessInfo: Sendable {
 // MARK: - Accessing Process Information
 extension ProcessInfo {
     /// Array of strings with the command-line arguments for the process.
+    ///
+    /// This array contains all the information passed in the `argv` array,
+    /// including the executable name in the first element.
     public var arguments: [String] { _processInfo.arguments }
 
     /// The variable names (keys) and their values in the environment from which the process was launched.
     public var environment: [String : String] { _processInfo.environment }
 
     /// Global unique identifier for the process.
+    ///
+    /// The global ID for the process includes the host name, process ID, and a
+    /// time stamp, which ensures that the ID is unique for the network. This
+    /// property generates a new string each time its getter is invoked, and it
+    /// uses a counter to guarantee that strings created from the same process
+    /// are unique.
     public var globallyUniqueString: String { _processInfo.globallyUniqueString }
 
     /// The identifier of the process (often called process ID).
     public var processIdentifier: Int32 { _processInfo.processIdentifier }
 
     /// The name of the process.
+    ///
+    /// The process name is used to register application defaults and is used in
+    /// error messages. It does not uniquely identify the process.
+    ///
+    /// > Warning: User defaults and other aspects of the environment might
+    /// > depend on the process name, so be very careful if you change it.
+    /// > Setting the process name in this manner is not thread safe.
     public var processName: String {
         get { _processInfo.processName }
         set { _processInfo.processName = newValue }
@@ -56,6 +76,10 @@ extension ProcessInfo {
     public var hostName: String { _processInfo.hostName }
 
     /// A string containing the version of the operating system on which the process is executing.
+    ///
+    /// The operating system version string is human readable, localized, and is
+    /// appropriate for displaying to the user. This string is _not_ appropriate
+    /// for parsing.
     public var operatingSystemVersionString: String {
         _processInfo.operatingSystemVersionString
     }
@@ -71,6 +95,14 @@ extension ProcessInfo {
 
     /// Returns a Boolean value indicating whether the version of the operating system on which the process
     /// is executing is the same or later than the given version.
+    ///
+    /// This method accounts for major, minor, and update versions of the
+    /// operating system.
+    ///
+    /// - Parameter version: The operating system version to test against.
+    /// - Returns: `true` if the operating system on which the process is
+    ///   executing is the same or later than the given version; otherwise
+    ///   `false`.
     public func isOperatingSystemAtLeast(_ version: OperatingSystemVersion) -> Bool {
         return _processInfo
             .isOperatingSystemAtLeast((
@@ -80,15 +112,25 @@ extension ProcessInfo {
     }
 }
 
+/// A structure that contains version information about the currently executing operating system, including major, minor, and patch version numbers.
+///
+/// Use the ``ProcessInfo`` property ``ProcessInfo/operatingSystemVersion`` to fetch an instance of this type. You can also pass this type to ``ProcessInfo/isOperatingSystemAtLeast(_:)`` to determine whether the current operating system version is the same or later than the given value.
 public struct OperatingSystemVersion: Hashable, Codable, Sendable {
+    /// The major release number, such as 10 in version 10.9.3.
     public let majorVersion: Int
+    /// The minor release number, such as 9 in version 10.9.3.
     public let minorVersion: Int
+    /// The update release number, such as 3 in version 10.9.3.
     public let patchVersion: Int
-    
+
+    /// Creates an empty operating system version.
+    ///
+    /// All fields are initialized to `0`.
     public init() {
         self.init(majorVersion: 0, minorVersion: 0, patchVersion: 0)
     }
-    
+
+    /// Creates an operating system version with the provided values.
     public init(majorVersion: Int, minorVersion: Int, patchVersion: Int) {
         self.majorVersion = majorVersion
         self.minorVersion = minorVersion
@@ -102,6 +144,13 @@ extension ProcessInfo {
     public var processorCount: Int { _processInfo.processorCount }
 
     /// The number of active processing cores available on the computer.
+    ///
+    /// Whereas the ``ProcessInfo/processorCount`` property reports the number of
+    /// advertised processing cores, the ``ProcessInfo/activeProcessorCount``
+    /// property reflects the actual number of active processing cores on the
+    /// system. There are a number of different factors that may cause a core to
+    /// not be active, including boot arguments, thermal throttling, or a
+    /// manufacturing defect.
     public var activeProcessorCount: Int { _processInfo.activeProcessorCount }
 
     /// The amount of physical memory on the computer in bytes.

--- a/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
+++ b/Sources/FoundationEssentials/ProgressManager/ProgressManager.swift
@@ -278,7 +278,7 @@ internal import _FoundationCollections
     /// If the `Subprogress` is not converted into a `ProgressManager` (for example, due to an error or early return),
     /// then the assigned count is marked as completed in the parent `ProgressManager`.
     ///
-    /// - Parameter count: The portion of `totalCount` to be delegated to the `Subprogress`.
+    /// - Parameter portionOfParentTotal: The portion of `totalCount` to be delegated to the `Subprogress`.
     /// - Returns: A `Subprogress` instance.
     public func subprogress(assigningCount portionOfParentTotal: Int) -> Subprogress {
         precondition(portionOfParentTotal > 0, "Giving out zero units is not a valid operation.")

--- a/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
@@ -17,11 +17,12 @@ internal import Synchronization
 // Plist Decoder
 //===----------------------------------------------------------------------===//
 
-/// `PropertyListDecoder` facilitates the decoding of property list values into semantic `Decodable` types.
 // NOTE: older overlays had Foundation.PropertyListDecoder as the ObjC
 // name. The two must coexist, so it was renamed. The old name must not
 // be used in the new runtime. _TtC10Foundation20_PropertyListDecoder
 // is the mangled name for Foundation._PropertyListDecoder.
+
+/// An object that decodes instances of data types from a property list.
 #if FOUNDATION_FRAMEWORK
 @_objcRuntimeName(_TtC10Foundation20_PropertyListDecoder)
 #endif
@@ -38,7 +39,8 @@ open class PropertyListDecoder {
 #endif
     // MARK: Options
 
-    /// Contextual user-provided information for use during decoding.
+    /// A dictionary you use to customize decoding by providing contextual
+    /// information.
     @preconcurrency
     open var userInfo: [CodingUserInfoKey : any Sendable] {
         get {
@@ -73,12 +75,13 @@ open class PropertyListDecoder {
 
     // MARK: - Constructing a Property List Decoder
 
-    /// Initializes `self` with default strategies.
+    /// Creates a new, reusable property list decoder.
     public init() {}
 
     // MARK: - Decoding Values
 
-    /// Decodes a top-level value of the given type from the given property list representation.
+    /// Returns a value of the specified type by decoding a property list using
+    /// the default property list format.
     ///
     /// - parameter type: The type of the value to decode.
     /// - parameter data: The data to decode from.
@@ -90,7 +93,8 @@ open class PropertyListDecoder {
         return try decode(type, from: data, format: &format)
     }
 
-    /// Decodes a top-level value of the given type from the given property list representation.
+    /// Returns a value of the specified type by decoding a property list using
+    /// the supplied format.
     ///
     /// - parameter type: The type of the value to decode.
     /// - parameter data: The data to decode from.

--- a/Sources/FoundationEssentials/PropertyList/PlistEncoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistEncoder.swift
@@ -16,11 +16,12 @@ internal import Synchronization
 // Plist Encoder
 //===----------------------------------------------------------------------===//
 
-/// `PropertyListEncoder` facilitates the encoding of `Encodable` values into property lists.
 // NOTE: older overlays had Foundation.PropertyListEncoder as the ObjC
 // name. The two must coexist, so it was renamed. The old name must not
 // be used in the new runtime. _TtC10Foundation20_PropertyListEncoder
 // is the mangled name for Foundation._PropertyListEncoder.
+
+/// An object that encodes instances of data types to a property list.
 #if FOUNDATION_FRAMEWORK
 @_objcRuntimeName(_TtC10Foundation20_PropertyListEncoder)
 #endif
@@ -29,7 +30,8 @@ open class PropertyListEncoder {
 
     // MARK: - Options
 
-    /// The output format to write the property list data in. Defaults to `.binary`.
+    /// A value that determines which property list format is used during
+    /// encoding.
     open var outputFormat: PropertyListDecoder.PropertyListFormat {
         get {
             optionsLock._unsafeLock()
@@ -52,7 +54,8 @@ open class PropertyListEncoder {
         }
     }
 
-    /// Contextual user-provided information for use during encoding.
+    /// A dictionary you use to customize the encoding process by providing
+    /// contextual information.
     @preconcurrency
     open var userInfo: [CodingUserInfoKey : any Sendable] {
         get {
@@ -88,12 +91,14 @@ open class PropertyListEncoder {
 
     // MARK: - Constructing a Property List Encoder
 
-    /// Initializes `self` with default strategies.
+    /// Creates a new, reusable property list encoder with the default
+    /// formatting settings.
     public init() {}
 
     // MARK: - Encoding Values
 
-    /// Encodes the given top-level value and returns its property list representation.
+    /// Returns a property list that represents an encoded version of the value
+    /// you supply.
     ///
     /// - parameter value: The value to encode.
     /// - returns: A new `Data` value containing the encoded property list data.

--- a/Sources/FoundationEssentials/SortComparator.swift
+++ b/Sources/FoundationEssentials/SortComparator.swift
@@ -10,14 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A comparison algorithm for a given type.
+/// A comparison algorithm for a specified type.
+///
+/// Objects that conform to ``SortComparator`` provide a comparison algorithm and storage for the sort order to use when comparing.
 @preconcurrency
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public protocol SortComparator<Compared>: Hashable, Sendable {
-    /// The type that the `SortComparator` provides a comparison for.
+    /// A type that the sort comparator can compare.
     associatedtype Compared
 
-    /// The relative ordering of lhs, and rhs.
+    /// Provides the relative ordering of two elements based on the sort order
+    /// of the comparator.
     ///
     /// The result of comparisons should be flipped if the current `order`
     /// is `reverse`.
@@ -30,21 +33,30 @@ public protocol SortComparator<Compared>: Hashable, Sendable {
     /// - Parameters:
     ///     - lhs: A value to compare.
     ///     - rhs: A value to compare.
+    /// - Returns: The relative ordering of the two values.
     func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult
 
-    /// If the `SortComparator`s resulting order is forward or reverse.
+    /// The sort order that the comparator uses to compare.
     var order: SortOrder { get set }
 }
 
-/// The orderings that sorts can be performed with.
+/// The orderings that you can perform sorts with.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @frozen
 public enum SortOrder: Hashable, Codable, Sendable {
-    /// The ordering where if compare(a, b) == .orderedAscending,
-    /// a is placed before b.
+    /// The ordering that places the first item before the second when comparing
+    /// two items using an ascending order.
+    ///
+    /// The ordering places the first item before the second when a
+    /// ``ComparisonResult`` of two items is
+    /// ``ComparisonResult/orderedAscending``.
     case forward
-    /// The ordering where if compare(a, b) == .orderedAscending,
-    /// a is placed after b.
+    /// The ordering that places the first item after the second when comparing
+    /// two items using an ascending order.
+    ///
+    /// The ordering places the first item after the second when a
+    /// ``ComparisonResult`` of two items is
+    /// ``ComparisonResult/orderedAscending``.
     case reverse
 
     public init(from decoder: Decoder) throws {
@@ -137,9 +149,12 @@ package struct AnySortComparator: SortComparator, Sendable {
     }
 }
 
-/// Compares `Comparable` types using their comparable implementation.
+/// A comparator that compares types according to their conformance to the comparable protocol.
+///
+/// The comparator uses the relevant type's <doc://com.apple.documentation/documentation/swift/comparable> implementation to compare instances.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct ComparableComparator<Compared: Comparable>: SortComparator, Sendable {
+    /// The sort order that the comparator uses to compare.
     public var order: SortOrder
     
 #if FOUNDATION_FRAMEWORK
@@ -160,6 +175,14 @@ public struct ComparableComparator<Compared: Comparable>: SortComparator, Sendab
         return .orderedSame
     }
 
+    /// Provides the relative ordering of two elements.
+    ///
+    /// The method returns flipped comparisons if the sort order is ``SortOrder/reverse``.
+    ///
+    /// - Parameters:
+    ///   - lhs: The first element to compare.
+    ///   - rhs: The second element to compare.
+    /// - Returns: The relative ordering between the two elements.
     public func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
         return unorderedCompare(lhs, rhs).withOrder(order)
     }

--- a/Sources/FoundationEssentials/String/String+IO.swift
+++ b/Sources/FoundationEssentials/String/String+IO.swift
@@ -53,7 +53,11 @@ extension String {
         switch encoding {
         case .ascii, .nonLossyASCII:
             func makeString(buffer: UnsafeBufferPointer<UInt8>) -> String? {
-                return String(_validating: buffer, as: Unicode.ASCII.self)
+                guard let span = try? UTF8Span(validating: buffer.span) else {
+                    return nil
+                }
+                guard span.isKnownASCII else { return nil }
+                return String(copying: span)
             }
 
             if let string = bytes.withContiguousStorageIfAvailable(makeString) ?? Array(bytes).withUnsafeBufferPointer(makeString) {
@@ -90,11 +94,7 @@ extension String {
                 if buffer.starts(with: [0xEF, 0xBB, 0xBF]) {
                     buffer = UnsafeBufferPointer(rebasing: buffer.suffix(from: 3))
                 }
-                if let string = String._tryFromUTF8(buffer) {
-                    return string
-                }
-
-                return String(_validating: buffer, as: UTF8.self)
+                return String._tryFromUTF8(buffer)
             }
 
             if let string = bytes.withContiguousStorageIfAvailable(makeString) ?? Array(bytes).withUnsafeBufferPointer(makeString) {
@@ -136,7 +136,7 @@ extension String {
             
             if let maybe, let maybe {
                 self = maybe
-            } else if let result = String(_validating: UTF16EndianAdaptor(bytes, endianness: e), as: UTF16.self) {
+            } else if let result = String(validating: UTF16EndianAdaptor(bytes, endianness: e), as: UTF16.self) {
                 self = result
             } else {
                 return nil
@@ -163,7 +163,7 @@ extension String {
             
             if let maybe, let maybe {
                 self = maybe
-            } else if let result = String(_validating: UTF32EndianAdaptor(bytes, endianness: e), as: UTF32.self) {
+            } else if let result = String(validating: UTF32EndianAdaptor(bytes, endianness: e), as: UTF32.self) {
                 self = result
             } else {
                 return nil

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -18,15 +18,20 @@ import Darwin
 
 internal import _FoundationCShims
 
-/**
- `TimeZone` defines the behavior of a time zone. Time zone values represent geopolitical regions. Consequently, these values have names for these regions. Time zone values also represent a temporal offset, either plus or minus, from Greenwich Mean Time (GMT) and an abbreviation (such as PST for Pacific Standard Time).
-
- `TimeZone` provides two static functions to get time zone values: `current` and `autoupdatingCurrent`. The `autoupdatingCurrent` time zone automatically tracks updates made by the user.
-
- Note that time zone database entries such as "America/Los_Angeles" are IDs, not names. An example of a time zone name is "Pacific Daylight Time". Although many `TimeZone` functions include the word "name", they refer to IDs.
-
- Cocoa does not provide any API to change the time zone of the computer, or of other applications.
- */
+/// Information about standard time conventions associated with a specific geopolitical region.
+///
+/// `TimeZone` defines the behavior of a time zone. Time zone values represent geopolitical regions. Consequently,
+/// these values have names for these regions. Time zone values also represent a temporal offset, either plus or
+/// minus, from Greenwich Mean Time (GMT) and an abbreviation (such as PST for Pacific Standard Time).
+///
+/// `TimeZone` provides two static functions to get time zone values: `current` and `autoupdatingCurrent`. The
+/// `autoupdatingCurrent` time zone automatically tracks updates made by the user.
+///
+/// Note that time zone database entries such as "America/Los_Angeles" are IDs, not names. An example of a time
+/// zone name is "Pacific Daylight Time". Although many `TimeZone` functions include the word "name", they refer
+/// to IDs.
+///
+/// Cocoa does not provide any API to change the time zone of the computer, or of other applications.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct TimeZone : Hashable, Equatable, Sendable {
     private var _tz: _TimeZoneProtocol
@@ -216,7 +221,10 @@ public struct TimeZone : Hashable, Equatable, Sendable {
         }
     }
 
-    /// Returns the date of the next (after the current instant) daylight saving time transition for the time zone. Depending on the time zone, the value of this property may represent a change of the time zone's offset from GMT. Returns `nil` if the time zone does not currently observe daylight saving time.
+    /// The date of the next (after the current instant) daylight saving time transition for the time zone.
+    ///
+    /// Depending on the time zone, the value of this property may represent a change of the time zone's offset
+    /// from GMT. The value is `nil` if the time zone does not currently observe daylight saving time.
     public var nextDaylightSavingTimeTransition: Date? {
         _tz.nextDaylightSavingTimeTransition(after: Date.now)
     }

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -28,6 +28,7 @@ public struct URLResourceValues {
     var _values: [URLResourceKey: Any]
     var _keys: Set<URLResourceKey>
 
+    /// Initializes a new resource values structure.
     public init() {
         _values = [:]
         _keys = []
@@ -633,11 +634,25 @@ internal func foundation_swift_url_v2_enabled() -> Bool {
 internal import os
 #endif
 
-/// A URL is a type that can potentially contain the location of a resource on a remote server, the path of a local file on disk, or even an arbitrary piece of encoded data.
+/// A value that identifies the location of a resource, such as an item on a remote server or the path to a local file.
 ///
-/// You can construct URLs and access their parts. For URLs that represent local files, you can also manipulate properties of those files directly, such as changing the file's last modification date. Finally, you can pass URLs to other APIs to retrieve the contents of those URLs. For example, you can use the URLSession classes to access the contents of remote resources, as described in URL Session Programming Guide.
+/// You can construct URLs and access their parts. For URLs that represent local
+/// files, you can also manipulate properties of those files directly, such as
+/// changing the file's last modification date. Finally, you can pass URLs to
+/// other APIs to retrieve the contents of those URLs. For example, you can use
+/// ``URLSession`` and its related classes to access the contents of remote
+/// resources.
 ///
-/// URLs are the preferred way to refer to local files. Most objects that read data from or write data to a file have methods that accept a URL instead of a pathname as the file reference. For example, you can get the contents of a local file URL as `String` by calling `func init(contentsOf:encoding:) throws`, or as a `Data` by calling `func init(contentsOf:options:) throws`.
+/// URLs are the preferred way to refer to local files. Most objects that read
+/// data from or write data to a file have methods that accept a URL instead of
+/// a pathname as the file reference. For example, you can get the contents of a
+/// local file URL as `String` by calling `init(contentsOf:encoding:)`, or as a
+/// ``Data`` by calling ``Data/init(contentsOf:options:)``.
+///
+/// As a convenience, you can use Swift's `async`-`await` syntax to
+/// asynchronously access the contents of a ``URL`` through the
+/// ``resourceBytes`` and ``lines`` properties. These properties use the shared
+/// ``URLSession`` instance to load the resource.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct URL: Equatable, Sendable, Hashable {
 
@@ -684,7 +699,9 @@ public struct URL: Equatable, Sendable, Hashable {
 #endif
 
 #if FOUNDATION_FRAMEWORK && !NO_FILESYSTEM
+    /// An alias for the bookmark resolution options type.
     public typealias BookmarkResolutionOptions = NSURL.BookmarkResolutionOptions
+    /// An alias for bookmark creation options.
     public typealias BookmarkCreationOptions = NSURL.BookmarkCreationOptions
 #endif
 
@@ -700,36 +717,79 @@ public struct URL: Equatable, Sendable, Hashable {
         _url = inner.convertingFileReference()
     }
 
-    /// Initialize with string.
+    /// Creates a URL instance from the provided string.
     ///
-    /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
+    /// - Parameter string: A URL location.
+    ///
+    /// > Important: For apps linked on or after iOS 17 and aligned OS versions,
+    /// > ``URL`` parsing has updated from the obsolete RFC 1738/1808 parsing to
+    /// > the same [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) parsing as
+    /// > ``URLComponents``. This unifies the parsing behaviors of the `URL` and
+    /// > `URLComponents` APIs. Now, `URL` automatically percent- and
+    /// > IDNA-encodes invalid characters to help create a valid URL.
+    ///
+    /// This initializer returns `nil` if the string doesn't represent a valid
+    /// URL even after encoding invalid characters. To check if a URL string is
+    /// strictly valid according to the RFC, use the new
+    /// ``URL/init(string:encodingInvalidCharacters:)`` initializer and pass
+    /// `encodingInvalidCharacters: false`. This leaves all characters as they
+    /// are and returns `nil` if the URL string is explicitly invalid.
     public init?(string: __shared String) {
         guard let inner = URL._type.init(string: string) else { return nil }
         _url = inner.convertingFileReference()
     }
 
-    /// Initialize with string, relative to another URL.
+    /// Creates a URL instance from the provided string, relative to another URL.
     ///
-    /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
+    /// - Parameters:
+    ///   - string: A relative URL location.
+    ///   - url: A URL that provides a base location that the string extends.
+    ///
+    /// > Important: For apps linked on or after iOS 17 and aligned OS versions,
+    /// > ``URL`` parsing has updated from the obsolete RFC 1738/1808 parsing to
+    /// > the same [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) parsing as
+    /// > ``URLComponents``. This unifies the parsing behaviors of the `URL` and
+    /// > `URLComponents` APIs. Now, `URL` automatically percent- and
+    /// > IDNA-encodes invalid characters to help create a valid URL.
+    ///
+    /// This initializer returns `nil` if the string doesn't represent a valid
+    /// URL even after encoding invalid characters. To check if a URL string is
+    /// strictly valid according to the RFC, use the new
+    /// ``URL/init(string:encodingInvalidCharacters:)`` initializer and pass
+    /// `encodingInvalidCharacters: false`. This leaves all characters as they
+    /// are and returns `nil` if the URL string is explicitly invalid.
     public init?(string: __shared String, relativeTo url: __shared URL?) {
         guard let inner = URL._type.init(string: string, relativeTo: url) else { return nil }
         _url = inner.convertingFileReference()
     }
 
-    /// Initialize with a URL string and the option to add (or skip) IDNA- and percent-encoding of invalid characters.
+    /// Creates a URL instance from the provided string, optionally IDNA- and percent-encoding any invalid characters.
     ///
-    /// If `encodingInvalidCharacters` is false, and the URL string is invalid according to RFC 3986, `nil` is returned.
-    /// If `encodingInvalidCharacters` is true, `URL` will try to encode the string to create a valid URL.
-    /// If the URL string is still invalid after encoding, `nil` is returned.
+    /// - Parameters:
+    ///   - string: A URL location.
+    ///   - encodingInvalidCharacters: A Boolean value that indicates whether the
+    ///     initializer attempts to encode any invalid characters in `string`.
+    ///
+    /// If `encodingInvalidCharacters` is `true`, this initializer tries to
+    /// encode the string to create a valid URL. If the URL string is still
+    /// invalid after encoding, the initializer returns `nil`.
+    ///
+    /// If `encodingInvalidCharacters` is `false`, and the URL string is invalid
+    /// according to RFC 3986, `nil` is returned.
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     public init?(string: __shared String, encodingInvalidCharacters: Bool) {
         guard let inner = URL._type.init(string: string, encodingInvalidCharacters: encodingInvalidCharacters) else { return nil }
         _url = inner.convertingFileReference()
     }
 
-    /// Initializes a newly created file URL referencing the local file or directory at path, relative to a base URL.
+    /// Creates a file URL that references the local file or directory at the given path, relative to a base URL.
     ///
-    /// If an empty string is used for the path, then the path is assumed to be ".".
+    /// - Parameters:
+    ///   - path: The location in the file system.
+    ///   - isDirectory: A Boolean value that indicates whether the path references a directory.
+    ///   - base: A base URL to resolve the path against.
+    ///
+    /// If an empty string is used for the path, the system interprets it as ".".
     /// - Note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
@@ -740,9 +800,13 @@ public struct URL: Equatable, Sendable, Hashable {
         _url = URL._type.init(fileURLWithPath: path, isDirectory: isDirectory, relativeTo: base).convertingFileReference()
     }
 
-    /// Initializes a newly created file URL referencing the local file or directory at path, relative to a base URL.
+    /// Creates a file URL that references the local file or directory at the given path, relative to a base URL.
     ///
-    /// If an empty string is used for the path, then the path is assumed to be ".".
+    /// - Parameters:
+    ///   - path: The location in the file system.
+    ///   - base: A base URL to resolve the path against.
+    ///
+    /// If an empty string is used for the path, the system interprets it as ".".
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
@@ -752,10 +816,14 @@ public struct URL: Equatable, Sendable, Hashable {
         _url = URL._type.init(fileURLWithPath: path, relativeTo: base).convertingFileReference()
     }
 
-    /// Initializes a newly created file URL referencing the local file or directory at path.
+    /// Creates a file URL that references the local file or directory at the given path.
     ///
-    /// If an empty string is used for the path, then the path is assumed to be ".".
-    /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
+    /// - Parameters:
+    ///   - path: The location in the file system.
+    ///   - isDirectory: A Boolean value that indicates whether the path references a directory.
+    ///
+    /// If an empty string is used for the path, the system interprets it as ".".
+    /// - Note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
@@ -765,9 +833,11 @@ public struct URL: Equatable, Sendable, Hashable {
         _url = URL._type.init(fileURLWithPath: path, isDirectory: isDirectory).convertingFileReference()
     }
 
-    /// Initializes a newly created file URL referencing the local file or directory at path.
+    /// Creates a file URL that references the local file or directory at the given path.
     ///
-    /// If an empty string is used for the path, then the path is assumed to be ".".
+    /// - Parameter path: The location in the file system.
+    ///
+    /// If an empty string is used for the path, the system interprets it as ".".
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use init(filePath:directoryHint:relativeTo:) instead")
@@ -796,7 +866,9 @@ public struct URL: Equatable, Sendable, Hashable {
 
     /// Initializes a newly created URL using the contents of the given data, relative to a base URL.
     ///
-    /// If the data representation is not a legal URL string as ASCII bytes, the URL object may not behave as expected. If the URL cannot be formed then this will return nil.
+    /// If the data representation isn't a legal URL string as ASCII bytes, the
+    /// URL object may not behave as expected. This initializer returns `nil` if
+    /// it can't form a valid URL from the provided data.
     @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
     public init?(dataRepresentation: __shared Data, relativeTo base: __shared URL?, isAbsolute: Bool = false) {
         guard let inner = URL._type.init(dataRepresentation: dataRepresentation, relativeTo: base, isAbsolute: isAbsolute) else { return nil }
@@ -811,7 +883,15 @@ public struct URL: Equatable, Sendable, Hashable {
         try self.init(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &bookmarkDataIsStale)
     }
 
-    /// Initializes a URL that refers to a location specified by resolving bookmark data.
+    /// Creates a URL that refers to a location specified by resolving bookmark data.
+    ///
+    /// - Parameters:
+    ///   - data: The bookmark data used to construct a URL.
+    ///   - options: Options taken into account when resolving the bookmark data.
+    ///   - url: The base URL that the bookmark data is relative to.
+    ///   - bookmarkDataIsStale: On return, if `true`, the bookmark data is
+    ///     stale. Your app should create a new bookmark using the returned URL
+    ///     and use it in place of any stored copies of the existing bookmark.
     @available(swift, introduced: 4.2)
     public init(resolvingBookmarkData data: __shared Data, options: BookmarkResolutionOptions = [], relativeTo url: __shared URL? = nil, bookmarkDataIsStale: inout Bool) throws {
         var stale: ObjCBool = false
@@ -820,7 +900,18 @@ public struct URL: Equatable, Sendable, Hashable {
         self.init(reference: nsURL)
     }
 
-    /// Creates and initializes a URL that refers to the location specified by resolving the alias file at `url`. If the `url` argument does not refer to an alias file as defined by the `.isAliasFileKey` property, the URL returned is the same as the `url` argument. This method fails and returns `nil` if the `url` argument is unreachable, or if the original file or directory could not be located or is not reachable, or if the original file or directory is on a volume that could not be located or mounted. The `URLBookmarkResolutionWithSecurityScope` option is not supported by this method.
+    /// Creates a URL that refers to the location specified by resolving an alias file.
+    ///
+    /// If the `url` argument doesn't refer to an alias file (as defined by the
+    /// ``URLResourceKey/isAliasFileKey`` property), the returned URL is the
+    /// same as the `url` argument.
+    ///
+    /// This method throws an error if the url argument is unreachable, the
+    /// original file or directory is unknown or unreachable, or the original
+    /// file or directory is on a volume that the system can't locate or mount.
+    ///
+    /// This method doesn't support the
+    /// ``NSURL/BookmarkResolutionOptions/withSecurityScope`` option.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public init(resolvingAliasFileAt url: __shared URL, options: BookmarkResolutionOptions = []) throws {
         self.init(reference: try NSURL(resolvingAliasFileAt: url, options: options))
@@ -828,51 +919,59 @@ public struct URL: Equatable, Sendable, Hashable {
 
 #endif // !NO_FILESYSTEM && FOUNDATION_FRAMEWORK
 
-    /// Initializes a newly created URL referencing the local file or directory at the file system representation of the path. File system representation is a null-terminated C string with canonical UTF-8 encoding.
+    /// Initializes a newly created URL referencing the local file or directory at the file system representation of the path.
+    ///
+    /// File system representation is a null-terminated C string with canonical
+    /// UTF-8 encoding.
     public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory: Bool, relativeTo base: __shared URL?) {
         _url = URL._type.init(fileURLWithFileSystemRepresentation: path, isDirectory: isDirectory, relativeTo: base).convertingFileReference()
     }
 
-    /// Returns the data representation of the URL's relativeString.
+    /// The data representation of the URL's relativeString.
     ///
-    /// If the URL was initialized with `init?(dataRepresentation:relativeTo:isAbsolute:)`, the data representation returned are the same bytes as those used at initialization; otherwise, the data representation returned are the bytes of the `relativeString` encoded with UTF8 string encoding.
+    /// If the URL was initialized with
+    /// `init?(dataRepresentation:relativeTo:isAbsolute:)`, the data
+    /// representation returned are the same bytes as those used at
+    /// initialization; otherwise, the data representation returned are the
+    /// bytes of the `relativeString` encoded with UTF8 string encoding.
     @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
     public var dataRepresentation: Data {
         return _url.dataRepresentation
     }
 
-    /// Returns the absolute string for the URL.
+    /// The absolute string for the URL.
     public var absoluteString: String {
         return _url.absoluteString
     }
 
-    /// Returns the relative portion of a URL.
+    /// The relative portion of a URL.
     ///
-    /// If `baseURL` is nil, or if the receiver is itself absolute, this is the same as `absoluteString`.
+    /// If `baseURL` is nil, or if the receiver is itself absolute, this is the
+    /// same as `absoluteString`.
     public var relativeString: String {
         return _url.relativeString
     }
 
-    /// Returns the base URL.
+    /// The base URL.
     ///
-    /// If the URL is itself absolute, then this value is nil.
+    /// If the URL is itself absolute, then this value is `nil`.
     public var baseURL: URL? {
         return _url.baseURL
     }
 
-    /// Returns the absolute URL.
+    /// The absolute URL.
     ///
-    /// If the URL is itself absolute, this will return self.
+    /// If the URL is itself absolute, this returns `self`.
     public var absoluteURL: URL {
         return _url.absoluteURL ?? self
     }
 
-    /// Returns the scheme of the URL.
+    /// The scheme of the URL.
     public var scheme: String? {
         return _url.scheme
     }
 
-    /// Returns true if the scheme is `file:`.
+    /// A Boolean that is true if the scheme is `file:`.
     public var isFileURL: Bool {
         return _url.isFileURL
     }
@@ -881,9 +980,12 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.hasAuthority
     }
 
-    /// Returns the host component of the URL if present, otherwise returns `nil`.
+    /// The host component of a URL if the URL conforms to RFC 3986; otherwise, nil.
     ///
-    /// - note: This function will resolve against the base `URL`.
+    /// > Note: This function resolves against the base `URL`.
+    ///
+    /// New code should use ``URL/host(percentEncoded:)`` instead of this
+    /// property.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use host(percentEncoded:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use host(percentEncoded:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use host(percentEncoded:) instead")
@@ -893,26 +995,38 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.host
     }
 
-    /// Returns the host component of the URL if present, otherwise returns `nil`.
+    /// Returns the host component of the URL, optionally removing any percent-encoding.
+    ///
+    /// The system doesn't allow certain characters in the URL host component,
+    /// so ``URL`` percent-encodes those characters to create a valid URL.
+    /// Calling this function with `percentEncoded = false` removes any
+    /// percent-encoding and returns the unencoded host.
+    ///
+    /// If the URL doesn't contain a host component according to
+    /// [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), this function
+    /// returns `nil`.
     ///
     /// - Parameter percentEncoded: Whether the host should be percent encoded,
     ///   defaults to `true`.
-    /// - Returns: The host component of the URL
+    /// - Returns: The host component of the URL.
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public func host(percentEncoded: Bool = true) -> String? {
         return _url.host(percentEncoded: percentEncoded)
     }
 
-    /// Returns the port component of the URL if present, otherwise returns `nil`.
+    /// The port component of the URL if the URL conforms to RFC 3986; otherwise, nil.
     ///
-    /// - note: This function will resolve against the base `URL`.
+    /// > Note: This function resolves against the base `URL`.
     public var port: Int? {
         return _url.port
     }
 
-    /// Returns the user component of the URL if present, otherwise returns `nil`.
+    /// The user component of the URL if the URL conforms to RFC 3986; otherwise, nil.
     ///
-    /// - note: This function will resolve against the base `URL`.
+    /// > Note: This function resolves against the base `URL`.
+    ///
+    /// New code should use ``URL/user(percentEncoded:)`` instead of this
+    /// property.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use user(percentEncoded:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use user(percentEncoded:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use user(percentEncoded:) instead")
@@ -922,7 +1036,17 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.user
     }
 
-    /// Returns the user component of the URL if present, otherwise returns `nil`.
+    /// Returns the user component of the URL, optionally removing any percent-encoding.
+    ///
+    /// The system doesn't allow certain characters in the URL user component,
+    /// so ``URL`` percent-encodes those characters to create a valid URL.
+    /// Calling this function with `percentEncoded = false` removes any
+    /// percent-encoding and returns the unencoded user.
+    ///
+    /// If the URL doesn't contain a user component according to
+    /// [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), this function
+    /// returns `nil`.
+    ///
     /// - Parameter percentEncoded: Whether the user should be percent encoded,
     ///   defaults to `true`.
     /// - Returns: The user component of the URL.
@@ -931,9 +1055,12 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.user(percentEncoded: percentEncoded)
     }
 
-    /// Returns the password component of the URL if present, otherwise returns `nil`.
+    /// The password component of the URL if the URL conforms to RFC 3986; otherwise, nil.
     ///
-    /// - note: This function will resolve against the base `URL`.
+    /// > Note: This function resolves against the base `URL`.
+    ///
+    /// New code should use ``URL/password(percentEncoded:)`` instead of this
+    /// property.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use password(percentEncoded:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use password(percentEncoded:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use password(percentEncoded:) instead")
@@ -943,7 +1070,17 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.password
     }
 
-    /// Returns the password component of the URL if present, otherwise returns `nil`.
+    /// Returns the password component of the URL, optionally removing any percent-encoding.
+    ///
+    /// The system doesn't allow certain characters in the URL password
+    /// component, so ``URL`` percent-encodes those characters to create a valid
+    /// URL. Calling this function with `percentEncoded = false` removes any
+    /// percent-encoding and returns the unencoded password.
+    ///
+    /// If the URL doesn't contain a password component according to
+    /// [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), this function
+    /// returns `nil`.
+    ///
     /// - Parameter percentEncoded: Whether the password should be percent encoded,
     ///   defaults to `true`.
     /// - Returns: The password component of the URL.
@@ -956,10 +1093,14 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.absolutePath(percentEncoded: percentEncoded)
     }
 
-    /// Returns the path component of the URL if present, otherwise returns an empty string.
+    /// The path component of the URL if the URL conforms to RFC 3986; otherwise, an empty string.
     ///
-    /// - note: This function will resolve against the base `URL`.
-    /// - returns: The path, or an empty string if the URL has an empty path.
+    /// > Note: This function resolves against the base `URL`.
+    ///
+    /// New code should use ``URL/path(percentEncoded:)`` instead of this
+    /// property.
+    ///
+    /// - Returns: The path, or an empty string if the URL has an empty path.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use path(percentEncoded:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use path(percentEncoded:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use path(percentEncoded:) instead")
@@ -969,8 +1110,17 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.path
     }
 
-    /// Returns the path component of the URL if present, otherwise returns an empty string.
-    /// - note: This function will resolve against the base `URL`.
+    /// Returns the path component of the URL, optionally removing any percent-encoding.
+    ///
+    /// The system doesn't allow certain characters in the URL path component,
+    /// so ``URL`` percent-encodes those characters to create a valid URL.
+    /// Calling this function with `percentEncoded = false` removes any
+    /// percent-encoding and returns the unencoded path.
+    ///
+    /// If the URL's path component is empty, this method returns an empty
+    /// string.
+    ///
+    /// - Note: This function resolves against the base `URL`.
     /// - Parameter percentEncoded: Whether the path should be percent encoded,
     ///   defaults to `true`.
     /// - Returns: The path component of the URL.
@@ -979,9 +1129,11 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.path(percentEncoded: percentEncoded)
     }
 
-    /// Returns the relative path of the URL if present, otherwise returns an empty string. This is the same as `path` if `baseURL` is `nil`.
+    /// The relative path of the URL if the URL conforms to RFC 3986, otherwise nil.
     ///
-    /// - returns: The relative path, or an empty string if the URL has an empty path.
+    /// This is the same as `path` if `baseURL` is `nil`.
+    ///
+    /// - Returns: The relative path, or an empty string if the URL has an empty path.
     public var relativePath: String {
         return _url.relativePath
     }
@@ -990,9 +1142,12 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.relativePath(percentEncoded: percentEncoded)
     }
 
-    /// Returns the query component of the URL if present, otherwise returns `nil`.
+    /// The query of the URL if the URL conforms to RFC 3986; otherwise, nil.
     ///
-    /// - note: This function will resolve against the base `URL`.
+    /// > Note: This function resolves against the base `URL`.
+    ///
+    /// New code should use ``URL/query(percentEncoded:)`` instead of this
+    /// property.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use query(percentEncoded:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use query(percentEncoded:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use query(percentEncoded:) instead")
@@ -1002,7 +1157,17 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.query
     }
 
-    /// Returns the password component of the URL if present, otherwise returns `nil`.
+    /// Returns the query component of the URL, optionally removing any percent-encoding.
+    ///
+    /// The system doesn't allow certain characters in the URL query component,
+    /// so ``URL`` percent-encodes those characters to create a valid URL.
+    /// Calling this function with `percentEncoded = false` removes any
+    /// percent-encoding and returns the unencoded query.
+    ///
+    /// If the URL doesn't contain a query component according to
+    /// [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), this function
+    /// returns `nil`.
+    ///
     /// - Parameter percentEncoded: Whether the query should be percent encoded,
     ///   defaults to `true`.
     /// - Returns: The query component of the URL.
@@ -1011,9 +1176,12 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.query(percentEncoded: percentEncoded)
     }
 
-    /// Returns the fragment component of the URL if present, otherwise returns `nil`.
+    /// The fragment component of the URL if the URL conforms to RFC 3986; otherwise, nil.
     ///
-    /// - note: This function will resolve against the base `URL`.
+    /// > Note: This function resolves against the base `URL`.
+    ///
+    /// New code should use ``URL/fragment(percentEncoded:)`` instead of this
+    /// property.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use fragment(percentEncoded:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use fragment(percentEncoded:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use fragment(percentEncoded:) instead")
@@ -1023,7 +1191,17 @@ public struct URL: Equatable, Sendable, Hashable {
         return _url.fragment
     }
 
-    /// Returns the password component of the URL if present, otherwise returns `nil`.
+    /// Returns the fragment component of the URL, optionally removing any percent-encoding.
+    ///
+    /// The system doesn't allow certain characters in the URL fragment
+    /// component, so ``URL`` percent-encodes those characters to create a valid
+    /// URL. Calling this function with `percentEncoded = false` removes any
+    /// percent-encoding and returns the unencoded fragment.
+    ///
+    /// If the URL doesn't contain a fragment component according to
+    /// [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), this function
+    /// returns `nil`.
+    ///
     /// - Parameter percentEncoded: Whether the fragment should be percent encoded,
     ///   defaults to `true`.
     /// - Returns: The fragment component of the URL.
@@ -1042,23 +1220,23 @@ public struct URL: Equatable, Sendable, Hashable {
     }
 
     // MARK: - Path manipulation
-    /// Returns true if the URL path represents a directory.
+    /// A Boolean that is true if the URL path represents a directory.
     @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
     public var hasDirectoryPath: Bool {
         return _url.hasDirectoryPath
     }
 
-    /// Returns the path components of the URL, or an empty array if the path is an empty string.
+    /// The path components of the URL, or an empty array if the path is an empty string.
     public var pathComponents: [String] {
         return _url.pathComponents
     }
 
-    /// Returns the last path component of the URL, or an empty string if the path is an empty string.
+    /// The last path component of the URL, or an empty string if the path is an empty string.
     public var lastPathComponent: String {
         return _url.lastPathComponent
     }
 
-    /// Returns the path extension of the URL, or an empty string if the path is an empty string.
+    /// The path extension of the URL, or an empty string if the path is an empty string.
     public var pathExtension: String {
         return _url.pathExtension
     }
@@ -1078,8 +1256,15 @@ public struct URL: Equatable, Sendable, Hashable {
 
     /// Returns a URL constructed by appending the given path component to self.
     ///
-    /// - note: This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing `/`. If you know in advance that the path component is a directory or not, then use `func appendingPathComponent(_:isDirectory:)`.
-    /// - parameter pathComponent: The path component to add.
+    /// > Note: This function performs a file system operation to determine if
+    /// > the path component is a directory. If so, it will append a trailing
+    /// > `/`. If you know in advance that the path component is a directory or
+    /// > not, then use `func appendingPathComponent(_:isDirectory:)`.
+    ///
+    /// New code should use ``URL/appending(path:directoryHint:)`` instead of
+    /// this method.
+    ///
+    /// - Parameter pathComponent: The path component to add.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use appending(path:directoryHint:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use appending(path:directoryHint:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use appending(path:directoryHint:) instead")
@@ -1131,8 +1316,15 @@ public struct URL: Equatable, Sendable, Hashable {
 
     /// Appends a path component to the URL.
     ///
-    /// - note: This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing `/`. If you know in advance that the path component is a directory or not, then use `func appendingPathComponent(_:isDirectory:)`.
-    /// - parameter pathComponent: The path component to add.
+    /// > Note: This function performs a file system operation to determine if
+    /// > the path component is a directory. If so, it will append a trailing
+    /// > `/`. If you know in advance that the path component is a directory or
+    /// > not, then use `func appendingPathComponent(_:isDirectory:)`.
+    ///
+    /// New code should use ``URL/append(path:directoryHint:)`` instead of this
+    /// method.
+    ///
+    /// - Parameter pathComponent: The path component to add.
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use append(path:directoryHint:) instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use append(path:directoryHint:) instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use append(path:directoryHint:) instead")
@@ -1167,23 +1359,23 @@ public struct URL: Equatable, Sendable, Hashable {
         self = deletingPathExtension()
     }
 
-    /// Returns a `URL` with any instances of ".." or "." removed from its path.
-    /// - note: This method does not consult the file system.
+    /// A version of the URL with any instances of ".." or "." resolved in its path.
     public var standardized: URL {
         return _url.standardized ?? self
     }
 
-    /// Standardizes the path of a file URL by removing dot segments.
+    /// Standardizes the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method does nothing.
     public mutating func standardize() {
         self = self.standardized
     }
 
 #if !NO_FILESYSTEM
 
-    /// Standardizes the path of a file URL.
+    /// A standardized version of the path of a file URL.
     ///
     /// If the `isFileURL` is false, this method returns `self`.
-    /// - note: This method consults the file system.
     public var standardizedFileURL: URL {
         return _url.standardizedFileURL ?? self
     }
@@ -1208,7 +1400,15 @@ public struct URL: Equatable, Sendable, Hashable {
 
     /// Returns whether the URL's resource exists and is reachable.
     ///
-    /// This method synchronously checks if the resource's backing store is reachable. Checking reachability is appropriate when making decisions that do not require other immediate operations on the resource, e.g. periodic maintenance of UI state that depends on the existence of a specific document. When performing operations such as opening a file or copying resource properties, it is more efficient to simply try the operation and handle failures. This method is currently applicable only to URLs for file system resources. For other URL types, `false` is returned.
+    /// This method synchronously checks if the resource's backing store is
+    /// reachable. Checking reachability is appropriate when making decisions
+    /// that do not require other immediate operations on the resource, e.g.
+    /// periodic maintenance of UI state that depends on the existence of a
+    /// specific document. When performing operations such as opening a file or
+    /// copying resource properties, it is more efficient to simply try the
+    /// operation and handle failures. This method is currently applicable only
+    /// to URLs for file system resources. For other URL types, `false` is
+    /// returned.
     public func checkResourceIsReachable() throws -> Bool {
         var error: NSError?
         let result = ns.checkResourceIsReachableAndReturnError(&error)
@@ -1458,9 +1658,17 @@ extension URL {
         return filePath.utf8.first == ._slash
     }
 
-    /// Initializes a newly created file URL referencing the local file or directory at path, relative to a base URL.
+    /// Creates a file URL that references a path you specify as a string.
     ///
-    /// If an empty string is used for the path, then the path is assumed to be ".".
+    /// - Parameters:
+    ///   - path: The location in the file system, as a string.
+    ///   - directoryHint: A hint to the initializer to indicate whether the
+    ///     path is a directory, or to instruct the initializer to make this
+    ///     determination.
+    ///   - base: A URL that provides a file system location that the path
+    ///     extends.
+    ///
+    /// If an empty string is used for the path, the system interprets it as ".".
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public init(filePath path: String, directoryHint: DirectoryHint = .inferFromPath, relativeTo base: URL? = nil) {
         let inner = URL._type.init(filePath: path, directoryHint: directoryHint, relativeTo: base)
@@ -1468,18 +1676,29 @@ extension URL {
     }
 
     /// Returns a URL constructed by appending the given path to self.
+    ///
+    /// This method doesn't percent-encode any path separators (`/`) in the
+    /// path component before appending the component to the path. If you want
+    /// this encoding, use ``URL/appending(component:directoryHint:)`` instead.
+    ///
     /// - Parameters:
-    ///   - path: The path to add
-    ///   - directoryHint: A hint to whether this URL will point to a directory
+    ///   - path: The path to add.
+    ///   - directoryHint: A hint to whether this URL will point to a directory.
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public func appending<S: StringProtocol>(path: S, directoryHint: DirectoryHint = .inferFromPath) -> URL {
         return _url.appending(path: path, directoryHint: directoryHint) ?? self
     }
 
-    /// Appends a path to the receiver.
+    /// Appends a path to the URL, with a hint for handling directory awareness.
     ///
-    /// - parameter path: The path to add.
-    /// - parameter directoryHint: A hint to whether this URL will point to a directory
+    /// This method doesn't percent-encode any path separators (`/`) in the
+    /// path component before appending the component to the path. If you want
+    /// this encoding, use ``URL/append(component:directoryHint:)`` instead.
+    ///
+    /// - Parameters:
+    ///   - path: The path to add.
+    ///   - directoryHint: A hint to whether this URL will point to a directory.
+    ///     Defaults to ``URL/DirectoryHint/inferFromPath``.
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public mutating func append<S: StringProtocol>(path: S, directoryHint: DirectoryHint = .inferFromPath) {
         self = appending(path: path, directoryHint: directoryHint)
@@ -1565,7 +1784,10 @@ extension URL {
         return URL(filePath: FileManager.default.currentDirectoryPath, directoryHint: .isDirectory)
     }
 
-    /// The home directory for the current user (~/).
+    /// The home directory for the current user.
+    ///
+    /// This URL is the equivalent of the shell value `~/`.
+    ///
     /// Complexity: O(1)
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var homeDirectory: URL {
@@ -1602,7 +1824,8 @@ extension URL {
         #endif
     }
 
-    /// The temporary directory for the current user.
+    /// The standard directory for temporary files.
+    ///
     /// Complexity: O(1)
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var temporaryDirectory: URL {
@@ -1615,82 +1838,79 @@ extension URL {
     }
 
 #if FOUNDATION_FRAMEWORK
-    /// Discardable cache files directory for the
-    /// current user. (~/Library/Caches).
+    /// The standard directory for discardable cache files.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var cachesDirectory: URL { url(for: .cachesDirectory, in: .userDomainMask) }
 
-    /// Supported applications (/Applications).
+    /// The standard directory for apps.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var applicationDirectory: URL { url(for: .applicationDirectory, in: .localDomainMask) }
 
-    /// Various user-visible documentation, support, and configuration
-    /// files for the current user (~/Library).
+    /// The library directory for the current user.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var libraryDirectory: URL { url(for: .libraryDirectory, in: .userDomainMask) }
 
-    /// User home directories (/Users).
+    /// The user home directories directory.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var userDirectory: URL { url(for: .userDirectory, in: .localDomainMask) }
 
-    /// Documents directory for the current user (~/Documents)
+    /// The standard directory for document files.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var documentsDirectory: URL { url(for: .documentDirectory, in: .userDomainMask) }
 
-    /// Desktop directory for the current user (~/Desktop)
+    /// The desktop directory for the current user.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var desktopDirectory: URL { url(for: .desktopDirectory, in: .userDomainMask) }
 
-    /// Application support files for the current
-    /// user (~/Library/Application Support)
+    /// The application support directory for the current user.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var applicationSupportDirectory: URL { url(for: .applicationSupportDirectory, in: .userDomainMask) }
 
-    /// Downloads directory for the current user (~/Downloads)
+    /// The downloads directory for the current user.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var downloadsDirectory: URL { url(for: .downloadsDirectory, in: .userDomainMask) }
 
-    /// Movies directory for the current user (~/Movies)
+    /// The movies directory for the current user.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var moviesDirectory: URL { url(for: .moviesDirectory, in: .userDomainMask) }
 
-    /// Music directory for the current user (~/Music)
+    /// The music directory for the current user.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var musicDirectory: URL { url(for: .musicDirectory, in: .userDomainMask) }
 
-    /// Pictures directory for the current user (~/Pictures)
+    /// The pictures directory for the current user.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var picturesDirectory: URL { url(for: .picturesDirectory, in: .userDomainMask) }
 
-    /// The user’s Public sharing directory (~/Public)
+    /// The user’s public sharing directory.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public static var sharedPublicDirectory: URL { url(for: .sharedPublicDirectory, in: .userDomainMask) }
 
-    /// Trash directory for the current user (~/.Trash)
+    /// The trash directory for the current user.
     /// Complexity: O(n) where n is the number of significant directories
     /// specified by `FileManager.SearchPathDirectory`
     @available(macOS 13.0, iOS 16.0, *)
@@ -1698,6 +1918,16 @@ extension URL {
     @available(watchOS, unavailable)
     public static var trashDirectory: URL { url(for: .trashDirectory, in: .userDomainMask) }
 
+    /// Creates a file URL for a common directory in a domain.
+    ///
+    /// - Parameters:
+    ///   - directory: The search path for the commonly used directory.
+    ///   - domain: The file system domain to search. Specify only one domain
+    ///     for this parameter.
+    ///   - url: The file URL for determining the location of the returned URL.
+    ///     Only the volume of this parameter is relevant.
+    ///   - shouldCreate: A Boolean value that indicates whether the initializer
+    ///     creates the directory if it doesn't already exist.
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public init(
         for directory: FileManager.SearchPathDirectory,
@@ -1731,15 +1961,16 @@ extension URL {
 #endif // !NO_FILESYSTEM
 
 extension URL {
+    /// A hint to URL file APIs for handling paths that may reference directories.
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public enum DirectoryHint: Sendable {
-        /// Specifies that the `URL` does reference a directory
+        /// A hint that specifies that a given path is a directory.
         case isDirectory
-        /// Specifies that the `URL` does **not** reference a directory
+        /// A hint that specifies that a given path isn't a directory.
         case notDirectory
-        /// Specifies that `URL` should check with the file system to determine whether it references a directory
+        /// A hint that directs a URL call to consult the file system to determine whether the path references a directory.
         case checkFileSystem
-        /// Specifies that `URL` should infer whether it references a directory based on whether it has a trailing slash
+        /// A hint that directs a URL call to infer whether a path references a directory based on whether it has a trailing slash.
         case inferFromPath
     }
 }
@@ -1812,6 +2043,7 @@ extension NSURL: _HasCustomAnyHashableRepresentation {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension URL: _CustomPlaygroundQuickLookable {
+    /// A playground quicklook for the URL.
     @available(*, deprecated, message: "URL.customPlaygroundQuickLook will be removed in a future Swift version")
     public var customPlaygroundQuickLook: PlaygroundQuickLook {
         return .url(absoluteString)
@@ -1854,6 +2086,9 @@ extension URL: Codable {
 //===----------------------------------------------------------------------===//
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension URL: _ExpressibleByFileReferenceLiteral {
+    /// Creates a URL from a playground file literal.
+    ///
+    /// - Parameter name: The playground file literal name, as a string.
     public init(fileReferenceLiteralResourceName name: String) {
         self = Bundle.main.url(forResource: name, withExtension: nil)!
     }

--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -14,9 +14,9 @@
 internal import _ForSwiftFoundation
 #endif
 
-/// A structure designed to parse URLs based on RFC 3986 and to construct URLs from their constituent parts.
+/// A structure that parses URLs into and constructs URLs from their constituent parts.
 ///
-/// You can easily obtain a `URL` based on the contents of a `URLComponents` or vice versa.
+/// This structure parses and constructs URLs according to [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt). Its behavior differs subtly from that of the ``URL`` structure, which conforms to older RFCs. However, you can easily obtain a ``URL`` value based on the contents of a ``URLComponents`` value or vice versa.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct URLComponents: Hashable, Equatable, Sendable {
     var components: _URLComponents
@@ -693,12 +693,12 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         }
     }
 
-    /// Initialize with all components undefined.
+    /// Initializes empty URLComponents.
     public init() {
         self.components = _URLComponents()
     }
 
-    /// Initialize with the components of a URL.
+    /// Initializes URLComponents from a URL, optionally resolving against its base URL.
     ///
     /// If resolvingAgainstBaseURL is `true` and url is a relative URL, the components of url.absoluteURL are used. If the url string from the URL is malformed, nil is returned.
     public init?(url: __shared URL, resolvingAgainstBaseURL resolve: Bool) {
@@ -714,9 +714,9 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         self.components = components
     }
 
-    /// Initialize with a URL string.
+    /// Initializes URLComponents from a URL string.
     ///
-    /// If the URLString is malformed, nil is returned.
+    /// Returns nil if the URL string is malformed.
     public init?(string: __shared String) {
         guard let components = _URLComponents(string: string) else {
             return nil
@@ -724,7 +724,8 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         self.components = components
     }
 
-    /// Initialize with a URL string and the option to add (or skip) IDNA- and percent-encoding of invalid characters.
+    /// Initializes URLComponents from a URL string, with option to encode invalid characters.
+    ///
     /// If `encodingInvalidCharacters` is false, and the URL string is invalid according to RFC 3986, `nil` is returned.
     /// If `encodingInvalidCharacters` is true, `URLComponents` will try to encode the string to create a valid URL.
     /// If the URL string is still invalid after encoding, `nil` is returned.
@@ -759,7 +760,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
     }
     #endif
 
-    /// Returns a URL created from the URLComponents.
+    /// A URL created from the components.
     ///
     /// If the URLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
     public var url: URL? {
@@ -772,7 +773,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         return URL(stringOrEmpty: string, relativeTo: nil)
     }
 
-    /// Returns a URL created from the URLComponents relative to a base URL.
+    /// Returns a URL based on the components relative to a base URL.
     ///
     /// If the URLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the URLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
     public func url(relativeTo base: URL?) -> URL? {
@@ -786,7 +787,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         return URL(stringOrEmpty: string, relativeTo: base)
     }
 
-    /// Returns a URL string created from the URLComponents.
+    /// A URL string derived from the components.
     ///
     /// If the URLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the URLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
@@ -800,7 +801,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components._uncheckedString(original: original)
     }
 
-    /// The scheme subcomponent of the URL.
+    /// The scheme subcomponent.
     ///
     /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
     /// Attempting to set the scheme with an invalid scheme string will cause an exception.
@@ -827,7 +828,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
     }
 #endif
 
-    /// The user subcomponent of the URL.
+    /// The user subcomponent.
     ///
     /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
     ///
@@ -837,7 +838,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         set { components.user = newValue }
     }
 
-    /// The password subcomponent of the URL.
+    /// The password subcomponent.
     ///
     /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
     ///
@@ -904,7 +905,9 @@ public struct URLComponents: Hashable, Equatable, Sendable {
 
     /// The user subcomponent, percent-encoded.
     ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlUserAllowed`).
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`.
+    ///
+    /// Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlUserAllowed`).
     public var percentEncodedUser: String? {
         get { components.percentEncodedUser }
         set {
@@ -925,7 +928,9 @@ public struct URLComponents: Hashable, Equatable, Sendable {
 
     /// The password subcomponent, percent-encoded.
     ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPasswordAllowed`).
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`.
+    ///
+    /// Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPasswordAllowed`).
     public var percentEncodedPassword: String? {
         get { components.percentEncodedPassword }
         set {
@@ -946,7 +951,9 @@ public struct URLComponents: Hashable, Equatable, Sendable {
 
     /// The host subcomponent, percent-encoded.
     ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlHostAllowed`).
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`.
+    ///
+    /// Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlHostAllowed`).
     @available(macOS, introduced: 10.10, deprecated: 100000.0, message: "Use encodedHost instead")
     @available(iOS, introduced: 8.0, deprecated: 100000.0, message: "Use encodedHost instead")
     @available(tvOS, introduced: 9.0, deprecated: 100000.0, message: "Use encodedHost instead")
@@ -970,6 +977,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
     }
 #endif
 
+    /// The host subcomponent, percent-encoded.
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public var encodedHost: String? {
         get { components.encodedHost }
@@ -991,7 +999,9 @@ public struct URLComponents: Hashable, Equatable, Sendable {
 
     /// The path subcomponent, percent-encoded.
     ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPathAllowed`).
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`.
+    ///
+    /// Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPathAllowed`).
     public var percentEncodedPath: String {
         get { components.percentEncodedPath }
         set {
@@ -1012,7 +1022,9 @@ public struct URLComponents: Hashable, Equatable, Sendable {
 
     /// The query subcomponent, percent-encoded.
     ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlQueryAllowed`).
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`.
+    ///
+    /// Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlQueryAllowed`).
     public var percentEncodedQuery: String? {
         get { components.percentEncodedQuery }
         set {
@@ -1033,7 +1045,9 @@ public struct URLComponents: Hashable, Equatable, Sendable {
 
     /// The fragment subcomponent, percent-encoded.
     ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlFragmentAllowed`).
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`.
+    ///
+    /// Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlFragmentAllowed`).
     public var percentEncodedFragment: String? {
         get { components.percentEncodedFragment }
         set {
@@ -1052,7 +1066,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
     }
 #endif
 
-    /// Returns the character range of the scheme in the string returned by `var string`.
+    /// The character range of the scheme in the ``string`` property.
     ///
     /// If the component does not exist, nil is returned.
     /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
@@ -1061,7 +1075,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components.rangeOf(.scheme)
     }
 
-    /// Returns the character range of the user in the string returned by `var string`.
+    /// The character range of the user in the ``string`` property.
     ///
     /// If the component does not exist, nil is returned.
     /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
@@ -1070,7 +1084,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components.rangeOf(.user)
     }
 
-    /// Returns the character range of the password in the string returned by `var string`.
+    /// The character range of the password in the ``string`` property.
     ///
     /// If the component does not exist, nil is returned.
     /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
@@ -1079,7 +1093,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components.rangeOf(.password)
     }
 
-    /// Returns the character range of the host in the string returned by `var string`.
+    /// The character range of the host in the ``string`` property.
     ///
     /// If the component does not exist, nil is returned.
     /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
@@ -1088,7 +1102,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components.rangeOf(.host)
     }
 
-    /// Returns the character range of the port in the string returned by `var string`.
+    /// The character range of the port in the ``string`` property.
     ///
     /// If the component does not exist, nil is returned.
     /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
@@ -1097,7 +1111,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components.rangeOf(.port)
     }
 
-    /// Returns the character range of the path in the string returned by `var string`.
+    /// The character range of the path in the ``string`` property.
     ///
     /// If the component does not exist, nil is returned.
     /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
@@ -1106,7 +1120,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components.rangeOf(.path)
     }
 
-    /// Returns the character range of the query in the string returned by `var string`.
+    /// The character range of the query in the ``string`` property.
     ///
     /// If the component does not exist, nil is returned.
     /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
@@ -1115,7 +1129,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components.rangeOf(.query)
     }
 
-    /// Returns the character range of the fragment in the string returned by `var string`.
+    /// The character range of the fragment in the ``string`` property.
     ///
     /// If the component does not exist, nil is returned.
     /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
@@ -1124,7 +1138,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         components.rangeOf(.fragment)
     }
 
-    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string.
+    /// The query subcomponent as an array of URLQueryItems.
     ///
     /// Each `URLQueryItem` represents a single key-value pair,
     ///
@@ -1139,7 +1153,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
         set { components.setQueryItems(newValue) }
     }
 
-    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string. Any percent-encoding in a query item name or value is retained
+    /// The query subcomponent as an array of percent-encoded URLQueryItems.
     ///
     /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. This property assumes the query item names and values are already correctly percent-encoded, and that the query item names do not contain the query item delimiter characters '&' and '='. Attempting to set an incorrectly percent-encoded query item or a query item name with the query item delimiter characters '&' and '=' will cause a `fatalError`.
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
@@ -1282,13 +1296,20 @@ extension NSURLComponents: _HasCustomAnyHashableRepresentation {
 #endif // FOUNDATION_FRAMEWORK
 
 
-/// A single name-value pair, for use with `URLComponents`.
+/// A single name-value pair from the query portion of a URL.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct URLQueryItem: Hashable, Equatable, Sendable {
 
+    /// The name of the query item.
     public var name: String
+    /// The value for the query item.
     public var value: String?
 
+    /// Creates a new query item with the name and value you specify.
+    ///
+    /// - Parameters:
+    ///   - name: The name for the query item.
+    ///   - value: The value for the query item.
     public init(name: __shared String, value: __shared String?) {
         self.name = name
         self.value = value

--- a/Sources/FoundationEssentials/UUID.swift
+++ b/Sources/FoundationEssentials/UUID.swift
@@ -14,12 +14,13 @@ internal import _FoundationCShims // uuid.h
 public typealias uuid_t = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 public typealias uuid_string_t = (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)
 
-/// Represents UUID strings, which can be used to uniquely identify types, interfaces, and other items.
+/// A universally unique value to identify types, interfaces, and other items.
 @available(macOS 10.8, iOS 6.0, tvOS 9.0, watchOS 2.0, *)
 public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
+    /// Returns the UUID as bytes.
     public private(set) var uuid: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
-    /* Create a new UUID with RFC 4122 version 4 random bytes */
+    /// Creates a UUID with RFC 4122 version 4 random bytes.
     public init() {
         withUnsafeMutablePointer(to: &uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
@@ -39,9 +40,11 @@ public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
         }
     }
 
-    /// Create a UUID from a string such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".
+    /// Creates a UUID from a string representation.
     ///
-    /// Returns nil for invalid strings.
+    /// Returns `nil` if the string isn't a valid UUID representation.
+    ///
+    /// - Parameter string: The string representation of a UUID, such as `E621E1F8-C36C-495A-93FC-0C247A3E6E5F`.
     public init?(uuidString string: __shared String) {
         let res = withUnsafeMutablePointer(to: &uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
@@ -53,12 +56,14 @@ public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
         }
     }
 
-    /// Create a UUID from a `uuid_t`.
+    /// Creates a UUID from the uuid C-language structure.
+    ///
+    /// - Parameter uuid: The C-language structure of a UUID.
     public init(uuid: uuid_t) {
         self.uuid = uuid
     }
 
-    /// Returns a string created from the UUID, such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+    /// Returns a string created from the UUID, such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".
     public var uuidString: String {
         var bytes: uuid_string_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         return withUUIDBytes { valBuffer in

--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -16,13 +16,44 @@ import FoundationEssentials
 
 internal import _FoundationICU
 
+/// A format style that provides string representations of byte counts.
+///
+/// The following example creates an `Int` representing 1,024 bytes, and then formats it as an
+/// expression of memory storage, with the default byte count format style.
+///
+/// ```swift
+/// let count: Int64 = 1024
+/// let formatted = count.formatted(.byteCount(style: .memory)) // "1 kB"
+/// ```
+///
+/// You can also customize a byte count format style, and use this to format one or more `Int64`
+/// instances. The following example creates a format style to only use kilobyte units, and to
+/// spell out the exact byte count of the measurement.
+///
+/// ```swift
+/// let style = ByteCountFormatStyle(
+///     style: .memory,
+///     allowedUnits: [.kb],
+///     spellsOutZero: true,
+///     includesActualByteCount: false,
+///     locale: Locale(identifier: "en_US"))
+/// let counts: [Int64] = [0, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
+/// let formatted = counts.map { style.format($0) }
+/// // ["Zero kB", "1 kB", "2 kB", "4 kB", "8 kB", "16 kB", "32 kB", "64 kB"]
+/// ```
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct ByteCountFormatStyle: FormatStyle, Sendable {
+    /// The semantic style the format style uses to represent a byte count value.
     public var style: Style { get { attributed.style } set { attributed.style = newValue} }
+    /// The units the format style can use to express the byte count.
     public var allowedUnits: Units { get { attributed.allowedUnits } set { attributed.allowedUnits = newValue} }
+    /// A Boolean value that indicates whether the format style should spell out zero-byte values as text.
     public var spellsOutZero: Bool { get { attributed.spellsOutZero } set { attributed.spellsOutZero = newValue} }
+    /// A Boolean value that indicates whether the format style should include the exact byte count, in addition to expressing it in terms of units.
     public var includesActualByteCount: Bool { get { attributed.includesActualByteCount } set { attributed.includesActualByteCount = newValue} }
+    /// The locale to use to format the numeric part of the byte count.
     public var locale: Locale { get { attributed.locale } set { attributed.locale = newValue} }
+    /// An attributed format style based on the byte count format style.
     public var attributed: Attributed
 
     internal enum Unit: Int {
@@ -54,24 +85,36 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
         static let binaryByteSizes: [Int64] = [1, 1024, 1048576, 1073741824, 1099511627776, 1125899906842624]
     }
 
+    /// Formats a numeric byte count, using this style.
     public func format(_ value: Int64) -> String {
         String(attributed.format(value).characters)
     }
 
+    /// Modifies the format style to use the specified locale.
     public func locale(_ locale: Locale) -> Self {
         var new = self
         new.locale = locale
         return new
     }
 
+    /// Initializes a byte count format style.
     public init(style: Style = .file, allowedUnits: Units = .all, spellsOutZero: Bool = true, includesActualByteCount: Bool = false, locale: Locale = .autoupdatingCurrent) {
         self.attributed = Attributed(style: style, allowedUnits: allowedUnits, spellsOutZero: spellsOutZero, includesActualByteCount: includesActualByteCount, locale: locale)
     }
 
+    /// The semantic style to use when formatting a byte count value.
     public enum Style: Int, Codable, Hashable, Sendable {
-        case file = 0, memory, decimal, binary
+        /// A style for representing file system storage.
+        case file = 0
+        /// The style for representing memory usage.
+        case memory
+        /// A style for representing byte counts as decimal values.
+        case decimal
+        /// A style for representing byte counts as binary values.
+        case binary
     }
 
+    /// The units to use when formatting a byte count, such as kilobytes or gigabytes.
     public struct Units: OptionSet, Codable, Hashable, Sendable {
         public var rawValue: UInt
 
@@ -83,17 +126,28 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
             }
         }
 
+        /// A value that indicates a format style should express byte counts in individual bytes.
         public static var bytes: Self { Self(rawValue: 1 << 0) }
+        /// The kilobytes unit.
         public static var kb: Self { Self(rawValue: 1 << 1) }
+        /// The megabytes unit.
         public static var mb: Self { Self(rawValue: 1 << 2) }
+        /// The gigabytes unit.
         public static var gb: Self { Self(rawValue: 1 << 3) }
+        /// The terabytes unit.
         public static var tb: Self { Self(rawValue: 1 << 4) }
+        /// The petabytes unit.
         public static var pb: Self { Self(rawValue: 1 << 5) }
+        /// The exabytes unit.
         public static var eb: Self { Self(rawValue: 1 << 6) }
+        /// The zettabytes unit.
         public static var zb: Self { Self(rawValue: 1 << 7) }
+        /// A value that indicates a format style should express byte counts as yottabytes or higher.
         public static var ybOrHigher: Self { Self(rawValue: 0x0FF << 8) }
 
+        /// A value that allows the use of all byte-count units.
         public static var all: Self { .init(rawValue: 0x0FFFF) }
+        /// A value that indicates a format style should use the most appropriate units to express a byte count.
         public static var `default`: Self { .all }
 
         fileprivate var smallestUnit: Unit {
@@ -105,13 +159,27 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
         }
     }
 
+    /// A format style that converts byte counts into attributed strings.
+    ///
+    /// Use the ``ByteCountFormatStyle/attributed`` modifier on a ``ByteCountFormatStyle`` to create a format style of this type.
+    ///
+    /// The attributed strings that this format style creates contain attributes from the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use these attributes to determine which runs of the attributed string represent different parts of the formatted value.
     public struct Attributed: FormatStyle, Sendable {
+        /// The semantic style the format style uses to represent a byte count value.
         public var style: Style
+        /// The units the format style can use to express the byte count.
         public var allowedUnits: Units
+        /// A Boolean value that indicates whether the format style should spell out zero-byte values as text.
         public var spellsOutZero: Bool
+        /// A Boolean value that indicates whether the format style should include the exact byte count, in addition to expressing it in terms of units.
         public var includesActualByteCount: Bool
+        /// The locale to use to format the numeric part of the byte count.
         public var locale: Locale
 
+        /// Modifies the format style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to apply to the format style.
+        /// - Returns: A format style that uses the specified locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             new.locale = locale
@@ -241,6 +309,10 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
             return attributedString
         }
         
+        /// Formats a numeric byte count, using this style.
+        ///
+        /// - Parameter value: The 64-bit byte count to format.
+        /// - Returns: A formatted attributed string representation of the byte count.
         public func format(_ value: Int64) -> AttributedString {
             _format(.integer(value), doubleValue: Double(value))
         }
@@ -249,6 +321,27 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == ByteCountFormatStyle {
+    /// Returns a format style to format a data storage value.
+    ///
+    /// Use this type method when the call point allows the use of ``ByteCountFormatStyle``.
+    /// You typically do this when calling the `formatted` method of `BinaryInteger` values
+    /// that represent byte counts, as seen here:
+    ///
+    /// ```swift
+    /// let count: Int64 = 1024
+    /// let formatted = count.formatted(.byteCount(style: .memory)) // "1 kB"
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - style: The style of byte count to express, such as memory or file system storage.
+    ///   - allowedUnits: The units the format style can use to express the byte count.
+    ///   - spellsOutZero: A Boolean value that indicates whether the format style should
+    ///     spell out zero-byte values as text, like `Zero kB`.
+    ///   - includesActualByteCount: A Boolean value that indicates whether the format style
+    ///     should include the exact byte count, in addition to expressing it in terms of
+    ///     units. For example, `1 kB (1,024 bytes)`.
+    /// - Returns: A format style for formatting a measurement of data storage, customized
+    ///   with the provided behaviors.
     static func byteCount(style: ByteCountFormatStyle.Style, allowedUnits: ByteCountFormatStyle.Units = .all, spellsOutZero: Bool = true, includesActualByteCount: Bool = false) -> Self {
         return ByteCountFormatStyle(style: style, allowedUnits: allowedUnits, spellsOutZero: spellsOutZero, includesActualByteCount: includesActualByteCount)
     }

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
@@ -16,14 +16,23 @@ import FoundationEssentials
 
 extension Date {
 
+    /// A format style that creates string representations of date intervals.
+    ///
+    /// Use `Date.IntervalFormatStyle` to create user-readable strings of date intervals.
+    /// The format style provides customization to show specific date and time components.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public struct IntervalFormatStyle : Codable, Hashable, Sendable {
 
+        /// The type that defines date interval styles that vary in length or in their included components.
         public typealias DateStyle = Date.FormatStyle.DateStyle
+        /// The type that defines time styles that vary in length or in their included components.
         public typealias TimeStyle = Date.FormatStyle.TimeStyle
 
+        /// The locale to use when formatting date interval values.
         public var locale: Locale
+        /// The time zone with which to specify date and time values.
         public var timeZone: TimeZone
+        /// The calendar to use for date values.
         public var calendar: Calendar
 
         // Internal
@@ -55,6 +64,10 @@ extension Date {
 
         // MARK: - FormatStyle conformance
 
+        /// Creates a locale-aware string representation from a date interval.
+        ///
+        /// - Parameter v: The date range to format.
+        /// - Returns: A string representation of the date range.
         public func format(_ v: Range<Date>) -> String {
             guard let formatter = ICUDateIntervalFormatter.formatter(for: self), let result = formatter.string(from: v) else {
                 return "\(v.lowerBound.description) - \(v.upperBound.description)"
@@ -62,6 +75,10 @@ extension Date {
             return result
         }
 
+        /// Modifies the date interval format style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale for formatting a date interval.
+        /// - Returns: A date interval format style with the provided locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             new.locale = locale
@@ -76,50 +93,79 @@ extension Date.IntervalFormatStyle : FormatStyle {}
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.IntervalFormatStyle {
 
+    /// The type that supports customizing formatting templates using the date format style's modifier functions, and constructing fixed-pattern date format strings.
     public typealias Symbol = Date.FormatStyle.Symbol
 
+    /// Modifies the date interval format style to include the year.
+    ///
+    /// - Returns: A date interval format style that includes the year.
     public func year() -> Self {
         var new = self
         new.symbols.year = .defaultDigits
         return new
     }
 
+    /// Modifies the date interval format style to include the month.
+    ///
+    /// - Parameter format: The month format style to apply.
+    /// - Returns: A date interval format style that includes the specified month style.
     public func month(_ format: Symbol.Month = .abbreviated) -> Self {
         var new = self
         new.symbols.month = format.option
         return new
     }
 
+    /// Modifies the date interval format style to include the day.
+    ///
+    /// - Returns: A date interval format style that includes the day.
     public func day() -> Self {
         var new = self
         new.symbols.day = .defaultDigits
         return new
     }
 
+    /// Modifies the date interval format style to include the weekday.
+    ///
+    /// - Parameter format: The weekday format style to apply.
+    /// - Returns: A date interval format style that includes the specified weekday style.
     public func weekday(_ format: Symbol.Weekday = .abbreviated) -> Self {
         var new = self
         new.symbols.weekday = format.option
         return new
     }
 
+    /// Modifies the date interval format style to include the hour.
+    ///
+    /// - Parameter format: The hour format style to apply.
+    /// - Returns: A date interval format style that includes the specified hour style.
     public func hour(_ format: Symbol.Hour = .defaultDigits(amPM: .abbreviated)) -> Self {
         var new = self
         new.symbols.hour = format.option
         return new
     }
 
+    /// Modifies the date interval format style to include the minute.
+    ///
+    /// - Returns: A date interval format style that includes the minute.
     public func minute() -> Self {
         var new = self
         new.symbols.minute = .defaultDigits
         return new
     }
 
+    /// Modifies the date interval format style to include the second.
+    ///
+    /// - Returns: A date interval format style that includes the second.
     public func second() -> Self {
         var new = self
         new.symbols.second = .defaultDigits
         return new
     }
 
+    /// Modifies the date interval format style to include the time zone.
+    ///
+    /// - Parameter format: The time zone format style to apply.
+    /// - Returns: A date interval format style that includes the specified time zone style.
     public func timeZone(_ format: Symbol.TimeZone = .genericName(.short)) -> Self {
         var new = self
         new.symbols.timeZoneSymbol = format.option
@@ -129,6 +175,7 @@ extension Date.IntervalFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == Date.IntervalFormatStyle {
+    /// A factory variable used to format a date interval.
     static var interval: Self {
         return Date.IntervalFormatStyle()
     }

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
@@ -20,11 +20,72 @@ typealias CalendarComponentAndValue = (component: Calendar.Component, value: Int
 
 extension Date {
 
+    /// A format style that forms locale-aware string representations of a relative date or time.
+    ///
+    /// Use the strings that the format style produces, such as "1 hour ago", "in 2 weeks", "yesterday", and "tomorrow" as standalone strings. Embedding them in other strings may not be grammatically correct.
+    ///
+    /// Express relative date formats in either ``Date/RelativeFormatStyle/Presentation/numeric`` or ``Date/RelativeFormatStyle/Presentation/named`` styles. For example:
+    ///
+    /// ```swift
+    /// if let past = Calendar.current.date(byAdding: .day, value: -7, to: Date()) {
+    /// var formatStyle = Date.RelativeFormatStyle()
+    ///
+    /// formatStyle.presentation = .numeric
+    /// past.formatted(formatStyle) // "1 week ago"
+    ///
+    /// formatStyle.presentation = .named
+    /// past.formatted(formatStyle) // "last week"
+    /// }
+    /// ```
+    ///
+    ///
+    /// Use the convenient static factory method ``FormatStyle/relative(presentation:unitsStyle:)`` to shorten the syntax when applying presentation and units style modifiers to customize the format. For example:
+    ///
+    /// ```swift
+    /// if let past = Calendar.current.date(byAdding: .day, value: 7, to: Date()) {
+    ///
+    /// past.formatted(.relative(presentation: .numeric)) // "in 1 week"
+    /// past.formatted(.relative(presentation: .named)) // "next week"
+    ///
+    /// past.formatted(.relative(presentation: .named, unitsStyle: .wide)) // "next week"
+    /// past.formatted(.relative(presentation: .named, unitsStyle: .narrow)) // "next wk."
+    /// past.formatted(.relative(presentation: .named, unitsStyle: .abbreviated)) // "next wk."
+    /// past.formatted(.relative(presentation: .named, unitsStyle: .spellOut)) // "next week"
+    /// past.formatted(.relative(presentation: .numeric, unitsStyle: .wide)) // "in 1 week"
+    /// past.formatted(.relative(presentation: .numeric, unitsStyle: .narrow)) // "in 1 wk."
+    /// past.formatted(.relative(presentation: .numeric, unitsStyle: .abbreviated)) // "in 1 wk."
+    /// past.formatted(.relative(presentation: .numeric, unitsStyle: .spellOut)) // "in one week"
+    /// }
+    /// ```
+    ///
+    ///
+    /// The ``FormatStyle/format(_:)`` instance method generates a string from the provided relative date. Once you create a style, you can use it to format relative dates multiple times.
+    ///
+    /// The following example applies a format style repeatedly to produce string representations of relative dates:
+    ///
+    /// ```swift
+    /// if let pastWeek = Calendar.current.date(byAdding: .day, value: -7, to: Date()),
+    /// let pastDay = Calendar.current.date(byAdding: .day, value: -1, to: Date()) {
+    ///
+    /// let formatStyle = Date.RelativeFormatStyle(
+    /// presentation: .named,
+    /// unitsStyle: .spellOut,
+    /// locale: Locale(identifier: "en_GB"),
+    /// calendar: Calendar.current,
+    /// capitalizationContext: .beginningOfSentence)
+    ///
+    /// formatStyle.format(pastDay) // "Yesterday"
+    /// formatStyle.format(pastWeek) // "Last week"
+    /// }
+    /// ```
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public struct RelativeFormatStyle : Codable, Hashable, Sendable {
         @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
         public typealias Field = Date.ComponentsFormatStyle.Field
 
+        /// A type that represents the style to use when formatting the units of relative dates.
+        ///
+        /// Cases include ``wide``, ``narrow``, ``abbreviated`` and ``spellOut``.
         public struct UnitsStyle : Codable, Hashable, Sendable {
             enum Option : Int, Codable, Hashable {
                 case wide
@@ -74,6 +135,7 @@ extension Date {
             public static var narrow: Self { .init(option: .narrow) }
         }
 
+        /// A type that represents the style to use when formatting relative dates, such as "1 week ago" or "last week".
         public struct Presentation : Codable, Hashable, Sendable {
             enum Option : Int, Codable, Hashable {
                 case numeric
@@ -88,10 +150,55 @@ extension Date {
             public static var named: Self { .init(option: .named) }
         }
 
+        /// Specifies the style to use when describing a relative date, such as "1 day ago" or "yesterday".
+        ///
+        /// Express relative date formats in either `numeric` or `named` styles.
+        /// For example:
+        ///
+        /// ```swift
+        /// if let past = Calendar.current.date(byAdding: .day, value: -7, to: Date()) {
+        ///     var formatStyle = Date.RelativeFormatStyle()
+        ///
+        ///     formatStyle.presentation = .numeric
+        ///     past.formatted(formatStyle) // "1 week ago"
+        ///
+        ///     formatStyle.presentation = .named
+        ///     past.formatted(formatStyle) // "last week"
+        /// }
+        /// ```
         public var presentation: Presentation
+        /// The style to use when formatting the quantity or the name of the unit, such as "1 day ago" or "one day ago".
+        ///
+        /// Express relative date format units in either `wide`, `narrow`,
+        /// `abbreviated`, or `spellOut` styles. For example:
+        ///
+        /// ```swift
+        /// if let past = Calendar.current.date(byAdding: .day, value: -14, to: Date()) {
+        ///     past.formatted(.relative(presentation: .named, unitsStyle: .wide)) // "2 weeks ago"
+        ///     past.formatted(.relative(presentation: .named, unitsStyle: .narrow)) // "2 wk. ago"
+        ///     past.formatted(.relative(presentation: .named, unitsStyle: .abbreviated)) // "2 wk. ago"
+        ///     past.formatted(.relative(presentation: .named, unitsStyle: .spellOut)) // "two weeks ago"
+        /// }
+        /// ```
         public var unitsStyle: UnitsStyle
+        /// The capitalization context to use when formatting the relative dates.
+        ///
+        /// Setting the capitalization context to `beginningOfSentence` sets the
+        /// first word of the relative date string to upper-case. A capitalization
+        /// context set to `middleOfSentence` keeps all words in the string
+        /// lower-cased.
+        ///
+        /// If you set this property to `nil`, the format style resets to using `unknown`.
         public var capitalizationContext: FormatStyleCapitalizationContext
+        /// The locale to use when formatting the relative date.
+        ///
+        /// The default value is `autoupdatingCurrent`. If you set this property
+        /// to `nil`, the format style resets to using `autoupdatingCurrent`.
         public var locale: Locale
+        /// The calendar to use when formatting relative dates.
+        ///
+        /// Defaults to `autoupdatingCurrent`. If you set this property to `nil`,
+        /// the format style resets to using `autoupdatingCurrent`.
         public var calendar: Calendar
 
         /// The fields that can be used in the formatted output.
@@ -116,6 +223,30 @@ extension Date {
             case _allowedFields = "allowedFields"
         }
 
+        /// Creates a relative date format style with the specified presentation, units, locale, calendar, and capitalization context.
+        ///
+        /// The following example creates a format style applied to a relative
+        /// date to create a string representation.
+        ///
+        /// ```swift
+        /// if let past = Calendar.current.date(byAdding: .day, value: -7, to: Date()) {
+        ///     let formatStyle = Date.RelativeFormatStyle(
+        ///         presentation: .named,
+        ///         unitsStyle: .abbreviated,
+        ///         locale: Locale(identifier: "en_US"),
+        ///         calendar: Calendar.current,
+        ///         capitalizationContext: .beginningOfSentence)
+        ///
+        ///     print(past.formatted(formatStyle)) // "Last wk."
+        /// }
+        /// ```
+        ///
+        /// - Parameters:
+        ///   - presentation: The style to use when describing a relative date, such as "1 day ago" or "yesterday".
+        ///   - unitsStyle: The style to use when formatting the quantity or the name of the unit, such as "1 day ago" or "one day ago".
+        ///   - locale: The locale to use when formatting the relative date.
+        ///   - calendar: The calendar to use when formatting the relative date.
+        ///   - capitalizationContext: The capitalization context to use when formatting the relative date.
         public init(presentation: Presentation = .numeric, unitsStyle: UnitsStyle = .wide, locale: Locale = .autoupdatingCurrent, calendar: Calendar = .autoupdatingCurrent, capitalizationContext: FormatStyleCapitalizationContext = .unknown) {
             self.presentation = presentation
             self.unitsStyle = unitsStyle
@@ -137,10 +268,36 @@ extension Date {
 
         // MARK: - FormatStyle conformance
 
+        /// Creates a locale-aware string representation from a relative date value.
+        ///
+        /// Once you create a style, you can use it to format relative dates
+        /// multiple times.
+        ///
+        /// ```swift
+        /// if let pastWeek = Calendar.current.date(byAdding: .day, value: -7, to: Date()),
+        ///    let pastDay = Calendar.current.date(byAdding: .day, value: -1, to: Date()) {
+        ///     let formatStyle = Date.RelativeFormatStyle(
+        ///         presentation: .named,
+        ///         unitsStyle: .spellOut,
+        ///         locale: Locale(identifier: "en_GB"),
+        ///         calendar: Calendar.current,
+        ///         capitalizationContext: .beginningOfSentence)
+        ///
+        ///     formatStyle.format(pastDay) // "Yesterday"
+        ///     formatStyle.format(pastWeek) // "Last week"
+        /// }
+        /// ```
+        ///
+        /// - Parameter destDate: The date to format.
+        /// - Returns: A string representation of the relative date.
         public func format(_ destDate: Date) -> String {
             return _format(destDate, refDate: Date.now)
         }
 
+        /// Modifies the relative date format style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to use when formatting relative dates.
+        /// - Returns: A relative date format style with the provided locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             new.locale = locale
@@ -320,6 +477,30 @@ extension DateComponents {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == Date.RelativeFormatStyle {
+    /// Returns a style for formatting a date as relative to the current date.
+    ///
+    /// Use this static method when the call point allows the use of
+    /// ``Date/RelativeFormatStyle``. You typically do this when calling the
+    /// ``Date/formatted(_:)`` method of ``Date``.
+    ///
+    /// The following example shows the relative format style with two different presentations.
+    ///
+    /// ```swift
+    /// if let past = Calendar.current.date(byAdding: .day, value: -7, to: Date()) {
+    ///     let formattedNumeric = past.formatted(
+    ///         .relative(presentation: .numeric)) // "1 week ago"
+    ///     let formattedNamed = past.formatted(
+    ///         .relative(presentation: .named)) // "last week"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - presentation: The style to use when describing a relative date; for example,
+    ///     "1 day ago" or "yesterday".
+    ///   - unitsStyle: The style to use when formatting the quantity or the name of the unit;
+    ///     for example, "1 day ago" or "one day ago".
+    /// - Returns: A relative date format style customized with the specified presentation and
+    ///   unit styles.
     static func relative(presentation: Date.RelativeFormatStyle.Presentation, unitsStyle: Date.RelativeFormatStyle.UnitsStyle = .wide) -> Self {
             .init(presentation: presentation, unitsStyle: unitsStyle)
     }

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+VerbatimFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+VerbatimFormatStyle.swift
@@ -18,7 +18,7 @@ import FoundationEssentials
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
-    /// Formats a `Date` using the given format.
+    /// A style that formats a date with an explicitly-specified style.
     public struct VerbatimFormatStyle : Sendable {
         public var timeZone: TimeZone
         public var calendar: Calendar
@@ -64,6 +64,40 @@ extension Date.VerbatimFormatStyle : FormatStyle {}
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension FormatStyle where Self == Date.VerbatimFormatStyle {
+    /// Returns a style for formatting a date with an explicitly-specified style.
+    ///
+    /// Use this format style only when you need to produce or parse an exact format, such as
+    /// when working with programmatically-produced date strings. For formatting dates that
+    /// people read, use ``FormatStyle/dateTime`` to get a localized ``Date/FormatStyle``
+    /// instead. To use the ISO-8601 standard, use ``FormatStyle/iso8601`` to get a
+    /// ``Date/ISO8601FormatStyle``.
+    ///
+    /// Use the dot-notation form of this type method when the call point allows the use of
+    /// ``Date/VerbatimFormatStyle``. You typically do this when calling the
+    /// ``Date/formatted(_:)`` method of ``Date``.
+    ///
+    /// The following example formats the current date with a verbatim format that uses a
+    /// two-digit month, two-digit day, and default-digits year, separated by slashes. This
+    /// style isn't localized --- it uses this format in any locale, ignoring locale-appropriate
+    /// conventions.
+    ///
+    /// ```swift
+    /// let date = Date()
+    /// let formatted = date.formatted(
+    ///     .verbatim("\(month: .twoDigits)/\(day: .twoDigits)/\(year: .defaultDigits)" as Date.FormatString,
+    ///               locale: .autoupdatingCurrent,
+    ///               timeZone: .current,
+    ///               calendar: .current)) // 12/05/2022
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - format: A ``Date/FormatString`` that provides the explicit components and their
+    ///     respective styles to use when formatting a date.
+    ///   - locale: The locale to use when formatting. Defaults to `nil`.
+    ///   - timeZone: The time zone to use when formatting.
+    ///   - calendar: The calendar to use when formatting.
+    /// - Returns: A date format style that uses the provided format string and timekeeping
+    ///   parameters.
     public static func verbatim(_ format: Date.FormatString, locale: Locale? = nil, timeZone: TimeZone, calendar: Calendar) -> Date.VerbatimFormatStyle { .init(format: format, locale: locale, timeZone: timeZone, calendar: calendar) }
 }
 

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
@@ -17,29 +17,452 @@ import FoundationEssentials
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.FormatStyle {
 
+    /// Types that customize formatting templates either by using the date format style's modifier functions or by constructing fixed-pattern date format strings.
     public struct Symbol : Hashable, Sendable {
         let symbolType: SymbolType
 
+        /// A type that specifies a format for the era in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/Era`` includes static factory variables that create custom ``Date/FormatStyle/Symbol/Era`` objects.
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``abbreviated`` | An abbreviated representation of an era. For example, `AD`, `BC`. |
+        /// | ``narrow`` | A narrow era representation. For example, `A`, `B`. |
+        /// | ``wide`` | A full representation of an era. For example, `Anno Domini`, `Before Christ`. |
+        ///
+        ///
+        /// To customize the era format in a string representation of a `Date`, use ``Date/FormatStyle/era(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/Era`` format styles applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 3:00 PM
+        /// meetingDate.formatted(Date.FormatStyle().era(.abbreviated)) // AD
+        /// meetingDate.formatted(Date.FormatStyle().era(.narrow)) // A
+        /// meetingDate.formatted(Date.FormatStyle().era(.wide)) // Anno Domini
+        /// meetingDate.formatted(Date.FormatStyle().era()) // AD
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``abbreviated`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Era : Hashable, Sendable { let option: SymbolType.EraOption? }
+        /// A type that specifies a format for the year in a date format style.
+        ///
+        /// The ``Date/FormatStyle/Symbol/Year`` type includes static factory variables and methods that create custom ``Date/FormatStyle/Symbol/Year`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``defaultDigits`` | The minimum number of digits that represents the full year. For example, `2`, `20`, `201`, `2017`. |
+        /// | ``twoDigits`` | The year's two lowest-order digits, zero-padded or truncated if necessary. For example, `02`, `20`, `01`, `17`, `73`. |
+        /// | ``padded(_:)`` | Three or more digits, zero-padded if necessary. For example, `002`, `020`, `201`, `2017`. |
+        /// | ``relatedGregorian(minimumLength:)`` | For non-Gregorian calendars, output corresponds to the extended Gregorian year in which the calendar's year begins. The default length is the minimum needed to show the full year. |
+        /// | ``extended(minimumLength:)`` | A single number designating the year of the calendar system, encompassing all supra-year fields. The default length is the minimum needed to show the full year. |
+        ///
+        ///
+        /// To customize the year format in a string representation of a `Date`, use ``Date/FormatStyle/year(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/Year`` formats applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 3:00 PM
+        /// meetingDate.formatted(Date.FormatStyle().year(.defaultDigits)) // 2021
+        /// meetingDate.formatted(Date.FormatStyle().year(.twoDigits)) // 21
+        /// meetingDate.formatted(Date.FormatStyle().year(.extended(minimumLength: 5))) // 02021
+        /// meetingDate.formatted(Date.FormatStyle().year(.extended())) // 2021
+        /// meetingDate.formatted(Date.FormatStyle().year(.padded(6))) // 002021
+        /// meetingDate.formatted(Date.FormatStyle().year(.relatedGregorian())) // 2021
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``Date/FormatStyle/Symbol/Year/defaultDigits`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Year : Hashable, Sendable { let option: SymbolType.YearOption? }
+        /// A type that specifies the format for a year in week-of-year calendars when you parse a string with a date format string.
         public struct YearForWeekOfYear : Hashable, Sendable { let option: SymbolType.YearForWeekOfYearOption? }
+        /// A type that specifies a format for a cyclic year in a date format style.
+        ///
+        /// Calendars such as the Chinese lunar calendar and Hindu calendars use 60-year cycles of year names. If the calendar doesn't provide cyclic year-name data, or if the year value to format is out of the range of years for which the system provides cyclic name data, then the formatting is numeric, as in ``Date/FormatStyle/Symbol/Year``.
+        ///
+        /// The ``Date/FormatStyle/Symbol/CyclicYear`` type includes static factory variables that create custom ``Date/FormatStyle/Symbol/CyclicYear`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``abbreviated`` | A shortened representation of the cyclic year appropriate for space-constrained applications.  |
+        /// | ``narrow`` | The shortest representation of the cyclic year. |
+        /// | ``wide`` | The full representation of the cyclic year. |
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``abbreviated`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see ``Date/FormatStyle``.
         public struct CyclicYear : Hashable, Sendable { let option: SymbolType.CyclicYearOption? }
+        /// A type that specifies the format for the quarter in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/Quarter`` includes static factory variables that create custom ``Date/FormatStyle/Symbol/Quarter`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``abbreviated`` | Abbreviated quarter name. For example, `Q2`.  |
+        /// | ``narrow`` | Minimum number of digits that represents the  numeric quarter. For example, `2`.  |
+        /// | ``oneDigit`` | One-digit numeric quarter. For example, `1`, `4`.  |
+        /// | ``twoDigits`` | Two-digit numeric quarter, zero-padded if necessary. For example, `01`, `04`. |
+        /// | ``wide`` | Wide quarter name. For example, `2nd quarter`. |
+        ///
+        ///
+        /// To customize the month format in a string representation of a `Date`, use ``Date/FormatStyle/quarter(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/Quarter`` format styles applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Oct 7, 2020 at 3:00 PM
+        /// meetingDate.formatted(Date.FormatStyle().quarter(.abbreviated)) // Q4
+        /// meetingDate.formatted(Date.FormatStyle().quarter(.narrow)) // 4th quarter
+        /// meetingDate.formatted(Date.FormatStyle().quarter(.oneDigit)) // 4
+        /// meetingDate.formatted(Date.FormatStyle().quarter(.twoDigits)) // 04
+        /// meetingDate.formatted(Date.FormatStyle().quarter(.wide)) // 4th quarter
+        /// meetingDate.formatted(Date.FormatStyle().quarter()) // Q4
+        ///
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``abbreviated`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Quarter : Hashable, Sendable { let option: SymbolType.QuarterOption? }
+        ///        A type that specifies a format for the month in a date format style.
+        ///
+        ///        The type ``Date/FormatStyle/Symbol/Month`` includes static factory variables that create custom ``Date/FormatStyle/Symbol/Month`` objects:
+        ///
+        ///        |Factory variable|Description|
+        ///        |---|---|
+        ///        | ``abbreviated`` | Abbreviated month name. For example, `Sep`. |
+        ///        | ``defaultDigits`` | Minimum number of digits that represents the numeric month. For example, `9`, `12`. |
+        ///        | ``narrow`` | Narrow month name. For example, `S`. |
+        ///        | ``twoDigits`` | Two-digit numeric month, zero-padded if necessary. For example, `09`, `12`. |
+        ///        | ``wide`` | Wide month name. For example, `September`. |
+        ///
+        ///
+        ///        To customize the month format in a string representation of a `Date`, use ``Date/FormatStyle/month(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/Month`` format styles applied to a date.
+        ///
+        ///        ```swift
+        ///        let meetingDate = Date() // Feb 9, 2021 at 3:00 PM
+        ///        meetingDate.formatted(Date.FormatStyle().month(.abbreviated)) // Feb
+        ///        meetingDate.formatted(Date.FormatStyle().month(.narrow)) // F
+        ///        meetingDate.formatted(Date.FormatStyle().month(.defaultDigits)) // 2
+        ///        meetingDate.formatted(Date.FormatStyle().month(.twoDigits)) // 02
+        ///        meetingDate.formatted(Date.FormatStyle().month(.wide)) // February
+        ///        meetingDate.formatted(Date.FormatStyle().month()) // Feb
+        ///        ```
+        ///
+        ///
+        ///        If no format is specified as a parameter, the ``abbreviated`` static variable is the default format.
+        ///
+        ///        For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Month : Hashable, Sendable { let option: SymbolType.MonthOption? }
+        /// A type that specifies the format for the week in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/Week`` includes static factory variables that create custom ``Date/FormatStyle/Symbol/Week`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``defaultDigits`` | The minimum number of digits that represents the full numeric week. For example, `1`, `18`. |
+        /// | ``twoDigits`` | Two-digit numeric week, zero-padded if necessary. For example, `01`, `18`. |
+        /// | ``weekOfMonth`` | The numeric week of the month. For example, `1`, `4`. |
+        ///
+        ///
+        /// To customize the week format in a string representation of a `Date`, use ``Date/FormatStyle/week(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/Week`` format styles applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // May 3, 2021 at 3:00 PM
+        /// meetingDate.formatted(Date.FormatStyle().week(.defaultDigits)) // 19
+        /// meetingDate.formatted(Date.FormatStyle().week(.twoDigits)) // 19
+        /// meetingDate.formatted(Date.FormatStyle().week(.weekOfMonth)) // 2
+        /// meetingDate.formatted(Date.FormatStyle().week()) // 19
+        ///
+        /// ```
+        ///
+        ///
+        /// An incomplete week at the start of a month is week of the month `1`. If no format is specified as a parameter, the ``defaultDigits`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Week : Hashable, Sendable { let option: SymbolType.WeekOption? }
+        /// A type that specifies the format for a day in a date format style.
+        ///
+        /// The ``Date/FormatStyle/Symbol/Day`` type includes static factory variables and methods that create custom ``Date/FormatStyle/Symbol/Day`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``defaultDigits`` | The minimum number of digits that shows the numeric day of month. For example, `1`, `18`. |
+        /// | ``julianModified(minimumLength:)`` | The modified Julian day. The field length specifies the minimum number of digits, zero-padded if necessary. For example, `2451334`. |
+        /// | ``ordinalOfDayInMonth`` | The ordinal of the day in the month. For example, the second Wednesday in July would yield `2`. |
+        /// | ``twoDigits`` | The two-digit numeric day of month, zero-padded if necessary. For example, `01`, `18`. |
+        ///
+        ///
+        /// To customize the day format in a string representation of a `Date`, use ``Date/FormatStyle/day(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/Day`` formats applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 3:00 PM
+        /// meetingDate.formatted(Date.FormatStyle().day(.defaultDigits)) // 9
+        /// meetingDate.formatted(Date.FormatStyle().day(.ordinalOfDayInMonth)) // 2 (second Tuesday of the month)
+        /// meetingDate.formatted(Date.FormatStyle().day(.twoDigits)) // 09
+        /// meetingDate.formatted(Date.FormatStyle().day(.julianModified(minimumLength: 12))) // 0002459255
+        /// meetingDate.formatted(Date.FormatStyle().day()) // 9
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``defaultDigits`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Day : Hashable, Sendable { let option: SymbolType.DayOption? }
+        /// A type that specifies the format for the day of the year in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/DayOfYear`` includes static factory variables that create custom ``Date/FormatStyle/Symbol/DayOfYear`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``defaultDigits`` | The minimum number of digits that represents the full day of the year. For example, `1`, `18`, `317`. |
+        /// | ``threeDigits`` | Three-digit numeric day of the year, zero-padded if necessary. For example, `001`, `018`, `317`.  |
+        /// | ``twoDigits`` | Two-digit numeric day of the year, zero-padded if necessary. This format has no effect on three-digit values. For example, `01`, `18`, `317`. |
+        ///
+        ///
+        /// To customize the day format in a string representation of a `Date`, use ``Date/FormatStyle/dayOfYear(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/DayOfYear`` formats applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 3:00 PM
+        /// meetingDate.formatted(Date.FormatStyle().dayOfYear(.defaultDigits)) // 40
+        /// meetingDate.formatted(Date.FormatStyle().dayOfYear(.twoDigits)) // 40
+        /// meetingDate.formatted(Date.FormatStyle().dayOfYear(.threeDigits)) // 040
+        /// meetingDate.formatted(Date.FormatStyle().dayOfYear()) // 40
+        ///
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``defaultDigits`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct DayOfYear : Hashable, Sendable { let option: SymbolType.DayOfYearOption? }
+        /// A type that specifies the format for the weekday name in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/Weekday`` includes static factory variables that create custom ``Date/FormatStyle/Symbol/Weekday`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``Date/FormatStyle/Symbol/Weekday/abbreviated`` | Abbreviated weekday name. For example, `Tue`. |
+        /// | ``Date/FormatStyle/Symbol/Weekday/wide`` |  Wide weekday name. For example, `Tuesday`. |
+        /// | ``Date/FormatStyle/Symbol/Weekday/narrow`` | Narrow weekday name. For example, `T`. |
+        /// | ``short`` | Short weekday name. For example, `Tu`. |
+        /// | ``oneDigit`` | Local numeric one-digit day of week. The value depends on the local starting day of the week. For example, this is `2` if Sunday is the first day of the week. |
+        /// | ``twoDigits`` | Local numeric two-digit day of week, zero-padded if necessary. The value depends on the local starting day of the week. For example, this is `02` if Sunday is the first day of the week. |
+        ///
+        ///
+        /// To customize the weekday, name format in a string representation of a `Date`, use ``Date/FormatStyle/weekday(_:)``. This example shows a variety of ``Date/FormatStyle/Symbol/Weekday`` format styles applied to a Thursday, using locale `en_US`:
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 18, 2021 at 3:00 PM
+        /// meetingDate.formatted(Date.FormatStyle().weekday(.abbreviated)) // Thu
+        /// meetingDate.formatted(Date.FormatStyle().weekday(.narrow)) // T
+        /// meetingDate.formatted(Date.FormatStyle().weekday(.short)) // Th
+        /// meetingDate.formatted(Date.FormatStyle().weekday(.wide)) // Thursday
+        /// meetingDate.formatted(Date.FormatStyle().weekday(.oneDigit)) // 5
+        /// meetingDate.formatted(Date.FormatStyle().weekday(.twoDigits)) // 05
+        /// meetingDate.formatted(Date.FormatStyle().weekday()) // Thu
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``Date/FormatStyle/Symbol/Weekday/abbreviated`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Weekday : Hashable, Sendable { let option: SymbolType.WeekdayOption? }
+        /// A type that specifies a format for the time period in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/DayPeriod`` includes static factory methods that create custom ``Date/FormatStyle/Symbol/DayPeriod`` objects.
+        ///
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``conversational(_:)`` | Conversational abbreviated period. For example, `at night`, `nachm.`, `iltap`. ![](spacer) Conversational narrow period. For example, `at night`, `nachmittags`, `iltapäivällä`. ![](spacer) Conversational wide period. For example, `at night`, `nachm.`, `ip.` |
+        /// | ``standard(_:)`` | Abbreviated period. For example, `am`. ![](spacer) Narrow period. For example, `a`. ![](spacer) Wide period. For example, `am`. |
+        /// | ``with12s(_:)`` | Abbreviated period including designations for noon and midnight. For example, `mid.` ![](spacer) Narrow period including designations for noon and midnight. For example, `md`. ![](spacer) Wide period including designations for noon and midnight. For example, `midnight`. |
+        ///
+        ///
+        /// The day period format style may be uppercase or lowercase depending on the locale and other options.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct DayPeriod : Hashable, Sendable { let option: SymbolType.DayPeriodOption? }
+        /// A type that specifies a format for the hour in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/Hour`` includes static factory variables and methods that create custom ``Date/FormatStyle/Symbol/Hour`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``defaultDigitsNoAMPM`` | The minimum number of digits that represents the full numeric hour. This doesn't include the day period (a.m. or p.m.). For example, `1`, `11`. |
+        /// | ``twoDigitsNoAMPM`` | Two-digit numeric hour, zero-padded if necessary. This doesn't include the day period (a.m. or p.m.). For example, `01`, `11`. |
+        /// | ``defaultDigits(amPM:)`` | The minimum number of digits that represents the full numeric hour. This may include the day period (a.m. or p.m.), depending on locale. For example, `7a` (`narrow`), `7AM` (`abbreviated`), `7A.M.` (`wide`). |
+        /// | ``twoDigits(amPM:)`` | Two-digit numeric hour, zero-padded if necessary. This may include the day period (a.m. or p.m.), depending on locale. For example, `07a` (`narrow`), `07AM` (`abbreviated`), `07A.M.` (`wide`). |
+        /// | ``conversationalDefaultDigits(amPM:)`` | The minimum number of digits that represents the full numeric hour. This may include the day period (a.m. or p.m.), depending on locale, and can include conversational period formats. For example, `7a` (`narrow`), `7AM` (`abbreviated`), `7A.M.` (`wide`). |
+        /// | ``conversationalTwoDigits(amPM:)`` | Two-digit numeric hour, zero-padded if necessary. This may include the day period (a.m. or p.m.), depending on locale, and can include conversational period formats. For example, `07a` (`narrow`), `07AM` (`abbreviated`), `07A.M.` (`wide`). |
+        ///
+        ///
+        /// To customize the hour format in a string representation of a `Date`, use ``Date/FormatStyle/hour(_:)`` The example below shows a variety of ``Date/FormatStyle/Symbol/Hour`` format styles applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 7:00 PM
+        /// meetingDate.formatted(Date.FormatStyle().hour(.defaultDigitsNoAMPM))
+        /// // 7
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().hour(.twoDigitsNoAMPM))
+        /// // 07
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().hour(.defaultDigits(amPM: .narrow)))
+        /// // 7p
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().hour(.twoDigits(amPM: .abbreviated))
+        /// // 07 PM
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().hour(.conversationalDefaultDigits(amPM: .wide))
+        /// // 7 P.M.
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``Date/FormatStyle/Symbol/Minute/defaultDigits`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Hour : Hashable, Sendable { let option: SymbolType.HourOption? }
+        /// A type that specifies the format for the minutes in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/Minute`` includes static factory variables that create custom ``Date/FormatStyle/Symbol/Minute`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``defaultDigits`` | The minimum number of digits that represents the  numeric minute. For example, `1`, `18`. |
+        /// | ``twoDigits`` | Two-digit numeric minute, zero-padded if necessary. For example, `01`, `18`. |
+        ///
+        ///
+        /// To customize the minute format in a string representation of a `Date`, use ``Date/FormatStyle/minute(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/Minute`` format styles applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 3:05 PM
+        /// meetingDate.formatted(Date.FormatStyle().minute(.defaultDigits)) // 5
+        /// meetingDate.formatted(Date.FormatStyle().minute(.twoDigits)) // 05
+        /// meetingDate.formatted(Date.FormatStyle().minute()) // 5
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``defaultDigits`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Minute : Hashable, Sendable { let option: SymbolType.MinuteOption? }
+        /// A type that specifies the format for the seconds in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/Second`` includes static factory variables that create custom ``Date/FormatStyle/Symbol/Second`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``defaultDigits`` | The minimum number of digits that represents the numeric second. For example, `1`, `18`. |
+        /// | ``twoDigits`` | Two-digit numeric second, zero-padded if necessary. For example, `01`, `18`. |
+        ///
+        ///
+        /// To customize the second format in a string representation of a `Date`, use ``Date/FormatStyle/second(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/Second`` format styles applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 3:05 PM
+        /// meetingDate.formatted(Date.FormatStyle().second(.defaultDigits)) // 5
+        /// meetingDate.formatted(Date.FormatStyle().second(.twoDigits)) // 05
+        /// meetingDate.formatted(Date.FormatStyle().second()) // 5
+        /// ```
+        ///
+        ///
+        /// If no format is specified as a parameter, the ``defaultDigits`` static variable is the default format.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct Second : Hashable, Sendable { let option: SymbolType.SecondOption? }
+        /// A type that specifies the format for the second fraction in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/SecondFraction`` includes static factory methods that create custom ``Date/FormatStyle/Symbol/SecondFraction`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``fractional(_:)`` | Returns the numerical representation of the fractional component of the second. For example, `8`, `827`. |
+        /// | ``milliseconds(_:)`` | Returns the number of milliseconds elapsed in the day. For example, `11122827`. |
+        ///
+        ///
+        /// To customize the second format in a string representation of a `Date`, use ``Date/FormatStyle/secondFraction(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/SecondFraction`` format styles applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 3:05:41 PM
+        /// meetingDate.formatted(Date.FormatStyle().secondFraction(.fractional(3))) // 827
+        /// meetingDate.formatted(Date.FormatStyle().secondFraction(.fractional(1))) // 8
+        /// meetingDate.formatted(Date.FormatStyle().secondFraction(.milliseconds(4))) // 11122827
+        /// ```
+        ///
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct SecondFraction : Hashable, Sendable { let option: SymbolType.SecondFractionOption? }
+        
+        /// A type that specifies a format for the time zone in a date format style.
+        ///
+        /// The type ``Date/FormatStyle/Symbol/TimeZone`` includes static factory variables and methods that create custom ``Date/FormatStyle/Symbol/TimeZone`` objects:
+        ///
+        /// |Factory variable|Description|
+        /// |---|---|
+        /// | ``specificName(_:)`` | The specific, non-location representation of a timezone. For example, `CDT` (`short`), `Central Daylight Time` (`long`). |
+        /// | ``genericName(_:)`` | The generic, non-location representation of a timezone. For example, `CT` (`short`), `Central Time` (`long`). |
+        /// | ``iso8601(_:)`` | The ISO 8601 representation of the timezone with hours, minutes, and optional seconds. For example, `-0500` (`short`), `-05:00` (`long`). |
+        /// | ``localizedGMT(_:)`` | The localized GMT format representation of a timezone. For example, `GMT-5` (`short`), `GMT-05:00` (`long`). |
+        /// | ``identifier(_:)`` | The timezone identifier. For example, `uschi` (`short`), `America/Chicago` (`long`). |
+        /// | ``exemplarLocation`` | The exemplar city for a timezone. For example, `Chicago`. |
+        /// | ``genericLocation`` | The generic location representation of a timezone. For example, `Chicago Time`. |
+        ///
+        ///
+        /// To customize the hour format in a string representation of a `Date`, use ``Date/FormatStyle/timeZone(_:)``. The following example shows a variety of ``Date/FormatStyle/Symbol/TimeZone`` format styles applied to a date.
+        ///
+        /// ```swift
+        /// let meetingDate = Date() // Feb 9, 2021 at 7:00 PM
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.specificName(.short)))
+        /// // CDT
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.specificName(.long)))
+        /// // Central Daylight Time
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.genericName(.short)))
+        /// // CT
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.genericName(.long)))
+        /// // Central Time
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.iso8601(.short)))
+        /// // -0500
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.iso8601(.long)))
+        /// // -05:00
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.localizedGMT(.short)))
+        /// // GMT-5
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.localizedGMT(.long)))
+        /// // GMT-05:00
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.identifier(.short)))
+        /// // uschi
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.identifier(.long)))
+        /// // America/Chicago
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.exemplarLocation))
+        /// // Chicago
+        ///
+        /// meetingDate.formatted(Date.FormatStyle().timeZone(.genericLocation))
+        /// // Chicago Time
+        ///
+        /// ```
+        ///
+        ///
+        /// If you don't provide a format, the system formats a timezone using the short ``specificName(_:)`` static function with the width ``Width/short``.
+        ///
+        /// For more information about formatting dates, see the ``Date/FormatStyle``.
         public struct TimeZone : Hashable, Sendable { let option: SymbolType.TimeZoneSymbolOption? }
-
+        
+        /// A type that specifies the format for a standalone quarter.
         public struct StandaloneQuarter : Hashable, Sendable { let option: SymbolType.StandaloneQuarterOption }
+        /// A type that specifies the format for a standalone month.
         public struct StandaloneMonth : Hashable, Sendable { let option: SymbolType.StandaloneMonthOption }
+        /// A type that specifies the format for a standalone weekday.
         public struct StandaloneWeekday : Hashable, Sendable { let option: SymbolType.StandaloneWeekdayOption }
+        /// A type that specifies a format for the hour in a date format style.
         public struct VerbatimHour : Hashable, Sendable { let option: SymbolType.VerbatimHourOption }
 
         static let maxPadding = 10
@@ -648,9 +1071,15 @@ public extension Date.FormatStyle.Symbol.StandaloneWeekday {
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension Date.FormatStyle.Symbol.DayPeriod {
 
+    /// A type representing the width of a day period in a format style.
+    ///
+    /// The possible values of a width are ``abbreviated``, ``narrow``, and ``wide``.
     enum Width : Sendable {
+        /// A shortened day period width representation.
         case abbreviated
+        /// A full day period width representation.
         case wide
+        /// The shortest day period width representation.
         case narrow
     }
 
@@ -709,6 +1138,9 @@ public extension Date.FormatStyle.Symbol.DayPeriod {
 /// Hour symbols.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension Date.FormatStyle.Symbol.Hour {
+    /// The format style of the string representation of the day period, before or after noon, in a date.
+    ///
+    /// Possible values for this style are: ``omitted``, ``narrow``, ``abbreviated``, and ``wide``.
     struct AMPMStyle : Codable, Hashable, Sendable {
         let rawValue: UInt
 
@@ -801,9 +1233,15 @@ public extension Date.FormatStyle.Symbol.Hour {
         return new
     }
 
+    /// Custom format style portraying the minimum number of digits that represents the numeric hour.
+    ///
+    /// This style doesn't include the day period symbol (a.m. or p.m.). For example, `1`, `11`.
     @available(*, deprecated, renamed:"defaultDigits(amPM:)")
     static var defaultDigitsNoAMPM: Self { .init(option: .defaultDigitsNoAMPM) }
 
+    /// Custom format style portraying the numeric hour using two digits.
+    ///
+    /// This style pads the hour with a leading zero if necessary. It doesn't include the day period symbol (a.m. or p.m.). For example, `01`, `11`.
     @available(*, deprecated, renamed:"twoDigits(amPM:)")
     static var twoDigitsNoAMPM: Self { .init(option: .twoDigitsNoAMPM) }
 }
@@ -811,6 +1249,7 @@ public extension Date.FormatStyle.Symbol.Hour {
 /// Hour symbols that does not take users' preferences into account, and is displayed as-is.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension Date.FormatStyle.Symbol.VerbatimHour {
+    /// A type that specifies the start of a clock representation for the format of a hour.
     struct HourCycle : Codable, Hashable, Sendable {
         /// The hour ranges from 0 to 11 in a 12-hour clock. Ranges from 0 to 23 in a 24-hour clock.
         public static let zeroBased = HourCycle(rawValue: 0)
@@ -821,6 +1260,7 @@ public extension Date.FormatStyle.Symbol.VerbatimHour {
         let rawValue : UInt
     }
 
+    /// A type that specifies a clock representation for the format of an hour.
     struct Clock : Codable, Hashable, Sendable {
         /// In a 12-hour clock system, the 24-hour day is divided into two periods, a.m. and p.m, and each period consists of 12 hours.
         /// - Note: Does not include the period marker (AM/PM). Specify a `PeriodSymbol` if that's desired.
@@ -922,8 +1362,13 @@ public extension Date.FormatStyle.Symbol.SecondFraction {
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension Date.FormatStyle.Symbol.TimeZone {
 
+    /// A type representing the width of a time zone in a format style.
+    ///
+    /// The possible values of a width are ``short`` and ``long``.
     enum Width : Sendable {
+        /// A short timezone representation.
         case short
+        /// A long timezone representation.
         case long
     }
 

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatString.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatString.swift
@@ -16,6 +16,15 @@ import FoundationEssentials
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
+    /// A type that represents a fixed date format string using string interpolation.
+    ///
+    /// Use `Date.FormatString` with ``Date/VerbatimFormatStyle`` or ``Date/ParseStrategy``
+    /// to create fixed-pattern format strings for dates. You build format strings using
+    /// string interpolation with date field symbols:
+    ///
+    /// ```swift
+    /// let format: Date.FormatString = "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits)"
+    /// ```
     public struct FormatString : Hashable, Sendable {
         internal var rawFormat: String = ""
     }
@@ -46,15 +55,20 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
         rawFormat = value.asDateFormatLiteral()
     }
 
+    /// The string interpolation type for building date format strings.
     public struct StringInterpolation : StringInterpolationProtocol, Sendable {
         public typealias StringLiteralType = String
         fileprivate var format: String = ""
+
+        /// Creates a new string interpolation with the given capacities.
         public init(literalCapacity: Int, interpolationCount: Int) {}
 
+        /// Appends a literal string segment to the format string.
         mutating public func appendLiteral(_ literal: String) {
             format += literal.asDateFormatLiteral()
         }
 
+        /// Appends an era symbol to the format string.
         mutating public func appendInterpolation(era: Date.FormatStyle.Symbol.Era) {
             guard let option = era.option else {
                 return
@@ -62,6 +76,7 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a year symbol to the format string.
         mutating public func appendInterpolation(year: Date.FormatStyle.Symbol.Year) {
             guard let option = year.option else {
                 return
@@ -69,6 +84,7 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a year-for-week-of-year symbol to the format string.
         mutating public func appendInterpolation(yearForWeekOfYear: Date.FormatStyle.Symbol.YearForWeekOfYear) {
             guard let option = yearForWeekOfYear.option else {
                 return
@@ -76,6 +92,7 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a cyclic year symbol to the format string.
         mutating public func appendInterpolation(cyclicYear: Date.FormatStyle.Symbol.CyclicYear) {
             guard let option = cyclicYear.option else {
                 return
@@ -83,6 +100,7 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a quarter symbol to the format string.
         mutating public func appendInterpolation(quarter: Date.FormatStyle.Symbol.Quarter) {
             guard let option = quarter.option else {
                 return
@@ -90,10 +108,12 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a standalone quarter symbol to the format string.
         mutating public func appendInterpolation(standaloneQuarter: Date.FormatStyle.Symbol.StandaloneQuarter) {
             format.append(standaloneQuarter.option.rawValue)
         }
 
+        /// Appends a month symbol to the format string.
         mutating public func appendInterpolation(month: Date.FormatStyle.Symbol.Month) {
             guard let option = month.option else {
                 return
@@ -101,10 +121,12 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a standalone month symbol to the format string.
         mutating public func appendInterpolation(standaloneMonth: Date.FormatStyle.Symbol.StandaloneMonth) {
             format.append(standaloneMonth.option.rawValue)
         }
 
+        /// Appends a week symbol to the format string.
         mutating public func appendInterpolation(week: Date.FormatStyle.Symbol.Week) {
             guard let option = week.option else {
                 return
@@ -112,6 +134,7 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a day symbol to the format string.
         mutating public func appendInterpolation(day: Date.FormatStyle.Symbol.Day) {
             guard let option = day.option else {
                 return
@@ -119,6 +142,7 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a day-of-year symbol to the format string.
         mutating public func appendInterpolation(dayOfYear: Date.FormatStyle.Symbol.DayOfYear) {
             guard let option = dayOfYear.option else {
                 return
@@ -126,6 +150,7 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a weekday symbol to the format string.
         mutating public func appendInterpolation(weekday: Date.FormatStyle.Symbol.Weekday) {
             guard let option = weekday.option else {
                 return
@@ -133,10 +158,12 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a standalone weekday symbol to the format string.
         mutating public func appendInterpolation(standaloneWeekday: Date.FormatStyle.Symbol.StandaloneWeekday) {
             format.append(standaloneWeekday.option.rawValue)
         }
 
+        /// Appends a day period symbol to the format string.
         mutating public func appendInterpolation(dayPeriod: Date.FormatStyle.Symbol.DayPeriod) {
             guard let option = dayPeriod.option else {
                 return
@@ -144,10 +171,12 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
             format.append(option.rawValue)
         }
 
+        /// Appends a verbatim hour symbol to the format string.
         mutating public func appendInterpolation(hour: Date.FormatStyle.Symbol.VerbatimHour) {
             format.append(hour.option.rawValue)
         }
 
+        /// Appends a minute symbol to the format string.
         mutating public func appendInterpolation(minute: Date.FormatStyle.Symbol.Minute) {
             guard let option = minute.option else {
                 return

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -20,16 +20,63 @@ internal import _FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
-    /// Converts `self` to its textual representation that contains both the date and time parts. The exact format depends on the user's preferences.
+    /// Generates a locale-aware string representation of a date using specified date and time format styles.
+    ///
+    /// When displaying a date to a user, use the convenient `formatted(date:time:)` instance method to customize the string representation of the date. Set the date and time styles of the date format style separately, according to your particular needs.
+    ///
+    /// For example, to create a string with a full date and no time representation, set the date style to `complete` and the time style to `omitted`. Conversely, to create a string representing only the time, set the date style to `omitted` and the time style to `complete`.
+    ///
+    /// ```swift
+    /// let birthday = Date()
+    ///
+    /// birthday.formatted(date: .complete, time: .omitted) // Sunday, January 17, 2021
+    /// birthday.formatted(date: .omitted, time: .complete) // 4:03:12 PM CST
+    /// ```
+    ///
+    /// You can create string representations of a `Date` instance with several levels of brevity using a variety of preset date and time styles. This example shows date styles of `long`, `abbreviated`, and `numeric`, and time styles of `shortened`, `standard`, and `complete`.
+    ///
+    /// ```swift
+    /// let birthday = Date()
+    ///
+    /// birthday.formatted(date: .long, time: .shortened) // January 17, 2021, 4:03 PM
+    /// birthday.formatted(date: .abbreviated, time: .standard) // Jan 17, 2021, 4:03:12 PM
+    /// birthday.formatted(date: .numeric, time: .complete) // 1/17/2021, 4:03:12 PM CST
+    ///
+    /// birthday.formatted() // Jan 17, 2021, 4:03 PM
+    /// ```
+    ///
+    /// The default date style is `abbreviated` and the default time style is `shortened`.
+    ///
+    /// For the default date formatting, use the `formatted()` method. To customize the formatted measurement string, use the `formatted(_:)` method and include a `Date.FormatStyle`.
+    ///
+    /// For more information about formatting dates, see ``Date/FormatStyle``.
+    ///
     /// - Parameters:
     ///   - date: The style for describing the date part.
     ///   - time: The style for describing the time part.
-    /// - Returns: A `String` describing `self`.
+    /// - Returns: A string, formatted according to the specified date and time styles.
     public func formatted(date: FormatStyle.DateStyle, time: FormatStyle.TimeStyle) -> String {
         let f = FormatStyle(date: date, time: time)
         return f.format(self)
     }
 
+    /// Generates a locale-aware string representation of a date using the default date format style.
+    ///
+    /// Use the `formatted()` method to apply the default format style to a date, as in the following example:
+    ///
+    /// ```swift
+    /// let birthday = Date()
+    /// print(birthday.formatted())
+    /// // 6/4/2021, 2:24 PM
+    /// ```
+    ///
+    /// The default date format style uses the `numeric` date style and the `shortened` time style.
+    ///
+    /// To customize the formatted measurement string, use either the ``Date/formatted(_:)`` method and include a `Measurement.FormatStyle` or the ``Date/formatted(date:time:)`` and include a date and time style.
+    ///
+    /// For more information about formatting dates, see ``Date/FormatStyle``.
+    ///
+    /// - Returns: A string, formatted according to the default style.
     public func formatted() -> String {
         self.formatted(Date.FormatStyle(date: .numeric, time: .shortened))
     }
@@ -214,7 +261,191 @@ extension Date.FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
-    /// Strategies for formatting a `Date`.
+    /// A structure that creates a locale-appropriate string representation of a date instance and converts strings of dates and times into date instances.
+    ///
+    /// A date format style shares the date and time formatting pattern preferred by the user's locale for formatting and parsing.
+    ///
+    /// When you want to apply a specific formatting style to a single ``Date`` instance, use ``Date/FormatStyle``. For other instances, use the following:
+    ///
+    /// - When working with date representations in ISO 8601 format, use ``Date/ISO8601FormatStyle``.
+    /// - To represent an interval between two date instances, use ``Date/RelativeFormatStyle``.
+    /// - To represent two dates as a pair, for example to get output that looks like `10/21/1985 1:45 PM - 9/13/2015 6:33 PM`, use ``Date/IntervalFormatStyle``.
+    ///
+    /// ### Formatting String Representations of Dates and Times
+    ///
+    /// ``Date/FormatStyle`` provides a variety of localized presets and configuration options to create user-visible representations of dates and times from instances of ``Date``.
+    ///
+    /// When displaying a date to a user, use the ``Date/formatted(date:time:)`` instance method. Set the date and time styles of the date format style separately, according to your particular needs.
+    ///
+    /// For example, to create a string with a full date and no time representation, set the ``DateStyle`` to ``DateStyle/complete`` and the ``TimeStyle`` to ``TimeStyle/omitted``. Conversely, to create a string representing only the time for the current locale and time zone, set the date style to ``DateStyle/omitted`` and the time style to ``TimeStyle/complete``, as the following code illustrates:
+    ///
+    /// ```swift
+    /// let birthday = Date()
+    ///
+    /// birthday.formatted(date: .complete, time: .omitted) // Sunday, January 17, 2021
+    /// birthday.formatted(date: .omitted, time: .complete) // 4:03:12 p.m. CST
+    /// ```
+    ///
+    ///
+    /// The results shown are for locale set to `en_US` and time zone set to `CST`.
+    ///
+    /// You can create string representations of a ``Date`` instance with various levels of brevity using preset date and time styles. The following example shows date styles of ``DateStyle/long``, ``DateStyle/abbreviated``, and ``DateStyle/numeric``, and time styles of ``TimeStyle/shortened``, ``TimeStyle/standard``, and ``TimeStyle/complete``:
+    ///
+    /// ```swift
+    /// let birthday = Date()
+    ///
+    /// birthday.formatted(date: .long, time: .shortened) // January 17, 2021, 4:03 PM
+    /// birthday.formatted(date: .abbreviated, time: .standard) // Jan 17, 2021, 4:03:12 PM
+    /// birthday.formatted(date: .numeric, time: .complete) // 1/17/2021, 4:03:12 PM CST
+    ///
+    /// birthday.formatted() // Jan 17, 2021, 4:03 PM
+    /// ```
+    ///
+    ///
+    /// The default date style is ``DateStyle/abbreviated`` and the default time style is ``TimeStyle/shortened``.
+    ///
+    /// For full customization of the string representation of a date, use the ``Date/formatted(_:)`` instance method of ``Date`` and provide a ``Date/FormatStyle`` instance.
+    ///
+    /// You can apply more customization of the date and time components and their representation in your app by appying a series of convenience modifiers to your format style. The following example applies a series of modifiers to the format style to precisely define the formatting of the year, month, day, hour, minute, and timezone components of the resulting string. The ordering of the date and time modifiers has no impact on the string produced.
+    ///
+    /// ```swift
+    /// // Call the .formatted method on an instance of Date passing in an instance of Date.FormatStyle.
+    ///
+    /// let birthday = Date()
+    ///
+    /// birthday.formatted(
+    /// Date.FormatStyle()
+    /// .year(.defaultDigits)
+    /// .month(.abbreviated)
+    /// .day(.twoDigits)
+    /// .hour(.defaultDigits(amPM: .abbreviated))
+    /// .minute(.twoDigits)
+    /// .timeZone(.identifier(.long))
+    /// .era(.wide)
+    /// .dayOfYear(.defaultDigits)
+    /// .weekday(.abbreviated)
+    /// .week(.defaultDigits)
+    /// )
+    /// // Sun, Jan 17, 2021 Anno Domini (week: 4), 11:18 AM America/Chicago
+    /// ```
+    ///
+    ///
+    /// ``Date/FormatStyle`` provides a convenient factory variable, ``FormatStyle/dateTime``, used to shorten the syntax when applying date and time modifiers to customize the format, as in the following example:
+    ///
+    /// ```swift
+    /// let localeArray = ["en_US", "sv_SE", "en_GB", "th_TH", "fr_BE"]
+    /// for localeID in localeArray {
+    /// print(meetingDate.formatted(.dateTime
+    /// .day(.twoDigits)
+    /// .month(.wide)
+    /// .weekday(.short)
+    /// .hour(.conversationalTwoDigits(amPM: .wide))
+    /// .locale(Locale(identifier: localeID))))
+    /// }
+    ///
+    /// // Th, November 12, 7 PM
+    /// // to 12 november 19
+    /// // Th 12 November, 19
+    /// // พฤ. 12 พฤศจิกายน 19
+    /// // je 12 novembre, 19 h
+    /// ```
+    ///
+    ///
+    /// ### Parsing Dates and Times
+    ///
+    /// To parse a ``Date`` instance from an input string, use a date parse strategy. For example:
+    ///
+    /// ```swift
+    /// let inputString = "Archive for month 8, archived on day 23 - complete."
+    /// let strategy = Date.ParseStrategy(format: "Archive for month \(month: .defaultDigits), archived on day \(day: .twoDigits) - complete.", locale: Locale(identifier: "en_US"), timeZone: TimeZone(abbreviation: "CDT")!)
+    /// if let date = try? Date(inputString, strategy: strategy) {
+    /// print(date.formatted()) // "Aug 23, 2000 at 12:00 AM"
+    /// }
+    /// ```
+    ///
+    ///
+    /// The time defaults to midnight local time unless explicitly defined.
+    ///
+    /// The parse instance method attempts to parse a provided string into an instance of date using the source date format style. The function throws an error if it can't parse the input string into a date instance.
+    ///
+    /// You can use ``Date/FormatStyle`` for round-trip formatting and parsing in a locale-aware manner. This date format style guides parsing the date instance from an input string, as the following code demonstrates:
+    ///
+    /// ```swift
+    /// let birthdayFormatStyle = Date.FormatStyle()
+    /// .year(.defaultDigits)
+    /// .month(.abbreviated)
+    /// .day(.twoDigits)
+    /// .hour(.defaultDigits(amPM: .abbreviated))
+    /// .minute(.twoDigits)
+    /// .timeZone(.identifier(.long))
+    /// .era(.abbreviated)
+    /// .weekday(.abbreviated)
+    ///
+    /// let yourBirthdayString = "Mon, Feb 17, 1997 AD, 1:27 AM America/Chicago"
+    ///
+    /// // Create a date instance from a string representation of a date.
+    /// let yourBirthday = try? birthdayFormatStyle.parse(yourBirthdayString)
+    /// // Feb 17, 1997 at 1:27 AM
+    ///
+    /// ```
+    ///
+    ///
+    /// The following round-trip date formatting example uses a date format style to create a locale-aware string representation of a date instance. Then, the date format style guides parsing the newly created string into a new date instance.
+    ///
+    /// ```swift
+    /// let myFormat = Date.FormatStyle()
+    /// .year()
+    /// .day()
+    /// .month()
+    /// .locale(Locale(identifier: "en_US"))
+    ///
+    /// let dateString = Date().formatted(myFormat)
+    /// // "Feb 17, 2021" for the "en_US" locale
+    ///
+    /// print(dateString) // Feb 17, 2021
+    ///
+    /// if let anniversary = try? Date(dateString, strategy: myFormat) {
+    /// print(anniversary.formatted(myFormat)) // Feb 17, 2021
+    /// print(anniversary.formatted()) // 2/17/2021, 12:00 AM
+    /// } else {
+    /// print("Can't parse string into date with this format.")
+    /// }
+    /// ```
+    ///
+    ///
+    /// After this code executes, `anniversary` contains a ``Date`` instance parsed from `dateString`.
+    ///
+    /// ### Applying Format Styles Repeatedly
+    ///
+    /// Once you create a date format style, you can use it to format dates multiple times.
+    ///
+    /// You can use a format style to parse a set of date instances from a set of string representations of dates. Then, use another format style, applied repeatedly, to produce more detailed string representations of those dates for a different locale. For example:
+    ///
+    /// ```swift
+    /// func formatIntroDates() {
+    /// let inputFormat = Date.FormatStyle()
+    /// .locale(Locale(identifier: "en_GB"))
+    /// .year()
+    /// .month()
+    /// .day()
+    /// // Parse string inputs into date instances.
+    /// guard let productIntroDate = try? Date("9 Jan 2007", strategy: inputFormat) else { return }
+    /// guard let anotherIntroDate = try? Date("27 Jan 2010", strategy: inputFormat) else { return }
+    /// guard let conferenceDate = try? Date("7 Jun 2021", strategy: inputFormat) else { return }
+    ///
+    /// let outputFormat = Date.FormatStyle() // Define format style for string output.
+    /// .locale(Locale(identifier: "en_US"))
+    /// .year()
+    /// .month(.wide)
+    /// .day(.twoDigits)
+    /// .weekday(.abbreviated)
+    ///
+    /// // Apply the output format on the three dates below.
+    /// print(outputFormat.format(conferenceDate)) // Mon, June 07, 2021
+    /// print(outputFormat.format(anotherIntroDate)) // Wed, January 27, 2010
+    /// print(outputFormat.format(productIntroDate)) // Tue, January 09, 2007
+    /// }
+    /// ```
     public struct FormatStyle : Sendable {
 
         var _symbols: DateFieldCollection?
@@ -229,6 +460,9 @@ extension Date {
         var _dateStyle: DateStyle? // For accessing locale pref's custom date format
 
         /// The locale to use when formatting date and time values.
+        ///
+        /// The default value is `autoupdatingCurrent`. If you set this property
+        /// to `nil`, the formatter resets to using `autoupdatingCurrent`.
         public var locale: Locale
 
         /// The time zone with which to specify date and time values.
@@ -240,7 +474,34 @@ extension Date {
         /// The capitalization formatting context used when formatting date and time values.
         public var capitalizationContext: FormatStyleCapitalizationContext
 
-        /// Returns a type erased attributed variant of this style.
+        /// A type-erased attributed variant of this style.
+        ///
+        /// Use a ``Date/FormatStyle`` instance to customize the lexical
+        /// representation of a date as a string. Use the format style's
+        /// `attributed` property to customize the visual representation of the
+        /// date as a string. Attributed strings can represent the subcomponent
+        /// characters, words, and phrases of a string with a custom combination
+        /// of font size, weight, and color.
+        ///
+        /// For example, the function below uses a date format style to create a
+        /// custom lexical representation of a date, then retrieves an attributed
+        /// string representation of the same date and applies a visual emphasis
+        /// to the year component of the date.
+        ///
+        /// ```swift
+        /// private func makeAttributedString() -> AttributedString {
+        ///     let date = Date()
+        ///     let formatStyle = Date.FormatStyle(date: .abbreviated, time: .standard)
+        ///     var attributedString = formatStyle.attributed.format(date)
+        ///     for run in attributedString.runs {
+        ///         if let dateFieldAttribute = run.attributes.foundation.dateField,
+        ///            dateFieldAttribute == .year {
+        ///             attributedString[run.range].inlinePresentationIntent = [.emphasized, .stronglyEmphasized]
+        ///         }
+        ///     }
+        ///     return attributedString
+        /// }
+        /// ```
         @available(macOS, deprecated: 15, introduced: 12, message: "Use attributedStyle instead")
         @available(iOS, deprecated: 18, introduced: 15, message: "Use attributedStyle instead")
         @available(tvOS, deprecated: 18, introduced: 15, message: "Use attributedStyle instead")
@@ -288,6 +549,9 @@ extension Date {
 
     // MARK: Type-Erased AttributedStyle
 
+    /// A structure that creates a locale-appropriate attributed string representation of a date instance.
+    ///
+    /// Use a ``Date/FormatStyle`` instance to customize the lexical representation of a date as a string. Use the format style's ``Date/FormatStyle/attributed`` property to customize the visual representation of the date as a string. Attributed strings can represent the subcomponent characters, words, and phrases of a string with a custom combination of font size, weight, and color.
     @available(macOS, deprecated: 15, introduced: 12, message: "Use Date.FormatStyle.Attributed or Date.VerbatimFormatStyle.Attributed instead")
     @available(iOS, deprecated: 18, introduced: 15, message: "Use Date.FormatStyle.Attributed or Date.VerbatimFormatStyle.Attributed instead")
     @available(tvOS, deprecated: 18, introduced: 15, message: "Use Date.FormatStyle.Attributed or Date.VerbatimFormatStyle.Attributed instead")
@@ -308,7 +572,12 @@ extension Date {
             self.innerStyle = style
         }
 
-        /// Returns an attributed string with `AttributeScopes.FoundationAttributes.DateFieldAttribute`
+        /// Creates a locale-aware attributed string representation from a date value.
+        ///
+        /// Once you create a style, you can use it to format dates multiple times.
+        ///
+        /// - Parameter value: The date to format.
+        /// - Returns: An attributed string representation of the date.
         public func format(_ value: Date) -> AttributedString {
             let fm: ICUDateFormatter?
             switch innerStyle {
@@ -325,6 +594,10 @@ extension Date {
             return str._attributedStringFromPositions(attributes)
         }
 
+        /// Modifies the date attributed style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to use when formatting a date.
+        /// - Returns: A date attributed style with the provided locale.
         public func locale(_ locale: Locale) -> Self {
             var newInnerStyle: InnerStyle
 
@@ -376,6 +649,10 @@ extension Date.FormatStyle {
             self.base = style
         }
 
+        /// Creates a locale-aware attributed string representation from a date value.
+        ///
+        /// - Parameter value: The date to format.
+        /// - Returns: An attributed string representation of the date.
         public func format(_ value: Date) -> AttributedString {
             guard let fm = ICUDateFormatter.cachedFormatter(for: base), let (str, attributes) = fm.attributedFormat(value) else {
                 return AttributedString("")
@@ -383,6 +660,10 @@ extension Date.FormatStyle {
             return str._attributedStringFromPositions(attributes)
         }
 
+        /// Modifies the date attributed style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to use when formatting a date.
+        /// - Returns: A date attributed style with the provided locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             new.base = base.locale(locale)
@@ -685,6 +966,45 @@ extension Date.FormatStyle.Attributed {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.FormatStyle : FormatStyle {
+    /// Creates a locale-aware string representation from a date value.
+    ///
+    /// Once you create a style, you can use it to format dates multiple times.
+    ///
+    /// The following example creates a format style to guide parsing a set of
+    /// string representations of dates. It also creates a second format style,
+    /// applying it repeatedly to produce more detailed string representations of
+    /// those dates for a different locale.
+    ///
+    /// ```swift
+    /// let inputFormat = Date.FormatStyle()
+    ///     .locale(Locale(identifier: "en_GB"))
+    ///     .year()
+    ///     .month()
+    ///     .day()
+    ///
+    /// let iphoneIntroductionDate = try! Date("9 Jan 2007", strategy: inputFormat)
+    /// let ipadIntroductionDate = try! Date("27 Jan 2010", strategy: inputFormat)
+    /// let wwdc2021Date = try! Date("7 Jun 2021", strategy: inputFormat)
+    ///
+    /// let outputFormat = Date.FormatStyle()
+    ///     .locale(Locale(identifier: "en_US"))
+    ///     .year()
+    ///     .month(.wide)
+    ///     .day(.twoDigits)
+    ///     .weekday(.abbreviated)
+    ///
+    /// print(outputFormat.format(wwdc2021Date))
+    /// // Mon, June 07, 2021
+    ///
+    /// print(outputFormat.format(ipadIntroductionDate))
+    /// // Wed, January 27, 2010
+    ///
+    /// print(outputFormat.format(iphoneIntroductionDate))
+    /// // Tue, January 09, 2007
+    /// ```
+    ///
+    /// - Parameter value: The date to format.
+    /// - Returns: A string representation of the date.
     public func format(_ value: Date) -> String {
         guard let fm = ICUDateFormatter.cachedFormatter(for: self), let result = fm.format(value) else {
             return ""
@@ -692,6 +1012,10 @@ extension Date.FormatStyle : FormatStyle {
         return result
     }
 
+    /// Modifies the date format style to use the specified locale.
+    ///
+    /// - Parameter locale: The locale to use when formatting a date.
+    /// - Returns: A date format style with the provided locale.
     public func locale(_ locale: Locale) -> Self {
         var new = self
         new.locale = locale
@@ -703,6 +1027,29 @@ extension Date.FormatStyle : FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.FormatStyle : ParseStrategy {
+    /// Parses a string into a date.
+    ///
+    /// The date format style guides parsing the date instance from an input
+    /// string, as the example below illustrates.
+    ///
+    /// ```swift
+    /// let birthdayFormatStyle = Date.FormatStyle()
+    ///     .year(.defaultDigits)
+    ///     .month(.abbreviated)
+    ///     .day(.twoDigits)
+    ///     .hour(.defaultDigits(amPM: .abbreviated))
+    ///     .minute(.twoDigits)
+    ///     .timeZone(.identifier(.long))
+    ///     .era(.abbreviated)
+    ///     .weekday(.abbreviated)
+    ///
+    /// let yourBirthdayString = "Mon, Feb 17, 1997 AD, 1:27 AM America/Chicago"
+    /// let yourBirthday = try? birthdayFormatStyle.parse(yourBirthdayString)
+    /// // Feb 17, 1997 at 1:27 AM
+    /// ```
+    ///
+    /// - Parameter value: The string to parse.
+    /// - Returns: An instance of `Date` parsed from the input string.
     public func parse(_ value: String) throws -> Date {
         guard let fm = ICUDateFormatter.cachedFormatter(for: self) else {
             throw CocoaError(CocoaError.formatting, userInfo: [ NSDebugDescriptionErrorKey: "Error creating icu date formatter" ])
@@ -756,7 +1103,35 @@ extension Date.FormatStyle : Codable, Hashable {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.FormatStyle {
-    /// Predefined date styles varied in lengths or the components included. The exact format depends on the locale.
+    /// Type that defines date styles varied in length or components included.
+    ///
+    /// The exact format depends on the locale. Possible values of date style include ``omitted``, ``numeric``, ``abbreviated``, ``long``, and ``complete``.
+    ///
+    /// The following code sample shows a variety of date style format results using the `en_US` locale.
+    ///
+    /// ```swift
+    /// let meetingDate = Date()
+    /// meetingDate.formatted(date: .omitted, time: .standard)
+    /// // 9:42:14 AM
+    ///
+    /// meetingDate.formatted(date: .numeric, time: .omitted)
+    /// // 10/17/2020
+    ///
+    /// meetingDate.formatted(date: .abbreviated, time: .omitted)
+    /// // Oct 17, 2020
+    ///
+    /// meetingDate.formatted(date: .long, time: .omitted)
+    /// // October 17, 2020
+    ///
+    /// meetingDate.formatted(date: .complete, time: .omitted)
+    /// // Saturday, October 17, 2020
+    ///
+    /// meetingDate.formatted()
+    /// // 10/17/2020, 9:42 AM
+    /// ```
+    ///
+    ///
+    /// The default date style is `numeric`.
     public struct DateStyle : Codable, Hashable, Sendable {
 
         /// Excludes the date part.
@@ -777,7 +1152,33 @@ extension Date.FormatStyle {
         let rawValue : UInt
     }
 
-    /// Predefined time styles varied in lengths or the components included. The exact format depends on the locale.
+    /// Type that defines time styles varied in length or components included.
+    ///
+    /// The exact format depends on the locale. Possible time styles include ``omitted``, ``shortened``, ``standard``, and ``complete``.
+    ///
+    /// The following code sample shows a variety of time style format results using the `en_US` locale.
+    ///
+    /// ```swift
+    /// let meetingDate = Date()
+    /// meetingDate.formatted(date: .numeric, time: .omitted)
+    /// // 10/17/2020
+    ///
+    /// meetingDate.formatted(date: .numeric, time: .shortened)
+    /// // 10/17/2020, 9:54 PM
+    ///
+    /// meetingDate.formatted(date: .numeric, time: .standard)
+    /// // 10/17/2020, 9:54:29 PM
+    ///
+    /// meetingDate.formatted(date: .numeric, time: .complete)
+    /// // 10/17/2020, 9:54:29 PM CDT
+    ///
+    /// meetingDate.formatted()
+    /// // 10/17/2020, 9:54 PM
+    ///
+    /// ```
+    ///
+    ///
+    /// The default time style is ``shortened``.
     public struct TimeStyle : Codable, Hashable, Sendable {
 
         /// Excludes the time part.
@@ -798,6 +1199,7 @@ extension Date.FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date.FormatStyle: ParseableFormatStyle {
+    /// The strategy used to parse a string into a date.
     public var parseStrategy: Date.FormatStyle {
         return self
     }
@@ -805,6 +1207,34 @@ extension Date.FormatStyle: ParseableFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == Date.FormatStyle {
+    /// A style for formatting a date and time.
+    ///
+    /// Use this type property when the call point allows the use of ``Date/FormatStyle``.
+    /// You typically do this when calling the ``Date/formatted(_:)`` method of ``Date``.
+    ///
+    /// Customize the date format style using modifier syntax to apply specific date and time
+    /// formats. For example:
+    ///
+    /// ```swift
+    /// let meetingDate = Date()
+    /// let localeArray = ["en_US", "sv_SE", "en_GB", "th_TH", "fr_BE"]
+    /// let formattedDates = localeArray.map { localeID in
+    ///     meetingDate.formatted(.dateTime
+    ///                           .day(.twoDigits)
+    ///                           .month(.wide)
+    ///                           .weekday(.short)
+    ///                           .hour(.conversationalTwoDigits(amPM: .wide))
+    ///                           .locale(Locale(identifier: localeID)))
+    ///         } // ["Mo, July 31 at 05 PM", "må 31 juli 17", "Mo, 31 July at 17", "จ. 31 กรกฎาคม เวลา 17", "lu 31 juillet à 17 h"]
+    /// ```
+    ///
+    /// The default format styles provided are ``Date/FormatStyle/DateStyle/numeric`` date format
+    /// and ``Date/FormatStyle/TimeStyle/shortened`` time format. For example:
+    ///
+    /// ```swift
+    /// let meetingDate = Date()
+    /// let formatted = meetingDate.formatted(.dateTime) // "7/31/2023, 5:15 PM"
+    /// ```
     static var dateTime: Self { .init() }
 }
 
@@ -815,6 +1245,41 @@ public extension ParseableFormatStyle where Self == Date.FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension ParseStrategy where Self == Date.FormatStyle {
+    /// A default format style for formatting dates.
+    ///
+    /// Use this type property when the call point allows the use of ``Date/FormatStyle``; in other
+    /// words, when the value type is ``Date``. Typically, you use this with the ``Date/formatted(_:)``
+    /// method of ``Date``.
+    ///
+    /// Customize the date format style using modifier syntax to apply specific date and time formats.
+    /// For example:
+    ///
+    /// ```swift
+    /// let meetingDate = Date()
+    /// let localeArray = ["en_US", "sv_SE", "en_GB", "th_TH", "fr_BE"]
+    /// for localeID in localeArray {
+    ///     print(meetingDate.formatted(.dateTime
+    ///                                 .day(.twoDigits)
+    ///                                 .month(.wide)
+    ///                                 .weekday(.short)
+    ///                                 .hour(.conversationalTwoDigits(amPM: .wide))
+    ///                                 .locale(Locale(identifier: localeID))))
+    /// }
+    ///
+    /// // Tu, October 27, 5 PM
+    /// // ti 27 oktober 17
+    /// // Tu 27 October, 17
+    /// // อ. 27 ตุลาคม 17
+    /// // ma 27 octobre à 17 h
+    /// ```
+    ///
+    /// The default format styles provided are ``Date/FormatStyle/DateStyle/numeric`` date format and
+    /// ``Date/FormatStyle/TimeStyle/shortened`` time format. For example:
+    ///
+    /// ```swift
+    /// let meetingDate = Date()
+    /// meetingDate.formatted(.dateTime)) // 10/28/2020, 12:13 AM
+    /// ```
     @_disfavoredOverload
     static var dateTime: Self { .init() }
 }
@@ -1088,7 +1553,18 @@ extension AttributeScopes.FoundationAttributes.DateFieldAttribute.Field {
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension Date.FormatStyle : CustomConsumingRegexComponent {
+    /// The type returned when capturing matching substrings with this strategy.
     public typealias RegexOutput = Date
+    /// Processes the input string within the specified bounds, beginning at the given index, and returns the end position of the match and the produced output.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture
+    /// calls it automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Date)? {
         guard index < bounds.upperBound else {
             return nil

--- a/Sources/FoundationInternationalization/Formatting/Date/DateParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateParseStrategy.swift
@@ -91,6 +91,13 @@ extension Date.ParseStrategy : ParseStrategy {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension ParseStrategy {
+    /// A fixed-format date parse strategy.
+    ///
+    /// - Parameters:
+    ///   - format: The string describing the parsing format.
+    ///   - timeZone: The ``TimeZone`` used to create the string representation of the date.
+    ///   - locale: The ``Locale`` used to create the string representation of the date.
+    /// - Returns: A strategy for parsing a date.
     static func fixed(format: Date.FormatString, timeZone: TimeZone, locale: Locale? = nil) -> Self where Self == Date.ParseStrategy {
         Date.ParseStrategy(format: format, locale: locale, timeZone: timeZone)
     }
@@ -100,7 +107,18 @@ public extension ParseStrategy {
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension Date.ParseStrategy : CustomConsumingRegexComponent {
+    /// The type returned when capturing matching substrings with this strategy.
     public typealias RegexOutput = Date
+    /// Processes the input string within the specified bounds, beginning at the given index, and returns the end position of the match and the produced output.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture
+    /// calls it automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Date)? {
         guard index < bounds.upperBound else {
             return nil

--- a/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
@@ -515,13 +515,13 @@ extension FormatStyle where Self == Duration.UnitsFormatStyle {
 
     /// A factory function to create a units format style to format a duration.
     /// - Parameters:
-    ///   - allowedUnits: The units that may be included in the output string.
+    ///   - units: The units that may be included in the output string.
     ///   - width: The width of the unit and the spacing between the value and the unit.
     ///   - maximumUnitCount: The maximum number of time units to include in the output string.
     ///   - zeroValueUnits: The strategy for how zero-value units are handled.
     ///   - valueLengthLimits: The padding or truncating behavior of the unit value.
     ///   - fractionalPart: The strategy for displaying a duration if it cannot be represented exactly with the allowed units.
-    ///   - Returns: A format style to format a duration.
+    /// - Returns: A format style to format a duration.
     public static func units<ValueRange: RangeExpression>(allowed units: Set<Duration.UnitsFormatStyle.Unit> = [.hours, .minutes, .seconds], width: Duration.UnitsFormatStyle.UnitWidth = .abbreviated, maximumUnitCount : Int? = nil, zeroValueUnits: Duration.UnitsFormatStyle.ZeroValueUnitsDisplayStrategy = .hide, valueLengthLimits: ValueRange, fractionalPart: Duration.UnitsFormatStyle.FractionalPartDisplayStrategy = .hide) -> Self where ValueRange.Bound == Int {
         .init(allowedUnits: units, width: width, maximumUnitCount: maximumUnitCount, zeroValueUnits: zeroValueUnits, valueLengthLimits: valueLengthLimits, fractionalPart: fractionalPart)
     }

--- a/Sources/FoundationInternationalization/Formatting/ListFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ListFormatStyle.swift
@@ -14,13 +14,124 @@
 import FoundationEssentials
 #endif
 
+/// A type that formats lists of items with a separator and conjunction appropriate for a given locale.
+///
+/// A list format style creates human readable text from a `Sequence` of values. Customize the formatting behavior
+/// of the list using the ``width``, ``listType``, and ``locale`` properties. The system automatically caches unique
+/// configurations of ``ListFormatStyle`` to enhance performance.
+///
+/// Use either `formatted()` or `formatted(_:)`, both instance methods of `Sequence`, to create a string
+/// representation of the items.
+///
+/// The `formatted()` method applies the default list format style to a sequence of strings. For example:
+///
+/// ```swift
+/// ["Kristin", "Paul", "Ana", "Bill"].formatted()
+/// // Kristin, Paul, Ana, and Bill
+/// ```
+///
+/// You can customize a list's `type` and `width` properties.
+///
+/// - The ``listType`` property specifies the semantics of the list.
+/// - The ``width`` property determines the size of the returned string.
+///
+/// The `formatted(_:)` method applies a custom list format style. You can use the static factory method
+/// `list(type:width:)` to create a custom list format style as a parameter to the method.
+///
+/// This example formats a sequence with a ``ListType/and`` list type and ``Width/short`` width:
+///
+/// ```swift
+/// ["Kristin", "Paul", "Ana", "Bill"].formatted(.list(type: .and, width: .short))
+/// // Kristin, Paul, Ana, & Bill
+/// ```
+///
+/// You can provide a member format style to transform each list element to a string in applications where the
+/// elements aren't already strings. For example, the following code sample uses an `IntegerFormatStyle` to convert
+/// a range of integer values into a list:
+///
+/// ```swift
+/// (5201719 ... 5201722).formatted(.list(memberStyle: IntegerFormatStyle(), type: .or, width: .standard))
+/// // For locale: en_US: 5,201,719, 5,201,720, 5,201,721, or 5,201,722
+/// // For locale: fr_CA: 5 201 719, 5 201 720, 5 201 721, ou 5 201 722
+/// ```
+///
+/// > Note:
+/// > The generated string is locale-dependent and incorporates linguistic and cultural conventions of the user.
+///
+/// You can create and reuse a list format style instance to format similar sequences. For example:
+///
+/// ```swift
+/// let percentStyle = ListFormatStyle<FloatingPointFormatStyle.Percent, StrideThrough<Double>>(memberStyle: .percent)
+/// stride(from: 7.5, through: 9.0, by: 0.5).formatted(percentStyle)
+/// // 7.5%, 8%, 8.5%, and 9%
+/// stride(from: 89.0, through: 95.0, by: 2.0).formatted(percentStyle)
+/// // 89%, 91%, 93%, and 95%
+/// ```
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct ListFormatStyle<Style: FormatStyle, Base: Sequence>: FormatStyle where Base.Element == Style.FormatInput, Style.FormatOutput == String {
     private(set) var memberStyle: Style
+    /// The size of the list.
+    ///
+    /// The `width` property controls the size of the list. The ``locale`` determines the formatting and
+    /// abbreviation of the string for the given `width`.
+    ///
+    /// For example, for English:
+    ///
+    /// ```swift
+    /// ["One", "Two", "Three"].formatted(.list(type: .and, width: .standard))
+    /// // "One, Two, and Three"
+    ///
+    /// ["One", "Two", "Three"].formatted(.list(type: .and, width: .short))
+    /// // "One, Two, & Three"
+    ///
+    /// ["One", "Two", "Three"].formatted(.list(type: .and, width: .narrow))
+    /// // "One, Two, Three"
+    /// ```
+    ///
+    /// The default value is ``Width/standard``.
     public var width: Width
+    /// The type of the list.
+    ///
+    /// The list type determines the semantics used in the return string.
+    ///
+    /// For example, for en\_US:
+    ///
+    /// ```swift
+    /// ["One", "Two", "Three"].formatted(.list(type: .and))
+    /// // "One, Two, and Three"
+    ///
+    /// ["One", "Two", "Three"].formatted(.list(type: .or))
+    /// // "One, Two, or Three"
+    /// ```
+    ///
+    /// The default value is ``ListType/and``.
     public var listType: ListType
+    /// The locale to use when formatting items in the list.
+    ///
+    /// A `Locale` instance is typically used to provide, format, and interpret information about and according to
+    /// the user's customs and preferences.
+    ///
+    /// Examples include ISO region and language codes, currency code, calendar, system of measurement, and decimal
+    /// separator.
+    ///
+    /// The default value is `Locale.autoupdatingCurrent`. If you set this property to `nil`, the formatter resets
+    /// to using `autoupdatingCurrent`.
     public var locale: Locale
 
+    /// Creates an instance using the provided format style.
+    ///
+    /// The input type of `memberStyle` must match the type of an element
+    /// in the sequence. The output type is a string.
+    ///
+    /// The following example uses a `FloatingPointFormatStyle.Descriptive`
+    /// member style to spell out a list:
+    ///
+    /// ```swift
+    /// [-3.0, 9.0, 11.6].formatted(.list(memberStyle: .descriptive, type: .and))
+    /// // minus three, nine, and eleven point six
+    /// ```
+    ///
+    /// - Parameter memberStyle: The format style applied to elements of the sequence.
     public init(memberStyle: Style) {
         self.memberStyle = memberStyle
         self.width = .standard
@@ -28,22 +139,60 @@ public struct ListFormatStyle<Style: FormatStyle, Base: Sequence>: FormatStyle w
         self.locale = .autoupdatingCurrent
     }
 
+    /// Creates a locale-aware string representation of the value.
+    ///
+    /// Once you create a style, you can use it to format similar sequences
+    /// multiple times. For example:
+    ///
+    /// ```swift
+    /// let percentStyle = ListFormatStyle<IntegerFormatStyle.Percent, [Int]>(memberStyle: .percent)
+    /// percentStyle.format([92, 98]) // 92% and 98%
+    /// percentStyle.format([67, 72, 99]) // 67%, 72%, and 99%
+    /// ```
+    ///
+    /// - Parameter value: The sequence of elements to format.
+    /// - Returns: A string representation of the provided sequence.
     public func format(_ value: Base) -> String {
         let formatter = ICUListFormatter.formatter(for: self)
         return formatter.format(strings: value.map(memberStyle.format(_:)))
     }
 
+    /// The type representing the width of a list.
+    ///
+    /// The possible values of a ``ListFormatStyle/width`` are `standard`, `short`, and `narrow`.
     public enum Width: Int, Codable, Sendable {
+        /// Specifies a standard list style.
+        ///
+        /// This width creates a list like `One, Two, and Three` in U.S. English.
         case standard
+        /// Specifies a short list style.
+        ///
+        /// This width creates a list like `One, Two, & Three` in U.S. English.
         case short
+        /// Specifies a narrow list style, the shortest list style.
+        ///
+        /// This width creates a list like `One, Two, Three` in U.S. English.
         case narrow
     }
 
+    /// A type that describes whether the returned list contains cumulative or alternative elements.
+    ///
+    /// The possible values of a ``ListFormatStyle/listType`` are `and` and `or`.
     public enum ListType: Int, Codable, Sendable {
+        /// Specifies an *and* list type.
+        ///
+        /// This creates a list like `One, Two, and Three` in U.S. English.
         case and
+        /// Specifies an *or* list type.
+        ///
+        /// This creates a list like `One, Two, or Three` in U.S. English.
         case or
     }
 
+    /// Modifies the list format style to use the specified locale.
+    ///
+    /// - Parameter locale: The locale to use when formatting items in the list.
+    /// - Returns: A list format style with the provided locale.
     public func locale(_ locale: Locale) -> Self {
         var new = self
         new.locale = locale
@@ -75,6 +224,31 @@ public extension Swift.Sequence where Element == String {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle {
+    /// Returns a format style to format a list of items.
+    ///
+    /// Use the dot-notation form of this type method when the call point allows the use of
+    /// ``ListFormatStyle``. You typically do this when calling the `formatted` method of
+    /// `Sequence`.
+    ///
+    /// The following example creates an array of integers, then uses the list format style
+    /// provided by this method to format the items. By using a currency ``IntegerFormatStyle``,
+    /// the list format style expresses each member as US dollars.
+    ///
+    /// ```swift
+    /// let items: [Int] = [100, 1000, 10000, 100000, 1000000]
+    /// let formatted = items.formatted(
+    ///     .list(memberStyle: .currency(code: "USD"),
+    ///           type: .and)
+    ///     .locale(Locale(identifier: "en_US"))) // "$100.00, $1,000.00, $10,000.00, $100,000.00, and $1,000,000.00"
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - memberStyle: The format style to apply to each item in the list.
+    ///   - type: The list type to apply, such as cumulative (``ListFormatStyle/ListType/and``)
+    ///     or alternative (``ListFormatStyle/ListType/or``) elements.
+    ///   - width: The width to use when formatting, such as ``ListFormatStyle/Width/standard``
+    ///     or ``ListFormatStyle/Width/narrow``.
+    /// - Returns: A list format style that formats an array as a textual list of items.
     static func list<MemberStyle, Base>(memberStyle: MemberStyle, type: Self.ListType, width: Self.Width = .standard) -> Self where Self == ListFormatStyle<MemberStyle, Base> {
         var style = ListFormatStyle<MemberStyle, Base>(memberStyle: memberStyle)
         style.width = width
@@ -85,6 +259,28 @@ public extension FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle {
+    /// Returns a format style to format a list of strings.
+    ///
+    /// Use the dot-notation form of this type method when the call point allows the use of
+    /// ``ListFormatStyle``, and the `Sequence` element type is `String`. You typically do this
+    /// when calling the `formatted` method of `Sequence`.
+    ///
+    /// The following example creates an array of strings, then uses the list format style
+    /// provided by this method to format the items.
+    ///
+    /// ```swift
+    /// let items = ["Atlantic", "Pacific", "Indian", "Arctic", "Southern"]
+    /// let formatted = items.formatted(
+    ///     .list(type:.and)
+    ///     .locale(Locale(identifier: "en_US"))) // "Atlantic, Pacific, Indian, Arctic, and Southern"
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - type: The list type to apply, such as cumulative (``ListFormatStyle/ListType/and``)
+    ///     or alternative (``ListFormatStyle/ListType/or``) elements.
+    ///   - width: The width to use when formatting, such as ``ListFormatStyle/Width/standard``
+    ///     or ``ListFormatStyle/Width/narrow``.
+    /// - Returns: A list format style that formats a string array as a textual list of items.
     static func list<Base>(type: Self.ListType, width: Self.Width = .standard) -> Self where Self == ListFormatStyle<StringStyle, Base> {
         var style = ListFormatStyle<StringStyle, Base>(memberStyle: StringStyle())
         style.width = width

--- a/Sources/FoundationInternationalization/Formatting/Measurement+FormatStyle+Stub.swift
+++ b/Sources/FoundationInternationalization/Formatting/Measurement+FormatStyle+Stub.swift
@@ -20,18 +20,19 @@ public class UnitDuration: Dimension {}
 extension Measurement where UnitType: Dimension {
     public struct FormatStyle : Sendable {
         public struct UnitWidth : Codable, Hashable, Sendable {
-            /// Examples for formatting a measurement with value of 37.20:
+            /// A unit width that shows the full unit name.
             ///
-            /// Shows the unit in its full spelling.
-            /// For example, "37.20 Calories", "37,20 litres"
+            /// For example, `37.20 Calories` or `37,20 litres`.
             public static var wide: Self { .init(option: .wide) }
 
-            /// Shows the unit using abbreviation.
-            /// For example, "37.20 Cal", "37,2 L"
+            /// An abbreviated unit width.
+            ///
+            /// For example, `37.20 Cal` or `37,2 L`.
             public static var abbreviated: Self { .init(option: .abbreviated) }
 
-            /// Shows the unit in the shortest form possible, and may condense the spacing between the value and the unit.
-            /// For example, "37.20Cal", "37,2L"
+            /// The shortest unit width.
+            ///
+            /// This width may condense the spacing between the value and the unit; for example, `37.20Cal` or `37,2L`.
             public static var narrow: Self { .init(option: .narrow) }
 
             enum Option: Int, Codable, Hashable {

--- a/Sources/FoundationInternationalization/Formatting/Number/Decimal+FormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/Decimal+FormatStyle.swift
@@ -16,12 +16,70 @@ import FoundationEssentials
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Decimal {
+    /// A structure that converts between decimal values and their textual representations.
     public struct FormatStyle: Sendable {
+        /// The locale of the format style.
+        ///
+        /// Use the ``locale(_:)`` modifier to create a copy of this format style with a different locale.
         public var locale: Locale
+
+        /// Creates a decimal format style that uses the given locale.
+        ///
+        /// Create a ``Decimal/FormatStyle`` instance when you intend to apply a given style to multiple
+        /// decimal values. The following example creates a style that uses the `en_US` locale, which
+        /// uses three-based grouping and comma separators. It then applies this style to all the
+        /// ``Decimal`` values in an array.
+        ///
+        /// ```swift
+        /// let enUSstyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        /// let decimals: [Decimal] = [100.1, 1000.2, 10000.3, 100000.4, 1000000.5]
+        /// let formattedDecimals = decimals.map { enUSstyle.format($0) } // ["100.1", "1,000.2", "10,000.3", "100,000.4", "1,000,000.5"]
+        /// ```
+        ///
+        /// To format a single integer, you can use the ``Decimal`` instance method ``Decimal/formatted(_:)``
+        /// passing in an instance of ``Decimal/FormatStyle``.
+        ///
+        /// - Parameter locale: The locale to use when formatting or parsing decimal values.
+        ///   Defaults to `Locale.autoupdatingCurrent`.
         public init(locale: Locale = .autoupdatingCurrent) {
             self.locale = locale
         }
 
+        /// An attributed format style based on the decimal format style.
+        ///
+        /// Use this modifier to create a ``Decimal/FormatStyle/Attributed`` instance, which formats
+        /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+        /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+        /// these attributes to determine which runs of the attributed string represent different
+        /// parts of the formatted value.
+        ///
+        /// The following example finds runs of the attributed string that represent different parts
+        /// of a formatted currency, and adds additional attributes like
+        /// ``AttributeScopes/SwiftUIAttributes/foregroundColor`` and
+        /// ``AttributeScopes/FoundationAttributes/inlinePresentationIntent``.
+        ///
+        /// ```swift
+        /// func attributedPrice(price: Decimal) -> AttributedString {
+        ///     var attributedPrice = price.formatted(
+        ///         .currency(code: "USD")
+        ///         .attributed)
+        ///
+        ///     for run in attributedPrice.runs {
+        ///         if run.attributes.numberSymbol == .currency ||
+        ///             run.attributes.numberSymbol == .decimalSeparator {
+        ///             attributedPrice[run.range].foregroundColor = .red
+        ///         }
+        ///         if run.attributes.numberPart == .integer ||
+        ///             run.attributes.numberPart == .fraction {
+        ///             attributedPrice[run.range].inlinePresentationIntent = [.stronglyEmphasized]
+        ///         }
+        ///     }
+        ///     return attributedPrice
+        /// }
+        /// ```
+        ///
+        /// User interface frameworks like SwiftUI can use these attributes when presenting the
+        /// attributed string.
         public var attributed: Attributed {
             return Attributed(style: self)
         }
@@ -29,30 +87,124 @@ extension Decimal {
         public typealias Configuration = NumberFormatStyleConfiguration
         internal var collection: Configuration.Collection = Configuration.Collection()
 
+        /// Modifies the format style to use the specified grouping.
+        ///
+        /// The following example creates a default ``Decimal/FormatStyle`` for the `en_US` locale,
+        /// and a second style that never uses grouping. It then applies each style to an array of
+        /// decimal values. The formatting that the modified style applies eliminates the three-digit
+        /// grouping usually performed for the `en_US` locale.
+        ///
+        /// ```swift
+        /// let defaultStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        /// let neverStyle = defaultStyle.grouping(.never)
+        /// let nums: [Decimal] = [100.1, 1000.2, 10000.3, 100000.4, 1000000.5]
+        /// let defaultNums = nums.map { defaultStyle.format($0) } // ["100.1", "1,000.2", "10,000.3", "100,000.4", "1,000,000.5"]
+        /// let neverNums = nums.map { neverStyle.format($0) } // ["100.1", "1000.2", "10000.3", "100000.4", "1000000.5"]
+        /// ```
+        ///
+        /// - Parameter group: The grouping to apply to the format style.
+        /// - Returns: A decimal format style modified to use the specified grouping.
         public func grouping(_ group: Configuration.Grouping) -> Self {
             var new = self
             new.collection.group = group
             return new
         }
 
+        /// Modifies the format style to use the specified precision.
+        ///
+        /// The ``NumberFormatStyleConfiguration/Precision`` type lets you specify fixed numbers of digits
+        /// to show for a number's integer and fractional parts. You can also set a fixed number of
+        /// significant digits.
+        ///
+        /// The following example creates a default ``Decimal/FormatStyle`` for the `en_US` locale,
+        /// and a second style that uses a maximum of four significant digits. It then applies each
+        /// style to an array of decimal values. The formatting applied by the modified style truncates
+        /// precision to `0` after the fourth most-significant digit.
+        ///
+        /// ```swift
+        /// let defaultStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        /// let precisionStyle = defaultStyle.precision(.significantDigits(1...4))
+        /// let nums: [Decimal] = [123.1, 1234.1, 12345.1, 123456.1, 1234567.1]
+        /// let defaultNums = nums.map { defaultStyle.format($0) } // ["123.1", "1,234.1", "12,345.1", "123,456.1", "1,234,567.1"]
+        /// let precisionNums = nums.map { precisionStyle.format($0) } // ["123.1", "1,234", "12,350", "123,500", "1,235,000"]
+        /// ```
+        ///
+        /// - Parameter p: The precision to apply to the format style.
+        /// - Returns: A decimal format style modified to use the specified precision.
         public func precision(_ p: Configuration.Precision) -> Self {
             var new = self
             new.collection.precision = p
             return new
         }
 
+        /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+        ///
+        /// The following example creates a default ``Decimal/FormatStyle`` for the `en_US` locale,
+        /// and a second style that displays a sign for all values except zero. It then applies each
+        /// style to an array of decimal values. The formatting that the modified style applies adds
+        /// the negative (`-`) or positive (`+`) sign to all the numbers.
+        ///
+        /// ```swift
+        /// let defaultStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        /// let alwaysStyle = defaultStyle.sign(strategy: .always(includingZero: false))
+        /// let nums: [Decimal] = [-2.1, -1.2, 0, 1.4, 2.5]
+        /// let defaultNums = nums.map { defaultStyle.format($0) } // ["-2.1", "-1.2", "0", "1.4", "2.5"]
+        /// let alwaysNums = nums.map { alwaysStyle.format($0) } // ["-2.1", "-1.2", "0", "+1.4", "+2.5"]
+        /// ```
+        ///
+        /// - Parameter strategy: The sign display strategy to apply to the format style.
+        /// - Returns: A decimal format style modified to use the specified sign display strategy.
         public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
             var new = self
             new.collection.signDisplayStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified decimal separator display strategy.
+        ///
+        /// The following example creates a default ``Decimal/FormatStyle`` for the `en_US` locale,
+        /// and a second style that uses the ``NumberFormatStyleConfiguration/DecimalSeparatorDisplayStrategy/always``
+        /// strategy. It then applies each style to an array of decimal values that don't have a
+        /// fractional part. The formatting that the modified style applies adds a trailing decimal
+        /// separator in all cases.
+        ///
+        /// ```swift
+        /// let defaultStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        /// let alwaysStyle = defaultStyle.decimalSeparator(strategy: .always)
+        /// let nums: [Decimal] = [100.0, 1000.0, 10000.0, 100000.0, 1000000.0]
+        /// let defaultNums = nums.map { defaultStyle.format($0) } // ["100", "1,000", "10,000", "100,000", "1,000,000"]
+        /// let alwaysNums = nums.map { alwaysStyle.format($0) } // ["100.", "1,000.", "10,000.", "100,000.", "1,000,000."]
+        /// ```
+        ///
+        /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+        /// - Returns: A decimal format style modified to use the specified decimal separator display strategy.
         public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
             var new = self
             new.collection.decimalSeparatorStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified rounding rule and increment.
+        ///
+        /// The following example creates a default ``Decimal/FormatStyle`` for the `en_US` locale,
+        /// and a modified style that rounds integers to the nearest multiple of `100`. It then
+        /// formats the value `1999.95` using these format styles.
+        ///
+        /// ```swift
+        /// let defaultStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        /// let roundedStyle = defaultStyle.rounded(rule: .toNearestOrEven,
+        ///                                         increment: 100)
+        /// let num: Decimal = 1999.95
+        /// let defaultNum = num.formatted(defaultStyle) // "1,999.95"
+        /// let roundedNum = num.formatted(roundedStyle) // "2,000"
+        /// ```
+        ///
+        /// - Parameters:
+        ///   - rule: The rounding rule to apply to the format style.
+        ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+        ///     produces a value that is an even multiple of this increment. If this parameter is
+        ///     `nil` (the default), the formatter doesn't apply an increment.
+        /// - Returns: A decimal format style modified to use the specified rounding rule and increment.
         public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Int? = nil) -> Self {
             var new = self
             new.collection.rounding = rule
@@ -62,19 +214,72 @@ extension Decimal {
             return new
         }
 
+        /// Modifies the format style to use the specified scale.
+        ///
+        /// The following example creates a default ``Decimal/FormatStyle`` for the `en_US` locale,
+        /// and a second style that scales by a `multiplicand` of `0.001`. It then applies each
+        /// style to an array of decimal values. The formatting that the modified style applies
+        /// expresses each value in terms of one-thousandths.
+        ///
+        /// ```swift
+        /// let defaultStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        /// let scaledStyle = defaultStyle.scale(0.001)
+        /// let nums: [Decimal] = [100.1, 1000.2, 10000.3, 100000.4, 1000000.5]
+        /// let defaultNums = nums.map { defaultStyle.format($0) } // ["100.1", "1,000.2", "10,000.3", "100,000.4", "1,000,000.5"]
+        /// let scaledNums = nums.map { scaledStyle.format($0) } // ["0.1001", "1.0002", "10.0003", "100.0004", "1,000.0005"]
+        /// ```
+        ///
+        /// - Parameter multiplicand: The multiplicand to apply to the format style.
+        /// - Returns: A decimal format style modified to use the specified scale.
         public func scale(_ multiplicand: Double) -> Self {
             var new = self
             new.collection.scale = multiplicand
             return new
         }
 
+        /// Modifies the format style to use the specified notation.
+        ///
+        /// The following example creates a default ``Decimal/FormatStyle`` for the `en_US` locale,
+        /// and a second style that uses scientific notation style. It then applies each style to
+        /// an array of decimal values.
+        ///
+        /// ```swift
+        /// let defaultStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        /// let scientificStyle = defaultStyle.notation(.scientific)
+        /// let nums: [Decimal] = [100.1, 1000.2, 10000.3, 100000.4, 1000000.5]
+        /// let defaultNums = nums.map { defaultStyle.format($0) } // ["100.1", "1,000.2", "10,000.3", "100,000.4", "1,000,000.5"]
+        /// let scientificNums = nums.map { scientificStyle.format($0) } // ["1.001E2", "1.0002E3", "1.00003E4", "1.000004E5", "1E6"]
+        /// ```
+        ///
+        /// - Parameter notation: The notation to apply to the format style.
+        /// - Returns: A decimal format style modified to use the specified notation.
         public func notation(_ notation: Configuration.Notation) -> Self {
             var new = self
             new.collection.notation = notation
             return new
         }
 
-        // FormatStyle
+        /// Formats a decimal value using this style.
+        ///
+        /// Use this method when you want to create a single style instance and then use it to format
+        /// multiple decimal values. The following example creates a style that uses the `en_US` locale
+        /// and then adds the ``NumberFormatStyleConfiguration/Notation/scientific`` modifier. It then
+        /// applies this style to all of the decimal values in an array.
+        ///
+        /// ```swift
+        /// let scientificStyle = Decimal.FormatStyle(
+        ///     locale: Locale(identifier: "en_US"))
+        ///     .notation(.scientific)
+        /// let nums: [Decimal] = [100.1, 1000.2, 10000.3, 100000.4, 1000000.5]
+        /// let formattedNums = nums.map { scientificStyle.format($0) } // ["1.001E2", "1.0002E3", "1.00003E4", "1.000004E5", "1E6"]
+        /// ```
+        ///
+        /// To format a single value, use the ``Decimal`` instance method ``Decimal/formatted(_:)``,
+        /// passing in an instance of ``Decimal/FormatStyle``, or ``Decimal/formatted()`` to use a
+        /// default style.
+        ///
+        /// - Parameter value: The decimal value to format.
+        /// - Returns: A string representation of `value` formatted according to the style's configuration.
         public func format(_ value: Decimal) -> String {
             if let f = ICUNumberFormatter.create(for: self), let res = f.format(value) {
                 return res
@@ -83,6 +288,27 @@ extension Decimal {
             return value.description
         }
 
+        /// Modifies the format style to use the specified locale.
+        ///
+        /// Use this modifier to change the locale that an existing format style uses. To instead
+        /// determine the locale that this format style uses, use the ``locale`` property.
+        ///
+        /// The following example creates a default ``Decimal/FormatStyle`` for the `en_US` locale,
+        /// and applies the ``notation(_:)`` modifier to use compact name notation. Next, the sample
+        /// creates a second style based on this, but that uses the German (`DE`) locale. It then
+        /// applies each style to an array of decimal values.
+        ///
+        /// ```swift
+        /// let compactStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+        ///     .notation(.compactName)
+        /// let germanStyle = compactStyle.locale(Locale(identifier: "DE"))
+        /// let nums: [Decimal] = [100, 1000, 10000, 100000, 1000000]
+        /// let enUSCompactNums = nums.map { compactStyle.format($0) } // ["100", "1K", "10K", "100K", "1M"]
+        /// let deCompactNums = nums.map { germanStyle.format($0) } // ["100", "1000", "10.000", "100.000", "1 Mio."]
+        /// ```
+        ///
+        /// - Parameter locale: The locale to apply to the format style.
+        /// - Returns: A decimal format style modified to use the provided locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             new.locale = locale
@@ -96,45 +322,84 @@ extension Decimal.FormatStyle : FormatStyle {}
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Decimal.FormatStyle {
+    /// A format style that converts between decimal percentage values and their textual representations.
     public struct Percent : Sendable {
         public typealias Configuration = NumberFormatStyleConfiguration
 
+        /// The locale of the format style.
+        ///
+        /// Use the ``locale(_:)`` modifier to create a copy of this format style with a different locale.
         public var locale: Locale
         // Set scale to 100 so we format 0.42 as "42%" instead of "0.42%"
         var collection: Configuration.Collection = Configuration.Collection(scale: 100)
 
+        /// Creates a decimal percent format style that uses the given locale.
+        ///
+        /// - Parameter locale: The locale to use when formatting or parsing decimal values.
+        ///   Defaults to `Locale.autoupdatingCurrent`.
         public init(locale: Locale = .autoupdatingCurrent) {
             self.locale = locale
         }
 
+        /// An attributed format style based on the decimal percent format style.
+        ///
+        /// Use this modifier to create a ``Decimal/FormatStyle/Attributed`` instance, which formats
+        /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+        /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+        /// these attributes to determine which runs of the attributed string represent different
+        /// parts of the formatted value.
         public var attributed: Attributed {
             return Attributed(style: self)
         }
 
+        /// Modifies the format style to use the specified grouping.
+        ///
+        /// - Parameter group: The grouping to apply to the format style.
+        /// - Returns: A decimal percent format style modified to use the specified grouping.
         public func grouping(_ group: Configuration.Grouping) -> Self {
             var new = self
             new.collection.group = group
             return new
         }
 
+        /// Modifies the format style to use the specified precision.
+        ///
+        /// - Parameter p: The precision to apply to the format style.
+        /// - Returns: A decimal percent format style modified to use the specified precision.
         public func precision(_ p: Configuration.Precision) -> Self {
             var new = self
             new.collection.precision = p
             return new
         }
 
+        /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+        ///
+        /// - Parameter strategy: The sign display strategy to apply to the format style.
+        /// - Returns: A decimal percent format style modified to use the specified sign display strategy.
         public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
             var new = self
             new.collection.signDisplayStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified decimal separator display strategy.
+        ///
+        /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+        /// - Returns: A decimal percent format style modified to use the specified decimal separator display strategy.
         public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
             var new = self
             new.collection.decimalSeparatorStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified rounding rule and increment.
+        ///
+        /// - Parameters:
+        ///   - rule: The rounding rule to apply to the format style.
+        ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+        ///     produces a value that is an even multiple of this increment. If this parameter is
+        ///     `nil` (the default), the formatter doesn't apply an increment.
+        /// - Returns: A decimal percent format style modified to use the specified rounding rule and increment.
         public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Int? = nil) -> Self {
             var new = self
             new.collection.rounding = rule
@@ -144,19 +409,30 @@ extension Decimal.FormatStyle {
             return new
         }
 
+        /// Modifies the format style to use the specified scale.
+        ///
+        /// - Parameter multiplicand: The multiplicand to apply to the format style.
+        /// - Returns: A decimal percent format style modified to use the specified scale.
         public func scale(_ multiplicand: Double) -> Self {
             var new = self
             new.collection.scale = multiplicand
             return new
         }
 
+        /// Modifies the format style to use the specified notation.
+        ///
+        /// - Parameter notation: The notation to apply to the format style.
+        /// - Returns: A decimal percent format style modified to use the specified notation.
         public func notation(_ notation: Configuration.Notation) -> Self {
             var new = self
             new.collection.notation = notation
             return new
         }
 
-        // FormatStyle
+        /// Formats a decimal value as a percentage, using this style.
+        ///
+        /// - Parameter value: The decimal value to format.
+        /// - Returns: A string representation of `value` formatted as a percentage according to the style's configuration.
         public func format(_ value: Decimal) -> String {
             if let f = ICUPercentNumberFormatter.create(for: self), let res = f.format(value) {
                 return res
@@ -165,6 +441,10 @@ extension Decimal.FormatStyle {
             return value.description
         }
 
+        /// Modifies the format style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to apply to the format style.
+        /// - Returns: A decimal percent format style modified to use the provided locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             new.locale = locale
@@ -172,48 +452,92 @@ extension Decimal.FormatStyle {
         }
     }
 
+    /// A format style that converts between decimal currency values and their textual representations.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public struct Currency : Sendable {
         public typealias Configuration = CurrencyFormatStyleConfiguration
 
+        /// The locale of the format style.
+        ///
+        /// Use the ``locale(_:)`` modifier to create a copy of this format style with a different locale.
         public var locale: Locale
+
+        /// The currency code this format style uses, such as `USD` or `EUR`.
         public var currencyCode: String
 
         internal var collection: Configuration.Collection
+
+        /// Creates a decimal currency format style that uses the given currency code and locale.
+        ///
+        /// - Parameters:
+        ///   - code: The currency code to use, such as `EUR` or `JPY`.
+        ///   - locale: The locale to use when formatting or parsing decimal values.
+        ///     Defaults to `Locale.autoupdatingCurrent`.
         public init(code: String, locale: Locale = .autoupdatingCurrent) {
             self.locale = locale
             self.currencyCode = code
             self.collection = Configuration.Collection(presentation: .standard)
         }
 
+        /// An attributed format style based on the decimal currency format style.
+        ///
+        /// Use this modifier to create a ``Decimal/FormatStyle/Attributed`` instance, which formats
+        /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+        /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+        /// these attributes to determine which runs of the attributed string represent different
+        /// parts of the formatted value.
         public var attributed: Attributed {
             return Attributed(style: self)
         }
 
+        /// Modifies the format style to use the specified grouping.
+        ///
+        /// - Parameter group: The grouping to apply to the format style.
+        /// - Returns: A decimal currency format style modified to use the specified grouping.
         public func grouping(_ group: Configuration.Grouping) -> Self {
             var new = self
             new.collection.group = group
             return new
         }
 
+        /// Modifies the format style to use the specified precision.
+        ///
+        /// - Parameter p: The precision to apply to the format style.
+        /// - Returns: A decimal currency format style modified to use the specified precision.
         public func precision(_ p: Configuration.Precision) -> Self {
             var new = self
             new.collection.precision = p
             return new
         }
 
+        /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+        ///
+        /// - Parameter strategy: The sign display strategy to apply to the format style.
+        /// - Returns: A decimal currency format style modified to use the specified sign display strategy.
         public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
             var new = self
             new.collection.signDisplayStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified decimal separator display strategy.
+        ///
+        /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+        /// - Returns: A decimal currency format style modified to use the specified decimal separator display strategy.
         public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
             var new = self
             new.collection.decimalSeparatorStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified rounding rule and increment.
+        ///
+        /// - Parameters:
+        ///   - rule: The rounding rule to apply to the format style.
+        ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+        ///     produces a value that is an even multiple of this increment. If this parameter is
+        ///     `nil` (the default), the formatter doesn't apply an increment.
+        /// - Returns: A decimal currency format style modified to use the specified rounding rule and increment.
         public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Int? = nil) -> Self {
             var new = self
             new.collection.rounding = rule
@@ -223,12 +547,22 @@ extension Decimal.FormatStyle {
             return new
         }
 
+        /// Modifies the format style to use the specified scale.
+        ///
+        /// - Parameter multiplicand: The multiplicand to apply to the format style.
+        /// - Returns: A decimal currency format style modified to use the specified scale.
         public func scale(_ multiplicand: Double) -> Self {
             var new = self
             new.collection.scale = multiplicand
             return new
         }
 
+        /// Modifies the format style to use the specified presentation.
+        ///
+        /// - Parameter p: A currency presentation value, such as
+        ///   ``CurrencyFormatStyleConfiguration/Presentation/isoCode`` or
+        ///   ``CurrencyFormatStyleConfiguration/Presentation/fullName``.
+        /// - Returns: A decimal currency format style modified to use the specified presentation.
         public func presentation(_ p: Configuration.Presentation) -> Self {
             var new = self
             new.collection.presentation = p
@@ -246,7 +580,10 @@ extension Decimal.FormatStyle {
             return new
         }
 
-        // FormatStyle
+        /// Formats a decimal value as a currency string, using this style.
+        ///
+        /// - Parameter value: The decimal value to format.
+        /// - Returns: A string representation of `value` formatted as a currency value according to the style's configuration.
         public func format(_ value: Decimal) -> String {
             if let f = ICUCurrencyNumberFormatter.create(for: self), let res = f.format(value) {
                 return res
@@ -255,6 +592,10 @@ extension Decimal.FormatStyle {
             return value.description
         }
 
+        /// Modifies the format style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to apply to the format style.
+        /// - Returns: A decimal currency format style modified to use the provided locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             new.locale = locale
@@ -262,6 +603,15 @@ extension Decimal.FormatStyle {
         }
     }
 
+    /// A format style that converts decimal values into attributed strings.
+    ///
+    /// Use the ``Decimal/FormatStyle/attributed`` modifier on a ``Decimal/FormatStyle`` to create
+    /// a format style of this type.
+    ///
+    /// The attributed strings that this format style creates contain attributes from the
+    /// ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use these
+    /// attributes to determine which runs of the attributed string represent different parts of
+    /// the formatted value.
     public struct Attributed : Sendable {
         enum Style : Hashable, Codable, Sendable {
             case decimal(Decimal.FormatStyle)
@@ -287,7 +637,13 @@ extension Decimal.FormatStyle {
             self.style = .percent(style)
         }
 
-        /// Returns an attributed string with `NumberFormatAttributes.SymbolAttribute` and `NumberFormatAttributes.NumberPartAttribute`.
+        /// Formats a decimal value, using this style.
+        ///
+        /// - Parameter value: The decimal value to format.
+        /// - Returns: An attributed string representation of `value`, formatted according to the
+        ///   style's configuration. The returned string contains attributes from the
+        ///   ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope to
+        ///   indicate runs formatted by this format style.
         public func format(_ value: Decimal) -> AttributedString {
             switch style {
             case .decimal(let formatStyle):
@@ -310,6 +666,10 @@ extension Decimal.FormatStyle {
             return AttributedString(value.description)
         }
 
+        /// Modifies the format style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to apply to the format style.
+        /// - Returns: A format style that uses the specified locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             switch style {
@@ -339,32 +699,61 @@ extension Decimal.FormatStyle.Attributed : FormatStyle {}
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Decimal.FormatStyle: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: Decimal.ParseStrategy<Self> { .init(formatStyle: self, lenient: true) }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Decimal.FormatStyle.Currency: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: Decimal.ParseStrategy<Self> { .init(formatStyle: self, lenient: true) }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Decimal.FormatStyle.Percent: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: Decimal.ParseStrategy<Self> { .init(formatStyle: self, lenient: true) }
 }
 
 // MARK: - FormatStyle protocol membership
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == Decimal.FormatStyle {
+    /// A style for formatting decimal values.
+    ///
+    /// Use this type property when the call point allows the use of ``Decimal/FormatStyle``.
+    /// You typically do this when calling the ``Decimal/formatted(_:)`` method of ``Decimal``.
     static var number: Self { .init() }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == Decimal.FormatStyle.Percent {
+    /// A style for formatting decimal values as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``Decimal/FormatStyle``.
+    /// You typically do this when calling the ``Decimal/formatted(_:)`` method of ``Decimal``.
     static var percent: Self { .init() }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == Decimal.FormatStyle.Currency {
+    /// Returns a format style to use decimal currency notation.
+    ///
+    /// Use the dot-notation form of this method when the call point allows the use of
+    /// ``Decimal/FormatStyle``. You typically do this when calling the ``Decimal/formatted(_:)``
+    /// method of ``Decimal``.
+    ///
+    /// The following example creates an array of decimals, then uses ``Decimal/formatted(_:)``
+    /// and the currency style provided by this method to format the values as US dollars.
+    ///
+    /// ```swift
+    /// let nums: [Decimal] = [100.01, 1000.02, 10000.03, 100000.04, 1000000.05]
+    /// let currencyNums = nums.map { $0.formatted(
+    ///     .currency(code:"USD")) } // ["$100.01", "$1,000.02", "$10,000.03", "$100,000.04", "$1,000,000.05"]
+    /// ```
+    ///
+    /// - Parameter code: The currency code to use, such as `EUR` or `JPY`. See ISO-4217 for
+    ///   a list of valid codes.
+    /// - Returns: A decimal format style that uses the specified currency code.
     static func currency(code: String) -> Self { .init(code: code, locale: .autoupdatingCurrent) }
 }
 
@@ -387,18 +776,52 @@ public extension ParseableFormatStyle where Self == Decimal.FormatStyle.Currency
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Decimal {
-    /// Format `self` using `Decimal.FormatStyle`
+    /// Formats the decimal using a default localized format style.
+    ///
+    /// - Returns: A string representation of the decimal, formatted according to the default format style.
     public func formatted() -> String {
         FormatStyle().format(self)
     }
 
 #if FOUNDATION_FRAMEWORK
-    /// Format `self` with the given format.
+    /// Formats the decimal using the provided format style.
+    ///
+    /// Use this method when you want to format a single decimal value with a specific
+    /// format style or multiple format styles. The following example shows the results
+    /// of formatting a given decimal value with format styles for the `en_US` and
+    /// `fr_FR` locales:
+    ///
+    /// ```swift
+    /// let decimal: Decimal = 123456.789
+    /// let usStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+    /// let frStyle = Decimal.FormatStyle(locale: Locale(identifier: "fr_FR"))
+    /// let formattedUS = decimal.formatted(usStyle) // 123,456.789
+    /// let formattedFR = decimal.formatted(frStyle) // 123 456,789
+    /// ```
+    ///
+    /// - Parameter format: The format style to apply when formatting the decimal.
+    /// - Returns: A localized, formatted string representation of the decimal.
     public func formatted<S: Foundation.FormatStyle>(_ format: S) -> S.FormatOutput where Self == S.FormatInput {
         format.format(self)
     }
 #else
-    /// Format `self` with the given format.
+    /// Formats the decimal using the provided format style.
+    ///
+    /// Use this method when you want to format a single decimal value with a specific
+    /// format style or multiple format styles. The following example shows the results
+    /// of formatting a given decimal value with format styles for the `en_US` and
+    /// `fr_FR` locales:
+    ///
+    /// ```swift
+    /// let decimal: Decimal = 123456.789
+    /// let usStyle = Decimal.FormatStyle(locale: Locale(identifier: "en_US"))
+    /// let frStyle = Decimal.FormatStyle(locale: Locale(identifier: "fr_FR"))
+    /// let formattedUS = decimal.formatted(usStyle) // 123,456.789
+    /// let formattedFR = decimal.formatted(frStyle) // 123 456,789
+    /// ```
+    ///
+    /// - Parameter format: The format style to apply when formatting the decimal.
+    /// - Returns: A localized, formatted string representation of the decimal.
     public func formatted<S: FoundationEssentials.FormatStyle>(_ format: S) -> S.FormatOutput where Self == S.FormatInput {
         format.format(self)
     }
@@ -410,6 +833,17 @@ extension Decimal {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension Decimal.FormatStyle : CustomConsumingRegexComponent {
     public typealias RegexOutput = Decimal
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Decimal)? {
         Decimal.ParseStrategy(formatStyle: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
@@ -418,6 +852,17 @@ extension Decimal.FormatStyle : CustomConsumingRegexComponent {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension Decimal.FormatStyle.Percent : CustomConsumingRegexComponent {
     public typealias RegexOutput = Decimal
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Decimal)? {
         Decimal.ParseStrategy(formatStyle: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
@@ -426,6 +871,17 @@ extension Decimal.FormatStyle.Percent : CustomConsumingRegexComponent {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension Decimal.FormatStyle.Currency : CustomConsumingRegexComponent {
     public typealias RegexOutput = Decimal
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Decimal)? {
         Decimal.ParseStrategy(formatStyle: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }

--- a/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
@@ -17,8 +17,11 @@ import FoundationEssentials
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Decimal {
 #if FOUNDATION_FRAMEWORK
+    /// A parse strategy for creating decimal values from formatted strings.
     public struct ParseStrategy<Format> : Foundation.ParseStrategy, Codable, Hashable where Format : Foundation.FormatStyle, Format.FormatInput == Decimal {
+        /// The format style describing the expected format of the string to parse.
         public var formatStyle: Format
+        /// A Boolean value that indicates whether the parse strategy permits some discrepancies when parsing.
         public var lenient: Bool
         internal init(formatStyle: Format, lenient: Bool) {
             self.formatStyle = formatStyle
@@ -26,8 +29,11 @@ extension Decimal {
         }
     }
 #else
+    /// A parse strategy for creating decimal values from formatted strings.
     public struct ParseStrategy<Format> : FoundationEssentials.ParseStrategy, Codable, Hashable where Format : FoundationEssentials.FormatStyle, Format.FormatInput == Decimal {
+        /// The format style describing the expected format of the string to parse.
         public var formatStyle: Format
+        /// A Boolean value that indicates whether the parse strategy permits some discrepancies when parsing.
         public var lenient: Bool
         internal init(formatStyle: Format, lenient: Bool) {
             self.formatStyle = formatStyle
@@ -74,6 +80,16 @@ extension Decimal.ParseStrategy {
         return (upperBoundInSubstr, value)
     }
 
+    /// Parses a decimal string in accordance with this strategy and returns the parsed value.
+    ///
+    /// Use this method to repeatedly parse decimal strings with the same ``Decimal/ParseStrategy``.
+    /// To parse a single decimal string, use the initializers inherited from ``Decimal`` that take
+    /// a `String` and a ``Decimal/FormatStyle`` as parameters.
+    ///
+    /// This method throws an error if the parse strategy can't parse the provided string.
+    ///
+    /// - Parameter value: The string to parse.
+    /// - Returns: The parsed decimal value.
     public func parse(_ value: String) throws -> Format.FormatInput {
         if let result = parse(value, startingAt: value.startIndex, in: value.startIndex..<value.endIndex) {
             return result.1
@@ -124,6 +140,12 @@ public extension Decimal {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension Decimal.ParseStrategy where Format == Decimal.FormatStyle {
+    /// Creates a parse strategy instance using the specified decimal format style.
+    ///
+    /// - Parameters:
+    ///   - format: A configured ``Decimal/FormatStyle`` that describes the string format to parse.
+    ///   - lenient: A Boolean value that indicates whether the parse strategy should permit some
+    ///     discrepancies when parsing. Defaults to `true`.
     init(format: Format, lenient: Bool = true) {
         self.formatStyle = format
         self.lenient = lenient
@@ -132,6 +154,12 @@ public extension Decimal.ParseStrategy where Format == Decimal.FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension Decimal.ParseStrategy where Format == Decimal.FormatStyle.Percent {
+    /// Creates a parse strategy instance using the specified decimal percentage format style.
+    ///
+    /// - Parameters:
+    ///   - format: A configured ``Decimal/FormatStyle/Percent`` that describes the percent string format to parse.
+    ///   - lenient: A Boolean value that indicates whether the parse strategy should permit some
+    ///     discrepancies when parsing. Defaults to `true`.
     init(format: Format, lenient: Bool = true) {
         self.formatStyle = format
         self.lenient = lenient
@@ -140,6 +168,12 @@ public extension Decimal.ParseStrategy where Format == Decimal.FormatStyle.Perce
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension Decimal.ParseStrategy where Format == Decimal.FormatStyle.Currency {
+    /// Creates a parse strategy instance using the specified decimal currency format style.
+    ///
+    /// - Parameters:
+    ///   - format: A configured ``Decimal/FormatStyle/Currency`` that describes the currency string format to parse.
+    ///   - lenient: A Boolean value that indicates whether the parse strategy should permit some
+    ///     discrepancies when parsing. Defaults to `true`.
     init(format: Format, lenient: Bool = true) {
         self.formatStyle = format
         self.lenient = lenient

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
@@ -15,14 +15,147 @@ import FoundationEssentials
 #endif
 
 
+/// A structure that converts between floating-point values and their textual representations.
+///
+/// Instances of ``FloatingPointFormatStyle`` create localized, human-readable text from <doc://com.apple.documentation/documentation/swift/binaryfloatingpoint> numbers and parse string representations of numbers into instances of <doc://com.apple.documentation/documentation/swift/binaryfloatingpoint> types. All of the Swift standard library's floating-point types, such as <doc://com.apple.documentation/documentation/swift/double>, <doc://com.apple.documentation/documentation/swift/float>, and <doc://com.apple.documentation/documentation/swift/float80>, conform to <doc://com.apple.documentation/documentation/swift/binaryfloatingpoint>, and therefore work with this format style.
+///
+/// ``FloatingPointFormatStyle`` includes two nested types, ``Percent`` and ``Currency``, for working with percentages and currencies, respectively. Each format style includes a configuration that determines how it represents numeric values, for things like grouping, displaying signs, and variant presentations like scientific notation. ``FloatingPointFormatStyle`` and ``Percent`` include a ``NumberFormatStyleConfiguration``, and ``Currency`` includes a ``CurrencyFormatStyleConfiguration``. You can customize numeric formatting for a style by adjusting its backing configuration. The system automatically caches unique configurations of a format style to enhance performance.
+///
+/// > Note:
+/// > Foundation provides another format style type, ``IntegerFormatStyle``, for working with numbers that conform to <doc://com.apple.documentation/documentation/swift/binaryinteger>. For Foundation's ``Decimal`` type, use ``Decimal/FormatStyle``.
+///
+/// ### Formatting floating-point values
+///
+/// Use the <doc://com.apple.documentation/documentation/swift/binaryfloatingpoint/formatted()> method to create a string representation of a floating-point value using the default ``FloatingPointFormatStyle`` configuration.
+///
+/// ```swift
+/// let formattedDefault = 12345.67.formatted()
+/// // formattedDefault is "12,345.67" in the en_US locale.
+/// // Other locales may use different separator and grouping behavior.
+/// ```
+///
+///
+/// You can specify a format style by providing an argument to the <doc://com.apple.documentation/documentation/swift/binaryfloatingpoint/formatted(_:)-4ksqj> method. The following example shows the number `0.1` represented in each of the available styles, in the `en_US` locale:
+///
+/// ```swift
+/// let number = 0.1
+///
+/// let formattedNumber = number.formatted(.number)
+/// // formattedNumber is "0.1".
+///
+/// let formattedPercent = number.formatted(.percent)
+/// // formattedPercent is "10%".
+///
+/// let formattedCurrency = number.formatted(.currency(code: "USD"))
+/// // formattedCurrency is "$0.10".
+/// ```
+///
+///
+/// Each style provides methods for updating its numeric configuration, including the number of significant digits, grouping length, and more. You can specify a numeric configuration by calling as many of these methods as you need in any order you choose. The following example shows the same number with default and custom configurations:
+///
+/// ```swift
+/// let exampleNumber = 123456.78
+///
+/// let defaultFormatting = exampleNumber.formatted(.number)
+/// // defaultFormatting is "123 456,78" for the "fr_FR" locale.
+/// // defaultFormatting is "123,456.78" for the "en_US" locale.
+///
+/// let customFormatting = exampleNumber.formatted(
+/// .number
+/// .grouping(.never)
+/// .sign(strategy: .always()))
+/// // customFormatting is "+123456.78"
+/// ```
+///
+///
+///
+///
+/// ### Creating a floating-point format style instance
+///
+/// The previous examples use static factory methods like ``FormatStyle/number-8c8rj`` to create format styles within the call to the <doc://com.apple.documentation/documentation/swift/binaryfloatingpoint/formatted(_:)-4ksqj> method. You can also create a ``FloatingPointFormatStyle`` instance and use it to repeatedly format different values, with the ``format(_:)`` method:
+///
+/// ```swift
+/// let percentFormatStyle = FloatingPointFormatStyle<Double>.Percent()
+///
+/// percentFormatStyle.format(0.5) // "50%"
+/// percentFormatStyle.format(0.855) // "85.5%"
+/// percentFormatStyle.format(1.0) // "100%"
+///
+/// ```
+///
+///
+///
+///
+/// ### Parsing floating-point values
+///
+/// You can use ``FloatingPointFormatStyle`` to parse strings into floating-point values. You can define the format style within the type's initializer or pass in a format style created outside the function, as shown here:
+///
+/// ```swift
+/// let price = try? Double("$3,500.63",
+/// format: .currency(code: "USD")) // 3500.63
+///
+/// let priceFormatStyle = FloatingPointFormatStyle<Double>.Currency(code: "USD")
+/// let salePrice = try? Double("$731.67",
+/// format: priceFormatStyle) // 731.67
+/// ```
+///
+///
+///
+///
+/// ### Matching regular expressions
+///
+/// Along with parsing numeric values in strings, you can use theSwift regular expression domain-specific language to match and capture numeric substrings. The following example defines a percentage format style to match a percentage value using `en_US` numeric conventions. The rest of the regular expression ignores any characters prior to a `": "` sequence that precedes the percentage substring.
+///
+/// ```swift
+/// import RegexBuilder
+/// let source = "Percentage complete: 55.1%"
+/// let matcher = Regex {
+/// OneOrMore(.any)
+/// ": "
+/// Capture {
+/// One(.localizedDoublePercentage(locale: Locale(identifier: "en_US")))
+/// }
+/// }
+/// let match = source.firstMatch(of: matcher)
+/// let localizedPercentage = match?.1
+/// print("\(localizedPercentage!)") // 0.551
+/// ```
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct FloatingPointFormatStyle<Value: BinaryFloatingPoint>: Codable, Hashable, Sendable {
+    /// The locale of the format style.
+    ///
+    /// Use the ``FormatStyle/locale(_:)`` modifier to create a copy of this format style with a different locale.
     public var locale: Locale
 
+    /// Creates a floating-point format style that uses the given locale.
+    ///
+    /// Create a ``FloatingPointFormatStyle`` when you intend to apply a given style to multiple
+    /// floating-point values. The following example creates a style that uses the `en_US` locale,
+    /// which uses three-based grouping and comma separators. It then applies this style to all the
+    /// `Double` values in an array.
+    ///
+    /// ```swift
+    /// let enUSstyle = FloatingPointFormatStyle<Double>(locale: Locale(identifier: "en_US"))
+    /// let nums = [100.1, 1000.2, 10000.3, 100000.4, 1000000.5]
+    /// let formattedNums = nums.map { enUSstyle.format($0) } // ["100.1", "1,000.2", "10,000.3", "100,000.4", "1,000,000.5"]
+    /// ```
+    ///
+    /// To format a single value, you can use the `BinaryFloatingPoint` instance method `formatted(_:)`,
+    /// passing in an instance of ``FloatingPointFormatStyle``.
+    ///
+    /// - Parameter locale: The locale to use when formatting or parsing floating-point values.
+    ///   Defaults to `Locale.autoupdatingCurrent`.
     public init(locale: Locale = .autoupdatingCurrent) {
         self.locale = locale
     }
 
+    /// An attributed format style based on the floating-point format style.
+    ///
+    /// Use this modifier to create a ``FloatingPointFormatStyle/Attributed`` instance, which formats
+    /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+    /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+    /// these attributes to determine which runs of the attributed string represent different
+    /// parts of the formatted value.
     public var attributed: FloatingPointFormatStyle.Attributed {
         return FloatingPointFormatStyle.Attributed(style: self)
     }
@@ -30,30 +163,54 @@ public struct FloatingPointFormatStyle<Value: BinaryFloatingPoint>: Codable, Has
     public typealias Configuration = NumberFormatStyleConfiguration
     internal var collection: Configuration.Collection = Configuration.Collection()
 
+    /// Modifies the format style to use the specified grouping.
+    ///
+    /// - Parameter group: The grouping to apply to the format style.
+    /// - Returns: A floating-point format style modified to use the specified grouping.
     public func grouping(_ group: Configuration.Grouping) -> Self {
         var new = self
         new.collection.group = group
         return new
     }
 
+    /// Modifies the format style to use the specified precision.
+    ///
+    /// - Parameter p: The precision to apply to the format style.
+    /// - Returns: A floating-point format style modified to use the specified precision.
     public func precision(_ p: Configuration.Precision) -> Self {
         var new = self
         new.collection.precision = p
         return new
     }
 
+    /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+    ///
+    /// - Parameter strategy: The sign display strategy to apply to the format style.
+    /// - Returns: A floating-point format style modified to use the specified sign display strategy.
     public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
         var new = self
         new.collection.signDisplayStrategy = strategy
         return new
     }
 
+    /// Modifies the format style to use the specified decimal separator display strategy.
+    ///
+    /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+    /// - Returns: A floating-point format style modified to use the specified decimal separator display strategy.
     public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
         var new = self
         new.collection.decimalSeparatorStrategy = strategy
         return new
     }
 
+    /// Modifies the format style to use the specified rounding rule and increment.
+    ///
+    /// - Parameters:
+    ///   - rule: The rounding rule to apply to the format style.
+    ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+    ///     produces a value that is an even multiple of this increment. If this parameter is
+    ///     `nil` (the default), the formatter doesn't apply an increment.
+    /// - Returns: A floating-point format style modified to use the specified rounding rule and increment.
     public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Double? = nil) -> Self {
         var new = self
         new.collection.rounding = rule
@@ -63,12 +220,20 @@ public struct FloatingPointFormatStyle<Value: BinaryFloatingPoint>: Codable, Has
         return new
     }
 
+    /// Modifies the format style to use the specified scale.
+    ///
+    /// - Parameter multiplicand: The multiplicand to apply to the format style.
+    /// - Returns: A floating-point format style modified to use the specified scale.
     public func scale(_ multiplicand: Double) -> Self {
         var new = self
         new.collection.scale = multiplicand
         return new
     }
 
+    /// Modifies the format style to use the specified notation.
+    ///
+    /// - Parameter notation: The notation to apply to the format style.
+    /// - Returns: A floating-point format style modified to use the specified notation.
     public func notation(_ notation: Configuration.Notation) -> Self {
         var new = self
         new.collection.notation = notation
@@ -78,13 +243,28 @@ public struct FloatingPointFormatStyle<Value: BinaryFloatingPoint>: Codable, Has
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointFormatStyle {
+    /// A format style that converts between floating-point percentage values and their textual representations.
     public struct Percent : Codable, Hashable, Sendable {
+        /// The locale of the format style.
+        ///
+        /// Use the ``FormatStyle/locale(_:)`` modifier to create a copy of this format style with a different locale.
         public var locale: Locale
 
+        /// Creates a floating-point percent format style that uses the given locale.
+        ///
+        /// - Parameter locale: The locale to use when formatting or parsing floating-point values.
+        ///   Defaults to `Locale.autoupdatingCurrent`.
         public init(locale: Locale = .autoupdatingCurrent) {
             self.locale = locale
         }
 
+        /// An attributed format style based on the floating-point percent format style.
+        ///
+        /// Use this modifier to create a ``FloatingPointFormatStyle/Attributed`` instance, which formats
+        /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+        /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+        /// these attributes to determine which runs of the attributed string represent different
+        /// parts of the formatted value.
         public var attributed: FloatingPointFormatStyle.Attributed {
             return FloatingPointFormatStyle.Attributed(style: self)
         }
@@ -94,30 +274,54 @@ extension FloatingPointFormatStyle {
         // Set scale to 100 so we format 0.42 as "42%" instead of "0.42%"
         var collection: Configuration.Collection = Configuration.Collection(scale: 100)
 
+        /// Modifies the format style to use the specified grouping.
+        ///
+        /// - Parameter group: The grouping to apply to the format style.
+        /// - Returns: A floating-point percent format style modified to use the specified grouping.
         public func grouping(_ group: Configuration.Grouping) -> Self {
             var new = self
             new.collection.group = group
             return new
         }
 
+        /// Modifies the format style to use the specified precision.
+        ///
+        /// - Parameter p: The precision to apply to the format style.
+        /// - Returns: A floating-point percent format style modified to use the specified precision.
         public func precision(_ p: Configuration.Precision) -> Self {
             var new = self
             new.collection.precision = p
             return new
         }
 
+        /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+        ///
+        /// - Parameter strategy: The sign display strategy to apply to the format style.
+        /// - Returns: A floating-point percent format style modified to use the specified sign display strategy.
         public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
             var new = self
             new.collection.signDisplayStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified decimal separator display strategy.
+        ///
+        /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+        /// - Returns: A floating-point percent format style modified to use the specified decimal separator display strategy.
         public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
             var new = self
             new.collection.decimalSeparatorStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified rounding rule and increment.
+        ///
+        /// - Parameters:
+        ///   - rule: The rounding rule to apply to the format style.
+        ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+        ///     produces a value that is an even multiple of this increment. If this parameter is
+        ///     `nil` (the default), the formatter doesn't apply an increment.
+        /// - Returns: A floating-point percent format style modified to use the specified rounding rule and increment.
         public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Double? = nil) -> Self {
             var new = self
             new.collection.rounding = rule
@@ -127,12 +331,20 @@ extension FloatingPointFormatStyle {
             return new
         }
 
+        /// Modifies the format style to use the specified scale.
+        ///
+        /// - Parameter multiplicand: The multiplicand to apply to the format style.
+        /// - Returns: A floating-point percent format style modified to use the specified scale.
         public func scale(_ multiplicand: Double) -> Self {
             var new = self
             new.collection.scale = multiplicand
             return new
         }
 
+        /// Modifies the format style to use the specified notation.
+        ///
+        /// - Parameter notation: The notation to apply to the format style.
+        /// - Returns: A floating-point percent format style modified to use the specified notation.
         public func notation(_ notation: Configuration.Notation) -> Self {
             var new = self
             new.collection.notation = notation
@@ -140,47 +352,91 @@ extension FloatingPointFormatStyle {
         }
     }
 
+    /// A format style that converts between floating-point currency values and their textual representations.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public struct Currency : Codable, Hashable, Sendable {
+        /// The locale of the format style.
+        ///
+        /// Use the ``FormatStyle/locale(_:)`` modifier to create a copy of this format style with a different locale.
         public var locale: Locale
+
+        /// The currency code this format style uses, such as `USD` or `EUR`.
         public let currencyCode: String
 
         public typealias Configuration = CurrencyFormatStyleConfiguration
         internal var collection: Configuration.Collection
+
+        /// Creates a floating-point currency format style that uses the given currency code and locale.
+        ///
+        /// - Parameters:
+        ///   - code: The currency code to use, such as `EUR` or `JPY`.
+        ///   - locale: The locale to use when formatting or parsing floating-point values.
+        ///     Defaults to `Locale.autoupdatingCurrent`.
         public init(code: String, locale: Locale = .autoupdatingCurrent) {
             self.locale = locale
             self.currencyCode = code
             self.collection = Configuration.Collection(presentation: .standard)
         }
 
+        /// An attributed format style based on the floating-point currency format style.
+        ///
+        /// Use this modifier to create a ``FloatingPointFormatStyle/Attributed`` instance, which formats
+        /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+        /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+        /// these attributes to determine which runs of the attributed string represent different
+        /// parts of the formatted value.
         public var attributed: FloatingPointFormatStyle.Attributed {
             return FloatingPointFormatStyle.Attributed(style: self)
         }
 
+        /// Modifies the format style to use the specified grouping.
+        ///
+        /// - Parameter group: The grouping to apply to the format style.
+        /// - Returns: A floating-point currency format style modified to use the specified grouping.
         public func grouping(_ group: Configuration.Grouping) -> Self {
             var new = self
             new.collection.group = group
             return new
         }
 
+        /// Modifies the format style to use the specified precision.
+        ///
+        /// - Parameter p: The precision to apply to the format style.
+        /// - Returns: A floating-point currency format style modified to use the specified precision.
         public func precision(_ p: Configuration.Precision) -> Self {
             var new = self
             new.collection.precision = p
             return new
         }
 
+        /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+        ///
+        /// - Parameter strategy: The sign display strategy to apply to the format style.
+        /// - Returns: A floating-point currency format style modified to use the specified sign display strategy.
         public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
             var new = self
             new.collection.signDisplayStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified decimal separator display strategy.
+        ///
+        /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+        /// - Returns: A floating-point currency format style modified to use the specified decimal separator display strategy.
         public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
             var new = self
             new.collection.decimalSeparatorStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified rounding rule and increment.
+        ///
+        /// - Parameters:
+        ///   - rule: The rounding rule to apply to the format style.
+        ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+        ///     produces a value that is an even multiple of this increment. If this parameter is
+        ///     `nil` (the default), the formatter doesn't apply an increment.
+        /// - Returns: A floating-point currency format style modified to use the specified rounding rule and increment.
         public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Double? = nil) -> Self {
             var new = self
             new.collection.rounding = rule
@@ -190,12 +446,22 @@ extension FloatingPointFormatStyle {
             return new
         }
 
+        /// Modifies the format style to use the specified scale.
+        ///
+        /// - Parameter multiplicand: The multiplicand to apply to the format style.
+        /// - Returns: A floating-point currency format style modified to use the specified scale.
         public func scale(_ multiplicand: Double) -> Self {
             var new = self
             new.collection.scale = multiplicand
             return new
         }
 
+        /// Modifies the format style to use the specified presentation.
+        ///
+        /// - Parameter p: A currency presentation value, such as
+        ///   ``CurrencyFormatStyleConfiguration/Presentation/isoCode`` or
+        ///   ``CurrencyFormatStyleConfiguration/Presentation/fullName``.
+        /// - Returns: A floating-point currency format style modified to use the specified presentation.
         public func presentation(_ p: Configuration.Presentation) -> Self {
             var new = self
             new.collection.presentation = p
@@ -219,6 +485,27 @@ extension FloatingPointFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointFormatStyle : FormatStyle {
+    /// Formats a floating-point value, using this style.
+    ///
+    /// Use this method when you want to create a single style instance and use it to format multiple
+    /// floating-point values. The following example creates a style that uses the `en_US` locale,
+    /// then adds the ``NumberFormatStyleConfiguration/Notation/scientific`` modifier. It applies this
+    /// style to all the floating-point values in an array.
+    ///
+    /// ```swift
+    /// let scientificStyle = FloatingPointFormatStyle<Double>(
+    ///     locale: Locale(identifier: "en_US"))
+    ///     .notation(.scientific)
+    /// let nums = [100.1, 1000.2, 10000.3, 100000.4, 1000000.5]
+    /// let formattedNums = nums.map { scientificStyle.format($0) } // ["1.001E2", "1.0002E3", "1.00003E4", "1.000004E5", "1E6"]
+    /// ```
+    ///
+    /// To format a single floating-point value, use the `BinaryFloatingPoint` instance method
+    /// `formatted(_:)`, passing in an instance of ``FloatingPointFormatStyle``, or `formatted()`
+    /// to use a default style.
+    ///
+    /// - Parameter value: The floating-point value to format.
+    /// - Returns: A string representation of `value` formatted according to the style's configuration.
     public func format(_ value: Value) -> String {
         if let nf = ICUNumberFormatter.create(for: self), let str = nf.format(Double(value)) {
             return str
@@ -226,6 +513,10 @@ extension FloatingPointFormatStyle : FormatStyle {
         return String(Double(value))
     }
 
+    /// Modifies the format style to use the specified locale.
+    ///
+    /// - Parameter locale: The locale to apply to the format style.
+    /// - Returns: A floating-point format style modified to use the provided locale.
     public func locale(_ locale: Locale) -> FloatingPointFormatStyle {
         var new = self
         new.locale = locale
@@ -235,6 +526,10 @@ extension FloatingPointFormatStyle : FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointFormatStyle.Percent : FormatStyle {
+    /// Formats a floating-point value as a percentage, using this style.
+    ///
+    /// - Parameter value: The floating-point value to format.
+    /// - Returns: A string representation of `value` formatted as a percentage according to the style's configuration.
     public func format(_ value: Value) -> String {
         if let nf = ICUPercentNumberFormatter.create(for: self), let str = nf.format(Double(value)) {
             return str
@@ -242,6 +537,10 @@ extension FloatingPointFormatStyle.Percent : FormatStyle {
         return String(Double(value))
     }
 
+    /// Modifies the format style to use the specified locale.
+    ///
+    /// - Parameter locale: The locale to apply to the format style.
+    /// - Returns: A floating-point percent format style modified to use the provided locale.
     public func locale(_ locale: Locale) -> FloatingPointFormatStyle.Percent {
         var new = self
         new.locale = locale
@@ -251,6 +550,10 @@ extension FloatingPointFormatStyle.Percent : FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointFormatStyle.Currency : FormatStyle {
+    /// Formats a floating-point value as a currency string, using this style.
+    ///
+    /// - Parameter value: The floating-point value to format.
+    /// - Returns: A string representation of `value` formatted as a currency value according to the style's configuration.
     public func format(_ value: Value) -> String {
         if let nf = ICUCurrencyNumberFormatter.create(for: self), let str = nf.format(Double(value)) {
             return str
@@ -258,6 +561,10 @@ extension FloatingPointFormatStyle.Currency : FormatStyle {
         return String(Double(value))
     }
 
+    /// Modifies the format style to use the specified locale.
+    ///
+    /// - Parameter locale: The locale to apply to the format style.
+    /// - Returns: A floating-point currency format style modified to use the provided locale.
     public func locale(_ locale: Locale) -> FloatingPointFormatStyle.Currency {
         var new = self
         new.locale = locale
@@ -268,6 +575,7 @@ extension FloatingPointFormatStyle.Currency : FormatStyle {
 // MARK: - ParseableFormatStyle protocol membership
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointFormatStyle: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: FloatingPointParseStrategy<Self> {
         return FloatingPointParseStrategy<Self>(format: self, lenient: true)
     }
@@ -275,6 +583,7 @@ extension FloatingPointFormatStyle: ParseableFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointFormatStyle.Currency: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: FloatingPointParseStrategy<Self> {
         return FloatingPointParseStrategy<Self>(format: self, lenient: true)
     }
@@ -282,6 +591,7 @@ extension FloatingPointFormatStyle.Currency: ParseableFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointFormatStyle.Percent: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: FloatingPointParseStrategy<Self> {
         return FloatingPointParseStrategy<Self>(format: self, lenient: true)
     }
@@ -291,30 +601,68 @@ extension FloatingPointFormatStyle.Percent: ParseableFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == FloatingPointFormatStyle<Double> {
+    /// A style for formatting the Swift standard double-precision floating-point type.
+    ///
+    /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryFloatingPoint`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == FloatingPointFormatStyle<Float> {
+    /// A style for formatting the Swift standard single-precision floating-point type.
+    ///
+    /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryFloatingPoint`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == FloatingPointFormatStyle<Double>.Percent {
+    /// A style for formatting the Swift standard double-precision floating-point type as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryFloatingPoint`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == FloatingPointFormatStyle<Float>.Percent {
+    /// A style for formatting the Swift standard single-precision floating-point type as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryFloatingPoint`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle {
+    /// Returns a format style to use floating-point currency notation.
+    ///
+    /// Use the dot-notation form of this method when the call point allows the use of
+    /// ``FloatingPointFormatStyle``. You typically do this when calling the `formatted` methods of
+    /// types that conform to `BinaryFloatingPoint`.
+    ///
+    /// The following example creates an array of doubles, then uses the currency style
+    /// provided by this method to format the doubles as US dollars:
+    ///
+    /// ```swift
+    /// let nums: [Double] = [100.01, 1000.02, 10000.03, 100000.04, 1000000.05]
+    /// let currencyNums = nums.map { $0.formatted(
+    ///     .currency(code:"USD")) } // ["$100.01", "$1,000.02", "$10,000.03", "$100,000.04", "$1,000,000.05"]
+    /// ```
+    ///
+    /// - Parameter code: The currency code to use, such as `EUR` or `JPY`. See ISO-4217 for
+    ///   a list of valid codes.
+    /// - Returns: A floating-point format style that uses the specified currency code.
     @_alwaysEmitIntoClient
     static func currency<Value>(code: String) -> Self where Self == FloatingPointFormatStyle<Value>.Currency {
         return Self(code: code)
@@ -324,12 +672,22 @@ public extension FormatStyle {
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64)) // Float16 is unavailable on Intel Macs
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == FloatingPointFormatStyle<Float16> {
+    /// A style for formatting 16-bit floating-point values.
+    ///
+    /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryFloatingPoint`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == FloatingPointFormatStyle<Float16>.Percent {
+    /// A style for formatting 16-bit floating-point values as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryFloatingPoint`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -339,6 +697,15 @@ public extension FormatStyle where Self == FloatingPointFormatStyle<Float16>.Per
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointFormatStyle {
+    /// A format style that converts floating-point values into attributed strings.
+    ///
+    /// Use the ``FloatingPointFormatStyle/attributed`` modifier on a ``FloatingPointFormatStyle``
+    /// to create a format style of this type.
+    ///
+    /// The attributed strings that this format style creates contain attributes from the
+    /// ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use these
+    /// attributes to determine which runs of the attributed string represent different parts of
+    /// the formatted value.
     public struct Attributed : Codable, Hashable, FormatStyle, Sendable {
         enum Style : Codable, Hashable, Sendable {
             case floatingPoint(FloatingPointFormatStyle)
@@ -375,7 +742,13 @@ extension FloatingPointFormatStyle {
             self.style = .currency(style)
         }
 
-        /// Returns an attributed string with `NumberFormatAttributes.SymbolAttribute` and `NumberFormatAttributes.NumberPartAttribute`.
+        /// Formats a floating-point value, using this style.
+        ///
+        /// - Parameter value: The floating-point value to format.
+        /// - Returns: An attributed string representation of `value`, formatted according to the
+        ///   style's configuration. The returned string contains attributes from the
+        ///   ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope to
+        ///   indicate runs formatted by this format style.
         public func format(_ value: Value) -> AttributedString {
             switch style {
             case .floatingPoint(let formatStyle):
@@ -398,6 +771,10 @@ extension FloatingPointFormatStyle {
             return AttributedString(Double(value).description)
         }
 
+        /// Modifies the format style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to apply to the format style.
+        /// - Returns: A format style that uses the specified locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             switch style {
@@ -421,6 +798,17 @@ extension FloatingPointFormatStyle {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension FloatingPointFormatStyle : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
         try FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
@@ -429,6 +817,17 @@ extension FloatingPointFormatStyle : CustomConsumingRegexComponent {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension FloatingPointFormatStyle.Percent : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
         try FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
@@ -437,6 +836,17 @@ extension FloatingPointFormatStyle.Percent : CustomConsumingRegexComponent {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension FloatingPointFormatStyle.Currency : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
         try FloatingPointParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
@@ -14,9 +14,12 @@
 import FoundationEssentials
 #endif
 
+/// A parse strategy for creating floating-point values from formatted strings.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct FloatingPointParseStrategy<Format> : Codable, Hashable where Format : FormatStyle, Format.FormatInput : BinaryFloatingPoint {
+    /// The format style this strategy uses when parsing strings.
     public var formatStyle: Format
+    /// A Boolean value that indicates whether parsing allows any discrepencies in the expected format.
     public var lenient: Bool
 }
 
@@ -25,6 +28,7 @@ extension FloatingPointParseStrategy : Sendable where Format : Sendable {}
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointParseStrategy: ParseStrategy {
+    /// Parses a floating-point string in accordance with this strategy and returns the parsed value.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func parse(_ value: String) throws -> Format.FormatInput {
         let trimmedString = value._trimmingWhitespace()
@@ -78,6 +82,7 @@ extension FloatingPointParseStrategy: ParseStrategy {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FloatingPointParseStrategy {
+    /// Creates a parse strategy instance using the specified floating-point format style.
     init<Value>(format: Format, lenient: Bool = true) where Format == FloatingPointFormatStyle<Value> {
         self.formatStyle = format
         self.lenient = lenient
@@ -86,6 +91,7 @@ public extension FloatingPointParseStrategy {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FloatingPointParseStrategy {
+    /// Creates a parse strategy instance using the specified floating-point currency format style.
     init<Value>(format: Format, lenient: Bool = true) where Format == FloatingPointFormatStyle<Value>.Currency {
         self.formatStyle = format
         self.lenient = lenient
@@ -94,6 +100,7 @@ public extension FloatingPointParseStrategy {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FloatingPointParseStrategy {
+    /// Creates a parse strategy instance using the specified floating-point percentage format style.
     init<Value>(format: Format, lenient: Bool = true) where Format == FloatingPointFormatStyle<Value>.Percent {
         self.formatStyle = format
         self.lenient = lenient

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
@@ -14,46 +14,218 @@
 import FoundationEssentials
 #endif
 
+/// A structure that converts between integer values and their textual representations.
+///
+/// Instances of ``IntegerFormatStyle`` create localized, human-readable text from <doc://com.apple.documentation/documentation/swift/binaryinteger> numbers and parse string representations of numbers into instances of <doc://com.apple.documentation/documentation/swift/binaryinteger> types. All of the Swift standard library's integer types, such as <doc://com.apple.documentation/documentation/swift/int> and <doc://com.apple.documentation/documentation/swift/uint32>, conform to <doc://com.apple.documentation/documentation/swift/binaryinteger>, and therefore work with this format style.
+///
+/// ``IntegerFormatStyle`` includes two nested types, ``Percent`` and ``Currency``, for working with percentages and currencies. Each format style includes a configuration that determines how it represents numeric values, for things like grouping, displaying signs, and variant presentations like scientific notation. ``IntegerFormatStyle`` and ``Percent`` include a ``NumberFormatStyleConfiguration``, and ``Currency`` includes a ``CurrencyFormatStyleConfiguration``. You can customize numeric formatting for a style by adjusting its backing configuration. The system automatically caches unique configurations of a format style to enhance performance.
+///
+/// > Note:
+/// > Foundation provides another format style type, ``FloatingPointFormatStyle``, for working with numbers that conform to <doc://com.apple.documentation/documentation/swift/binaryfloatingpoint>. For Foundation's ``Decimal`` type, use ``Decimal/FormatStyle``.
+///
+///
+///
+/// ### Formatting integers
+///
+/// Use the <doc://com.apple.documentation/documentation/swift/binaryinteger/formatted()> method to create a string representation of an integer using the default ``IntegerFormatStyle`` configuration.
+///
+/// ```swift
+/// let formattedDefault = 123456.formatted()
+/// // formattedDefault is "123,456" in en_US locale.
+/// // Other locales may use different separator and grouping behavior.
+/// ```
+///
+///
+/// You can specify a format style by providing an argument to the <doc://com.apple.documentation/documentation/swift/binaryinteger/formatted(_:)-73k3e> method. The following example shows the number `12345` represented in each of the available styles, in the `en_US` locale:
+///
+/// ```swift
+/// let number = 123456
+///
+/// let formattedNumber = number.formatted(.number)
+/// // formattedNumber is "123,456".
+///
+/// let formattedPercent = number.formatted(.percent)
+/// // formattedPercent is "123,456%".
+///
+/// let formattedCurrency = number.formatted(.currency(code: "USD"))
+/// // formattedCurrency is "$123,456.00".
+/// ```
+///
+///
+/// Each style provides methods for updating its numeric configuration, including the number of significant digits, grouping length, and more. You can specify a numeric configuration by calling as many of these methods as you need in any order you choose. The following example shows the same number with default and custom configurations:
+///
+/// ```swift
+/// let exampleNumber = 123456
+///
+/// let defaultFormatting = exampleNumber.formatted(.number)
+/// // defaultFormatting is "125 000" for the "fr_FR" locale
+/// // defaultFormatting is "125000" for the "jp_JP" locale
+/// // defaultFormatting is "125,000" for the "en_US" locale
+///
+/// let customFormatting = exampleNumber.formatted(
+/// .number
+/// .grouping(.never)
+/// .sign(strategy: .always()))
+/// // customFormatting is "+123456"
+/// ```
+///
+///
+///
+///
+/// ### Creating an integer format style instance
+///
+/// The previous examples use static factory methods like ``FormatStyle/number-7fxvo`` to create format styles within the call to the <doc://com.apple.documentation/documentation/swift/binaryinteger/formatted(_:)-73k3e> method. You can also create an ``IntegerFormatStyle`` instance and use it to repeatedly format different values with the ``format(_:)`` method:
+///
+/// ```swift
+/// let percentFormatStyle = IntegerFormatStyle<Int>.Percent()
+///
+/// percentFormatStyle.format(50) // "50%"
+/// percentFormatStyle.format(85) // "85%"
+/// percentFormatStyle.format(100) // "100%"
+/// ```
+///
+///
+///
+///
+/// ### Parsing integers
+///
+/// You can use ``IntegerFormatStyle`` to parse strings into integer values. You can define the format style within the type's initializer or pass in a format style you create prior to calling the method, as shown here:
+///
+/// ```swift
+/// let price = try? Int("$123,456",
+/// format: .currency(code: "USD")) // 123456
+///
+/// let priceFormatStyle = IntegerFormatStyle<Int>.Currency(code: "USD")
+/// let salePrice = try? Int("$120,000",
+/// format: priceFormatStyle) // 120000
+/// ```
+///
+///
+///
+///
+/// ### Matching regular expressions
+///
+/// Along with parsing numeric values in strings, you can use the Swift regular expression domain-specific language to match and capture numeric substrings. The following example defines a currency format style to match and capture a currency value using US dollars and `en_US` numeric conventions. The rest of the regular expression ignores any characters prior to a `": "` sequence that precedes the currency substring.
+///
+/// ```swift
+/// import RegexBuilder
+///
+/// let source = "Payment due: $123,456"
+/// let matcher = Regex {
+/// OneOrMore(.any)
+/// ": "
+/// Capture {
+/// One(.localizedIntegerCurrency(code: Locale.Currency("USD"),
+/// locale: Locale(identifier: "en_US")))
+/// }
+/// }
+/// let match = source.firstMatch(of: matcher)
+/// let localizedInteger = match?.1 // 123456
+/// ```
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct IntegerFormatStyle<Value: BinaryInteger>: Codable, Hashable, Sendable {
     public typealias Configuration = NumberFormatStyleConfiguration
 
+    /// The locale of the format style.
+    ///
+    /// Use the ``FormatStyle/locale(_:)`` modifier to create a copy of this format style with a different locale.
     public var locale: Locale
     internal var collection: Configuration.Collection = Configuration.Collection()
 
+    /// Creates an integer format style that uses the given locale.
+    ///
+    /// Create an ``IntegerFormatStyle`` when you intend to apply a given style to multiple integers.
+    /// The following example creates a style that uses the `en_US` locale, which uses three-based
+    /// grouping and comma separators. It then applies this style to all the integers in an array.
+    ///
+    /// ```swift
+    /// let enUSstyle = IntegerFormatStyle<Int>(locale: Locale(identifier: "en_US"))
+    /// let nums = [100, 1000, 10000, 100000, 1000000]
+    /// let formattedNums = nums.map { enUSstyle.format($0) } // ["100", "1,000", "10,000", "100,000", "1,000,000"]
+    /// ```
+    ///
+    /// To format a single integer, you can use the `BinaryInteger` instance method `formatted(_:)`,
+    /// passing in an instance of ``IntegerFormatStyle``.
+    ///
+    /// - Parameter locale: The locale to use when formatting or parsing integers.
+    ///   Defaults to `Locale.autoupdatingCurrent`.
     public init(locale: Locale = .autoupdatingCurrent) {
         self.locale = locale
     }
 
+    /// An attributed format style based on the integer format style.
+    ///
+    /// Use this modifier to create an ``IntegerFormatStyle/Attributed`` instance, which formats
+    /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+    /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+    /// these attributes to determine which runs of the attributed string represent different
+    /// parts of the formatted value.
     public var attributed: IntegerFormatStyle.Attributed {
         return IntegerFormatStyle.Attributed(style: self)
     }
 
 
+    /// Modifies the format style to use the specified grouping.
+    ///
+    /// The following example creates a default ``IntegerFormatStyle`` for the `en_US` locale,
+    /// and a second style that never uses grouping. It then applies each style to an array of
+    /// integers. The formatting that the modified style applies eliminates the three-digit
+    /// grouping usually performed for the `en_US` locale.
+    ///
+    /// ```swift
+    /// let defaultStyle = IntegerFormatStyle<Int>(locale: Locale(identifier: "en_US"))
+    /// let neverStyle = defaultStyle.grouping(.never)
+    /// let nums = [100, 1000, 10000, 100000, 1000000]
+    /// let defaultNums = nums.map { defaultStyle.format($0) } // ["100", "1,000", "10,000", "100,000", "1,000,000"]
+    /// let neverNums = nums.map { neverStyle.format($0) } // ["100", "1000", "10000", "100000", "1000000"]
+    /// ```
+    ///
+    /// - Parameter group: The grouping to apply to the format style.
+    /// - Returns: An integer format style modified to use the specified grouping.
     public func grouping(_ group: Configuration.Grouping) -> Self {
         var new = self
         new.collection.group = group
         return new
     }
 
+    /// Modifies the format style to use the specified precision.
+    ///
+    /// - Parameter p: The precision to apply to the format style.
+    /// - Returns: An integer format style modified to use the specified precision.
     public func precision(_ p: Configuration.Precision) -> Self {
         var new = self
         new.collection.precision = p
         return new
     }
 
+    /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+    ///
+    /// - Parameter strategy: The sign display strategy to apply to the format style.
+    /// - Returns: An integer format style modified to use the specified sign display strategy.
     public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
         var new = self
         new.collection.signDisplayStrategy = strategy
         return new
     }
 
+    /// Modifies the format style to use the specified decimal separator display strategy.
+    ///
+    /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+    /// - Returns: An integer format style modified to use the specified decimal separator display strategy.
     public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
         var new = self
         new.collection.decimalSeparatorStrategy = strategy
         return new
     }
 
+    /// Modifies the format style to use the specified rounding rule and increment.
+    ///
+    /// - Parameters:
+    ///   - rule: The rounding rule to apply to the format style.
+    ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+    ///     produces a value that is an even multiple of this increment. If this parameter is
+    ///     `nil` (the default), the formatter doesn't apply an increment.
+    /// - Returns: An integer format style modified to use the specified rounding rule and increment.
     public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Int? = nil) -> Self {
         var new = self
         new.collection.rounding = rule
@@ -63,12 +235,20 @@ public struct IntegerFormatStyle<Value: BinaryInteger>: Codable, Hashable, Senda
         return new
     }
 
+    /// Modifies the format style to use the specified scale.
+    ///
+    /// - Parameter multiplicand: The multiplicand to apply to the format style.
+    /// - Returns: An integer format style modified to use the specified scale.
     public func scale(_ multiplicand: Double) -> Self {
         var new = self
         new.collection.scale = multiplicand
         return new
     }
 
+    /// Modifies the format style to use the specified notation.
+    ///
+    /// - Parameter notation: The notation to apply to the format style.
+    /// - Returns: An integer format style modified to use the specified notation.
     public func notation(_ notation: Configuration.Notation) -> Self {
         var new = self
         new.collection.notation = notation
@@ -78,45 +258,84 @@ public struct IntegerFormatStyle<Value: BinaryInteger>: Codable, Hashable, Senda
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerFormatStyle {
+    /// A format style that converts between integer percentage values and their textual representations.
     public struct Percent : Codable, Hashable, Sendable {
         public typealias Configuration = NumberFormatStyleConfiguration
 
+        /// The locale of the format style.
+        ///
+        /// Use the ``FormatStyle/locale(_:)`` modifier to create a copy of this format style with a different locale.
         public var locale: Locale
         // Specifically set scale to 1 so `42` is formatted as `42%`.
         var collection: Configuration.Collection = Configuration.Collection(scale: 1)
 
+        /// Creates an integer percent format style that uses the given locale.
+        ///
+        /// - Parameter locale: The locale to use when formatting or parsing integers.
+        ///   Defaults to `Locale.autoupdatingCurrent`.
         public init(locale: Locale = .autoupdatingCurrent) {
             self.locale = locale
         }
 
+        /// An attributed format style based on the integer percent format style.
+        ///
+        /// Use this modifier to create an ``IntegerFormatStyle/Attributed`` instance, which formats
+        /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+        /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+        /// these attributes to determine which runs of the attributed string represent different
+        /// parts of the formatted value.
         public var attributed: IntegerFormatStyle.Attributed {
             return IntegerFormatStyle.Attributed(style: self)
         }
 
+        /// Modifies the format style to use the specified grouping.
+        ///
+        /// - Parameter group: The grouping to apply to the format style.
+        /// - Returns: An integer percent format style modified to use the specified grouping.
         public func grouping(_ group: Configuration.Grouping) -> Self {
             var new = self
             new.collection.group = group
             return new
         }
 
+        /// Modifies the format style to use the specified precision.
+        ///
+        /// - Parameter p: The precision to apply to the format style.
+        /// - Returns: An integer percent format style modified to use the specified precision.
         public func precision(_ p: Configuration.Precision) -> Self {
             var new = self
             new.collection.precision = p
             return new
         }
 
+        /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+        ///
+        /// - Parameter strategy: The sign display strategy to apply to the format style.
+        /// - Returns: An integer percent format style modified to use the specified sign display strategy.
         public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
             var new = self
             new.collection.signDisplayStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified decimal separator display strategy.
+        ///
+        /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+        /// - Returns: An integer percent format style modified to use the specified decimal separator display strategy.
         public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
             var new = self
             new.collection.decimalSeparatorStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified rounding rule and increment.
+        ///
+        /// - Parameters:
+        ///   - rule: The rounding rule to apply to the format style.
+        ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+        ///     produces a value that is an even multiple of this increment. If this parameter is
+        ///     `nil` (the default), the formatter doesn't apply an increment.
+        /// - Returns: An integer percent format style modified to use the specified rounding rule and increment.
         public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Int? = nil) -> Self {
             var new = self
             new.collection.rounding = rule
@@ -126,12 +345,20 @@ extension IntegerFormatStyle {
             return new
         }
 
+        /// Modifies the format style to use the specified scale.
+        ///
+        /// - Parameter multiplicand: The multiplicand to apply to the format style.
+        /// - Returns: An integer percent format style modified to use the specified scale.
         public func scale(_ multiplicand: Double) -> Self {
             var new = self
             new.collection.scale = multiplicand
             return new
         }
 
+        /// Modifies the format style to use the specified notation.
+        ///
+        /// - Parameter notation: The notation to apply to the format style.
+        /// - Returns: An integer percent format style modified to use the specified notation.
         public func notation(_ notation: Configuration.Notation) -> Self {
             var new = self
             new.collection.notation = notation
@@ -139,48 +366,92 @@ extension IntegerFormatStyle {
         }
     }
 
+    /// A format style that converts between integer currency values and their textual representations.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public struct Currency : Codable, Hashable, Sendable {
         public typealias Configuration = CurrencyFormatStyleConfiguration
 
+        /// The locale of the format style.
+        ///
+        /// Use the ``FormatStyle/locale(_:)`` modifier to create a copy of this format style with a different locale.
         public var locale: Locale
+
+        /// The currency code this format style uses, such as `USD` or `EUR`.
         public let currencyCode: String
 
         internal var collection: Configuration.Collection
+
+        /// Creates an integer currency format style that uses the given currency code and locale.
+        ///
+        /// - Parameters:
+        ///   - code: The currency code to use, such as `EUR` or `JPY`.
+        ///   - locale: The locale to use when formatting or parsing integers.
+        ///     Defaults to `Locale.autoupdatingCurrent`.
         public init(code: String, locale: Locale = .autoupdatingCurrent) {
             self.locale = locale
             self.currencyCode = code
             self.collection = Configuration.Collection(presentation: .standard)
         }
 
+        /// An attributed format style based on the integer currency format style.
+        ///
+        /// Use this modifier to create an ``IntegerFormatStyle/Attributed`` instance, which formats
+        /// values as ``AttributedString`` instances. These attributed strings contain attributes from
+        /// the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use
+        /// these attributes to determine which runs of the attributed string represent different
+        /// parts of the formatted value.
         public var attributed: IntegerFormatStyle.Attributed {
             return IntegerFormatStyle.Attributed(style: self)
         }
 
+        /// Modifies the format style to use the specified grouping.
+        ///
+        /// - Parameter group: The grouping to apply to the format style.
+        /// - Returns: An integer currency format style modified to use the specified grouping.
         public func grouping(_ group: Configuration.Grouping) -> Self {
             var new = self
             new.collection.group = group
             return new
         }
 
+        /// Modifies the format style to use the specified precision.
+        ///
+        /// - Parameter p: The precision to apply to the format style.
+        /// - Returns: An integer currency format style modified to use the specified precision.
         public func precision(_ p: Configuration.Precision) -> Self {
             var new = self
             new.collection.precision = p
             return new
         }
 
+        /// Modifies the format style to use the specified sign display strategy for displaying or omitting sign symbols.
+        ///
+        /// - Parameter strategy: The sign display strategy to apply to the format style.
+        /// - Returns: An integer currency format style modified to use the specified sign display strategy.
         public func sign(strategy: Configuration.SignDisplayStrategy) -> Self {
             var new = self
             new.collection.signDisplayStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified decimal separator display strategy.
+        ///
+        /// - Parameter strategy: The decimal separator display strategy to apply to the format style.
+        /// - Returns: An integer currency format style modified to use the specified decimal separator display strategy.
         public func decimalSeparator(strategy: Configuration.DecimalSeparatorDisplayStrategy) -> Self {
             var new = self
             new.collection.decimalSeparatorStrategy = strategy
             return new
         }
 
+        /// Modifies the format style to use the specified rounding rule and increment.
+        ///
+        /// - Parameters:
+        ///   - rule: The rounding rule to apply to the format style.
+        ///   - increment: A multiple by which the formatter rounds the fractional part. The formatter
+        ///     produces a value that is an even multiple of this increment. If this parameter is
+        ///     `nil` (the default), the formatter doesn't apply an increment.
+        /// - Returns: An integer currency format style modified to use the specified rounding rule and increment.
         public func rounded(rule: Configuration.RoundingRule = .toNearestOrEven, increment: Int? = nil) -> Self {
             var new = self
             new.collection.rounding = rule
@@ -190,12 +461,22 @@ extension IntegerFormatStyle {
             return new
         }
 
+        /// Modifies the format style to use the specified scale.
+        ///
+        /// - Parameter multiplicand: The multiplicand to apply to the format style.
+        /// - Returns: An integer currency format style modified to use the specified scale.
         public func scale(_ multiplicand: Double) -> Self {
             var new = self
             new.collection.scale = multiplicand
             return new
         }
 
+        /// Modifies the format style to use the specified presentation.
+        ///
+        /// - Parameter p: A currency presentation value, such as
+        ///   ``CurrencyFormatStyleConfiguration/Presentation/isoCode`` or
+        ///   ``CurrencyFormatStyleConfiguration/Presentation/fullName``.
+        /// - Returns: An integer currency format style modified to use the specified presentation.
         public func presentation(_ p: Configuration.Presentation) -> Self {
             var new = self
             new.collection.presentation = p
@@ -219,7 +500,10 @@ extension IntegerFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerFormatStyle : FormatStyle {
-    /// Returns a localized string for the given value. Supports up to 64-bit signed integer precision. Values not representable by `Int64` are clamped.
+    /// Returns a localized string for the given integer value.
+    ///
+    /// Supports up to 64-bit signed integer precision. Values not representable by `Int64` are clamped.
+    ///
     /// - Parameter value: The value to be formatted.
     /// - Returns: A localized string for the given value.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -240,6 +524,10 @@ extension IntegerFormatStyle : FormatStyle {
         return String(value)
     }
 
+    /// Modifies the format style to use the specified locale.
+    ///
+    /// - Parameter locale: The locale to apply to the format style.
+    /// - Returns: An integer format style modified to use the provided locale.
     public func locale(_ locale: Locale) -> IntegerFormatStyle {
         var new = self
         new.locale = locale
@@ -249,7 +537,10 @@ extension IntegerFormatStyle : FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerFormatStyle.Percent : FormatStyle {
-    /// Returns a localized string for the given value in percentage. Supports up to 64-bit signed integer precision. Values not representable by `Int64` are clamped.
+    /// Returns a localized string for the given value in percentage.
+    ///
+    /// Supports up to 64-bit signed integer precision. Values not representable by `Int64` are clamped.
+    ///
     /// - Parameter value: The value to be formatted.
     /// - Returns: A localized string for the given value in percentage.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -270,6 +561,10 @@ extension IntegerFormatStyle.Percent : FormatStyle {
         return String(value)
     }
 
+    /// Modifies the format style to use the specified locale.
+    ///
+    /// - Parameter locale: The locale to apply to the format style.
+    /// - Returns: An integer percent format style modified to use the provided locale.
     public func locale(_ locale: Locale) -> IntegerFormatStyle.Percent {
         var new = self
         new.locale = locale
@@ -279,7 +574,10 @@ extension IntegerFormatStyle.Percent : FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerFormatStyle.Currency : FormatStyle {
-    /// Returns a localized currency string for the given value. Supports up to 64-bit signed integer precision. Values not representable by `Int64` are clamped.
+    /// Returns a localized currency string for the given value.
+    ///
+    /// Supports up to 64-bit signed integer precision. Values not representable by `Int64` are clamped.
+    ///
     /// - Parameter value: The value to be formatted.
     /// - Returns: A localized currency string for the given value.
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -300,6 +598,10 @@ extension IntegerFormatStyle.Currency : FormatStyle {
         return String(value)
     }
 
+    /// Modifies the format style to use the specified locale.
+    ///
+    /// - Parameter locale: The locale to apply to the format style.
+    /// - Returns: An integer currency format style modified to use the provided locale.
     public func locale(_ locale: Locale) -> IntegerFormatStyle.Currency {
         var new = self
         new.locale = locale
@@ -311,6 +613,7 @@ extension IntegerFormatStyle.Currency : FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerFormatStyle: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: IntegerParseStrategy<Self> {
         return IntegerParseStrategy(format: self, lenient: true)
     }
@@ -318,12 +621,14 @@ extension IntegerFormatStyle: ParseableFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerFormatStyle.Currency: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: IntegerParseStrategy<Self> {
         return IntegerParseStrategy(format: self, lenient: true)
     }
 }
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerFormatStyle.Percent: ParseableFormatStyle {
+    /// The parse strategy that this format style uses.
     public var parseStrategy: IntegerParseStrategy<Self> {
         return IntegerParseStrategy(format: self, lenient: true)
     }
@@ -335,6 +640,11 @@ extension IntegerFormatStyle.Percent: ParseableFormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int> {
+    /// A style for formatting the Swift default integer type.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -342,6 +652,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int16> {
+    /// A style for formatting 16-bit signed integers.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -349,6 +664,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int16> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int32> {
+    /// A style for formatting 32-bit signed integers.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -356,6 +676,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int32> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int64> {
+    /// A style for formatting 64-bit signed integers.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -363,6 +688,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int64> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int8> {
+    /// A style for formatting 8-bit signed integers.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -370,6 +700,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int8> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt> {
+    /// A style for formatting the Swift unsigned integer type.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -377,6 +712,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt16> {
+    /// A style for formatting 16-bit unsigned integers.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -384,6 +724,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt16> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt32> {
+    /// A style for formatting 32-bit unsigned integers.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -391,6 +736,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt32> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt64> {
+    /// A style for formatting 64-bit unsigned integers.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -398,6 +748,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt64> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt8> {
+    /// A style for formatting 8-bit unsigned integers.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var number: Self { Self() }
 }
@@ -407,6 +762,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt8> {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int>.Percent {
+    /// A style for formatting signed integer types in Swift as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -414,6 +774,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int16>.Percent {
+    /// A style for formatting 16-bit signed integers as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -421,6 +786,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int16>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int32>.Percent {
+    /// A style for formatting 32-bit signed integers as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -428,6 +798,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int32>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int64>.Percent {
+    /// A style for formatting 64-bit signed integers as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -435,6 +810,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int64>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<Int8>.Percent {
+    /// A style for formatting 8-bit signed integers as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -442,6 +822,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int8>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt>.Percent {
+    /// A style for formatting signed integer types in Swift as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -449,6 +834,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt16>.Percent {
+    /// A style for formatting 16-bit unsigned integers as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -456,6 +846,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt16>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt32>.Percent {
+    /// A style for formatting 32-bit unsigned integers as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -463,6 +858,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt32>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt64>.Percent {
+    /// A style for formatting 64-bit unsigned integers as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -470,6 +870,11 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt64>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle where Self == IntegerFormatStyle<UInt8>.Percent {
+    /// A style for formatting 8-bit unsigned integers as a percent representation.
+    ///
+    /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
+    /// You typically do this when calling the `formatted` methods of types that conform to
+    /// `BinaryInteger`.
     @_alwaysEmitIntoClient
     static var percent: Self { Self() }
 }
@@ -478,6 +883,24 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt8>.Percent {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension FormatStyle {
+    /// Returns a format style to use integer currency notation.
+    ///
+    /// Use the dot-notation form of this method when the call point allows the use of
+    /// ``IntegerFormatStyle``. You typically do this when calling the `formatted` methods of
+    /// types that conform to `BinaryInteger`.
+    ///
+    /// The following example creates an array of integers, then uses the currency style
+    /// provided by this method to format the integers as US dollars:
+    ///
+    /// ```swift
+    /// let nums: [Int] = [100, 1000, 10000, 100000, 1000000]
+    /// let currencyNums = nums.map { $0.formatted(
+    ///     .currency(code:"USD")) } // ["$100.00", "$1,000.00", "$10,000.00", "$100,000.00", "$1,000,000.00"]
+    /// ```
+    ///
+    /// - Parameter code: The currency code to use, such as `EUR` or `JPY`. See ISO-4217 for
+    ///   a list of valid codes.
+    /// - Returns: An integer format style that uses the specified currency code.
     static func currency<V: BinaryInteger>(code: String) -> Self where Self == IntegerFormatStyle<V>.Currency {
         return Self(code: code)
     }
@@ -487,6 +910,38 @@ public extension FormatStyle {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerFormatStyle {
+    /// A format style that converts integers into attributed strings.
+    ///
+    /// Use the ``IntegerFormatStyle/attributed`` modifier on a ``FloatingPointFormatStyle`` to create a format style of this type.
+    ///
+    /// The attributed strings that this format style creates contain attributes from the ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope. Use these attributes to determine which runs of the attributed string represent different parts of the formatted value.
+    ///
+    /// The following example finds runs of the attributed string that represent different parts of a formatted currency, and adds additional attributes like ``AttributeScopes/SwiftUIAttributes/foregroundColor`` and ``AttributeScopes/FoundationAttributes/inlinePresentationIntent``.
+    ///
+    /// ```swift
+    /// func attributedPrice(price: Decimal) -> AttributedString {
+    /// var attributedPrice = price.formatted(
+    /// .currency(code: "USD")
+    /// .attributed)
+    ///
+    /// for run in attributedPrice.runs {
+    /// if run.attributes.numberSymbol == .currency ||
+    /// run.attributes.numberSymbol == .decimalSeparator  {
+    /// attributedPrice[run.range].foregroundColor = .red
+    /// }
+    /// if run.attributes.numberPart == .integer ||
+    /// run.attributes.numberPart == .fraction {
+    /// attributedPrice[run.range].inlinePresentationIntent = [.stronglyEmphasized]
+    /// }
+    /// }
+    /// return attributedPrice
+    /// }
+    /// ```
+    ///
+    ///
+    /// User interface frameworks like SwiftUI can use these attributes when presenting the attributed string, as seen here:
+    ///
+    /// ![The currency value $1,234.56, with the dollar sign and decimal separator in red, and the digits in bold.](media-4099417)
     public struct Attributed : Codable, Hashable, FormatStyle, Sendable {
         enum Style : Codable, Hashable {
             case integer(IntegerFormatStyle)
@@ -512,9 +967,15 @@ extension IntegerFormatStyle {
             self.style = .currency(style)
         }
 
-        /// Returns an attributed string with `NumberFormatAttributes.SymbolAttribute` and `NumberFormatAttributes.NumberPartAttribute`. Values not representable by `Int64` are clamped.
-        /// - Parameter value: The value to be formatted.
-        /// - Returns: A localized attributed string for the given value.
+        /// Formats an integer, using this style.
+        ///
+        /// Values not representable by `Int64` are clamped.
+        ///
+        /// - Parameter value: The integer to format.
+        /// - Returns: An attributed string representation of `value`, formatted according to the
+        ///   style's configuration. The returned string contains attributes from the
+        ///   ``AttributeScopes/FoundationAttributes/NumberFormatAttributes`` attribute scope to
+        ///   indicate runs formatted by this format style.
         public func format(_ value: Value) -> AttributedString {
             // Formatting Int64 is the fastest option -- try that first.
             let numberValue: ICUNumberFormatterBase.Value
@@ -543,6 +1004,10 @@ extension IntegerFormatStyle {
             return AttributedString(String(value).description)
         }
 
+        /// Modifies the format style to use the specified locale.
+        ///
+        /// - Parameter locale: The locale to apply to the format style.
+        /// - Returns: A format style that uses the specified locale.
         public func locale(_ locale: Locale) -> Self {
             var new = self
             switch style {
@@ -566,6 +1031,17 @@ extension IntegerFormatStyle {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension IntegerFormatStyle : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
         try IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
@@ -574,6 +1050,17 @@ extension IntegerFormatStyle : CustomConsumingRegexComponent {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension IntegerFormatStyle.Percent : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
         try IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }
@@ -582,6 +1069,17 @@ extension IntegerFormatStyle.Percent : CustomConsumingRegexComponent {
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension IntegerFormatStyle.Currency : CustomConsumingRegexComponent {
     public typealias RegexOutput = Value
+
+    /// Matches the input string within the specified bounds, beginning at the given index.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture calls it
+    /// automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
     public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: Value)? {
         try IntegerParseStrategy(format: self, lenient: false).parse(input, startingAt: index, in: bounds)
     }

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -14,9 +14,12 @@
 import FoundationEssentials
 #endif
 
+/// A parse strategy for creating integer values from formatted strings.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct IntegerParseStrategy<Format> : Codable, Hashable where Format : FormatStyle, Format.FormatInput : BinaryInteger {
+    /// The format style this strategy uses when parsing strings.
     public var formatStyle: Format
+    /// A Boolean value that indicates whether parsing allows any discrepencies in the expected format.
     public var lenient: Bool
 }
 
@@ -25,6 +28,7 @@ extension IntegerParseStrategy : Sendable where Format : Sendable {}
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerParseStrategy: ParseStrategy {
+    /// Parses an integer string in accordance with this strategy and returns the parsed value.
     public func parse(_ value: String) throws -> Format.FormatInput {
         let trimmedString = value._trimmingWhitespace()
         guard let result = try parse(trimmedString, startingAt: trimmedString.startIndex, in: trimmedString.startIndex..<trimmedString.endIndex) else {
@@ -89,6 +93,7 @@ extension IntegerParseStrategy: ParseStrategy {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension IntegerParseStrategy {
+    /// Creates a parse strategy instance using the specified integer format style.
     init<Value>(format: Format, lenient: Bool = true) where Format == IntegerFormatStyle<Value> {
         self.formatStyle = format
         self.lenient = lenient
@@ -97,6 +102,7 @@ public extension IntegerParseStrategy {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension IntegerParseStrategy {
+    /// Creates a parse strategy instance using the specified integer percentage format style.
     init<Value>(format: Format, lenient: Bool = true) where Format == IntegerFormatStyle<Value>.Percent {
         self.formatStyle = format
         self.lenient = lenient
@@ -105,6 +111,7 @@ public extension IntegerParseStrategy {
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension IntegerParseStrategy {
+    /// Creates a parse strategy instance using the specified integer currency format style.
     init<Value>(format: Format, lenient: Bool = true) where Format == IntegerFormatStyle<Value>.Currency {
         self.formatStyle = format
         self.lenient = lenient

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -16,6 +16,7 @@ import FoundationEssentials
 
 internal import _FoundationICU
 
+/// The capitalization formatting context used when formatting dates and times.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct FormatStyleCapitalizationContext : Codable, Hashable, Sendable {
 
@@ -88,6 +89,9 @@ public struct FormatStyleCapitalizationContext : Codable, Hashable, Sendable {
     }
 }
 
+/// Configuration settings for formatting numbers of different types.
+///
+/// This type is effectively a namespace to collect types that configure parts of a formatted number, such as grouping, precision, and separator and sign characters.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum NumberFormatStyleConfiguration {
     internal struct Collection : Codable, Hashable, Sendable {
@@ -101,10 +105,14 @@ public enum NumberFormatStyleConfiguration {
         var notation: Notation?
     }
 
+    /// The type used for rounding rule values.
+    ///
+    /// ``NumberFormatStyleConfiguration`` uses the `FloatingPointRoundingRule` enumeration for rounding rule values.
     public typealias RoundingRule = FloatingPointRoundingRule
 
     typealias Scale = Double
 
+    /// A structure that an integer format style uses to configure grouping.
     public struct Grouping : Codable, Hashable, CustomStringConvertible, Sendable {
         enum Option : Int, Codable, Hashable {
             case automatic
@@ -117,7 +125,9 @@ public enum NumberFormatStyleConfiguration {
         }
         var option: Option
 
+        /// A grouping behavior that automatically applies locale-appropriate grouping.
         public static var automatic: Self { .init(option: .automatic) }
+        /// A grouping behavior that never groups digits.
         public static var never: Self { .init(option: .hidden) }
 
         public var description: String {
@@ -130,6 +140,7 @@ public enum NumberFormatStyleConfiguration {
         }
     }
 
+    /// A structure that an integer format style uses to configure precision.
     public struct Precision : Codable, Hashable, Sendable {
 
         enum Option: Hashable {
@@ -149,11 +160,35 @@ public enum NumberFormatStyleConfiguration {
         // min 2, max 4: 1.23004 -> 1.23
         // ^ Trailing zero digits to the right of the decimal separator are suppressed after the minimum number of significant digits have been shown
 
+        /// Returns a precision that constrains formatted values to a range of significant digits.
+        ///
+        /// When using this precision, the formatter rounds values that have more significant digits than the maximum of the range, as seen in the following example:
+        ///
+        /// ```swift
+        /// let myNum = 123456.formatted(.number
+        ///     .precision(.significantDigits(2...4))
+        ///     .rounded(rule: .down)) // "123,400"
+        /// ```
+        ///
+        /// - Parameter limits: A range from the minimum to the maximum number of significant digits to use when formatting values.
+        /// - Returns: A precision that constrains formatted values to a range of significant digits.
         public static func significantDigits<R: RangeExpression>(_ limits: R) -> Self where R.Bound == Int {
             let (lower, upper) = limits.clampedLowerAndUpperBounds(validSignificantDigits)
             return Precision(option: .significantDigits(min: lower ?? validSignificantDigits.lowerBound, max: upper))
         }
 
+        /// Returns a precision that constrains formatted values to a given number of significant digits.
+        ///
+        /// When using this precision, the formatter rounds values that have more significant digits than the maximum of the range, as seen in the following example:
+        ///
+        /// ```swift
+        /// let myNum = 123456.formatted(.number
+        ///     .precision(.significantDigits(4))
+        ///     .rounded(rule: .down)) // "123,400"
+        /// ```
+        ///
+        /// - Parameter digits: The maximum number of significant digits to use when formatting values.
+        /// - Returns: A precision that constrains formatted values to a given number of significant digits.
         public static func significantDigits(_ digits: Int) -> Self {
             return Precision(option: .significantDigits(min: digits, max: digits))
         }
@@ -162,6 +197,21 @@ public enum NumberFormatStyleConfiguration {
         // minInt 5: 1997 -> 01997
         // maxFrac 2: 0.125 -> 0.12
         // minFrac 4: 0.125 -> 0.1250
+        /// Returns a precision that constrains formatted values to ranges of allowed digits in the integer and fraction parts.
+        ///
+        /// When using this precision, the formatter rounds values that have more digits than the maximum of the range, as seen in the following example:
+        ///
+        /// ```swift
+        /// let myNum = 12345.6789.formatted(.number
+        ///     .precision(.integerAndFractionLength(integerLimits: 2...,
+        ///                                          fractionLimits: 2...3))
+        ///     .rounded(rule: .down)) // "12,345.678"
+        /// ```
+        ///
+        /// - Parameters:
+        ///   - integerLimits: A range from the minimum to the maximum number of digits to use when formatting the integer part of a number.
+        ///   - fractionLimits: A range from the minimum to the maximum number of digits to use when formatting the fraction part of a number.
+        /// - Returns: A precision that constrains formatted values to ranges of digits in the integer and fraction parts.
         public static func integerAndFractionLength<R1: RangeExpression, R2: RangeExpression>(integerLimits: R1, fractionLimits: R2) -> Self where R1.Bound == Int, R2.Bound == Int {
             let (minInt, maxInt) =  integerLimits.clampedLowerAndUpperBounds(validPartLength)
             let (minFrac, maxFrac) = fractionLimits.clampedLowerAndUpperBounds(validPartLength)
@@ -169,29 +219,61 @@ public enum NumberFormatStyleConfiguration {
             return Precision(option: .integerAndFractionalLength(minInt: minInt, maxInt: maxInt, minFraction: minFrac, maxFraction: maxFrac))
         }
 
+        /// Returns a precision that constrains formatted values a given number of allowed digits in the integer and fraction parts.
+        ///
+        /// When using this precision, the formatter pads values with fewer digits than the specified digits for the integer or fraction parts. Similarly, it rounds values that have more digits than specified. The following example shows this behavior, padding the integer part while rounding the fraction:
+        ///
+        /// ```swift
+        /// let myNum = 12345.6789.formatted(.number
+        ///     .precision(.integerAndFractionLength(integer: 6,
+        ///                                          fraction: 3))
+        ///     .rounded(rule: .down)) // "012,345.678"
+        /// ```
+        ///
+        /// - Parameters:
+        ///   - integer: The number of digits to use when formatting the integer part of a number.
+        ///   - fraction: The number of digits to use when formatting the fraction part of a number.
+        /// - Returns: A precision that constrains formatted values a given number of digits in the integer and fraction parts.
         public static func integerAndFractionLength(integer: Int, fraction: Int) -> Self {
             return Precision(option: .integerAndFractionalLength(minInt: integer, maxInt: integer, minFraction: fraction, maxFraction: fraction))
         }
 
+        /// Returns a precision that constrains formatted values to a range of allowed digits in the integer part.
+        ///
+        /// - Parameter limits: A range from the minimum to the maximum number of digits to use when formatting the integer part of a number.
+        /// - Returns: A precision that constrains formatted values to ranges of digits in the integer part.
         public static func integerLength<R: RangeExpression>(_ limits: R) -> Self {
             let (minInt, maxInt) = limits.clampedLowerAndUpperBounds(validPartLength)
             return Precision(option: .integerAndFractionalLength(minInt: minInt, maxInt: maxInt, minFraction: nil, maxFraction: nil))
         }
 
+        /// Returns a precision that constrains formatted values to a given number of allowed digits in the integer part.
+        ///
+        /// - Parameter length: The number of digits to use when formatting the integer part of a number.
+        /// - Returns: A precision that constrains formatted values to a given number of allowed digits in the integer part.
         public static func integerLength(_ length: Int) -> Self {
             return Precision(option: .integerAndFractionalLength(minInt: length, maxInt: length, minFraction: nil, maxFraction: nil))
         }
 
+        /// Returns a precision that constrains formatted values to a range of allowed digits in the fraction part.
+        ///
+        /// - Parameter limits: A range from the minimum to the maximum number of digits to use when formatting the fraction part of a number.
+        /// - Returns: A precision that constrains formatted values to a range of allowed digits in the fraction part.
         public static func fractionLength<R: RangeExpression>(_ limits: R) -> Self where R.Bound == Int {
             let (minFrac, maxFrac) = limits.clampedLowerAndUpperBounds(validPartLength)
             return Precision(option: .integerAndFractionalLength(minInt: nil, maxInt: nil, minFraction: minFrac, maxFraction: maxFrac))
         }
 
+        /// Returns a precision that constrains formatted values to a given number of allowed digits in the fraction part.
+        ///
+        /// - Parameter length: The number of digits to use when formatting the fraction part of a number.
+        /// - Returns: A precision that constrains formatted values to a given number of allowed digits in the fraction part.
         public static func fractionLength(_ length: Int) -> Self {
             return Precision(option: .integerAndFractionalLength(minInt: nil, maxInt: nil, minFraction: length, maxFraction: length))
         }
     }
 
+    /// A structure that an integer format style uses to configure a decimal separator display strategy.
     public struct DecimalSeparatorDisplayStrategy : Codable, Hashable, CustomStringConvertible, Sendable {
         enum Option : Int, Codable, Hashable {
             case automatic
@@ -199,11 +281,13 @@ public enum NumberFormatStyleConfiguration {
         }
         var option: Option
 
+        /// A strategy to automatically configure locale-appropriate decimal separator display behavior.
         // "1.1", "1"
         public static var automatic: Self {
             .init(option: .automatic)
         }
 
+        /// A strategy that always displays decimal separators.
         // "1.1", "1."
         public static var always : Self { .init(option: .always) }
 
@@ -217,6 +301,7 @@ public enum NumberFormatStyleConfiguration {
         }
     }
 
+    /// A structure that an integer format style uses to configure a sign display strategy.
     public struct SignDisplayStrategy : Codable, Hashable, CustomStringConvertible, Sendable {
         enum Option : Int, Hashable, Codable {
             case always
@@ -227,15 +312,21 @@ public enum NumberFormatStyleConfiguration {
         var negative: Option
         var zero: Option
 
+        /// A strategy to automatically configure locale-appropriate sign display behavior.
         // Show the minus sign on negative numbers, and do not show the sign on positive numbers or zero
         public static var automatic: Self {
             SignDisplayStrategy(positive: .hidden, negative: .always, zero: .hidden)
         }
 
+        /// A strategy to never display sign symbols.
         public static var never: Self {
             SignDisplayStrategy(positive: .hidden, negative: .hidden, zero: .hidden)
         }
 
+        /// A strategy to always display sign symbols.
+        ///
+        /// - Parameter includingZero: A Boolean value that determines whether the format style should apply sign characters to zero values. Defaults to `true`.
+        /// - Returns: A strategy to always display sign symbols, with the given behavior for zero values.
         // Show the minus sign on negative numbers and the plus sign on positive numbers, and zero if specified
         public static func always(includingZero: Bool = true) -> Self {
             SignDisplayStrategy(positive: .always, negative: .always, zero: includingZero ? .always : .hidden)
@@ -261,6 +352,7 @@ public enum NumberFormatStyleConfiguration {
         }
     }
 
+    /// A structure that an integer format style uses to configure notation.
     public struct Notation : Codable, Hashable, CustomStringConvertible, Sendable {
         enum Option : Int, Codable, Hashable {
             case automatic
@@ -269,11 +361,28 @@ public enum NumberFormatStyleConfiguration {
         }
         var option: Option
 
+        /// A notation constant that formats values with scientific notation.
+        ///
+        /// The following example shows the effect of using scientific notation with a format style:
+        ///
+        /// ```swift
+        /// let scientific = 12345.formatted(.number
+        ///     .notation(.scientific)) // 1.2345E4"
+        /// ```
         public static var scientific: Self { .init(option: .scientific) }
+        /// A notation that automatically provides locale-appropriate behavior.
         public static var automatic: Self { .init(option: .automatic) }
 
-        /// Formats the number with localized prefixes or suffixes corresponding to powers of ten. Rounds to integer while showing at least two significant digits by default.
-        /// For example, "42.3K" for 42300 for the "en_US" locale.
+        /// A locale-appropriate compact name notation.
+        ///
+        /// A compact name notation, when available in the format style's locale, that uses prefixes or suffixes corresponding to powers of ten. The following example shows a compact name notation in the `fr_FR` locale:
+        ///
+        /// ```swift
+        /// let compactNameFormatted = 1234.formatted(.number
+        ///     .locale(Locale(identifier: "fr_FR"))
+        ///     .notation(.compactName)) // "1,2 k"
+        /// ```
+        ///
         /// - note: We do not support parsing a number string containing localized prefixes or suffixes.
         public static var compactName: Self { .init(option: .compactName) }
 
@@ -311,11 +420,16 @@ public enum NumberFormatStyleConfiguration {
 @available(*, unavailable)
 extension NumberFormatStyleConfiguration : Sendable {}
 
+/// Configuration settings for formatting currency values.
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum CurrencyFormatStyleConfiguration {
+    /// The type used to configure grouping for currency format styles.
     public typealias Grouping = NumberFormatStyleConfiguration.Grouping
+    /// The type used to configure precision for currency format styles.
     public typealias Precision = NumberFormatStyleConfiguration.Precision
+    /// The type used to configure decimal separator display strategies for currency format styles.
     public typealias DecimalSeparatorDisplayStrategy = NumberFormatStyleConfiguration.DecimalSeparatorDisplayStrategy
+    /// The type used to configure rounding rules for currency format styles.
     public typealias RoundingRule = NumberFormatStyleConfiguration.RoundingRule
     /// The type used to configure notation for currency format styles.
     @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
@@ -334,6 +448,7 @@ public enum CurrencyFormatStyleConfiguration {
         var notation: Notation?
     }
 
+    /// A structure used to configure sign display strategies for currency format styles.
     public struct SignDisplayStrategy: Codable, Hashable, Sendable {
         enum Option : Int, Hashable, Codable {
             case always
@@ -344,28 +459,42 @@ public enum CurrencyFormatStyleConfiguration {
         var zero: Option
         var accounting: Bool = false
 
+        /// A strategy to automatically configure sign display.
         public static var automatic: Self {
             SignDisplayStrategy(positive: .hidden, negative: .always, zero: .hidden)
         }
 
+        /// A strategy to never show the sign.
         public static var never: Self {
             SignDisplayStrategy(positive: .hidden, negative: .hidden, zero: .hidden)
         }
 
+        /// A sign display strategy to always show the sign, with a configurable behavior for handling zero values.
+        ///
+        /// - Parameter showZero: A Boolean value that indicates whether to show the sign symbol on zero values. Defaults to `true`.
+        /// - Returns: A sign display strategy that always displays the sign, and uses the specified handling of zero values.
         // Show the minus sign on negative numbers and the plus sign on positive numbers, and zero if specified
         public static func always(showZero: Bool = true) -> Self {
             SignDisplayStrategy(positive: .always, negative: .always, zero: showZero ? .always : .hidden)
         }
 
+        /// A sign display strategy to use accounting principles.
+        ///
+        /// This strategy always shows the currency symbol, and shows negative values in parenthesis. Examples of this strategy include `$123`, `$0`, and `($123)`.
         public static var accounting: Self {
             SignDisplayStrategy(positive: .hidden, negative: .always, zero: .hidden, accounting: true)
         }
 
+        /// A sign display strategy to use accounting principles, with a configurable behavior for handling zero values.
+        ///
+        /// - Parameter showZero: A Boolean value that indicates whether to show the sign symbol on zero values. Defaults to `false`.
+        /// - Returns: A strategy that uses accounting principles, and the specified handling of zero values.
         public static func accountingAlways(showZero: Bool = false) -> Self {
             SignDisplayStrategy(positive: .always, negative: .always, zero: showZero ? .always : .hidden, accounting: true)
         }
     }
 
+    /// A structure used to configure the presentation of currency format styles.
     public struct Presentation: Codable, Hashable, Sendable {
         enum Option : Int, Codable, Hashable {
             case narrow
@@ -375,9 +504,21 @@ public enum CurrencyFormatStyleConfiguration {
         }
         internal var option: Option
 
+        /// A presentation that shows a condensed expression of the currency.
+        ///
+        /// This presentation produces output like `$123.00`.
         public static var narrow: Self { Presentation(option: .narrow) }
+        /// A presentation that shows a standard expression of the currency.
+        ///
+        /// This presentation produces output like `US$ 123.00`.
         public static var standard: Self { Presentation(option: .standard) }
+        /// A presentation that shows the ISO code of the currency.
+        ///
+        /// This presentation produces output like `USD 123.00`.
         public static var isoCode: Self { Presentation(option: .isoCode) }
+        /// A presentation that shows the full name of the currency.
+        ///
+        /// This presentation produces output like `123.00 US dollars`.
         public static var fullName: Self { Presentation(option: .fullName) }
     }
 }

--- a/Sources/FoundationInternationalization/FoundationInternationalization.docc/FoundationInternationalization.md
+++ b/Sources/FoundationInternationalization/FoundationInternationalization.docc/FoundationInternationalization.md
@@ -1,0 +1,6 @@
+# ``FoundationInternationalization``
+
+
+Access networking services for your app.
+
+The FoundationInternationalization library adds fundamental networking interfaces. 

--- a/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
@@ -23,7 +23,9 @@ internal import _FoundationICU
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Components {
 
-    /// - Parameter identifier: Unicode language identifier such as "en-u-nu-thai-ca-buddhist-kk-true"
+    /// Creates a locale components instance with the specified identifier.
+    ///
+    /// - Parameter identifier: A BCP-47 language identifier such as `en-u-nu-thai-ca-buddhist` or an ICU-style identifier such as `en@calendar=buddhist;numbers=thai`.
     public init(identifier: String) {
         let languageComponents = Locale.Language.Components(identifier: identifier)
         self.init(languageCode: languageComponents.languageCode, script: languageComponents.script, languageRegion: languageComponents.region)
@@ -138,7 +140,7 @@ extension Locale.LanguageCode {
         }
     }
     
-    /// Returns if the language is an ISO-639 language
+    /// A Boolean value that indicates whether the language is an ISO-639 language.
     public var isISOLanguage: Bool {
         if Locale.LanguageCode._isoLanguageCodeStrings.contains(_normalizedIdentifier) {
             return true
@@ -147,7 +149,7 @@ extension Locale.LanguageCode {
         }
     }
 
-    /// Returns a list of `Locale` language codes that are two-letter language codes defined in ISO 639 and two-letter codes without a two-letter equivalent
+    /// An array of language codes defined in ISO 639.
     public static var isoLanguageCodes: [Locale.LanguageCode] {
         return _isoLanguageCodeStrings.map { Locale.LanguageCode($0) }
     }
@@ -181,13 +183,31 @@ extension Locale.Script {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Region {
+    /// A Boolean value that indicates whether the region is an ISO-defined region.
     public var isISORegion: Bool {
         var status = U_ZERO_ERROR
         let region = uregion_getRegionFromCode(identifier, &status)
         return status.isSuccess && region != nil
     }
 
-    /// Returns all the sub-regions of the region
+    /// An array of all the sub-regions of the region.
+    ///
+    /// The following example looks up the sub-regions of region `021`, which represents North America.
+    ///
+    /// ```swift
+    /// let northAmericaRegion = Locale.Region("021")
+    /// let subRegions = northAmericaRegion.subRegions //BM, CA, GL, PM, US
+    /// ```
+    ///
+    /// The returned `subRegions` have the following identifiers:
+    ///
+    /// | Identifier | Country |
+    /// |---|---|
+    /// | BM | Bermuda |
+    /// | CA | Canada |
+    /// | GL | Greenland |
+    /// | PM | Saint Pierre and Miquelon |
+    /// | US | United States |
     public var subRegions : [Locale.Region] {
         var status = U_ZERO_ERROR
         let icuRegion = uregion_getRegionFromCode(identifier, &status)
@@ -204,7 +224,14 @@ extension Locale.Region {
         return e.elements.map { Locale.Region($0) }
     }
 
-    /// Returns the region within which the region is contained, e.g. for `US`, returns `Northern America`
+    /// The region that contains this region, if any.
+    ///
+    /// The following example shows how to look up the containing region for the `US` region.
+    ///
+    /// ```swift
+    /// let usRegion = Locale.Region("US")
+    /// let containingRegion = usRegion.containingRegion //Identifier "021": Northern America
+    /// ```
     public var containingRegion: Locale.Region? {
         var status = U_ZERO_ERROR
         let icuRegion = uregion_getRegionFromCode(identifier, &status)
@@ -227,7 +254,9 @@ extension Locale.Region {
         return Locale.Region(code)
     }
 
-    /// Returns the continent of the region. Returns `nil` if the continent cannot be determined, such as when the region isn't an ISO region
+    /// The continent that contains this region, if any.
+    ///
+    /// This value can be `nil` when the system can't determine the appropriate continent, such as when the region isn't an ISO region.
     public var continent: Locale.Region? {
         var status = U_ZERO_ERROR
         let icuRegion = uregion_getRegionFromCode(identifier, &status)
@@ -251,7 +280,7 @@ extension Locale.Region {
         return Locale.Region(code)
     }
 
-    /// Returns a list of regions of a specified type defined by ISO
+    /// An array of regions defined by ISO.
     public static var isoRegions: [Locale.Region] {
         _isoRegionCodes.map { Locale.Region($0) }
     }
@@ -496,16 +525,17 @@ extension Locale.Collation {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Currency {
+    /// A Boolean value that indicates whether the currency is in the list of ISO-defined currencies.
     public var isISOCurrency: Bool {
         identifier.withCString(encodedAs: UTF16.self) {
             ucurr_getNumericCode($0) != 0
         }
     }
 
-    /// Represents an unknown currency, used when no currency is involved in a transaction
+    /// A representation of an "unknown" currency, for use with transactions that don't involve any currency.
     public static let unknown = Locale.Currency("xxx")
 
-    /// Returns a list of `Locale` currency codes defined in ISO-4217
+    /// An array containing currencies defined by the currency codes in ISO-4217.
     public static var isoCurrencies: [Locale.Currency] {
         var status = U_ZERO_ERROR
         let values = ucurr_openISOCurrencies(UInt32(UCURR_ALL.rawValue), &status)
@@ -638,8 +668,9 @@ extension Locale.Language {
         return Locale.LanguageDirection(layoutType: orientation)
     }
 
-    /// Ordering of characters within a line.
-    /// For example, left-to-right for English; top-to-bottom for Mongolian in the Mongolian Script
+    /// The ordering of characters within a line.
+    ///
+    /// For example, English uses left-to-right while Mongolian in the Mongolian script uses top-to-bottom.
     public var characterDirection: Locale.LanguageDirection {
         var status = U_ZERO_ERROR
         let orientation = uloc_getCharacterOrientation(components.identifier, &status)
@@ -652,8 +683,11 @@ extension Locale.Language {
 
     // MARK: - Getting information
 
-    /// Returns the parent language of a language. For example, the parent language of `"en_US_POSIX"` is `"en_US"`
-    /// Returns nil if the parent language cannot be determined
+    /// The parent language of this language, if available.
+    ///
+    /// For example, the parent language of `en_US_POSIX` is `en_US`.
+    ///
+    /// If the system can't determine a parent language, this value is `nil`.
     public var parent: Locale.Language? {
         let parentID = _withFixedCharBuffer { buffer, size, status in
             return ualoc_getAppleParent(components.identifier, buffer, size, &status)
@@ -668,12 +702,34 @@ extension Locale.Language {
 
     }
     
+    /// Returns a Boolean value that indicates if the given language shares a common parent with this language.
+    ///
+    /// - Parameter language: A language to compare parentage with.
+    /// - Returns: `true` if this language and `language` share a common parent; `false` otherwise.
     public func hasCommonParent(with language: Locale.Language) -> Bool {
         self.parent == language.parent
     }
 
-    /// Returns if `self` and the specified `language` are equal after expanding missing components
-    /// For example, `en`, `en-Latn`, `en-US`, and `en-Latn-US` are equivalent
+    /// Returns a Boolean value that indicates whether this language and another language are equivalent after expanding missing components.
+    ///
+    /// - Parameter language: A language to compare equivalence with.
+    /// - Returns: `true` if the two languages are equivalent; `false` otherwise.
+    ///
+    /// The following example shows equivalence tests run on various ways of expressing the US English language, followed by a test against UK English.
+    ///
+    /// ```swift
+    /// let en = Locale.Language(identifier: "en")
+    /// let enUS = Locale.Language(identifier: "en-US")
+    /// let enLatn = Locale.Language(identifier: "en-Latn")
+    /// let enLatnUS = Locale.Language(identifier: "en-Latn-US")
+    ///
+    /// let test1 = en.isEquivalent(to: enUS) // true
+    /// let test2 = en.isEquivalent(to: enLatn) // true
+    /// let test3 = en.isEquivalent(to: enLatnUS) // true
+    ///
+    /// let enUK = Locale.Language(identifier: "en-UK")
+    /// let test4 = en.isEquivalent(to: enUK) // false
+    /// ```
     public func isEquivalent(to language: Locale.Language) -> Bool {
         return self.maximalIdentifier == language.maximalIdentifier
     }
@@ -735,7 +791,7 @@ extension Locale.Language {
     
     // MARK: -
 
-    /// The language code of the language. Returns nil if it cannot be determined
+    /// The language code that identifies the language. Returns `nil` if it cannot be determined.
     public var languageCode: Locale.LanguageCode? {
         var result: Locale.LanguageCode?
         if let lang = components.languageCode {
@@ -748,7 +804,7 @@ extension Locale.Language {
         return result
     }
 
-    /// The script of the language. Returns nil if it cannot be determined
+    /// The script of the language. Returns `nil` if it cannot be determined.
     public var script: Locale.Script? {
         var result: Locale.Script?
         if let script = components.script {
@@ -762,7 +818,7 @@ extension Locale.Language {
         return result
     }
 
-    /// The region of the language. Returns nil if it cannot be determined
+    /// The region of the language. Returns `nil` if it cannot be determined.
     public var region: Locale.Region? {
         var result: Locale.Region?
         if let script = components.region {
@@ -778,7 +834,9 @@ extension Locale.Language {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Language.Components {
-    /// - Parameter identifier: Unicode language identifier, such as "en-US", "es-419", "zh-Hant-TW"
+    /// Creates a language components instance from a language identifier.
+    ///
+    /// - Parameter identifier: A Unicode language identifier, like `en-US`, `es-419`, or `zh-Hant-TW`.
     public init(identifier: String) {
         let languageCode = _withFixedCharBuffer { buffer, size, status in
             uloc_getLanguage(identifier, buffer, size, &status)
@@ -811,6 +869,9 @@ extension Locale.Language.Components {
         self = Locale.Language.Components(languageCode: lc, script: sc, region: rc)
     }
     
+    /// Creates a language components instance from an existing language instance.
+    ///
+    /// - Parameter language: A `Locale.Language` instance. This initializer copies over the language code, script, and region from the provided language.
     public init(language: Locale.Language) {
         self = Locale.Language.Components(languageCode: language.languageCode, script: language.script, region: language.region)
     }

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1510,7 +1510,7 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Locale {
-    /// Returns the `Locale` identifier from a given Windows locale code, or nil if it could not be converted.
+    /// Returns the locale identifier from a given Windows locale code, or `nil` if it could not be converted.
     public static func identifier(fromWindowsLocaleCode code: Int) -> String? {
         guard let unsigned = UInt32(exactly: code) else {
             return nil
@@ -1523,7 +1523,7 @@ extension Locale {
         return result
     }
 
-    /// Returns the Windows locale code from a given identifier, or nil if it could not be converted.
+    /// Returns the Windows locale code from a given identifier, or `nil` if it could not be converted.
     public static func windowsLocaleCode(fromIdentifier identifier: String) -> Int? {
         let result = uloc_getLCID(identifier)
         if result == 0 {
@@ -1534,12 +1534,17 @@ extension Locale {
     }
     
     /// Returns the identifier conforming to the specified standard for the specified string.
+    ///
+    /// - Parameters:
+    ///   - type: The identifier type used by `string`, such as ``Locale/IdentifierType/icu`` or ``Locale/IdentifierType/bcp47``.
+    ///   - string: An identifier string that complies with the standard indicated by `type`.
+    /// - Returns: A locale identifier.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public static func identifier(_ type: IdentifierType, from string: String) -> String {
         Locale(identifier: string).identifier(type)
     }
 
-    /// Returns a list of available `Locale` identifiers.
+    /// A list of available identifiers.
     public static var availableIdentifiers: [String] {
         var working = Set<String>()
         let localeCount = uloc_countAvailable()
@@ -1551,7 +1556,7 @@ extension Locale {
         return Array(working)
     }
 
-    /// Returns a list of common `Locale` currency codes.
+    /// A list of common currency codes.
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public static var commonISOCurrencyCodes: [String] {
         Locale.Currency.commonISOCurrencies

--- a/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
@@ -579,7 +579,7 @@ extension NSLocale : _HasCustomAnyHashableRepresentation {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Locale {
-    /// Returns a list of available `Locale` language codes.
+    /// A list of available language codes.
     @available(macOS, deprecated: 13, message: "Use `Locale.LanguageCode.isoLanguageCodes` instead")
     @available(iOS, deprecated: 16, message: "Use `Locale.LanguageCode.isoLanguageCodes` instead")
     @available(tvOS, deprecated: 16, message: "Use `Locale.LanguageCode.isoLanguageCodes` instead")
@@ -606,7 +606,7 @@ extension Locale {
         }
     }
 
-    /// Returns a list of available `Locale` region codes.
+    /// A list of available region codes.
     @available(macOS, deprecated: 13, message: "Use `Locale.Region.isoRegions` instead")
     @available(iOS, deprecated: 16, message: "Use `Locale.Region.isoRegions` instead")
     @available(tvOS, deprecated: 16, message: "Use `Locale.Region.isoRegions` instead")
@@ -620,7 +620,7 @@ extension Locale {
 #endif
     }
 
-    /// Returns a list of available `Locale` currency codes.
+    /// A list of available currency codes.
     @available(macOS, deprecated: 13, message: "Use `Locale.Currency.isoCurrencies` instead")
     @available(iOS, deprecated: 16, message: "Use `Locale.Currency.isoCurrencies` instead")
     @available(tvOS, deprecated: 16, message: "Use `Locale.Currency.isoCurrencies` instead")

--- a/Sources/FoundationInternationalization/String/KeyPathComparator.swift
+++ b/Sources/FoundationInternationalization/String/KeyPathComparator.swift
@@ -14,14 +14,14 @@
 import FoundationEssentials
 #endif
 
-/// Compares elements using a `KeyPath`, and a `SortComparator` which compares
-/// elements of the `KeyPath`s `Value` type.
+/// A comparator that uses another sort comparator to provide the comparison of values at a key path.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct KeyPathComparator<Compared>: SortComparator {
-    /// The key path to the property to be used for comparisons.
+    /// The key path that the comparator uses to compare properties.
     @preconcurrency
     public let keyPath: PartialKeyPath<Compared> & Sendable
 
+    /// The sort order that the comparator uses to compare properties.
     public var order: SortOrder {
         get {
             comparator.order
@@ -251,6 +251,14 @@ public struct KeyPathComparator<Compared>: SortComparator {
         self.order = order
     }
 
+    /// Provides the relative ordering of two items according to the ordering of the properties that the comparator's key path references.
+    ///
+    /// The method returns flipped comparisons if the sort order is ``SortOrder/reverse``.
+    ///
+    /// - Parameters:
+    ///   - lhs: The first property to compare.
+    ///   - rhs: The second property to compare.
+    /// - Returns: The relative ordering for the compared properties.
     public func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
         let lhsField = extractField(lhs)
         let rhsField = extractField(rhs)

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -14,7 +14,7 @@
 import FoundationEssentials
 #endif
 
-/// A serializable description of how to sort numeric and `String` types.
+/// A serializable description of how to sort numerics and strings.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {    
     /// The set of supported safely serializable comparisons.
@@ -222,7 +222,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
         return result
     }
 
-    /// Sort order.
+    /// The sort order that the sort descriptor uses to compare.
     public var order: SortOrder
 
     /// The `String` key specifying the property to be compared.
@@ -1072,21 +1072,21 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     
 
 #if FOUNDATION_FRAMEWORK
-    /// Creates a `SortDescriptor` describing the same sort as the
-    /// `NSSortDescriptor` over the given `Compared` type.
+    /// Creates a sort descriptor using a sort descriptor and a type that you specify.
     ///
-    /// Returns `nil` if there is no `SortDescriptor` equivalent to the given
-    /// `NSSortDescriptor`, or if the `NSSortDescriptor`s selector is not one of
-    /// the standard string comparison algorithms, or `compare(_:)`.
+    /// Returns `nil` if there isn't a ``SortDescriptor`` equivalent to the
+    /// ``NSSortDescriptor`` you specify, or if the selector to
+    /// ``NSSortDescriptor`` isn't one of the standard string comparison
+    /// algorithms or `compare(_:)`.
     ///
-    /// The comparison for the created `SortDescriptor` uses the
-    /// `NSSortDescriptor`s associated selector directly, so in cases where
-    /// using the `NSSortDescriptor`s comparison would crash, the
-    /// `SortDescriptor`s comparison will as well.
+    /// The comparison for the created ``SortDescriptor`` uses the selector to
+    /// the associated ``NSSortDescriptor`` directly, so in cases where the
+    /// comparison of ``NSSortDescriptor`` might crash, the ``SortDescriptor``
+    /// comparison crashes as well.
     ///
     /// - Parameters:
-    ///     - descriptor: The `NSSortDescriptor` to convert.
-    ///     - comparedType: The type the resulting `SortDescriptor` compares.
+    ///     - descriptor: A sort descriptor.
+    ///     - comparedType: The type that the sort descriptor compares.
     public init?(_ descriptor: NSSortDescriptor, comparing comparedType: Compared.Type) where Compared: NSObject {
         guard let keyString = descriptor.key else { return nil }
         guard let selector = descriptor.selector else { return nil }
@@ -1098,6 +1098,12 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     }
 #endif
     
+    /// Provides the relative ordering of two elements.
+    ///
+    /// - Parameters:
+    ///   - lhs: The first element to compare.
+    ///   - rhs: The second element to compare.
+    /// - Returns: The relative ordering between the two elements.
     public func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
         switch comparison {
         case .comparable(let comparator, let keyPath):

--- a/Sources/FoundationInternationalization/String/String+SortComparator.swift
+++ b/Sources/FoundationInternationalization/String/String+SortComparator.swift
@@ -270,17 +270,14 @@ extension SortComparator where Self == String.Comparator {
 #if FOUNDATION_FRAMEWORK
     // https://github.com/apple/swift-foundation/issues/284
     
-    /// Compares `String`s as compared by the Finder.
-    ///
-    /// Uses a localized, numeric comparison in the current locale.
-    ///
-    /// The default `String.Comparator` used in `String` comparisons.
+    /// A comparator that compares a string using a localized, numeric
+    /// comparison in the current locale.
     public static var localizedStandard: String.Comparator {
         String.Comparator(.localizedStandard)
     }
 
-    /// Compares `String`s using a localized comparison in the current
-    /// locale.
+    /// A comparator that compares a string using a localized comparison in
+    /// the current locale.
     public static var localized: String.Comparator {
         String.Comparator(.localized)
     }


### PR DESCRIPTION
This is an initial import of DocC documentation for Foundation.

The source is content from the sources that produce the docs at developer.apple.com. Not all documentation exists here. Conceptual documentation, articles, and documentation about ObjC-only types are not included at this time.

For the most part I preferred the documentation phrasing rather than existing comments. In some rare cases, I chose to augment the documentation with content from the source. If there was already docs comments, and it was fairly divergent from the documentation, I kept the comments as actual comments (`//`) and imported the docs for DocC (`///`).

I also added stubs of the high level `.docc` directories for FoundationEssentials and FoundationInternationalization.