### PR TITLE
Disable the test while I investigate a fix for the format change caused by ICU

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -1333,12 +1333,14 @@ extension DateFormatStyleTests {
         _verify(.dateTime.hour(.conversationalDefaultDigits(amPM: .omitted)), expectedFormat: "hh", locale: enUS)
         _verify(.dateTime.hour(.conversationalTwoDigits(amPM: .omitted)), expectedFormat: "hh", locale: enUS)
 
+#if FIXED_HOUR_SYMBOL_175541251
         let enGB = Locale(identifier: "en_GB")
         _verify(.dateTime.hour(.defaultDigits(amPM: .abbreviated)), expectedFormat: "H", locale: enGB)
         _verify(.dateTime.hour(.defaultDigits(amPM: .omitted)), expectedFormat: "H", locale: enGB)
         _verify(.dateTime.hour(.twoDigits(amPM: .omitted)), expectedFormat: "HH", locale: enGB)
         _verify(.dateTime.hour(.conversationalDefaultDigits(amPM: .omitted)), expectedFormat: "H", locale: enGB)
         _verify(.dateTime.hour(.conversationalTwoDigits(amPM: .omitted)), expectedFormat: "HH", locale: enGB)
+#endif
     }
 }
 #endif


### PR DESCRIPTION
Darwin ICU recently changed how "J" and "j" symbols resolve into date formats, and caused these test failures. Disabling the tests while figuring out the fix for now.

175861506
