### PR TITLE
Re-enable new build system in Android + Wasm CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,12 +26,6 @@ jobs:
       enable_android_sdk_build: true
       android_sdk_versions: '["nightly-main"]'
 
-      # Temporarily use native build system on Android due to https://github.com/swiftlang/swift/issues/88282
-      android_sdk_build_command: 'swift build --build-system native'
-
-      # Temporarily use native build system on Android due to https://github.com/swiftlang/swift/issues/88283
-      wasm_sdk_build_command: 'swift build --build-system native'
-
   cmake_build:
     name: Build (CMake)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts https://github.com/swiftlang/swift-foundation/pull/1884 now that the underlying issues are addressed.

### Motivation:

In https://github.com/swiftlang/swift-foundation/pull/1884 we updated Android + WASM CI to use the native build system due to issues with swift-build (https://github.com/swiftlang/swift/issues/88282 and https://github.com/swiftlang/swift/issues/88283). Both of those issues have been addressed as of the 4/17 toolchain, so we can now allow CI to use the new build system again.

### Modifications:

Reverts the CI change from #1884 

### Result:

CI will build the package using the new build system

### Testing:

CI configuration change will be tested by validating that CI still passes.
