### PR TITLE
Restore backslash decoding behavior for Windows file URL paths

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Impl.swift
+++ b/Sources/FoundationEssentials/URL/URL_Impl.swift
@@ -641,11 +641,14 @@ extension _URL {
                     fromSpan: urlPath.extracting(inputStart...)
                 )
             } else {
-                // Percent-decode, excluding "%00", "%2F", and "%5C"
+                // Percent-decode, excluding "%00", "%2F"
                 guard let decodedLength = URLEncoder.percentDecodeUnchecked(
                     input: urlPath.extracting(inputStart...),
                     output: .init(rebasing: outBuffer[rootLength...]),
-                    excludingASCII: .windowsPath
+                    // Using .posixPath (not .windowsPath) because URL(string:)
+                    // percent-encodes "\" to "%5C", and clients may expect it
+                    // to return decoded.
+                    excludingASCII: .posixPath
                 ) else {
                     return 0
                 }
@@ -751,11 +754,10 @@ extension _URL {
                 return "/"
             }
             let component = path.extracting(componentRange)
-            #if os(Windows)
-            let mask: PercentDecodingASCIIExclusionMask = isFileURL ? .windowsPath : .none
-            #else
+            // Note: .windowsPath is not used for Windows here because "\"
+            // is percent-encoded in URL(string:) initializers, so clients
+            // may expect it to return decoded.
             let mask: PercentDecodingASCIIExclusionMask = isFileURL ? .posixPath : .none
-            #endif
             return String(unsafeUninitializedCapacity: component.count) { buffer in
                 URLEncoder.percentDecodeUnchecked(
                     input: component,

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -791,6 +791,16 @@ private struct URLTests {
     }
     #endif
 
+    @Test func percentEncodedBackslashInFileURLPath() throws {
+        // URL(string:) percent-encodes "\" to "%5C", and clients expect file
+        // path APIs to return it decoded (matches prior _SwiftURL behavior).
+        let url = URL(string: #"file:///C:\hello\world"#)!
+        #expect(url.absoluteString == "file:///C:%5Chello%5Cworld")
+        #expect(url.lastPathComponent == #"C:\hello\world"#)
+        #expect(url.fileSystemPath(style: .windows) == #"/C:\hello\world"#)
+        #expect(url.fileSystemPath(style: .posix) == #"/C:\hello\world"#)
+    }
+
     @Test func relativeDotDotResolution() throws {
         let baseURL = URL(filePath: "/docs/src/")
         var result = URL(filePath: "../images/foo.png", relativeTo: baseURL)


### PR DESCRIPTION
Restore Windows `URL.path` behavior of decoding `%5C` to `\`.

### Motivation:

`URL`'s POSIX path behavior is to decode all percent-escapes sequences except `%2F -> /` and `%00 -> \0`. The implementation in #1857 extended this behavior for Windows paths such that `%5C` was no longer decoded to `\`. A test failure in sourcekit-lsp revealed this is problematic because clients can pass a `file://` URL string containing backslashes to `URL(string:)`, which will encode all `\` to `%5C`. These clients then expect to receive the decoded `\` characters from the file path APIs.

### Modifications:

Replace usages of the `.windowsPath` pecent-decoding exclusion mask with `.posixPath` to restore previous behavior of only excluding `%2F` and `%00`.

### Result:

`URL(string: #"file:///C:\hello\world"#)?.path` will now return `#"/C:\hello\world"#` as it did previously instead of `"/C:%5Chello%5Cworld"`. Note that `URL(filePath:)` is the recommended initializer to use in this scenario as it avoids leading `/` issues by canonicalizing on initialization.

### Testing:

Added unit test to verify prior behavior.
