### PR TITLE
new-codable: Remove typed throws workarounds

### DIFF
--- a/Sources/NewCodable/JSON/ParserState.swift
+++ b/Sources/NewCodable/JSON/ParserState.swift
@@ -714,43 +714,33 @@ extension JSONParserDecoder {
             @inline(__always)
             @_lifetime(self: copy self)
             mutating func matchExpectedString(_ str: StaticString) throws(JSONError) -> Bool {
-                do {
-                    let cmp = try bytes.extracting(unchecked: readOffset..<endOffset).withUnsafeBytes { buff in
-                        if buff.count < str.utf8CodeUnitCount { throw JSONError.unexpectedEndOfFile }
-                        return memcmp(buff.baseAddress!, str.utf8Start, str.utf8CodeUnitCount)
-                    }
-                    guard cmp == 0 else {
-                        return false
-                    }
-                    
-                    // If all looks good, advance past the string.
-                    self.moveReaderIndex(forwardBy: str.utf8CodeUnitCount)
-                    return true
-                } catch {
-                    // TODO: Remove unsavory workaroud
-                    throw error as! JSONError
+                let cmp = try bytes.extracting(unchecked: readOffset..<endOffset).withUnsafeBytes { buff throws(JSONError) in
+                    if buff.count < str.utf8CodeUnitCount { throw JSONError.unexpectedEndOfFile }
+                    return memcmp(buff.baseAddress!, str.utf8Start, str.utf8CodeUnitCount)
                 }
+                guard cmp == 0 else {
+                    return false
+                }
+                
+                // If all looks good, advance past the string.
+                self.moveReaderIndex(forwardBy: str.utf8CodeUnitCount)
+                return true
             }
 
             @inlinable
             @inline(__always)
             @_lifetime(self: copy self)
             mutating func readExpectedString(_ str: StaticString, typeDescriptor: String) throws(JSONError) {
-                do {
-                    let cmp = try bytes.extracting(unchecked: readOffset..<endOffset).withUnsafeBytes { buff in
-                        if buff.count < str.utf8CodeUnitCount { throw JSONError.unexpectedEndOfFile }
-                        return memcmp(buff.baseAddress!, str.utf8Start, str.utf8CodeUnitCount)
-                    }
-                    guard cmp == 0 else {
-                        throw errorForUnmatchedCharacter(in: str, typeDescriptor: typeDescriptor)
-                    }
-                    
-                    // If all looks good, advance past the string.
-                    self.moveReaderIndex(forwardBy: str.utf8CodeUnitCount)
-                } catch {
-                    // TODO: Remove unsavory workaroud
-                    throw error as! JSONError
+                let cmp = try bytes.extracting(unchecked: readOffset..<endOffset).withUnsafeBytes { buff throws(JSONError) in
+                    if buff.count < str.utf8CodeUnitCount { throw JSONError.unexpectedEndOfFile }
+                    return memcmp(buff.baseAddress!, str.utf8Start, str.utf8CodeUnitCount)
                 }
+                guard cmp == 0 else {
+                    throw errorForUnmatchedCharacter(in: str, typeDescriptor: typeDescriptor)
+                }
+                
+                // If all looks good, advance past the string.
+                self.moveReaderIndex(forwardBy: str.utf8CodeUnitCount)
             }
 
             @inlinable

--- a/Sources/NewCodable/SharedTypes.swift
+++ b/Sources/NewCodable/SharedTypes.swift
@@ -721,33 +721,28 @@ extension BinaryInteger {
             return try closure(array.span)
         }
         
-        // TODO: Remove awkward workaround for lack of typed-throws on withUnsafeTemporaryAllocation.
-        do {
-            return try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: 40) { buffer in
-                func _ascii(_ digit: UInt8) -> UTF8.CodeUnit {
-                    UInt8(("0" as Unicode.Scalar).value) + digit
-                }
-                let isNegative = Self.isSigned && self < (0 as Self)
-                var value = magnitude
-                
-                var index = buffer.count&-1
-                while value != 0 {
-                    let (quotient, remainder) = value.quotientAndRemainder(dividingBy: 10)
-                    buffer[index] = _ascii(UInt8(truncatingIfNeeded: remainder))
-                    index -= 1
-                    value = quotient
-                }
-                if isNegative {
-                    buffer[index] = UInt8(("-" as Unicode.Scalar).value)
-                    index -= 1
-                }
-                let length = buffer.count &- (index &+ 1)
-                
-                return try closure(buffer.span.extracting(last: length))
+        return try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: 40) { buffer throws(E) in
+            func _ascii(_ digit: UInt8) -> UTF8.CodeUnit {
+                UInt8(("0" as Unicode.Scalar).value) + digit
             }
-        } catch let error as E {
-            throw error
-        } catch { fatalError() }
+            let isNegative = Self.isSigned && self < (0 as Self)
+            var value = magnitude
+            
+            var index = buffer.count&-1
+            while value != 0 {
+                let (quotient, remainder) = value.quotientAndRemainder(dividingBy: 10)
+                buffer[index] = _ascii(UInt8(truncatingIfNeeded: remainder))
+                index -= 1
+                value = quotient
+            }
+            if isNegative {
+                buffer[index] = UInt8(("-" as Unicode.Scalar).value)
+                index -= 1
+            }
+            let length = buffer.count &- (index &+ 1)
+            
+            return try closure(buffer.span.extracting(last: length))
+        }
 
     }
     


### PR DESCRIPTION
Removes unnecessary workarounds for `withUnsafeBytes` and `withUnsafeTemporaryAllocation` calls.

### Motivation:

Instead of those workarounds we can specify error types of the closures (which I think the compiler just fails to infer).

### Modifications:

- Removes do-catch wrapper blocks around `withUnsafeBytes` and `withUnsafeTemporaryAllocation` calls, removes dynamic casts of errors
- Specifies error types of the closures instead

### Result:

- The code is simplified
- Dynamic casts of errors in the workarounds don't block Embedded Swift compilation anymore

### Testing:
- Ran tests using Xcode 26.4.1 Swift toolchain
- Managed to build `NewCodable` using `swift-6.3.1-RELEASE_wasm-embedded` SDK (though it required other changes in the codebase)
