### PR TITLE
Generalize concrete implementations of withUnsafeBytes to typed throws for ContiguousBytes conformers

### DIFF
--- a/Sources/FoundationEssentials/Data/ContiguousBytes.swift
+++ b/Sources/FoundationEssentials/Data/ContiguousBytes.swift
@@ -137,9 +137,20 @@ extension Data : ContiguousBytes { }
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension UnsafeRawBufferPointer : ContiguousBytes {
-    // TODO: Generalize for typed throws
-    @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    // TODO: This should be limited to DATA_LEGACY_ABI once clients are rebuilt
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
+    @usableFromInline
+    @abi(func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R)
+    func __legacy_withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+        return try withUnsafeBytes(body)
+    }
+
+    @_alwaysEmitIntoClient
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(self)
     }
 
@@ -152,9 +163,20 @@ extension UnsafeRawBufferPointer : ContiguousBytes {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension UnsafeMutableRawBufferPointer : ContiguousBytes {
-    // TODO: Generalize for typed throws
-    @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    // TODO: This should be limited to DATA_LEGACY_ABI once clients are rebuilt
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
+    @usableFromInline
+    @abi(func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R)
+    func __legacy_withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+        return try withUnsafeBytes(body)
+    }
+
+    @_alwaysEmitIntoClient
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 
@@ -168,9 +190,20 @@ extension UnsafeMutableRawBufferPointer : ContiguousBytes {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
-    // TODO: Generalize for typed throws
-    @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    // TODO: This should be limited to DATA_LEGACY_ABI once clients are rebuilt
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
+    @usableFromInline
+    @abi(func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R)
+    func __legacy_withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+        return try withUnsafeBytes(body)
+    }
+
+    @_alwaysEmitIntoClient
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 
@@ -184,9 +217,20 @@ extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
-    // TODO: Generalize for typed throws
-    @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    // TODO: This should be limited to DATA_LEGACY_ABI once clients are rebuilt
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
+    @usableFromInline
+    @abi(func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R)
+    func __legacy_withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+        return try withUnsafeBytes(body)
+    }
+
+    @_alwaysEmitIntoClient
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 
@@ -200,9 +244,20 @@ extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension EmptyCollection : ContiguousBytes where Element == UInt8 {
-    // TODO: Generalize for typed throws
-    @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    // TODO: This should be limited to DATA_LEGACY_ABI once clients are rebuilt
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
+    @usableFromInline
+    @abi(func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R)
+    func __legacy_withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+        return try withUnsafeBytes(body)
+    }
+
+    @_alwaysEmitIntoClient
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(UnsafeRawBufferPointer(start: nil, count: 0))
     }
 
