### PR TITLE
Replace use of static var with newly-initialized `Data` 

### DIFF
--- a/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
@@ -333,7 +333,7 @@ internal struct BuiltInUnicodeScalarSet {
     // CFUniCharGetBitmapForPlane
     internal func bitmap(forPlane plane: Int, isInverted: Bool) -> (BitmapResult, Data) {
         
-        var bitmap = _CharacterSet.allZeros
+        var bitmap = Data(repeating: 0, count: _CharacterSet.__kCFBitmapSize)
         var bitmapMutableSpan = bitmap.mutableSpan
         
         if let (src, invertBitmapData) = _bitmapPtrForPlane(plane) {

--- a/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
@@ -333,7 +333,7 @@ internal struct BuiltInUnicodeScalarSet {
     // CFUniCharGetBitmapForPlane
     internal func bitmap(forPlane plane: Int, isInverted: Bool) -> (BitmapResult, Data) {
         
-        var bitmap = Data(repeating: 0, count: _CharacterSet.bitmapSize)
+        var bitmap = Data(repeating: 0, count: _CharacterSet.__kCFBitmapSize)
         var bitmapMutableSpan = bitmap.mutableSpan
         
         if let (src, invertBitmapData) = _bitmapPtrForPlane(plane) {
@@ -484,9 +484,9 @@ internal struct BuiltInUnicodeScalarSet {
 #if !FOUNDATION_FRAMEWORK
 struct _CharacterSet {
     
-    static let bitmapSize = 8192
-    static let allZeros = Data(repeating: 0x00, count: bitmapSize)
-    static let allOnes = Data(repeating: 0xFF, count: bitmapSize)
+    static let __kCFBitmapSize = 8192
+    static let allZeros = Data(repeating: 0x00, count: __kCFBitmapSize)
+    static let allOnes = Data(repeating: 0xFF, count: __kCFBitmapSize)
     
     enum Operation {
         case add

--- a/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
@@ -333,7 +333,7 @@ internal struct BuiltInUnicodeScalarSet {
     // CFUniCharGetBitmapForPlane
     internal func bitmap(forPlane plane: Int, isInverted: Bool) -> (BitmapResult, Data) {
         
-        var bitmap = Data(repeating: 0, count: _CharacterSet.__kCFBitmapSize)
+        var bitmap = Data(repeating: 0, count: _CharacterSet.bitmapSize)
         var bitmapMutableSpan = bitmap.mutableSpan
         
         if let (src, invertBitmapData) = _bitmapPtrForPlane(plane) {


### PR DESCRIPTION
This PR fixes a memory issue found related to the use of `_CharacterSet.allZeros` instead of `Data.init()`. 

### Motivation:

This fixes a memory issue. 

### Modifications:

Replaced `_CharacterSet.allZeros` with `Data.init()`. 

### Result:

Nothing changes, the functionality stays the same. 

### Testing:

The existing tests pass. 
