### PR TITLE
Remove Swift 4 Obsoleted APIs

### DIFF
--- a/Sources/FoundationEssentials/Decimal/Decimal+Compatibility.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Compatibility.swift
@@ -27,33 +27,6 @@ extension Decimal {
 }
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
-extension Decimal {
-    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
-    @_transparent
-    public mutating func add(_ other: Decimal) {
-        self += other
-    }
-
-    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
-    @_transparent
-    public mutating func subtract(_ other: Decimal) {
-        self -= other
-    }
-
-    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
-    @_transparent
-    public mutating func multiply(by other: Decimal) {
-        self *= other
-    }
-
-    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
-    @_transparent
-    public mutating func divide(by other: Decimal) {
-        self /= other
-    }
-}
-
-@available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal : _ObjectiveCBridgeable {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSDecimalNumber {


### PR DESCRIPTION
Removes all APIs obsoleted in Swift 4

### Motivation:

APIs obsoleted in Swift 4 cannot be called by any code today built with the latest toolchain because the latest toolchain does not support Swift 3 mode. Therefore, this code is dead and cannot be called and therefore can be removed.

### Modifications:

Removes all APIs obsoleted in Swift 4

### Result:

APIs obsoleted in Swift 4 are no longer present

### Testing:

N/A, this is removing code that is by definition uncallable