@@ -216,11 +271,22 @@ extension EmptyCollection : ContiguousBytes where Element == UInt8 {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension CollectionOfOne : ContiguousBytes where Element == UInt8 {
-    // TODO: Generalize for typed throws
-    @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    // TODO: This should be limited to DATA_LEGACY_ABI once clients are rebuilt
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
+    @usableFromInline
+    @abi(func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R)
+    func __legacy_withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+        return try withUnsafeBytes(body)
+    }
+
+    @_alwaysEmitIntoClient
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         let element = self.first!
-        return try Swift.withUnsafeBytes(of: element) { (buffer) in
+        return try Swift.withUnsafeBytes(of: element) { (buffer) throws(E) in
             return try body(buffer)
         }
     }
@@ -240,15 +306,39 @@ extension CollectionOfOne : ContiguousBytes where Element == UInt8 {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Slice : ContiguousBytes where Base : ContiguousBytes {
-    // TODO: Generalize for typed throws
-    @inlinable
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    // TODO: This should be limited to DATA_LEGACY_ABI once clients are rebuilt
+    @available(macOS, obsoleted: 1.0)
+    @available(iOS, obsoleted: 1.0)
+    @available(watchOS, obsoleted: 1.0)
+    @available(tvOS, obsoleted: 1.0)
+    @available(visionOS, obsoleted: 1.0)
+    @usableFromInline
+    @abi(func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R)
+    func __legacy_withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+        return try withUnsafeBytes(body)
+    }
+
+    @_alwaysEmitIntoClient
+    public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         let offset = base.distance(from: base.startIndex, to: self.startIndex)
-        return try base.withUnsafeBytes { ptr in
+        #if !hasFeature(Embedded)
+        do {
+            return try base.withUnsafeBytes { (ptr) in
+                let slicePtr = ptr.baseAddress?.advanced(by: offset)
+                let sliceBuffer = UnsafeRawBufferPointer(start: slicePtr, count: self.count)
+                return try body(sliceBuffer)
+            }
+        } catch let error {
+            // Note: withUnsafeBytes is rethrowing, so we have an "any Error" here that needs casting.
+            throw error as! E
+        }
+        #else
+        return try base.withUnsafeBytes { (ptr) throws(E) in
             let slicePtr = ptr.baseAddress?.advanced(by: offset)
             let sliceBuffer = UnsafeRawBufferPointer(start: slicePtr, count: self.count)
             return try body(sliceBuffer)
         }
+        #endif
     }
 }
 

--- a/Tests/FoundationEssentialsTests/DataLegacyABITests.swift
+++ b/Tests/FoundationEssentialsTests/DataLegacyABITests.swift
@@ -74,6 +74,41 @@ extension Foundation.__DataStorage {
     final func __testable_withUnsafeMutableBytes<R>(in: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> R) throws -> R
 }
 
+extension UnsafeRawBufferPointer {
+    @_silgen_name("$sSW10FoundationE15withUnsafeBytesyxxSWKXEKlF")
+    func __testable_withUnsafeBytes<R>(body: (UnsafeRawBufferPointer) throws -> R) throws -> R
+}
+
+extension UnsafeMutableRawBufferPointer {
+    @_silgen_name("$sSw10FoundationE15withUnsafeBytesyxxSWKXEKlF")
+    func __testable_withUnsafeBytes<R>(body: (UnsafeRawBufferPointer) throws -> R) throws -> R
+}
+
+extension UnsafeBufferPointer where Element == UInt8 {
+    @_silgen_name("$sSR10Foundations5UInt8VRszlE15withUnsafeBytesyqd__qd__SWKXEKlF")
+    func __testable_withUnsafeBytes<R>(body: (UnsafeRawBufferPointer) throws -> R) throws -> R
+}
+
+extension UnsafeMutableBufferPointer where Element == UInt8 {
+    @_silgen_name("$sSr10Foundations5UInt8VRszlE15withUnsafeBytesyqd__qd__SWKXEKlF")
+    func __testable_withUnsafeBytes<R>(body: (UnsafeRawBufferPointer) throws -> R) throws -> R
+}
+
+extension EmptyCollection where Element == UInt8 {
+    @_silgen_name("$ss15EmptyCollectionV10Foundations5UInt8VRszlE15withUnsafeBytesyqd__qd__SWKXEKlF")
+    func __testable_withUnsafeBytes<R>(body: (UnsafeRawBufferPointer) throws -> R) throws -> R
+}
+
+extension CollectionOfOne where Element == UInt8 {
+    @_silgen_name("$ss15CollectionOfOneV10Foundations5UInt8VRszlE15withUnsafeBytesyqd__qd__SWKXEKlF")
+    func __testable_withUnsafeBytes<R>(body: (UnsafeRawBufferPointer) throws -> R) throws -> R
+}
+
+extension Slice where Base: ContiguousBytes {
+    @_silgen_name("$ss5SliceV10FoundationAC15ContiguousBytesRzrlE010withUnsafeD0yqd__qd__SWKXEKlF")
+    func __testable_withUnsafeBytes<R>(body: (UnsafeRawBufferPointer) throws -> R) throws -> R
+}
+
 @Suite("Foundation Legacy ABI")
 private final class FoundationLegacyABITests {
 
@@ -177,6 +212,42 @@ private final class FoundationLegacyABITests {
         }
         #expect(slice[count7] == 31)
         #expect(countA.0 == 40-count7)
+    }
+
+    @Test func validateContiguousBytesLegacyABI() throws {
+        let ptr = UnsafeMutablePointer<UInt8>(bitPattern: 0xABC)
+        try UnsafeRawBufferPointer(start: ptr, count: 1).__testable_withUnsafeBytes { buffer in
+            #expect(buffer.baseAddress == UnsafeRawPointer(ptr))
+            #expect(buffer.count == 1)
+        }
+        try UnsafeMutableRawBufferPointer(start: ptr, count: 1).__testable_withUnsafeBytes { buffer in
+            #expect(buffer.baseAddress == UnsafeRawPointer(ptr))
+            #expect(buffer.count == 1)
+        }
+        try UnsafeBufferPointer<UInt8>(start: ptr, count: 1).__testable_withUnsafeBytes { buffer in
+            #expect(buffer.baseAddress == UnsafeRawPointer(ptr))
+            #expect(buffer.count == 1)
+        }
+        try UnsafeMutableBufferPointer<UInt8>(start: ptr, count: 1).__testable_withUnsafeBytes { buffer in
+            #expect(buffer.baseAddress == UnsafeRawPointer(ptr))
+            #expect(buffer.count == 1)
+        }
+
+        try EmptyCollection().__testable_withUnsafeBytes { buffer in
+            #expect(buffer.baseAddress == nil)
+            #expect(buffer.count == 0)
+        }
+
+        try CollectionOfOne(UInt8(2)).__testable_withUnsafeBytes { buffer in
+            #expect(buffer.baseAddress != nil)
+            #expect(buffer.count == 1)
+        }
+
+        try Slice<Data>().__testable_withUnsafeBytes { buffer in
+            // Data never provide's a nil base address, so Slice<Data> won't either
+            #expect(buffer.baseAddress != nil)
+            #expect(buffer.count == 0)
+        }
     }
 }
 


### PR DESCRIPTION
Adopt typed throws in `withUnsafeBytes` concrete declarations

### Motivation:

Adopting typed throws here implements a piece of API originally landed in #1565 but reverted in #1762 due to build failures in client projects. Those failures have been resolved with https://github.com/swiftlang/swift/pull/87708 so we can now re-land this change

### Modifications:

- Updates existing `rethrows` `withUnsafeBytes` declarations to ABI-only (following previous conventions defined in #1905)
- Adds new `@_alwaysEmitIntoClient` implementations of `withUnsafeBytes` that support typed throws 

### Result:

Callers can now use typed throws with the concrete `withUnsafeBytes` implementations

### Testing:

Existing tests validate `withUnsafeBytes` functionality, new tests added to validate ABI-only entry point
