### PR TITLE
Update `hasIdenticalStorage` calls to `hasIdenticalSwiftStorage` calls 

### DIFF
--- a/Sources/FoundationEssentials/URL/URLEncoder.swift
+++ b/Sources/FoundationEssentials/URL/URLEncoder.swift
@@ -759,17 +759,17 @@ extension StringProtocol {
         #endif
 
         let string = _specializingCast(self, to: String.self) ?? String(self)
-        if allowedCharacters.hasIdenticalStorage(to: .urlPathAllowed) {
+        if allowedCharacters.hasIdenticalSwiftStorage(to: .urlPathAllowed) {
             return URLEncoder.percentEncode(path: string)
-        } else if allowedCharacters.hasIdenticalStorage(to: .urlHostAllowed) {
+        } else if allowedCharacters.hasIdenticalSwiftStorage(to: .urlHostAllowed) {
             return URLEncoder.percentEncode(host: string)
-        } else if allowedCharacters.hasIdenticalStorage(to: .urlQueryAllowed) {
+        } else if allowedCharacters.hasIdenticalSwiftStorage(to: .urlQueryAllowed) {
             return URLEncoder.percentEncode(string: string, component: .query, skipAlreadyEncoded: false)
-        } else if allowedCharacters.hasIdenticalStorage(to: .urlFragmentAllowed) {
+        } else if allowedCharacters.hasIdenticalSwiftStorage(to: .urlFragmentAllowed) {
             return URLEncoder.percentEncode(string: string, component: .fragment, skipAlreadyEncoded: false)
-        } else if allowedCharacters.hasIdenticalStorage(to: .urlUserAllowed) {
+        } else if allowedCharacters.hasIdenticalSwiftStorage(to: .urlUserAllowed) {
             return URLEncoder.percentEncode(string: string, component: .user, skipAlreadyEncoded: false)
-        } else if allowedCharacters.hasIdenticalStorage(to: .urlPasswordAllowed) {
+        } else if allowedCharacters.hasIdenticalSwiftStorage(to: .urlPasswordAllowed) {
             return URLEncoder.percentEncode(string: string, component: .password, skipAlreadyEncoded: false)
         }
 


### PR DESCRIPTION
This PR updates the call sites of `URLEncoder` to align with the change in `CharacterSet`. 

### Motivation:

`CharacterSet` changed method name from `hasIdenticalStorage` to `hasIdenticalSwiftStorage`. 

### Modifications:

Update call sites involving `hasIdenticalStorage`. 

### Result:

No changes in functionality are expected. 

### Testing:

The existing tests pass with this change and there are no build errors. 
