### PR TITLE
Align URLComponents.path behavior with URL for file paths

### DIFF
--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -239,8 +239,18 @@ public struct URLComponents: Hashable, Equatable, Sendable {
             _port = newValue
         }
 
+        private var isFileURL: Bool {
+            guard var scheme, scheme.utf8.count == 4 else { return false }
+            return scheme.withUTF8 {
+                ($0[0] | 0x20) == UInt8(ascii: "f") &&
+                ($0[1] | 0x20) == UInt8(ascii: "i") &&
+                ($0[2] | 0x20) == UInt8(ascii: "l") &&
+                ($0[3] | 0x20) == UInt8(ascii: "e")
+            }
+        }
+
         var path: String {
-            get { Parser.percentDecode(percentEncodedPath) ?? "" }
+            get { Parser.percentDecode(percentEncodedPath, excluding: isFileURL ? [0, ._slash] : []) ?? "" }
             set {
                 reset(.path)
                 _path = Parser.percentEncode(newValue, component: .path) ?? ""


### PR DESCRIPTION
Align `URLComponents.path` behavior with `URL.path` by not decoding `%2F` or `%00` for file URLs.

### Motivation:

`URLComponents.path` and `URL.path` should produce identical output for file URLs, but today `URLComponents.path` decodes `%2F` to `/` and `%00` to `\0` while `URL.path` preserves both. The same divergence exists between their Objective-C counterparts.

### Modifications:

When the `URLComponents` scheme is `file` (case-insensitive), exclude `/` and `\0` from percent-decoding in the `path` getter.

### Result:

For file URLs, `URLComponents.path` no longer decodes `%2F` to `/` or `%00` to `\0`, matching the behavior of `URL.path`.

### Testing:

Existing unit tests, plus added unit tests for `NSURLComponents`, which exercises this code path.

