### PR TITLE
Enable combining multiple macros on a single type

### DIFF
--- a/Sources/NewCodable/Macros.swift
+++ b/Sources/NewCodable/Macros.swift
@@ -15,27 +15,27 @@
 /// The macro spellings in this file are provisional and may evolve with the
 /// macro-based Codable design. The per-property marker macros below are
 /// especially likely to change as the feature set is refined.
-@attached(extension, conformances: JSONEncodable, names: named(CodingFields), named(encode))
+@attached(extension, conformances: JSONEncodable, names: named(JSONCodingFields), named(encode))
 public macro JSONEncodable() = #externalMacro(module: "NewCodableMacros", type: "JSONEncodableMacro")
 
 /// Experimental macro that synthesizes `JSONDecodable` conformance.
-@attached(extension, conformances: JSONDecodable, names: named(CodingFields), named(decode))
+@attached(extension, conformances: JSONDecodable, names: named(JSONCodingFields), named(decode))
 public macro JSONDecodable() = #externalMacro(module: "NewCodableMacros", type: "JSONDecodableMacro")
 
 /// Experimental macro that synthesizes both `JSONEncodable` and `JSONDecodable`.
-@attached(extension, conformances: JSONEncodable, JSONDecodable, names: named(CodingFields), named(encode), named(decode))
+@attached(extension, conformances: JSONEncodable, JSONDecodable, names: named(JSONCodingFields), named(encode), named(decode))
 public macro JSONCodable() = #externalMacro(module: "NewCodableMacros", type: "JSONCodableMacro")
 
 /// Experimental macro that synthesizes `CommonEncodable` conformance.
-@attached(extension, conformances: CommonEncodable, names: named(CodingFields), named(encode))
+@attached(extension, conformances: CommonEncodable, names: named(CommonCodingFields), named(encode))
 public macro CommonEncodable() = #externalMacro(module: "NewCodableMacros", type: "CommonEncodableMacro")
 
 /// Experimental macro that synthesizes `CommonDecodable` conformance.
-@attached(extension, conformances: CommonDecodable, names: named(CodingFields), named(decode))
+@attached(extension, conformances: CommonDecodable, names: named(CommonCodingFields), named(decode))
 public macro CommonDecodable() = #externalMacro(module: "NewCodableMacros", type: "CommonDecodableMacro")
 
 /// Experimental macro that synthesizes both `CommonEncodable` and `CommonDecodable`.
-@attached(extension, conformances: CommonEncodable, CommonDecodable, names: named(CodingFields), named(encode), named(decode))
+@attached(extension, conformances: CommonEncodable, CommonDecodable, names: named(CommonCodingFields), named(encode), named(decode))
 public macro CommonCodable() = #externalMacro(module: "NewCodableMacros", type: "CommonCodableMacro")
 
 /// Experimental per-property marker macro for overriding the serialized key.

--- a/Sources/NewCodable/Macros.swift
+++ b/Sources/NewCodable/Macros.swift
@@ -15,27 +15,27 @@
 /// The macro spellings in this file are provisional and may evolve with the
 /// macro-based Codable design. The per-property marker macros below are
 /// especially likely to change as the feature set is refined.
-@attached(extension, conformances: JSONEncodable, names: named(JSONCodingFields), named(encode))
+@attached(extension, conformances: JSONEncodable, names: named(CodingFields), named(JSONCodingFields), named(encode))
 public macro JSONEncodable() = #externalMacro(module: "NewCodableMacros", type: "JSONEncodableMacro")
 
 /// Experimental macro that synthesizes `JSONDecodable` conformance.
-@attached(extension, conformances: JSONDecodable, names: named(JSONCodingFields), named(decode))
+@attached(extension, conformances: JSONDecodable, names: named(CodingFields), named(JSONCodingFields), named(decode))
 public macro JSONDecodable() = #externalMacro(module: "NewCodableMacros", type: "JSONDecodableMacro")
 
 /// Experimental macro that synthesizes both `JSONEncodable` and `JSONDecodable`.
-@attached(extension, conformances: JSONEncodable, JSONDecodable, names: named(JSONCodingFields), named(encode), named(decode))
+@attached(extension, conformances: JSONEncodable, JSONDecodable, names: named(CodingFields), named(JSONCodingFields), named(encode), named(decode))
 public macro JSONCodable() = #externalMacro(module: "NewCodableMacros", type: "JSONCodableMacro")
 
 /// Experimental macro that synthesizes `CommonEncodable` conformance.
-@attached(extension, conformances: CommonEncodable, names: named(CommonCodingFields), named(encode))
+@attached(extension, conformances: CommonEncodable, names: named(CodingFields), named(CommonCodingFields), named(encode))
 public macro CommonEncodable() = #externalMacro(module: "NewCodableMacros", type: "CommonEncodableMacro")
 
 /// Experimental macro that synthesizes `CommonDecodable` conformance.
-@attached(extension, conformances: CommonDecodable, names: named(CommonCodingFields), named(decode))
+@attached(extension, conformances: CommonDecodable, names: named(CodingFields), named(CommonCodingFields), named(decode))
 public macro CommonDecodable() = #externalMacro(module: "NewCodableMacros", type: "CommonDecodableMacro")
 
 /// Experimental macro that synthesizes both `CommonEncodable` and `CommonDecodable`.
-@attached(extension, conformances: CommonEncodable, CommonDecodable, names: named(CommonCodingFields), named(encode), named(decode))
+@attached(extension, conformances: CommonEncodable, CommonDecodable, names: named(CodingFields), named(CommonCodingFields), named(encode), named(decode))
 public macro CommonCodable() = #externalMacro(module: "NewCodableMacros", type: "CommonCodableMacro")
 
 /// Experimental per-property marker macro for overriding the serialized key.

--- a/Sources/NewCodableMacros/CommonCodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonCodableMacro.swift
@@ -52,6 +52,7 @@ struct CommonCodableExpansion: CodableExpansion {
         }
     }
     
+    let fieldTypeName = "CommonCodingFields"
     let encodableProtocolName = "CommonEncodable"
     let decodableProtocolName = "CommonDecodable"
     let combinedProtocolName = "CommonCodable"

--- a/Sources/NewCodableMacros/CommonCodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonCodableMacro.swift
@@ -31,11 +31,12 @@ extension CommonCodableMacro: ExtensionMacro {
             in: context) else {
             return []
         }
-        
+
         let expansion = CommonCodableExpansion(type: .both, accessLevel: accessLevel(of: declaration))
-        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
-        let encodingImpl = typeDecl.makeEncodableExtension(expansion: expansion)
-        let decodingImpl = typeDecl.makeDecodableExtension(expansion: expansion)
+        let peers = detectPeerMacros(node: node, declaration: declaration, expansion: expansion)
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion, peers: peers)
+        let encodingImpl = typeDecl.makeEncodableExtension(expansion: expansion, peers: peers)
+        let decodingImpl = typeDecl.makeDecodableExtension(expansion: expansion, peers: peers)
         return codingFields + encodingImpl + decodingImpl
     }
 }
@@ -44,21 +45,17 @@ struct CommonCodableExpansion: CodableExpansion {
     let type: CodableExpansionType
     let accessLevel: CodableDeclarationAccessLevel
     
-    var fieldProtocolName: String {
-        switch type {
-        case .encodingOnly: "StaticStringEncodingField"
-        case .decodingOnly: "StaticStringDecodingField"
-        case .both: "StaticStringCodingField"
-        }
-    }
-    
     let fieldTypeName = "CommonCodingFields"
     let encodableProtocolName = "CommonEncodable"
     let decodableProtocolName = "CommonDecodable"
     let combinedProtocolName = "CommonCodable"
     
+    let encodableFieldProtocolName = "StaticStringEncodingField"
+    let decodableFieldProtocolName = "StaticStringDecodingField"
+    let combinedFieldProtocolName = "StaticStringCodingField"
+
     let decoderType = "some CommonDecoder & ~Escapable"
     let structDecoderType = "some CommonStructDecoder & ~Escapable"
-    
+
     let encoderType = "some CommonEncoder & ~Copyable & ~Escapable"
 }

--- a/Sources/NewCodableMacros/CommonDecodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonDecodableMacro.swift
@@ -34,8 +34,9 @@ extension CommonDecodableMacro: ExtensionMacro {
         }
         
         let expansion = CommonCodableExpansion(type: .decodingOnly, accessLevel: accessLevel(of: declaration))
-        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
-        let impl = typeDecl.makeDecodableExtension(expansion: expansion)
+        let peers = detectPeerMacros(node: node, declaration: declaration, expansion: expansion)
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion, peers: peers)
+        let impl = typeDecl.makeDecodableExtension(expansion: expansion, peers: peers)
         return codingFields + impl
     }
 }

--- a/Sources/NewCodableMacros/CommonEncodableMacro.swift
+++ b/Sources/NewCodableMacros/CommonEncodableMacro.swift
@@ -34,8 +34,9 @@ extension CommonEncodableMacro: ExtensionMacro {
         }
         
         let expansion = CommonCodableExpansion(type: .encodingOnly, accessLevel: accessLevel(of: declaration))
-        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
-        let impl = typeDecl.makeEncodableExtension(expansion: expansion)
+        let peers = detectPeerMacros(node: node, declaration: declaration, expansion: expansion)
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion, peers: peers)
+        let impl = typeDecl.makeEncodableExtension(expansion: expansion, peers: peers)
         return codingFields + impl
     }
 }

--- a/Sources/NewCodableMacros/JSONCodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONCodableMacro.swift
@@ -52,6 +52,7 @@ struct JSONCodableExpanion: CodableExpansion {
         }
     }
     
+    let fieldTypeName = "JSONCodingFields"
     let encodableProtocolName = "JSONEncodable"
     let decodableProtocolName = "JSONDecodable"
     let combinedProtocolName = "JSONCodable"

--- a/Sources/NewCodableMacros/JSONCodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONCodableMacro.swift
@@ -31,11 +31,12 @@ extension JSONCodableMacro: ExtensionMacro {
             in: context) else {
             return []
         }
-        
+
         let expansion = JSONCodableExpanion(type: .both, accessLevel: accessLevel(of: declaration))
-        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
-        let encodingImpl = typeDecl.makeEncodableExtension(expansion: expansion)
-        let decodingImpl = typeDecl.makeDecodableExtension(expansion: expansion)
+        let peers = detectPeerMacros(node: node, declaration: declaration, expansion: expansion)
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion, peers: peers)
+        let encodingImpl = typeDecl.makeEncodableExtension(expansion: expansion, peers: peers)
+        let decodingImpl = typeDecl.makeDecodableExtension(expansion: expansion, peers: peers)
         return codingFields + encodingImpl + decodingImpl
     }
 }
@@ -43,22 +44,18 @@ extension JSONCodableMacro: ExtensionMacro {
 struct JSONCodableExpanion: CodableExpansion {
     let type: CodableExpansionType
     let accessLevel: CodableDeclarationAccessLevel
-    
-    var fieldProtocolName: String {
-        switch type {
-        case .encodingOnly: "JSONOptimizedEncodingField"
-        case .decodingOnly: "JSONOptimizedDecodingField"
-        case .both: "JSONOptimizedCodingField"
-        }
-    }
-    
+
     let fieldTypeName = "JSONCodingFields"
     let encodableProtocolName = "JSONEncodable"
     let decodableProtocolName = "JSONDecodable"
     let combinedProtocolName = "JSONCodable"
 
+    let encodableFieldProtocolName = "JSONOptimizedEncodingField"
+    let decodableFieldProtocolName = "JSONOptimizedDecodingField"
+    let combinedFieldProtocolName = "JSONOptimizedCodingField"
+
     let decoderType = "some JSONDecoderProtocol & ~Escapable"
     let structDecoderType = "some JSONDictionaryDecoder & ~Escapable"
-    
+
     let encoderType = "JSONDirectEncoder"
 }

--- a/Sources/NewCodableMacros/JSONDecodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONDecodableMacro.swift
@@ -34,8 +34,9 @@ extension JSONDecodableMacro: ExtensionMacro {
         }
         
         let expansion = JSONCodableExpanion(type: .decodingOnly, accessLevel: accessLevel(of: declaration))
-        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
-        let impl = typeDecl.makeDecodableExtension(expansion: expansion)
+        let peers = detectPeerMacros(node: node, declaration: declaration, expansion: expansion)
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion, peers: peers)
+        let impl = typeDecl.makeDecodableExtension(expansion: expansion, peers: peers)
         return codingFields + impl
     }
 }

--- a/Sources/NewCodableMacros/JSONEncodableMacro.swift
+++ b/Sources/NewCodableMacros/JSONEncodableMacro.swift
@@ -34,8 +34,9 @@ extension JSONEncodableMacro: ExtensionMacro {
         }
         
         let expansion = JSONCodableExpanion(type: .encodingOnly, accessLevel: accessLevel(of: declaration))
-        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion)
-        let impl = typeDecl.makeEncodableExtension(expansion: expansion)
+        let peers = detectPeerMacros(node: node, declaration: declaration, expansion: expansion)
+        let codingFields = typeDecl.makeCodingFieldsExtension(expansion: expansion, peers: peers)
+        let impl = typeDecl.makeEncodableExtension(expansion: expansion, peers: peers)
         return codingFields + impl
     }
 }

--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -267,9 +267,9 @@ enum CodableTypeDeclaration {
         let ext: ExtensionDeclSyntax?
         switch self {
         case .structDecl(let typeName, let properties):
-            ext = NewCodableMacros.makeEncodableExtension(for: typeName, with: properties, expansion: expansion, hasPeer: peers.multiFormat)
+            ext = NewCodableMacros.makeEncodableExtension(for: typeName, with: properties, expansion: expansion, peerInfo: peers)
         case .enumDecl(let typeName, let cases):
-            ext = makeEnumEncodableExtension(for: typeName, with: cases, expansion: expansion, hasPeer: peers.multiFormat)
+            ext = makeEnumEncodableExtension(for: typeName, with: cases, expansion: expansion, peerInfo: peers)
         }
         return [ext].compactMap { $0 }
     }
@@ -277,12 +277,12 @@ enum CodableTypeDeclaration {
     func makeDecodableExtension(expansion: some CodableExpansion, peers: PeerMacroInfo) -> [ExtensionDeclSyntax] {
         switch self {
         case .structDecl(let typeName, let properties):
-            if let ext = NewCodableMacros.makeDecodableExtension(for: typeName, with: properties, expansion: expansion, hasPeer: peers.multiFormat) {
+            if let ext = NewCodableMacros.makeDecodableExtension(for: typeName, with: properties, expansion: expansion, peerInfo: peers) {
                 return [ext]
             }
             return []
         case .enumDecl(let typeName, let cases):
-            return makeEnumDecodableExtension(for: typeName, with: cases, expansion: expansion, hasPeer: peers.multiFormat)
+            return makeEnumDecodableExtension(for: typeName, with: cases, expansion: expansion, peerInfo: peers)
         }
     }
 }
@@ -756,7 +756,7 @@ func makeEncodableExtension(
     for typeName: TokenSyntax,
     with properties: [DetailedStoredProperty],
     expansion: some CodableExpansion,
-    hasPeer: Bool
+    peerInfo: PeerMacroInfo
 ) -> ExtensionDeclSyntax? {
     let accessLevelPrefix = expansion.accessLevel.inlineDeclPrefix
     let extensionDecl: DeclSyntax
@@ -772,7 +772,7 @@ func makeEncodableExtension(
     } else {
         let fieldType = expansion.fieldTypeName
         let encodeStatements: String
-        if hasPeer {
+        if peerInfo.multiFormat {
             encodeStatements = properties.map {
                 "try structEncoder.encode(field: \(fieldType)(.\($0.name)), value: self.\($0.name))"
             }.joined(separator: "\n")
@@ -804,7 +804,7 @@ func makeDecodableExtension(
     for typeName: TokenSyntax,
     with properties: [DetailedStoredProperty],
     expansion: some CodableExpansion,
-    hasPeer: Bool
+    peerInfo: PeerMacroInfo
 ) -> ExtensionDeclSyntax? {
     let accessLevelPrefix = expansion.accessLevel.inlineDeclPrefix
     let decl: DeclSyntax
@@ -862,7 +862,7 @@ func makeDecodableExtension(
             """
         }
 
-        let switchExpr = hasPeer ? "_codingField!.base" : "_codingField!"
+        let switchExpr = peerInfo.multiFormat ? "_codingField!.base" : "_codingField!"
 
         decl = """
         extension \(typeName): \(raw: expansion.decodableProtocolName) {
@@ -1367,7 +1367,7 @@ func makeEnumEncodableExtension(
     for typeName: TokenSyntax,
     with cases: [EnumCaseInfo],
     expansion: some CodableExpansion,
-    hasPeer: Bool
+    peerInfo: PeerMacroInfo
 ) -> ExtensionDeclSyntax? {
     let switchCases: String
     if cases.isEmpty {
@@ -1376,7 +1376,7 @@ func makeEnumEncodableExtension(
     } else {
         switchCases = cases.map { enumCase -> String in
             if enumCase.associatedValues.isEmpty {
-                let fieldRef = hasPeer
+                let fieldRef = peerInfo.multiFormat
                     ? "\(expansion.fieldTypeName)(.\(enumCase.name))"
                     : "\(expansion.fieldTypeName).\(enumCase.name)"
                 return """
@@ -1386,12 +1386,12 @@ func makeEnumEncodableExtension(
             } else {
                 let bindings = enumCase.associatedValues.map { "let \($0.encodedName)" }.joined(separator: ", ")
                 let fieldsEnumName = "\(expansion.fieldTypeName).\(capitalizedCaseName(enumCase.name))Fields"
-                let fieldRef = hasPeer
+                let fieldRef = peerInfo.multiFormat
                     ? "\(expansion.fieldTypeName)(.\(enumCase.name))"
                     : "\(expansion.fieldTypeName).\(enumCase.name)"
 
                 let encodeStatements = enumCase.associatedValues.map {
-                    if hasPeer {
+                    if peerInfo.multiFormat {
                         return "try valueEncoder.encode(field: \(fieldsEnumName)(.\($0.encodedName)), value: \($0.encodedName))"
                     } else {
                         return "try valueEncoder.encode(field: \(fieldsEnumName).\($0.encodedName), value: \($0.encodedName))"
@@ -1436,7 +1436,7 @@ func makeEnumDecodableExtension(
     for typeName: TokenSyntax,
     with cases: [EnumCaseInfo],
     expansion: some CodableExpansion,
-    hasPeer: Bool
+    peerInfo: PeerMacroInfo
 ) -> [ExtensionDeclSyntax] {
     // Generate the main decode method
     let mainDecl: DeclSyntax
@@ -1449,7 +1449,7 @@ func makeEnumDecodableExtension(
         }
         """
     } else {
-        let switchExpr = hasPeer ? "_codingField!.base" : "_codingField!"
+        let switchExpr = peerInfo.multiFormat ? "_codingField!.base" : "_codingField!"
 
         // Cases with associated values delegate to per-case decode methods on nested field enums.
         // Cases without associated values just return the case directly.

--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -65,14 +65,24 @@ protocol CodableExpansion: Equatable {
     /// The access level that the macro should use for codable protocol conformances
     var accessLevel: CodableDeclarationAccessLevel { get }
 
-    /// The name of the field protocol, which will differ depending on whether we're adding just encodable, just decodable, or both.
-    var fieldProtocolName: String { get }
-    
     /// The encodable/decodable/combined protocol names.
     var encodableProtocolName: String { get }
     var decodableProtocolName: String { get }
     var combinedProtocolName: String { get }
+
+    /// The name of the field protocol, which will differ depending on whether we're adding just encodable, just decodable, or both.
+    var fieldProtocolName: String { get }
     
+    /// The name of the generated CodingFields enum type. Each format uses a distinct name
+    /// so that multiple codable macros can be stacked on the same type without conflicts.
+    var fieldTypeName: String { get }
+
+    /// Whether the generated field enum should include key lookup functionality
+    var fieldTypeIncludesKeyLookup: Bool { get }
+    
+    /// Whether the generated field enum should include an "unknown" case
+    var fieldTypeIncludesUnknownCase: Bool { get }
+        
     /// The decoder parameter type in the decode function signature (without `inout`)
     var decoderType: String { get }
     
@@ -81,12 +91,6 @@ protocol CodableExpansion: Equatable {
     
     /// The encoder parameter type in the encode function signature (without `inout`)
     var encoderType: String { get }
-    
-    /// Whether the generated field enum should include key lookup functionality
-    var fieldTypeIncludesKeyLookup: Bool { get }
-    
-    /// Whether the generated field enum should include an "unknown" case
-    var fieldTypeIncludesUnknownCase: Bool { get }
 }
 
 extension CodableExpansion {
@@ -429,7 +433,7 @@ func makeCodingFieldsExtension (
 
         decl = """
         extension \(typeName) {
-            enum CodingFields: \(raw: expansion.fieldProtocolName) {
+            enum \(raw: expansion.fieldTypeName): \(raw: expansion.fieldProtocolName) {
                 \(raw: cases)
 
                 @_transparent
@@ -439,7 +443,7 @@ func makeCodingFieldsExtension (
                     }
                 }
 
-                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> \(raw: expansion.fieldTypeName) {
                     switch UTF8SpanComparator(key) {
                     \(raw: fieldForKeyCases)
                     default:
@@ -452,7 +456,7 @@ func makeCodingFieldsExtension (
     } else {
         decl = """
         extension \(typeName) {
-            enum CodingFields: \(raw: expansion.fieldProtocolName) {
+            enum \(raw: expansion.fieldTypeName): \(raw: expansion.fieldProtocolName) {
                 \(raw: cases)
 
                 @_transparent
@@ -520,8 +524,9 @@ func makeEncodableExtension(
         }
         """
     } else {
+        let fieldType = expansion.fieldTypeName
         let encodeStatements = properties.map {
-            "try structEncoder.encode(field: CodingFields.\($0.name), value: self.\($0.name))"
+            "try structEncoder.encode(field: \(fieldType).\($0.name), value: self.\($0.name))"
         }.joined(separator: "\n")
 
         let fieldCount = properties.count
@@ -608,9 +613,9 @@ func makeDecodableExtension(
             \(raw: accessLevelPrefix)static func decode(from decoder: inout \(raw: expansion.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
                 try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                     \(raw: varDeclarations)
-                    var _codingField: CodingFields?
+                    var _codingField: \(raw: expansion.fieldTypeName)?
                     try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(\(raw: expansion.fieldTypeName).self)
                     } andValue: { valueDecoder throws(CodingError.Decoding) in
                         switch _codingField! {
                         \(raw: switchCases)
@@ -756,7 +761,7 @@ func makeEnumCodingFieldsExtension(
 
         decl = """
         extension \(typeName) {
-        enum CodingFields: \(raw: expansion.fieldProtocolName) {
+        enum \(raw: expansion.fieldTypeName): \(raw: expansion.fieldProtocolName) {
         \(raw: joinedCases)
 
         @_transparent
@@ -766,7 +771,7 @@ func makeEnumCodingFieldsExtension(
             }
         }
 
-        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> \(raw: expansion.fieldTypeName) {
             switch UTF8SpanComparator(key) {
             \(raw: fieldForKeyCases)
             default:
@@ -779,7 +784,7 @@ func makeEnumCodingFieldsExtension(
     } else {
         decl = """
         extension \(typeName) {
-        enum CodingFields: \(raw: expansion.fieldProtocolName) {
+        enum \(raw: expansion.fieldTypeName): \(raw: expansion.fieldProtocolName) {
         \(raw: joinedCases)
 
         @_transparent
@@ -815,10 +820,10 @@ func makeEnumEncodableExtension(
     } else {
         switchCases = cases.map { enumCase -> String in
             if enumCase.associatedValues.isEmpty {
-                return "case .\(enumCase.name):\ntry encoder.encodeEnumCase(CodingFields.\(enumCase.name))"
+                return "case .\(enumCase.name):\ntry encoder.encodeEnumCase(\(expansion.fieldTypeName).\(enumCase.name))"
             } else {
                 let bindings = enumCase.associatedValues.map { "let \($0.encodedName)" }.joined(separator: ", ")
-                let fieldsEnumName = "CodingFields.\(capitalizedCaseName(enumCase.name))Fields"
+                let fieldsEnumName = "\(expansion.fieldTypeName).\(capitalizedCaseName(enumCase.name))Fields"
 
                 let encodeStatements = enumCase.associatedValues.map {
                     "try valueEncoder.encode(field: \(fieldsEnumName).\($0.encodedName), value: \($0.encodedName))"
@@ -826,7 +831,7 @@ func makeEnumEncodableExtension(
 
                 return """
                 case .\(enumCase.name)(\(bindings)):
-                try encoder.encodeEnumCase(CodingFields.\(enumCase.name), associatedValueCount: \(enumCase.associatedValues.count)) { valueEncoder throws(CodingError.Encoding) in
+                try encoder.encodeEnumCase(\(expansion.fieldTypeName).\(enumCase.name), associatedValueCount: \(enumCase.associatedValues.count)) { valueEncoder throws(CodingError.Encoding) in
                 \(encodeStatements)
                 }
                 """
@@ -878,7 +883,7 @@ func makeEnumDecodableExtension(
         // Cases without associated values just return the case directly.
         let caseDecodeStatements = cases.map { enumCase -> String in
             if enumCase.hasAssociatedValues {
-                let fieldsEnumName = "CodingFields.\(capitalizedCaseName(enumCase.name))Fields"
+                let fieldsEnumName = "\(expansion.fieldTypeName).\(capitalizedCaseName(enumCase.name))Fields"
                 return "case .\(enumCase.name): try \(fieldsEnumName).decode(from: &valuesDecoder)"
             } else {
                 return "case .\(enumCase.name): .\(enumCase.name)"
@@ -888,9 +893,9 @@ func makeEnumDecodableExtension(
         mainDecl = """
         extension \(typeName): \(raw: expansion.decodableProtocolName) {
             static func decode(from decoder: inout \(raw: expansion.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
-                var _codingField: CodingFields?
+                var _codingField: \(raw: expansion.fieldTypeName)?
                 return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                    _codingField = try fieldDecoder.decode(CodingFields.self)
+                    _codingField = try fieldDecoder.decode(\(raw: expansion.fieldTypeName).self)
                 } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                     return switch _codingField! {
                     \(raw: caseDecodeStatements)

--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -54,14 +54,30 @@ enum CodableExpansionType {
     case encodingOnly
     case decodingOnly
     case both
+    
+    /// Whether the generated field enum should include key lookup functionality
+    var requiresCodingFieldLookup: Bool {
+        switch self {
+        case .encodingOnly: false
+        default: true
+        }
+    }
+
+    /// Whether the generated field enum should include an "unknown" case by default
+    var defaultCodingFieldIncludesUnknownCase: Bool {
+        switch self {
+        case .encodingOnly: false
+        default: true
+        }
+    }
 }
 
 /// Represents the kind of coding fields to generate
 protocol CodableExpansion: Equatable {
-    
+
     /// Describes which set of protocol(s) we're expanding.
     var type: CodableExpansionType { get }
-    
+
     /// The access level that the macro should use for codable protocol conformances
     var accessLevel: CodableDeclarationAccessLevel { get }
 
@@ -69,47 +85,135 @@ protocol CodableExpansion: Equatable {
     var encodableProtocolName: String { get }
     var decodableProtocolName: String { get }
     var combinedProtocolName: String { get }
-
-    /// The name of the field protocol, which will differ depending on whether we're adding just encodable, just decodable, or both.
-    var fieldProtocolName: String { get }
     
-    /// The name of the generated CodingFields enum type. Each format uses a distinct name
-    /// so that multiple codable macros can be stacked on the same type without conflicts.
+    /// The protocol names to use for CodingFields
+    var encodableFieldProtocolName: String { get }
+    var decodableFieldProtocolName: String { get }
+    var combinedFieldProtocolName: String { get }
+
+    /// The name of the generated CodingFields type used in encode/decode references.
     var fieldTypeName: String { get }
 
-    /// Whether the generated field enum should include key lookup functionality
-    var fieldTypeIncludesKeyLookup: Bool { get }
-    
     /// Whether the generated field enum should include an "unknown" case
-    var fieldTypeIncludesUnknownCase: Bool { get }
-        
+    func fieldTypeIncludesUnknownCase(withExpansionTypeOverride: CodableExpansionType?) -> Bool
+
     /// The decoder parameter type in the decode function signature (without `inout`)
     var decoderType: String { get }
-    
+
     /// The struct decoder type for per-case decode methods (e.g. "some JSONDictionaryDecoder & ~Escapable")
     var structDecoderType: String { get }
-    
+
     /// The encoder parameter type in the encode function signature (without `inout`)
     var encoderType: String { get }
 }
 
 extension CodableExpansion {
-    var fieldTypeIncludesKeyLookup: Bool {
-        switch self.type {
-        case .encodingOnly: false
-        default: true
+    var ownMacroNames: Set<String> {
+        [combinedProtocolName, encodableProtocolName, decodableProtocolName]
+    }
+    
+    func protocolName(for type: CodableExpansionType) -> String {
+        switch type {
+        case .both: combinedProtocolName
+        case .encodingOnly: encodableProtocolName
+        case .decodingOnly: decodableProtocolName
         }
     }
     
-    var fieldTypeIncludesUnknownCase: Bool {
-        switch self.type {
-        case .encodingOnly: false
-        default: true
+    var currentProtocolName: String {
+        protocolName(for: self.type)
+    }
+    
+    func combinesIntoBidirectionalCodable(with otherProtocolName: String) -> Bool {
+        if type == .both || otherProtocolName == combinedProtocolName {
+            return true
         }
+        return switch (currentProtocolName, otherProtocolName) {
+        case (encodableProtocolName, decodableProtocolName), (decodableProtocolName, encodableProtocolName): true
+        default: false
+        }
+    }
+    
+    func fieldTypeProtocolName(forExpansionType expansionType: CodableExpansionType) -> String {
+        switch expansionType {
+        case .encodingOnly: encodableFieldProtocolName
+        case .decodingOnly: decodableFieldProtocolName
+        case .both: combinedFieldProtocolName
+        }
+    }
+    func fieldTypeIncludesUnknownCase() -> Bool {
+        self.fieldTypeIncludesUnknownCase(withExpansionTypeOverride: nil)
+    }
+    
+    func fieldTypeIncludesUnknownCase(withExpansionTypeOverride override: CodableExpansionType?) -> Bool {
+        (override ?? self.type).defaultCodingFieldIncludesUnknownCase
     }
 }
 
-// MARK: - Codable Type Declaration
+// MARK: - Peer Macro Detection
+
+/// Returns true if the given attribute name looks like a codable macro
+/// (ends in "Codable", "Encodable", or "Decodable").
+private func isCodableMacroName(_ name: String) -> Bool {
+    name.hasSuffix("Codable") || name.hasSuffix("Encodable") || name.hasSuffix("Decodable")
+}
+
+/// Encapsulates the results of peer macro detection for a codable macro expansion.
+struct PeerMacroInfo {
+    /// Whether a codable macro from a DIFFERENT format is present (e.g. @CommonCodable on a @JSONCodable type).
+    let multiFormat: Bool
+    /// Whether this macro is the first codable macro attribute lexically on the declaration.
+    let isFirst: Bool
+    /// When there are matched peer macros (e.g. @JSONDecodable alongside @JSONEncodable), this overrides the default expansion for the field types to .both
+    let codingFieldsExpansionOverride: CodableExpansionType?
+}
+
+/// Computes all peer macro detection info for the given node, declaration, and expansion.
+func detectPeerMacros(
+    node: AttributeSyntax,
+    declaration: some DeclGroupSyntax,
+    expansion: some CodableExpansion
+) -> PeerMacroInfo {
+    let nodeId = node.attributeName.as(IdentifierTypeSyntax.self)
+    let nodeName = nodeId?.name.text
+
+    var multiFormat = false
+    var isFirst = true
+    var hasSameFormatPeer = false
+    var foundFirstCodable = false
+
+    for element in declaration.attributes {
+        guard let attr = element.as(AttributeSyntax.self),
+              let id = attr.attributeName.as(IdentifierTypeSyntax.self) else { continue }
+        let name = id.name.text
+
+        guard isCodableMacroName(name) else { continue }
+
+        // Different-format peer detection
+        if !expansion.ownMacroNames.contains(name) {
+            multiFormat = true
+        }
+
+        // isFirst: is our node the first codable macro?
+        if !foundFirstCodable {
+            foundFirstCodable = true
+            if name != nodeName {
+                isFirst = false
+            }
+        }
+
+        // Same-format peer detection (only relevant for non-.both expansions)
+        if expansion.type != .both && expansion.combinesIntoBidirectionalCodable(with: name) {
+            hasSameFormatPeer = true
+        }
+    }
+
+    return PeerMacroInfo(
+        multiFormat: multiFormat,
+        isFirst: isFirst,
+        codingFieldsExpansionOverride: hasSameFormatPeer ? .both : nil
+    )
+}
 
 /// Abstracts over struct and enum declarations for codable macro expansion.
 /// Validates the declaration, extracts the relevant data, and provides methods
@@ -150,37 +254,35 @@ enum CodableTypeDeclaration {
         }
     }
 
-    func makeCodingFieldsExtension(expansion: some CodableExpansion) -> [ExtensionDeclSyntax] {
+    func makeCodingFieldsExtension(expansion: some CodableExpansion, peers: PeerMacroInfo) -> [ExtensionDeclSyntax] {
+        switch self {
+        case .structDecl(let typeName, let properties):
+            return NewCodableMacros.makeCodingFieldsExtension(for: typeName, from: properties, expansion: expansion, peers: peers)
+        case .enumDecl(let typeName, let cases):
+            return makeEnumCodingFieldsExtension(for: typeName, from: cases, expansion: expansion, peers: peers)
+        }
+    }
+
+    func makeEncodableExtension(expansion: some CodableExpansion, peers: PeerMacroInfo) -> [ExtensionDeclSyntax] {
         let ext: ExtensionDeclSyntax?
         switch self {
         case .structDecl(let typeName, let properties):
-            ext = NewCodableMacros.makeCodingFieldsExtension(for: typeName, from: properties, expansion: expansion)
+            ext = NewCodableMacros.makeEncodableExtension(for: typeName, with: properties, expansion: expansion, hasPeer: peers.multiFormat)
         case .enumDecl(let typeName, let cases):
-            ext = makeEnumCodingFieldsExtension(for: typeName, from: cases, expansion: expansion)
+            ext = makeEnumEncodableExtension(for: typeName, with: cases, expansion: expansion, hasPeer: peers.multiFormat)
         }
         return [ext].compactMap { $0 }
     }
 
-    func makeEncodableExtension(expansion: some CodableExpansion) -> [ExtensionDeclSyntax] {
-        let ext: ExtensionDeclSyntax?
+    func makeDecodableExtension(expansion: some CodableExpansion, peers: PeerMacroInfo) -> [ExtensionDeclSyntax] {
         switch self {
         case .structDecl(let typeName, let properties):
-            ext = NewCodableMacros.makeEncodableExtension(for: typeName, with: properties, expansion: expansion)
-        case .enumDecl(let typeName, let cases):
-            ext = makeEnumEncodableExtension(for: typeName, with: cases, expansion: expansion)
-        }
-        return [ext].compactMap { $0 }
-    }
-
-    func makeDecodableExtension(expansion: some CodableExpansion) -> [ExtensionDeclSyntax] {
-        switch self {
-        case .structDecl(let typeName, let properties):
-            if let ext = NewCodableMacros.makeDecodableExtension(for: typeName, with: properties, expansion: expansion) {
+            if let ext = NewCodableMacros.makeDecodableExtension(for: typeName, with: properties, expansion: expansion, hasPeer: peers.multiFormat) {
                 return [ext]
             }
             return []
         case .enumDecl(let typeName, let cases):
-            return makeEnumDecodableExtension(for: typeName, with: cases, expansion: expansion)
+            return makeEnumDecodableExtension(for: typeName, with: cases, expansion: expansion, hasPeer: peers.multiFormat)
         }
     }
 }
@@ -400,26 +502,73 @@ func defaultValueExpression(from attributes: AttributeListSyntax) -> String? {
 
 // MARK: - Coding Fields Generation
 
-/// Unified function for generating coding fields with any expansion kind
-func makeCodingFieldsExtension (
+/// Unified function for generating coding fields with any expansion kind.
+/// When `peers.multiFormat` is true and `peers.isFirst` is true, generates a base CodingFields enum + wrapper struct.
+/// When `peers.multiFormat` is true and `peers.isFirst` is false, generates only the wrapper struct.
+/// When `peers.multiFormat` is false, generates the current format-specific enum directly.
+func makeCodingFieldsExtension(
     for typeName: TokenSyntax,
     from properties: [DetailedStoredProperty],
-    expansion: some CodableExpansion
-) -> ExtensionDeclSyntax? {
+    expansion: some CodableExpansion,
+    peers: PeerMacroInfo
+) -> [ExtensionDeclSyntax] {
     if properties.isEmpty {
-        return nil
+        return []
     }
-    
-    let casesList = properties.map { "case \($0.name)" } + (expansion.fieldTypeIncludesUnknownCase ? ["case unknown"] : [])
+
+    if !peers.multiFormat {
+        // Single macro (or same-format pair): only the first generates fields.
+        if !peers.isFirst {
+            return []
+        }
+        // Generate format-specific enum directly.
+        if let ext = makeSingleFormatCodingFieldsEnum(for: typeName, from: properties, expansion: expansion, codingFieldsExpansionOverride: peers.codingFieldsExpansionOverride) {
+            return [ext]
+        }
+        return []
+    }
+
+    // Dual macro (different format): generate base + wrapper
+    var results: [ExtensionDeclSyntax] = []
+
+    if peers.isFirst {
+        if let base = makeBaseCodingFieldsEnum(for: typeName, from: properties, expansion: expansion) {
+            results.append(base)
+        }
+    }
+
+    if let wrapper = makeWrapperFieldsStruct(for: typeName, from: properties, expansion: expansion) {
+        results.append(wrapper)
+    }
+
+    return results
+}
+
+/// Generates the original format-specific enum (used when no peer macro is present).
+/// When `codingFieldsExpansionOverride` is `.both`, generates as if this were a bidirectional expansion
+/// (includes unknown case, key lookup, and combined protocol conformance).
+/// This handles the case where @JSONEncodable + @JSONDecodable are used together.
+private func makeSingleFormatCodingFieldsEnum(
+    for typeName: TokenSyntax,
+    from properties: [DetailedStoredProperty],
+    expansion: some CodableExpansion,
+    codingFieldsExpansionOverride: CodableExpansionType? = nil
+) -> ExtensionDeclSyntax? {
+    let includesUnknown = expansion.fieldTypeIncludesUnknownCase(withExpansionTypeOverride: codingFieldsExpansionOverride)
+    let effectiveFieldExpansionType = codingFieldsExpansionOverride ?? expansion.type
+    let includesKeyLookup = effectiveFieldExpansionType.requiresCodingFieldLookup
+    let protocolName = expansion.fieldTypeProtocolName(forExpansionType: effectiveFieldExpansionType)
+
+    let casesList = properties.map { "case \($0.name)" } + (includesUnknown ? ["case unknown"] : [])
     let cases = casesList.joined(separator: "\n")
 
     let switchCasesList = properties.map {
         "case .\($0.name): \"\($0.key)\""
-    } + (expansion.fieldTypeIncludesUnknownCase ? ["case .unknown: fatalError()"] : [])
+    } + (includesUnknown ? ["case .unknown: fatalError()"] : [])
     let joinedSwitchCases = switchCasesList.joined(separator: "\n")
 
     let decl: DeclSyntax
-    if expansion.fieldTypeIncludesKeyLookup {
+    if includesKeyLookup {
         let fieldForKeyCasesList = properties.flatMap { prop -> [String] in
             var cases = ["case \"\(prop.key)\": .\(prop.name)"]
             for alias in prop.aliases {
@@ -429,11 +578,11 @@ func makeCodingFieldsExtension (
         }
         let fieldForKeyCases = fieldForKeyCasesList.joined(separator: "\n")
 
-        let defaultCase = expansion.fieldTypeIncludesUnknownCase ? ".unknown" : "throw CodingError.unknownKey(key)"
+        let defaultCase = includesUnknown ? ".unknown" : "throw CodingError.unknownKey(key)"
 
         decl = """
         extension \(typeName) {
-            enum \(raw: expansion.fieldTypeName): \(raw: expansion.fieldProtocolName) {
+            enum \(raw: expansion.fieldTypeName): \(raw: protocolName) {
                 \(raw: cases)
 
                 @_transparent
@@ -456,7 +605,7 @@ func makeCodingFieldsExtension (
     } else {
         decl = """
         extension \(typeName) {
-            enum \(raw: expansion.fieldTypeName): \(raw: expansion.fieldProtocolName) {
+            enum \(raw: expansion.fieldTypeName): \(raw: protocolName) {
                 \(raw: cases)
 
                 @_transparent
@@ -464,6 +613,102 @@ func makeCodingFieldsExtension (
                     switch self {
                     \(raw: joinedSwitchCases)
                     }
+                }
+            }
+        }
+        """
+    }
+    return decl.as(ExtensionDeclSyntax.self)
+}
+
+/// Generates the shared base CodingFields enum (cases + staticString + field(for:comparator:)).
+/// The base always includes the `unknown` case and `field(for:comparator:)` since the peer macro may need decoding.
+private func makeBaseCodingFieldsEnum(
+    for typeName: TokenSyntax,
+    from properties: [DetailedStoredProperty],
+    expansion: some CodableExpansion
+) -> ExtensionDeclSyntax? {
+    // Base always includes unknown and key lookup since the peer macro may need them.
+    let casesList = properties.map { "case \($0.name)" } + ["case unknown"]
+    let cases = casesList.joined(separator: "\n")
+
+    let switchCasesList = properties.map {
+        "case .\($0.name): \"\($0.key)\""
+    } + ["case .unknown: fatalError()"]
+    let joinedSwitchCases = switchCasesList.joined(separator: "\n")
+
+    let fieldForKeyCasesList = properties.flatMap { prop -> [String] in
+        var cases = ["case \"\(prop.key)\": .\(prop.name)"]
+        for alias in prop.aliases {
+            cases.append("case \"\(alias)\": .\(prop.name)")
+        }
+        return cases
+    }
+    let fieldForKeyCases = fieldForKeyCasesList.joined(separator: "\n")
+
+    let decl: DeclSyntax = """
+    extension \(typeName) {
+        enum CodingFields {
+            \(raw: cases)
+
+            @_transparent
+            var staticString: StaticString {
+                switch self {
+                \(raw: joinedSwitchCases)
+                }
+            }
+
+            @inline(__always)
+            static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+                switch comparator {
+                \(raw: fieldForKeyCases)
+                default:
+                    .unknown
+                }
+            }
+        }
+    }
+    """
+    return decl.as(ExtensionDeclSyntax.self)
+}
+
+/// Generates a format-specific wrapper struct that delegates to the base CodingFields enum.
+private func makeWrapperFieldsStruct(
+    for typeName: TokenSyntax,
+    from properties: [DetailedStoredProperty],
+    expansion: some CodableExpansion
+) -> ExtensionDeclSyntax? {
+    let fieldTypeProtocolName = expansion.fieldTypeProtocolName(forExpansionType: expansion.type)
+    let decl: DeclSyntax
+    if expansion.type.requiresCodingFieldLookup {
+        decl = """
+        extension \(typeName) {
+            struct \(raw: expansion.fieldTypeName): \(raw: fieldTypeProtocolName) {
+                var base: CodingFields
+                init(_ base: CodingFields) { self.base = base }
+
+                @_transparent
+                var staticString: StaticString {
+                    base.staticString
+                }
+
+                @inline(__always)
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> \(raw: expansion.fieldTypeName) {
+                    .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
+                }
+            }
+        }
+        """
+    } else {
+        decl = """
+        extension \(typeName) {
+            struct \(raw: expansion.fieldTypeName): \(raw: fieldTypeProtocolName) {
+                var base: CodingFields
+                init(_ base: CodingFields) { self.base = base }
+
+                @_transparent
+                var staticString: StaticString {
+                    base.staticString
                 }
             }
         }
@@ -510,7 +755,8 @@ enum SharedMacroDiagnostic: DiagnosticMessage {
 func makeEncodableExtension(
     for typeName: TokenSyntax,
     with properties: [DetailedStoredProperty],
-    expansion: some CodableExpansion
+    expansion: some CodableExpansion,
+    hasPeer: Bool
 ) -> ExtensionDeclSyntax? {
     let accessLevelPrefix = expansion.accessLevel.inlineDeclPrefix
     let extensionDecl: DeclSyntax
@@ -525,9 +771,16 @@ func makeEncodableExtension(
         """
     } else {
         let fieldType = expansion.fieldTypeName
-        let encodeStatements = properties.map {
-            "try structEncoder.encode(field: \(fieldType).\($0.name), value: self.\($0.name))"
-        }.joined(separator: "\n")
+        let encodeStatements: String
+        if hasPeer {
+            encodeStatements = properties.map {
+                "try structEncoder.encode(field: \(fieldType)(.\($0.name)), value: self.\($0.name))"
+            }.joined(separator: "\n")
+        } else {
+            encodeStatements = properties.map {
+                "try structEncoder.encode(field: \(fieldType).\($0.name), value: self.\($0.name))"
+            }.joined(separator: "\n")
+        }
 
         let fieldCount = properties.count
 
@@ -550,7 +803,8 @@ func makeEncodableExtension(
 func makeDecodableExtension(
     for typeName: TokenSyntax,
     with properties: [DetailedStoredProperty],
-    expansion: some CodableExpansion
+    expansion: some CodableExpansion,
+    hasPeer: Bool
 ) -> ExtensionDeclSyntax? {
     let accessLevelPrefix = expansion.accessLevel.inlineDeclPrefix
     let decl: DeclSyntax
@@ -608,6 +862,8 @@ func makeDecodableExtension(
             """
         }
 
+        let switchExpr = hasPeer ? "_codingField!.base" : "_codingField!"
+
         decl = """
         extension \(typeName): \(raw: expansion.decodableProtocolName) {
             \(raw: accessLevelPrefix)static func decode(from decoder: inout \(raw: expansion.decoderType)) throws(CodingError.Decoding) -> \(typeName) {
@@ -617,7 +873,7 @@ func makeDecodableExtension(
                     try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                         _codingField = try fieldDecoder.decode(\(raw: expansion.fieldTypeName).self)
                     } andValue: { valueDecoder throws(CodingError.Decoding) in
-                        switch _codingField! {
+                        switch \(raw: switchExpr) {
                         \(raw: switchCases)
                         case .unknown: break
                         }
@@ -634,16 +890,57 @@ func makeDecodableExtension(
 
 // MARK: - Enum Coding Fields Generation
 
-/// Generates the CodingFields enum extension for an enum type's case names,
+/// Generates the CodingFields extension(s) for an enum type's case names,
 /// along with per-case field enums for cases with associated values.
 func makeEnumCodingFieldsExtension(
     for typeName: TokenSyntax,
     from cases: [EnumCaseInfo],
     expansion: some CodableExpansion,
-) -> ExtensionDeclSyntax? {
+    peers: PeerMacroInfo
+) -> [ExtensionDeclSyntax] {
     if cases.isEmpty {
-        return nil
+        return []
     }
+
+    if !peers.multiFormat {
+        // Single macro (or same-format pair): only the first generates fields.
+        if !peers.isFirst {
+            return []
+        }
+        // Generate format-specific enum directly.
+        if let ext = makeSingleFormatEnumCodingFields(for: typeName, from: cases, expansion: expansion, codingFieldsExpansionOverride: peers.codingFieldsExpansionOverride) {
+            return [ext]
+        }
+        return []
+    }
+
+    // Dual macro (different format): generate base + wrapper
+    var results: [ExtensionDeclSyntax] = []
+
+    if peers.isFirst {
+        if let base = makeBaseEnumCodingFields(for: typeName, from: cases, expansion: expansion) {
+            results.append(base)
+        }
+    }
+
+    if let wrapper = makeEnumWrapperFieldsStruct(for: typeName, from: cases, expansion: expansion) {
+        results.append(wrapper)
+    }
+
+    return results
+}
+
+/// Generates the original format-specific enum CodingFields for an enum type (single macro case).
+/// When `codingFieldsExpansionOverride` is `.both`, generates as if this were a bidirectional expansion.
+private func makeSingleFormatEnumCodingFields(
+    for typeName: TokenSyntax,
+    from cases: [EnumCaseInfo],
+    expansion: some CodableExpansion,
+    codingFieldsExpansionOverride: CodableExpansionType? = nil
+) -> ExtensionDeclSyntax? {
+    let effectiveFieldExpansionType = codingFieldsExpansionOverride ?? expansion.type
+    let includesKeyLookup = (codingFieldsExpansionOverride ?? expansion.type).defaultCodingFieldIncludesUnknownCase
+    let protocolName = expansion.fieldTypeProtocolName(forExpansionType: effectiveFieldExpansionType)
 
     let casesList = cases.map { "case \($0.name)" }
     let joinedCases = casesList.joined(separator: "\n")
@@ -654,7 +951,224 @@ func makeEnumCodingFieldsExtension(
     let joinedSwitchCases = switchCasesList.joined(separator: "\n")
 
     // Generate per-case field enums for cases with associated values
+    let perCaseFieldEnums = generatePerCaseFieldEnums(for: typeName, from: cases, expansion: expansion, codingFieldsExpansionOverride: codingFieldsExpansionOverride)
+    let perCaseSection = perCaseFieldEnums.isEmpty ? "" : "\n\n\(perCaseFieldEnums)"
+
+    let decl: DeclSyntax
+    if includesKeyLookup {
+        let fieldForKeyCasesList = cases.flatMap { c -> [String] in
+            var entries = ["case \"\(c.key)\": .\(c.name)"]
+            for alias in c.aliases {
+                entries.append("case \"\(alias)\": .\(c.name)")
+            }
+            return entries
+        }
+        let fieldForKeyCases = fieldForKeyCasesList.joined(separator: "\n")
+
+        decl = """
+        extension \(typeName) {
+        enum \(raw: expansion.fieldTypeName): \(raw: protocolName) {
+        \(raw: joinedCases)
+
+        @_transparent
+        var staticString: StaticString {
+            switch self {
+            \(raw: joinedSwitchCases)
+            }
+        }
+
+        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> \(raw: expansion.fieldTypeName) {
+            switch UTF8SpanComparator(key) {
+            \(raw: fieldForKeyCases)
+            default:
+                throw CodingError.unknownKey(key)
+            }
+        }\(raw: perCaseSection)
+        }
+        }
+        """
+    } else {
+        decl = """
+        extension \(typeName) {
+        enum \(raw: expansion.fieldTypeName): \(raw: protocolName) {
+        \(raw: joinedCases)
+
+        @_transparent
+        var staticString: StaticString {
+            switch self {
+            \(raw: joinedSwitchCases)
+            }
+        }\(raw: perCaseSection)
+        }
+        }
+        """
+    }
+    return decl.as(ExtensionDeclSyntax.self)
+}
+
+/// Generates the shared base CodingFields enum for an enum type (with per-case field enums).
+/// The base always includes `field(for:comparator:)` since the peer macro may need decoding.
+private func makeBaseEnumCodingFields(
+    for typeName: TokenSyntax,
+    from cases: [EnumCaseInfo],
+    expansion: some CodableExpansion
+) -> ExtensionDeclSyntax? {
+    let casesList = cases.map { "case \($0.name)" }
+    let joinedCases = casesList.joined(separator: "\n")
+
+    let switchCasesList = cases.map {
+        "case .\($0.name): \"\($0.key)\""
+    }
+    let joinedSwitchCases = switchCasesList.joined(separator: "\n")
+
+    let fieldForKeyCasesList = cases.flatMap { c -> [String] in
+        var entries = ["case \"\(c.key)\": .\(c.name)"]
+        for alias in c.aliases {
+            entries.append("case \"\(alias)\": .\(c.name)")
+        }
+        return entries
+    }
+    let fieldForKeyCases = fieldForKeyCasesList.joined(separator: "\n")
+
+    // Generate base per-case field enums for cases with associated values
+    let basePerCaseFieldEnums = generateBasePerCaseFieldEnums(for: typeName, from: cases)
+    let perCaseSection = basePerCaseFieldEnums.isEmpty ? "" : "\n\n\(basePerCaseFieldEnums)"
+
+    let decl: DeclSyntax = """
+    extension \(typeName) {
+    enum CodingFields {
+    \(raw: joinedCases)
+
+    @_transparent
+    var staticString: StaticString {
+        switch self {
+        \(raw: joinedSwitchCases)
+        }
+    }
+
+    @inline(__always)
+    static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+        switch comparator {
+        \(raw: fieldForKeyCases)
+        default:
+            throw CodingError.unknownKey(key)
+        }
+    }\(raw: perCaseSection)
+    }
+    }
+    """
+    return decl.as(ExtensionDeclSyntax.self)
+}
+
+/// Generates base per-case field enums for enum cases with associated values.
+/// These live inside the shared `CodingFields` enum and contain cases, `staticString`,
+/// and a generic `field(for:comparator:)` method.
+private func generateBasePerCaseFieldEnums(
+    for typeName: TokenSyntax,
+    from cases: [EnumCaseInfo]
+) -> String {
     let casesWithAssociatedValues = cases.filter { $0.hasAssociatedValues }
+    if casesWithAssociatedValues.isEmpty { return "" }
+
+    let perCaseFieldEnums = casesWithAssociatedValues.map { enumCase -> String in
+        let fieldsEnumName = "\(capitalizedCaseName(enumCase.name))Fields"
+        let fieldCases = enumCase.associatedValues.map { "case \($0.encodedName)" }.joined(separator: "\n")
+        let fieldSwitchCases = enumCase.associatedValues.map {
+            "case .\($0.encodedName): \"\($0.encodedName)\""
+        }.joined(separator: "\n")
+
+        let fieldForKeyCases = enumCase.associatedValues.map {
+            "case \"\($0.encodedName)\": .\($0.encodedName)"
+        }.joined(separator: "\n")
+
+        return """
+        enum \(fieldsEnumName) {
+        \(fieldCases)
+
+        @_transparent
+        var staticString: StaticString {
+            switch self {
+            \(fieldSwitchCases)
+            }
+        }
+
+        @inline(__always)
+        static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> \(fieldsEnumName) {
+            switch comparator {
+            \(fieldForKeyCases)
+            default:
+                throw CodingError.unknownKey(key)
+            }
+        }
+        }
+        """
+    }.joined(separator: "\n\n")
+    return perCaseFieldEnums
+}
+
+/// Generates a format-specific wrapper struct for an enum type (with per-case wrapper structs).
+private func makeEnumWrapperFieldsStruct(
+    for typeName: TokenSyntax,
+    from cases: [EnumCaseInfo],
+    expansion: some CodableExpansion
+) -> ExtensionDeclSyntax? {
+    // Generate per-case field wrapper structs that live inside the wrapper struct
+    let fieldProtocolName = expansion.fieldTypeProtocolName(forExpansionType: expansion.type)
+    let perCaseFieldWrappers = generatePerCaseFieldWrapperStructs(for: typeName, from: cases, expansion: expansion)
+    let perCaseSection = perCaseFieldWrappers.isEmpty ? "" : "\n\n\(perCaseFieldWrappers)"
+
+    let decl: DeclSyntax
+    if expansion.type.requiresCodingFieldLookup {
+        decl = """
+        extension \(typeName) {
+        struct \(raw: expansion.fieldTypeName): \(raw: fieldProtocolName) {
+        var base: CodingFields
+        init(_ base: CodingFields) { self.base = base }
+
+        @_transparent
+        var staticString: StaticString {
+            base.staticString
+        }
+
+        @inline(__always)
+        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> \(raw: expansion.fieldTypeName) {
+            .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
+        }\(raw: perCaseSection)
+        }
+        }
+        """
+    } else {
+        decl = """
+        extension \(typeName) {
+        struct \(raw: expansion.fieldTypeName): \(raw: fieldProtocolName) {
+        var base: CodingFields
+        init(_ base: CodingFields) { self.base = base }
+
+        @_transparent
+        var staticString: StaticString {
+            base.staticString
+        }\(raw: perCaseSection)
+        }
+        }
+        """
+    }
+    return decl.as(ExtensionDeclSyntax.self)
+}
+
+/// Generates per-case nested field enums for enum cases with associated values.
+/// Returns content with minimal indentation (suitable for insertion into a DeclSyntax literal
+/// where the enum is at 0-relative indentation). The caller can add extra indentation if needed.
+private func generatePerCaseFieldEnums(
+    for typeName: TokenSyntax,
+    from cases: [EnumCaseInfo],
+    expansion: some CodableExpansion,
+    codingFieldsExpansionOverride: CodableExpansionType? = nil
+) -> String {
+    let casesWithAssociatedValues = cases.filter { $0.hasAssociatedValues }
+    let effectiveFieldExpansionType = codingFieldsExpansionOverride ?? expansion.type
+    let includesKeyLookup = effectiveFieldExpansionType.requiresCodingFieldLookup
+    let includesDecode = effectiveFieldExpansionType != .encodingOnly
+    let protocolName = expansion.fieldTypeProtocolName(forExpansionType: effectiveFieldExpansionType)
     let perCaseFieldEnums = casesWithAssociatedValues.map { enumCase -> String in
         let fieldsEnumName = "\(capitalizedCaseName(enumCase.name))Fields"
         let fieldCases = enumCase.associatedValues.map { "case \($0.encodedName)" }.joined(separator: "\n")
@@ -663,7 +1177,7 @@ func makeEnumCodingFieldsExtension(
         }.joined(separator: "\n")
 
         let decodeSection: String
-        if expansion.type != .encodingOnly {
+        if includesDecode {
             let varDeclarations = enumCase.associatedValues.map {
                 "var \($0.encodedName): \($0.typeName)?"
             }.joined(separator: "\n        ")
@@ -705,13 +1219,13 @@ func makeEnumCodingFieldsExtension(
             decodeSection = ""
         }
 
-        if expansion.fieldTypeIncludesKeyLookup {
+        if includesKeyLookup {
             let fieldForKeyCases = enumCase.associatedValues.map {
                 "case \"\($0.encodedName)\": .\($0.encodedName)"
             }.joined(separator: "\n")
 
             return """
-            enum \(fieldsEnumName): \(expansion.fieldProtocolName) {
+            enum \(fieldsEnumName): \(protocolName) {
                 \(fieldCases)
 
                 @_transparent
@@ -732,7 +1246,7 @@ func makeEnumCodingFieldsExtension(
             """
         } else {
             return """
-            enum \(fieldsEnumName): \(expansion.fieldProtocolName) {
+            enum \(fieldsEnumName): \(protocolName) {
                 \(fieldCases)
 
                 @_transparent
@@ -745,59 +1259,100 @@ func makeEnumCodingFieldsExtension(
             """
         }
     }.joined(separator: "\n\n")
+    return perCaseFieldEnums
+}
 
-    let perCaseSection = perCaseFieldEnums.isEmpty ? "" : "\n\n\(perCaseFieldEnums)"
+/// Generates per-case wrapper structs for enum cases with associated values (multi-format case).
+/// These wrap the base `CodingFields.XxxFields` enum and add format-specific `decode(from:)`.
+private func generatePerCaseFieldWrapperStructs(
+    for typeName: TokenSyntax,
+    from cases: [EnumCaseInfo],
+    expansion: some CodableExpansion
+) -> String {
+    let casesWithAssociatedValues = cases.filter { $0.hasAssociatedValues }
+    if casesWithAssociatedValues.isEmpty { return "" }
 
-    let decl: DeclSyntax
-    if expansion.fieldTypeIncludesKeyLookup {
-        let fieldForKeyCasesList = cases.flatMap { c -> [String] in
-            var entries = ["case \"\(c.key)\": .\(c.name)"]
-            for alias in c.aliases {
-                entries.append("case \"\(alias)\": .\(c.name)")
+    let includesDecode = expansion.type != .encodingOnly
+    let protocolName = expansion.fieldTypeProtocolName(forExpansionType: expansion.type)
+
+    let perCaseFieldWrappers = casesWithAssociatedValues.map { enumCase -> String in
+        let fieldsEnumName = "\(capitalizedCaseName(enumCase.name))Fields"
+
+        let decodeSection: String
+        if includesDecode {
+            let varDeclarations = enumCase.associatedValues.map {
+                "var \($0.encodedName): \($0.typeName)?"
+            }.joined(separator: "\n        ")
+
+            let decodeSwitchCases = enumCase.associatedValues.map {
+                "case .\($0.encodedName): \($0.encodedName) = try valueDecoder.decode(\($0.typeName).self)"
+            }.joined(separator: "\n            ")
+
+            let guardLetNames = enumCase.associatedValues.map { "let \($0.encodedName)" }.joined(separator: ", ")
+
+            let args = enumCase.associatedValues.map { param -> String in
+                if param.label != nil {
+                    return "\(param.encodedName): \(param.encodedName)"
+                } else {
+                    return "\(param.encodedName)"
+                }
+            }.joined(separator: ", ")
+
+            decodeSection = """
+
+
+                static func decode(from decoder: inout \(expansion.structDecoderType)) throws(CodingError.Decoding) -> \(typeName) {
+                    \(varDeclarations)
+                    var _field: \(fieldsEnumName)?
+                    try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                        _field = try fieldDecoder.decode(\(fieldsEnumName).self)
+                    } andValue: { valueDecoder throws(CodingError.Decoding) in
+                        switch _field!.base {
+                        \(decodeSwitchCases)
+                        }
+                    }
+                    guard \(guardLetNames) else {
+                        throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                    }
+                    return .\(enumCase.name)(\(args))
+                }
+            """
+        } else {
+            decodeSection = ""
+        }
+
+        if expansion.type.requiresCodingFieldLookup {
+            return """
+            struct \(fieldsEnumName): \(protocolName) {
+                var base: CodingFields.\(fieldsEnumName)
+                init(_ base: CodingFields.\(fieldsEnumName)) { self.base = base }
+
+                @_transparent
+                var staticString: StaticString {
+                    base.staticString
+                }
+
+                @inline(__always)
+                static func field(for key: UTF8Span) throws(CodingError.Decoding) -> \(fieldsEnumName) {
+                    .init(try CodingFields.\(fieldsEnumName).field(for: key, comparator: UTF8SpanComparator(key)))
+                }\(decodeSection)
             }
-            return entries
-        }
-        let fieldForKeyCases = fieldForKeyCasesList.joined(separator: "\n")
+            """
+        } else {
+            return """
+            struct \(fieldsEnumName): \(protocolName) {
+                var base: CodingFields.\(fieldsEnumName)
+                init(_ base: CodingFields.\(fieldsEnumName)) { self.base = base }
 
-        decl = """
-        extension \(typeName) {
-        enum \(raw: expansion.fieldTypeName): \(raw: expansion.fieldProtocolName) {
-        \(raw: joinedCases)
-
-        @_transparent
-        var staticString: StaticString {
-            switch self {
-            \(raw: joinedSwitchCases)
+                @_transparent
+                var staticString: StaticString {
+                    base.staticString
+                }\(decodeSection)
             }
+            """
         }
-
-        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> \(raw: expansion.fieldTypeName) {
-            switch UTF8SpanComparator(key) {
-            \(raw: fieldForKeyCases)
-            default:
-                throw CodingError.unknownKey(key)
-            }
-        }\(raw: perCaseSection)
-        }
-        }
-        """
-    } else {
-        decl = """
-        extension \(typeName) {
-        enum \(raw: expansion.fieldTypeName): \(raw: expansion.fieldProtocolName) {
-        \(raw: joinedCases)
-
-        @_transparent
-        var staticString: StaticString {
-            switch self {
-            \(raw: joinedSwitchCases)
-            }
-        }\(raw: perCaseSection)
-        }
-        }
-        """
-    }
-    return decl.as(ExtensionDeclSyntax.self)
+    }.joined(separator: "\n\n")
+    return perCaseFieldWrappers
 }
 
 // MARK: - Enum Encodable Extension Generation
@@ -811,7 +1366,8 @@ private func capitalizedCaseName(_ name: String) -> String {
 func makeEnumEncodableExtension(
     for typeName: TokenSyntax,
     with cases: [EnumCaseInfo],
-    expansion: some CodableExpansion
+    expansion: some CodableExpansion,
+    hasPeer: Bool
 ) -> ExtensionDeclSyntax? {
     let switchCases: String
     if cases.isEmpty {
@@ -820,18 +1376,31 @@ func makeEnumEncodableExtension(
     } else {
         switchCases = cases.map { enumCase -> String in
             if enumCase.associatedValues.isEmpty {
-                return "case .\(enumCase.name):\ntry encoder.encodeEnumCase(\(expansion.fieldTypeName).\(enumCase.name))"
+                let fieldRef = hasPeer
+                    ? "\(expansion.fieldTypeName)(.\(enumCase.name))"
+                    : "\(expansion.fieldTypeName).\(enumCase.name)"
+                return """
+                case .\(enumCase.name):
+                    try encoder.encodeEnumCase(\(fieldRef))
+                """
             } else {
                 let bindings = enumCase.associatedValues.map { "let \($0.encodedName)" }.joined(separator: ", ")
                 let fieldsEnumName = "\(expansion.fieldTypeName).\(capitalizedCaseName(enumCase.name))Fields"
+                let fieldRef = hasPeer
+                    ? "\(expansion.fieldTypeName)(.\(enumCase.name))"
+                    : "\(expansion.fieldTypeName).\(enumCase.name)"
 
                 let encodeStatements = enumCase.associatedValues.map {
-                    "try valueEncoder.encode(field: \(fieldsEnumName).\($0.encodedName), value: \($0.encodedName))"
+                    if hasPeer {
+                        return "try valueEncoder.encode(field: \(fieldsEnumName)(.\($0.encodedName)), value: \($0.encodedName))"
+                    } else {
+                        return "try valueEncoder.encode(field: \(fieldsEnumName).\($0.encodedName), value: \($0.encodedName))"
+                    }
                 }.joined(separator: "\n")
 
                 return """
                 case .\(enumCase.name)(\(bindings)):
-                try encoder.encodeEnumCase(\(expansion.fieldTypeName).\(enumCase.name), associatedValueCount: \(enumCase.associatedValues.count)) { valueEncoder throws(CodingError.Encoding) in
+                try encoder.encodeEnumCase(\(fieldRef), associatedValueCount: \(enumCase.associatedValues.count)) { valueEncoder throws(CodingError.Encoding) in
                 \(encodeStatements)
                 }
                 """
@@ -866,7 +1435,8 @@ func makeEnumEncodableExtension(
 func makeEnumDecodableExtension(
     for typeName: TokenSyntax,
     with cases: [EnumCaseInfo],
-    expansion: some CodableExpansion
+    expansion: some CodableExpansion,
+    hasPeer: Bool
 ) -> [ExtensionDeclSyntax] {
     // Generate the main decode method
     let mainDecl: DeclSyntax
@@ -879,6 +1449,8 @@ func makeEnumDecodableExtension(
         }
         """
     } else {
+        let switchExpr = hasPeer ? "_codingField!.base" : "_codingField!"
+
         // Cases with associated values delegate to per-case decode methods on nested field enums.
         // Cases without associated values just return the case directly.
         let caseDecodeStatements = cases.map { enumCase -> String in
@@ -897,7 +1469,7 @@ func makeEnumDecodableExtension(
                 return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
                     _codingField = try fieldDecoder.decode(\(raw: expansion.fieldTypeName).self)
                 } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
-                    return switch _codingField! {
+                    return switch \(raw: switchExpr) {
                     \(raw: caseDecodeStatements)
                     }
                 }

--- a/Tests/NewCodableMacrosTests/CombinedMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CombinedMacroTests.swift
@@ -1,0 +1,1117 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import SwiftSyntaxMacrosGenericTestSupport
+import Testing
+import NewCodableMacros
+
+/// Tests that verify correct behavior when multiple codable macros are stacked
+/// on a single type. Each macro generates its own independent JSONCodingFields type:
+/// - JSON macros generate `JSONCodingFields` (conforming to JSONOptimized*Field protocols)
+/// - Common macros generate `CommonCodingFields` (conforming to StaticString*Field protocols)
+///
+/// Each macro always generates its own fields unconditionally, regardless of order.
+@Suite("Combined Codable Macros")
+struct CombinedMacroTests {
+
+    // MARK: - @JSONCodable @CommonCodable (JSON first)
+
+    @Test func jsonCodableAndCommonCodable() {
+        assertMacroExpansion(
+            """
+            @JSONCodable @CommonCodable
+            struct Person {
+                let name: String
+                let age: Int
+            }
+            """,
+            expandedSource: """
+            struct Person {
+                let name: String
+                let age: Int
+            }
+
+            extension Person {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case name
+                    case age
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .age:
+                            "age"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "age":
+                            .age
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
+                    }
+                }
+            }
+
+            extension Person: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var age: Int?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .age:
+                                age = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let age else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'age'")
+                        }
+                        return Person(name: name, age: age)
+                    }
+                }
+            }
+
+            extension Person {
+                enum CommonCodingFields: StaticStringCodingField {
+                    case name
+                    case age
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .age:
+                            "age"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "age":
+                            .age
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
+                    }
+                }
+            }
+
+            extension Person: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var age: Int?
+                        var _codingField: CommonCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .age:
+                                age = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let age else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'age'")
+                        }
+                        return Person(name: name, age: age)
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    // MARK: - @CommonCodable @JSONCodable (Common first — order independence)
+
+    @Test func commonCodableAndJSONCodable() {
+        assertMacroExpansion(
+            """
+            @CommonCodable @JSONCodable
+            struct Person {
+                let name: String
+                let age: Int
+            }
+            """,
+            expandedSource: """
+            struct Person {
+                let name: String
+                let age: Int
+            }
+
+            extension Person {
+                enum CommonCodingFields: StaticStringCodingField {
+                    case name
+                    case age
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .age:
+                            "age"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "age":
+                            .age
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
+                    }
+                }
+            }
+
+            extension Person: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var age: Int?
+                        var _codingField: CommonCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .age:
+                                age = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let age else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'age'")
+                        }
+                        return Person(name: name, age: age)
+                    }
+                }
+            }
+
+            extension Person {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case name
+                    case age
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .age:
+                            "age"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "age":
+                            .age
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
+                    }
+                }
+            }
+
+            extension Person: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var age: Int?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .age:
+                                age = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let age else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'age'")
+                        }
+                        return Person(name: name, age: age)
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    // MARK: - Mixed partial macros
+
+    @Test func jsonEncodableAndCommonDecodable() {
+        assertMacroExpansion(
+            """
+            @JSONEncodable @CommonDecodable
+            struct Item {
+                let name: String
+                let value: Int
+            }
+            """,
+            expandedSource: """
+            struct Item {
+                let name: String
+                let value: Int
+            }
+
+            extension Item {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
+                    case name
+                    case value
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .value:
+                            "value"
+                        }
+                    }
+                }
+            }
+
+            extension Item: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.value, value: self.value)
+                    }
+                }
+            }
+
+            extension Item {
+                enum CommonCodingFields: StaticStringDecodingField {
+                    case name
+                    case value
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .value:
+                            "value"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "value":
+                            .value
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Item: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Item {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var value: Int?
+                        var _codingField: CommonCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .value:
+                                value = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let value else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'value'")
+                        }
+                        return Item(name: name, value: value)
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    @Test func commonEncodableAndJSONDecodable() {
+        assertMacroExpansion(
+            """
+            @CommonEncodable @JSONDecodable
+            struct Item {
+                let name: String
+                let value: Int
+            }
+            """,
+            expandedSource: """
+            struct Item {
+                let name: String
+                let value: Int
+            }
+
+            extension Item {
+                enum CommonCodingFields: StaticStringEncodingField {
+                    case name
+                    case value
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .value:
+                            "value"
+                        }
+                    }
+                }
+            }
+
+            extension Item: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.value, value: self.value)
+                    }
+                }
+            }
+
+            extension Item {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
+                    case name
+                    case value
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .value:
+                            "value"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "value":
+                            .value
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Item: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Item {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var value: Int?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .value:
+                                value = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let value else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'value'")
+                        }
+                        return Item(name: name, value: value)
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    // MARK: - Empty struct with both macros
+
+    @Test func emptyStructWithBothMacros() {
+        assertMacroExpansion(
+            """
+            @JSONCodable @CommonCodable
+            struct Empty {
+            }
+            """,
+            expandedSource: """
+            struct Empty {
+            }
+
+            extension Empty: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 0) { _ throws(CodingError.Encoding) in
+                    }
+                }
+            }
+
+            extension Empty: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Empty {
+                    try decoder.decodeStruct { _ throws(CodingError.Decoding) in
+                        Empty()
+                    }
+                }
+            }
+
+            extension Empty: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 0) { _ throws(CodingError.Encoding) in
+                    }
+                }
+            }
+
+            extension Empty: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Empty {
+                    try decoder.decodeStruct { _ throws(CodingError.Decoding) in
+                        Empty()
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    // MARK: - Custom CodingKey with both macros
+
+    @Test func customCodingKeyWithBothMacros() {
+        assertMacroExpansion(
+            """
+            @JSONCodable @CommonCodable
+            struct Post {
+                @CodingKey("date_published") let publishDate: String
+                let title: String
+            }
+            """,
+            expandedSource: """
+            struct Post {
+                let publishDate: String
+                let title: String
+            }
+
+            extension Post {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case publishDate
+                    case title
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .publishDate:
+                            "date_published"
+                        case .title:
+                            "title"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "date_published":
+                            .publishDate
+                        case "title":
+                            .title
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Post: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.publishDate, value: self.publishDate)
+                        try structEncoder.encode(field: JSONCodingFields.title, value: self.title)
+                    }
+                }
+            }
+
+            extension Post: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Post {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var publishDate: String?
+                        var title: String?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .publishDate:
+                                publishDate = try valueDecoder.decode(String.self)
+                            case .title:
+                                title = try valueDecoder.decode(String.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let publishDate else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'date_published'")
+                        }
+                        guard let title else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'title'")
+                        }
+                        return Post(publishDate: publishDate, title: title)
+                    }
+                }
+            }
+
+            extension Post {
+                enum CommonCodingFields: StaticStringCodingField {
+                    case publishDate
+                    case title
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .publishDate:
+                            "date_published"
+                        case .title:
+                            "title"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "date_published":
+                            .publishDate
+                        case "title":
+                            .title
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Post: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CommonCodingFields.publishDate, value: self.publishDate)
+                        try structEncoder.encode(field: CommonCodingFields.title, value: self.title)
+                    }
+                }
+            }
+
+            extension Post: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Post {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var publishDate: String?
+                        var title: String?
+                        var _codingField: CommonCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .publishDate:
+                                publishDate = try valueDecoder.decode(String.self)
+                            case .title:
+                                title = try valueDecoder.decode(String.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let publishDate else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'date_published'")
+                        }
+                        guard let title else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'title'")
+                        }
+                        return Post(publishDate: publishDate, title: title)
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    // MARK: - Enum with both macros
+
+    @Test func enumWithBothMacros() {
+        assertMacroExpansion(
+            """
+            @JSONCodable @CommonCodable
+            enum Direction {
+                case north
+                case south
+            }
+            """,
+            expandedSource: """
+            enum Direction {
+                case north
+                case south
+            }
+
+            extension Direction {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case north
+                    case south
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .north:
+                            "north"
+                        case .south:
+                            "south"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "north":
+                            .north
+                        case "south":
+                            .south
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Direction: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .north:
+                        try encoder.encodeEnumCase(JSONCodingFields.north)
+                    case .south:
+                        try encoder.encodeEnumCase(JSONCodingFields.south)
+                    }
+                }
+            }
+
+            extension Direction: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Direction {
+                    var _codingField: JSONCodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .north:
+                            .north
+                        case .south:
+                            .south
+                        }
+                    }
+                }
+            }
+
+            extension Direction {
+                enum CommonCodingFields: StaticStringCodingField {
+                    case north
+                    case south
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .north:
+                            "north"
+                        case .south:
+                            "south"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "north":
+                            .north
+                        case "south":
+                            .south
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Direction: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .north:
+                        try encoder.encodeEnumCase(CommonCodingFields.north)
+                    case .south:
+                        try encoder.encodeEnumCase(CommonCodingFields.south)
+                    }
+                }
+            }
+
+            extension Direction: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Direction {
+                    var _codingField: CommonCodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .north:
+                            .north
+                        case .south:
+                            .south
+                        }
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    // MARK: - Enum with associated values and both macros
+
+    @Test func enumWithAssociatedValuesAndBothMacros() {
+        assertMacroExpansion(
+            """
+            @JSONCodable @CommonCodable
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+            """,
+            expandedSource: """
+            enum Shape {
+                case circle(radius: Double)
+                case point
+            }
+
+            extension Shape {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case circle
+                    case point
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .circle:
+                            "circle"
+                        case .point:
+                            "point"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "circle":
+                            .circle
+                        case "point":
+                            .point
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum CircleFields: JSONOptimizedCodingField {
+                        case radius
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .radius:
+                                "radius"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "radius":
+                                .radius
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                            var radius: Double?
+                            var _field: CircleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(CircleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .radius:
+                                    radius = try valueDecoder.decode(Double.self)
+                                }
+                            }
+                            guard let radius else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .circle(radius: radius)
+                        }
+                    }
+                }
+            }
+
+            extension Shape: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .circle(let radius):
+                        try encoder.encodeEnumCase(JSONCodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.CircleFields.radius, value: radius)
+                        }
+                    case .point:
+                        try encoder.encodeEnumCase(JSONCodingFields.point)
+                    }
+                }
+            }
+
+            extension Shape: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                    var _codingField: JSONCodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .circle:
+                            try JSONCodingFields.CircleFields.decode(from: &valuesDecoder)
+                        case .point:
+                            .point
+                        }
+                    }
+                }
+            }
+
+            extension Shape {
+                enum CommonCodingFields: StaticStringCodingField {
+                    case circle
+                    case point
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .circle:
+                            "circle"
+                        case .point:
+                            "point"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "circle":
+                            .circle
+                        case "point":
+                            .point
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum CircleFields: StaticStringCodingField {
+                        case radius
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .radius:
+                                "radius"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
+                            switch UTF8SpanComparator(key) {
+                            case "radius":
+                                .radius
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                            var radius: Double?
+                            var _field: CircleFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(CircleFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .radius:
+                                    radius = try valueDecoder.decode(Double.self)
+                                }
+                            }
+                            guard let radius else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .circle(radius: radius)
+                        }
+                    }
+                }
+            }
+
+            extension Shape: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    switch self {
+                    case .circle(let radius):
+                        try encoder.encodeEnumCase(CommonCodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CommonCodingFields.CircleFields.radius, value: radius)
+                        }
+                    case .point:
+                        try encoder.encodeEnumCase(CommonCodingFields.point)
+                    }
+                }
+            }
+
+            extension Shape: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
+                    var _codingField: CommonCodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .circle:
+                            try CommonCodingFields.CircleFields.decode(from: &valuesDecoder)
+                        case .point:
+                            .point
+                        }
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+}
+
+private let combinedTestMacros: [String: Macro.Type] = [
+    "JSONCodable": JSONCodableMacro.self,
+    "JSONEncodable": JSONEncodableMacro.self,
+    "JSONDecodable": JSONDecodableMacro.self,
+    "CommonCodable": CommonCodableMacro.self,
+    "CommonEncodable": CommonEncodableMacro.self,
+    "CommonDecodable": CommonDecodableMacro.self,
+    "CodingKey": CodingKeyMacro.self,
+    "CodableDefault": CodableDefaultMacro.self,
+    "DecodableAlias": DecodableAliasMacro.self,
+]

--- a/Tests/NewCodableMacrosTests/CombinedMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CombinedMacroTests.swift
@@ -17,18 +17,18 @@ import Testing
 import NewCodableMacros
 
 /// Tests that verify correct behavior when multiple codable macros are stacked
-/// on a single type. Each macro generates its own independent JSONCodingFields type:
-/// - JSON macros generate `JSONCodingFields` (conforming to JSONOptimized*Field protocols)
-/// - Common macros generate `CommonCodingFields` (conforming to StaticString*Field protocols)
-///
-/// Each macro always generates its own fields unconditionally, regardless of order.
+/// on a single type. When peers are present:
+/// - The first macro lexically generates a shared base `CodingFields` enum
+/// - Each macro generates its own wrapper struct (e.g. `JSONCodingFields`, `CommonCodingFields`)
+///   that holds a `base: CodingFields` value and conforms to the format-specific field protocol.
+/// - encode/decode use wrapper struct field references.
 @Suite("Combined Codable Macros")
 struct CombinedMacroTests {
 
     // MARK: - @JSONCodable @CommonCodable (JSON first)
 
     @Test func jsonCodableAndCommonCodable() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable @CommonCodable
             struct Person {
@@ -43,7 +43,7 @@ struct CombinedMacroTests {
             }
 
             extension Person {
-                enum JSONCodingFields: JSONOptimizedCodingField {
+                enum CodingFields {
                     case name
                     case age
                     case unknown
@@ -60,8 +60,9 @@ struct CombinedMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
-                        switch UTF8SpanComparator(key) {
+                    @inline(__always)
+                    static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+                        switch comparator {
                         case "name":
                             .name
                         case "age":
@@ -73,11 +74,30 @@ struct CombinedMacroTests {
                 }
             }
 
+            extension Person {
+                struct JSONCodingFields: JSONOptimizedCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+
+                    @inline(__always)
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
+                    }
+                }
+            }
+
             extension Person: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
-                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
+                        try structEncoder.encode(field: JSONCodingFields(.name), value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields(.age), value: self.age)
                     }
                 }
             }
@@ -91,7 +111,7 @@ struct CombinedMacroTests {
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                             _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
-                            switch _codingField! {
+                            switch _codingField!.base {
                             case .name:
                                 name = try valueDecoder.decode(String.self)
                             case .age:
@@ -112,32 +132,20 @@ struct CombinedMacroTests {
             }
 
             extension Person {
-                enum CommonCodingFields: StaticStringCodingField {
-                    case name
-                    case age
-                    case unknown
+                struct CommonCodingFields: StaticStringCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
 
                     @_transparent
                     var staticString: StaticString {
-                        switch self {
-                        case .name:
-                            "name"
-                        case .age:
-                            "age"
-                        case .unknown:
-                            fatalError()
-                        }
+                        base.staticString
                     }
 
+                    @inline(__always)
                     static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
-                        switch UTF8SpanComparator(key) {
-                        case "name":
-                            .name
-                        case "age":
-                            .age
-                        default:
-                            .unknown
-                        }
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
                     }
                 }
             }
@@ -145,8 +153,8 @@ struct CombinedMacroTests {
             extension Person: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
+                        try structEncoder.encode(field: CommonCodingFields(.name), value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields(.age), value: self.age)
                     }
                 }
             }
@@ -160,7 +168,7 @@ struct CombinedMacroTests {
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                             _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
-                            switch _codingField! {
+                            switch _codingField!.base {
                             case .name:
                                 name = try valueDecoder.decode(String.self)
                             case .age:
@@ -187,7 +195,7 @@ struct CombinedMacroTests {
     // MARK: - @CommonCodable @JSONCodable (Common first — order independence)
 
     @Test func commonCodableAndJSONCodable() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable @JSONCodable
             struct Person {
@@ -202,7 +210,7 @@ struct CombinedMacroTests {
             }
 
             extension Person {
-                enum CommonCodingFields: StaticStringCodingField {
+                enum CodingFields {
                     case name
                     case age
                     case unknown
@@ -219,8 +227,9 @@ struct CombinedMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
-                        switch UTF8SpanComparator(key) {
+                    @inline(__always)
+                    static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+                        switch comparator {
                         case "name":
                             .name
                         case "age":
@@ -232,11 +241,30 @@ struct CombinedMacroTests {
                 }
             }
 
+            extension Person {
+                struct CommonCodingFields: StaticStringCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+
+                    @inline(__always)
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
+                    }
+                }
+            }
+
             extension Person: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
+                        try structEncoder.encode(field: CommonCodingFields(.name), value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields(.age), value: self.age)
                     }
                 }
             }
@@ -250,7 +278,7 @@ struct CombinedMacroTests {
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                             _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
-                            switch _codingField! {
+                            switch _codingField!.base {
                             case .name:
                                 name = try valueDecoder.decode(String.self)
                             case .age:
@@ -271,32 +299,20 @@ struct CombinedMacroTests {
             }
 
             extension Person {
-                enum JSONCodingFields: JSONOptimizedCodingField {
-                    case name
-                    case age
-                    case unknown
+                struct JSONCodingFields: JSONOptimizedCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
 
                     @_transparent
                     var staticString: StaticString {
-                        switch self {
-                        case .name:
-                            "name"
-                        case .age:
-                            "age"
-                        case .unknown:
-                            fatalError()
-                        }
+                        base.staticString
                     }
 
+                    @inline(__always)
                     static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
-                        switch UTF8SpanComparator(key) {
-                        case "name":
-                            .name
-                        case "age":
-                            .age
-                        default:
-                            .unknown
-                        }
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
                     }
                 }
             }
@@ -304,8 +320,8 @@ struct CombinedMacroTests {
             extension Person: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
-                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
+                        try structEncoder.encode(field: JSONCodingFields(.name), value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields(.age), value: self.age)
                     }
                 }
             }
@@ -319,7 +335,7 @@ struct CombinedMacroTests {
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                             _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
-                            switch _codingField! {
+                            switch _codingField!.base {
                             case .name:
                                 name = try valueDecoder.decode(String.self)
                             case .age:
@@ -346,7 +362,7 @@ struct CombinedMacroTests {
     // MARK: - Mixed partial macros
 
     @Test func jsonEncodableAndCommonDecodable() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable @CommonDecodable
             struct Item {
@@ -361,33 +377,7 @@ struct CombinedMacroTests {
             }
 
             extension Item {
-                enum JSONCodingFields: JSONOptimizedEncodingField {
-                    case name
-                    case value
-
-                    @_transparent
-                    var staticString: StaticString {
-                        switch self {
-                        case .name:
-                            "name"
-                        case .value:
-                            "value"
-                        }
-                    }
-                }
-            }
-
-            extension Item: JSONEncodable {
-                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
-                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
-                        try structEncoder.encode(field: JSONCodingFields.value, value: self.value)
-                    }
-                }
-            }
-
-            extension Item {
-                enum CommonCodingFields: StaticStringDecodingField {
+                enum CodingFields {
                     case name
                     case value
                     case unknown
@@ -404,8 +394,9 @@ struct CombinedMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
-                        switch UTF8SpanComparator(key) {
+                    @inline(__always)
+                    static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+                        switch comparator {
                         case "name":
                             .name
                         case "value":
@@ -413,6 +404,48 @@ struct CombinedMacroTests {
                         default:
                             .unknown
                         }
+                    }
+                }
+            }
+
+            extension Item {
+                struct JSONCodingFields: JSONOptimizedEncodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+                }
+            }
+
+            extension Item: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields(.name), value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields(.value), value: self.value)
+                    }
+                }
+            }
+
+            extension Item {
+                struct CommonCodingFields: StaticStringDecodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+
+                    @inline(__always)
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
                     }
                 }
             }
@@ -426,7 +459,7 @@ struct CombinedMacroTests {
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                             _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
-                            switch _codingField! {
+                            switch _codingField!.base {
                             case .name:
                                 name = try valueDecoder.decode(String.self)
                             case .value:
@@ -451,7 +484,7 @@ struct CombinedMacroTests {
     }
 
     @Test func commonEncodableAndJSONDecodable() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable @JSONDecodable
             struct Item {
@@ -466,33 +499,7 @@ struct CombinedMacroTests {
             }
 
             extension Item {
-                enum CommonCodingFields: StaticStringEncodingField {
-                    case name
-                    case value
-
-                    @_transparent
-                    var staticString: StaticString {
-                        switch self {
-                        case .name:
-                            "name"
-                        case .value:
-                            "value"
-                        }
-                    }
-                }
-            }
-
-            extension Item: CommonEncodable {
-                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
-                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CommonCodingFields.value, value: self.value)
-                    }
-                }
-            }
-
-            extension Item {
-                enum JSONCodingFields: JSONOptimizedDecodingField {
+                enum CodingFields {
                     case name
                     case value
                     case unknown
@@ -509,8 +516,9 @@ struct CombinedMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
-                        switch UTF8SpanComparator(key) {
+                    @inline(__always)
+                    static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+                        switch comparator {
                         case "name":
                             .name
                         case "value":
@@ -518,6 +526,48 @@ struct CombinedMacroTests {
                         default:
                             .unknown
                         }
+                    }
+                }
+            }
+
+            extension Item {
+                struct CommonCodingFields: StaticStringEncodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+                }
+            }
+
+            extension Item: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CommonCodingFields(.name), value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields(.value), value: self.value)
+                    }
+                }
+            }
+
+            extension Item {
+                struct JSONCodingFields: JSONOptimizedDecodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+
+                    @inline(__always)
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
                     }
                 }
             }
@@ -531,7 +581,7 @@ struct CombinedMacroTests {
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                             _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
-                            switch _codingField! {
+                            switch _codingField!.base {
                             case .name:
                                 name = try valueDecoder.decode(String.self)
                             case .value:
@@ -558,7 +608,7 @@ struct CombinedMacroTests {
     // MARK: - Empty struct with both macros
 
     @Test func emptyStructWithBothMacros() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable @CommonCodable
             struct Empty {
@@ -605,7 +655,7 @@ struct CombinedMacroTests {
     // MARK: - Custom CodingKey with both macros
 
     @Test func customCodingKeyWithBothMacros() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable @CommonCodable
             struct Post {
@@ -620,7 +670,7 @@ struct CombinedMacroTests {
             }
 
             extension Post {
-                enum JSONCodingFields: JSONOptimizedCodingField {
+                enum CodingFields {
                     case publishDate
                     case title
                     case unknown
@@ -637,8 +687,9 @@ struct CombinedMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
-                        switch UTF8SpanComparator(key) {
+                    @inline(__always)
+                    static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+                        switch comparator {
                         case "date_published":
                             .publishDate
                         case "title":
@@ -650,11 +701,30 @@ struct CombinedMacroTests {
                 }
             }
 
+            extension Post {
+                struct JSONCodingFields: JSONOptimizedCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+
+                    @inline(__always)
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
+                    }
+                }
+            }
+
             extension Post: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: JSONCodingFields.publishDate, value: self.publishDate)
-                        try structEncoder.encode(field: JSONCodingFields.title, value: self.title)
+                        try structEncoder.encode(field: JSONCodingFields(.publishDate), value: self.publishDate)
+                        try structEncoder.encode(field: JSONCodingFields(.title), value: self.title)
                     }
                 }
             }
@@ -668,7 +738,7 @@ struct CombinedMacroTests {
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                             _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
-                            switch _codingField! {
+                            switch _codingField!.base {
                             case .publishDate:
                                 publishDate = try valueDecoder.decode(String.self)
                             case .title:
@@ -689,32 +759,20 @@ struct CombinedMacroTests {
             }
 
             extension Post {
-                enum CommonCodingFields: StaticStringCodingField {
-                    case publishDate
-                    case title
-                    case unknown
+                struct CommonCodingFields: StaticStringCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
 
                     @_transparent
                     var staticString: StaticString {
-                        switch self {
-                        case .publishDate:
-                            "date_published"
-                        case .title:
-                            "title"
-                        case .unknown:
-                            fatalError()
-                        }
+                        base.staticString
                     }
 
+                    @inline(__always)
                     static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
-                        switch UTF8SpanComparator(key) {
-                        case "date_published":
-                            .publishDate
-                        case "title":
-                            .title
-                        default:
-                            .unknown
-                        }
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
                     }
                 }
             }
@@ -722,8 +780,8 @@ struct CombinedMacroTests {
             extension Post: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CommonCodingFields.publishDate, value: self.publishDate)
-                        try structEncoder.encode(field: CommonCodingFields.title, value: self.title)
+                        try structEncoder.encode(field: CommonCodingFields(.publishDate), value: self.publishDate)
+                        try structEncoder.encode(field: CommonCodingFields(.title), value: self.title)
                     }
                 }
             }
@@ -737,7 +795,7 @@ struct CombinedMacroTests {
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                             _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
-                            switch _codingField! {
+                            switch _codingField!.base {
                             case .publishDate:
                                 publishDate = try valueDecoder.decode(String.self)
                             case .title:
@@ -764,7 +822,7 @@ struct CombinedMacroTests {
     // MARK: - Enum with both macros
 
     @Test func enumWithBothMacros() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable @CommonCodable
             enum Direction {
@@ -779,7 +837,7 @@ struct CombinedMacroTests {
             }
 
             extension Direction {
-                enum JSONCodingFields: JSONOptimizedCodingField {
+                enum CodingFields {
                     case north
                     case south
 
@@ -793,8 +851,9 @@ struct CombinedMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
-                        switch UTF8SpanComparator(key) {
+                    @inline(__always)
+                    static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+                        switch comparator {
                         case "north":
                             .north
                         case "south":
@@ -806,13 +865,32 @@ struct CombinedMacroTests {
                 }
             }
 
+            extension Direction {
+                struct JSONCodingFields: JSONOptimizedCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+
+                    @inline(__always)
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
+                    }
+                }
+            }
+
             extension Direction: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .north:
-                        try encoder.encodeEnumCase(JSONCodingFields.north)
+                        try encoder.encodeEnumCase(JSONCodingFields(.north))
                     case .south:
-                        try encoder.encodeEnumCase(JSONCodingFields.south)
+                        try encoder.encodeEnumCase(JSONCodingFields(.south))
                     }
                 }
             }
@@ -823,7 +901,7 @@ struct CombinedMacroTests {
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
                         _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
-                        return switch _codingField! {
+                        return switch _codingField!.base {
                         case .north:
                             .north
                         case .south:
@@ -834,29 +912,20 @@ struct CombinedMacroTests {
             }
 
             extension Direction {
-                enum CommonCodingFields: StaticStringCodingField {
-                    case north
-                    case south
+                struct CommonCodingFields: StaticStringCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
 
                     @_transparent
                     var staticString: StaticString {
-                        switch self {
-                        case .north:
-                            "north"
-                        case .south:
-                            "south"
-                        }
+                        base.staticString
                     }
 
+                    @inline(__always)
                     static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
-                        switch UTF8SpanComparator(key) {
-                        case "north":
-                            .north
-                        case "south":
-                            .south
-                        default:
-                            throw CodingError.unknownKey(key)
-                        }
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
                     }
                 }
             }
@@ -865,9 +934,9 @@ struct CombinedMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .north:
-                        try encoder.encodeEnumCase(CommonCodingFields.north)
+                        try encoder.encodeEnumCase(CommonCodingFields(.north))
                     case .south:
-                        try encoder.encodeEnumCase(CommonCodingFields.south)
+                        try encoder.encodeEnumCase(CommonCodingFields(.south))
                     }
                 }
             }
@@ -878,7 +947,7 @@ struct CombinedMacroTests {
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
                         _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
-                        return switch _codingField! {
+                        return switch _codingField!.base {
                         case .north:
                             .north
                         case .south:
@@ -895,7 +964,7 @@ struct CombinedMacroTests {
     // MARK: - Enum with associated values and both macros
 
     @Test func enumWithAssociatedValuesAndBothMacros() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable @CommonCodable
             enum Shape {
@@ -910,7 +979,7 @@ struct CombinedMacroTests {
             }
 
             extension Shape {
-                enum JSONCodingFields: JSONOptimizedCodingField {
+                enum CodingFields {
                     case circle
                     case point
 
@@ -924,8 +993,9 @@ struct CombinedMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
-                        switch UTF8SpanComparator(key) {
+                    @inline(__always)
+                    static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CodingFields {
+                        switch comparator {
                         case "circle":
                             .circle
                         case "point":
@@ -935,7 +1005,7 @@ struct CombinedMacroTests {
                         }
                     }
 
-                    enum CircleFields: JSONOptimizedCodingField {
+                    enum CircleFields {
                         case radius
 
                         @_transparent
@@ -946,13 +1016,50 @@ struct CombinedMacroTests {
                             }
                         }
 
-                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
-                            switch UTF8SpanComparator(key) {
+                        @inline(__always)
+                        static func field(for key: UTF8Span, comparator: some DecodingFieldUTF8SpanComparator & ~Escapable) throws(CodingError.Decoding) -> CircleFields {
+                            switch comparator {
                             case "radius":
                                 .radius
                             default:
                                 throw CodingError.unknownKey(key)
                             }
+                        }
+                    }
+                }
+            }
+
+            extension Shape {
+                struct JSONCodingFields: JSONOptimizedCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
+
+                    @_transparent
+                    var staticString: StaticString {
+                        base.staticString
+                    }
+
+                    @inline(__always)
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
+                    }
+
+                    struct CircleFields: JSONOptimizedCodingField {
+                        var base: CodingFields.CircleFields
+                        init(_ base: CodingFields.CircleFields) {
+                            self.base = base
+                        }
+
+                        @_transparent
+                        var staticString: StaticString {
+                            base.staticString
+                        }
+
+                        @inline(__always)
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
+                            .init(try CodingFields.CircleFields.field(for: key, comparator: UTF8SpanComparator(key)))
                         }
 
                         static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
@@ -961,7 +1068,7 @@ struct CombinedMacroTests {
                             try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                                 _field = try fieldDecoder.decode(CircleFields.self)
                             } andValue: { valueDecoder throws(CodingError.Decoding) in
-                                switch _field! {
+                                switch _field!.base {
                                 case .radius:
                                     radius = try valueDecoder.decode(Double.self)
                                 }
@@ -979,11 +1086,11 @@ struct CombinedMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .circle(let radius):
-                        try encoder.encodeEnumCase(JSONCodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: JSONCodingFields.CircleFields.radius, value: radius)
+                        try encoder.encodeEnumCase(JSONCodingFields(.circle), associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.CircleFields(.radius), value: radius)
                         }
                     case .point:
-                        try encoder.encodeEnumCase(JSONCodingFields.point)
+                        try encoder.encodeEnumCase(JSONCodingFields(.point))
                     }
                 }
             }
@@ -994,7 +1101,7 @@ struct CombinedMacroTests {
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
                         _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
-                        return switch _codingField! {
+                        return switch _codingField!.base {
                         case .circle:
                             try JSONCodingFields.CircleFields.decode(from: &valuesDecoder)
                         case .point:
@@ -1005,49 +1112,36 @@ struct CombinedMacroTests {
             }
 
             extension Shape {
-                enum CommonCodingFields: StaticStringCodingField {
-                    case circle
-                    case point
+                struct CommonCodingFields: StaticStringCodingField {
+                    var base: CodingFields
+                    init(_ base: CodingFields) {
+                        self.base = base
+                    }
 
                     @_transparent
                     var staticString: StaticString {
-                        switch self {
-                        case .circle:
-                            "circle"
-                        case .point:
-                            "point"
-                        }
+                        base.staticString
                     }
 
+                    @inline(__always)
                     static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
-                        switch UTF8SpanComparator(key) {
-                        case "circle":
-                            .circle
-                        case "point":
-                            .point
-                        default:
-                            throw CodingError.unknownKey(key)
-                        }
+                        .init(try CodingFields.field(for: key, comparator: UTF8SpanComparator(key)))
                     }
 
-                    enum CircleFields: StaticStringCodingField {
-                        case radius
+                    struct CircleFields: StaticStringCodingField {
+                        var base: CodingFields.CircleFields
+                        init(_ base: CodingFields.CircleFields) {
+                            self.base = base
+                        }
 
                         @_transparent
                         var staticString: StaticString {
-                            switch self {
-                            case .radius:
-                                "radius"
-                            }
+                            base.staticString
                         }
 
+                        @inline(__always)
                         static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CircleFields {
-                            switch UTF8SpanComparator(key) {
-                            case "radius":
-                                .radius
-                            default:
-                                throw CodingError.unknownKey(key)
-                            }
+                            .init(try CodingFields.CircleFields.field(for: key, comparator: UTF8SpanComparator(key)))
                         }
 
                         static func decode(from decoder: inout some CommonStructDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
@@ -1056,7 +1150,7 @@ struct CombinedMacroTests {
                             try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
                                 _field = try fieldDecoder.decode(CircleFields.self)
                             } andValue: { valueDecoder throws(CodingError.Decoding) in
-                                switch _field! {
+                                switch _field!.base {
                                 case .radius:
                                     radius = try valueDecoder.decode(Double.self)
                                 }
@@ -1074,11 +1168,11 @@ struct CombinedMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .circle(let radius):
-                        try encoder.encodeEnumCase(CommonCodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CommonCodingFields.CircleFields.radius, value: radius)
+                        try encoder.encodeEnumCase(CommonCodingFields(.circle), associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CommonCodingFields.CircleFields(.radius), value: radius)
                         }
                     case .point:
-                        try encoder.encodeEnumCase(CommonCodingFields.point)
+                        try encoder.encodeEnumCase(CommonCodingFields(.point))
                     }
                 }
             }
@@ -1089,12 +1183,190 @@ struct CombinedMacroTests {
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
                         _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
-                        return switch _codingField! {
+                        return switch _codingField!.base {
                         case .circle:
                             try CommonCodingFields.CircleFields.decode(from: &valuesDecoder)
                         case .point:
                             .point
                         }
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    // MARK: - Same-format split macros (@JSONEncodable @JSONDecodable)
+
+    @Test func jsonEncodableAndJsonDecodable() {
+        AssertMacroExpansion(
+            """
+            @JSONEncodable @JSONDecodable
+            struct Person {
+                let name: String
+                let age: Int
+            }
+            """,
+            expandedSource: """
+            struct Person {
+                let name: String
+                let age: Int
+            }
+
+            extension Person {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case name
+                    case age
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .age:
+                            "age"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "age":
+                            .age
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
+                    }
+                }
+            }
+
+            extension Person: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var age: Int?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .age:
+                                age = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let age else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'age'")
+                        }
+                        return Person(name: name, age: age)
+                    }
+                }
+            }
+            """,
+            macros: combinedTestMacros
+        )
+    }
+
+    @Test func commonEncodableAndCommonDecodable() {
+        AssertMacroExpansion(
+            """
+            @CommonEncodable @CommonDecodable
+            struct Person {
+                let name: String
+                let age: Int
+            }
+            """,
+            expandedSource: """
+            struct Person {
+                let name: String
+                let age: Int
+            }
+
+            extension Person {
+                enum CommonCodingFields: StaticStringCodingField {
+                    case name
+                    case age
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .age:
+                            "age"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "age":
+                            .age
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Person: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
+                    }
+                }
+            }
+
+            extension Person: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Person {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var age: Int?
+                        var _codingField: CommonCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .age:
+                                age = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        guard let age else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'age'")
+                        }
+                        return Person(name: name, age: age)
                     }
                 }
             }

--- a/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
@@ -20,7 +20,7 @@ import NewCodableMacros
 struct CommonCodableMacroTests {
 
     @Test func basicStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             struct Person {
@@ -108,7 +108,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func optionalProperty() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             struct Item {
@@ -193,7 +193,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func customCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             struct Post {
@@ -281,7 +281,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func emptyStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             struct Empty {
@@ -311,7 +311,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func defaultValue() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             struct Config {
@@ -396,7 +396,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func aliasFullRoundtrip() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             struct User {
@@ -472,7 +472,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func aliasCombinedWithCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             struct User {
@@ -548,7 +548,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func publicStructEmitsPublicMembers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             public struct Person {
@@ -636,7 +636,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func errorOnNonStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             class NotAStruct {
@@ -658,7 +658,7 @@ struct CommonCodableMacroTests {
     // MARK: - Enum Tests
 
     @Test func enumNoAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             enum Direction {
@@ -732,7 +732,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func enumWithAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             enum Shape {
@@ -846,7 +846,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func enumWithUnlabeledAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             enum Wrapper {
@@ -1009,7 +1009,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func enumWithCustomCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             enum Status {
@@ -1083,7 +1083,7 @@ struct CommonCodableMacroTests {
     }
 
     @Test func enumWithDecodableAlias() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonCodable
             enum Status {

--- a/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
@@ -35,7 +35,7 @@ struct CommonCodableMacroTests {
             }
             
             extension Person {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case name
                     case age
                     case unknown
@@ -52,7 +52,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -68,8 +68,8 @@ struct CommonCodableMacroTests {
             extension Person: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -79,9 +79,9 @@ struct CommonCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var age: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -123,7 +123,7 @@ struct CommonCodableMacroTests {
             }
             
             extension Item {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case name
                     case rating
                     case unknown
@@ -140,7 +140,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -156,8 +156,8 @@ struct CommonCodableMacroTests {
             extension Item: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.rating, value: self.rating)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.rating, value: self.rating)
                     }
                 }
             }
@@ -167,9 +167,9 @@ struct CommonCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var rating: Double?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -208,7 +208,7 @@ struct CommonCodableMacroTests {
             }
             
             extension Post {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case publishDate
                     case title
                     case unknown
@@ -225,7 +225,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "date_published":
                             .publishDate
@@ -241,8 +241,8 @@ struct CommonCodableMacroTests {
             extension Post: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.publishDate, value: self.publishDate)
-                        try structEncoder.encode(field: CodingFields.title, value: self.title)
+                        try structEncoder.encode(field: CommonCodingFields.publishDate, value: self.publishDate)
+                        try structEncoder.encode(field: CommonCodingFields.title, value: self.title)
                     }
                 }
             }
@@ -252,9 +252,9 @@ struct CommonCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var publishDate: String?
                         var title: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .publishDate:
@@ -326,7 +326,7 @@ struct CommonCodableMacroTests {
             }
             
             extension Config {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case name
                     case locale
                     case unknown
@@ -343,7 +343,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -359,8 +359,8 @@ struct CommonCodableMacroTests {
             extension Config: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.locale, value: self.locale)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.locale, value: self.locale)
                     }
                 }
             }
@@ -370,9 +370,9 @@ struct CommonCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var locale: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -409,7 +409,7 @@ struct CommonCodableMacroTests {
             }
             
             extension User {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case userName
                     case unknown
 
@@ -423,7 +423,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "userName":
                             .userName
@@ -439,7 +439,7 @@ struct CommonCodableMacroTests {
             extension User: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: CommonCodingFields.userName, value: self.userName)
                     }
                 }
             }
@@ -448,9 +448,9 @@ struct CommonCodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> User {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var userName: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .userName:
@@ -485,7 +485,7 @@ struct CommonCodableMacroTests {
             }
             
             extension User {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case userName
                     case unknown
 
@@ -499,7 +499,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "user_name":
                             .userName
@@ -515,7 +515,7 @@ struct CommonCodableMacroTests {
             extension User: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: CommonCodingFields.userName, value: self.userName)
                     }
                 }
             }
@@ -524,9 +524,9 @@ struct CommonCodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> User {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var userName: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .userName:
@@ -563,7 +563,7 @@ struct CommonCodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case name
                     case age
                     case unknown
@@ -580,7 +580,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -596,8 +596,8 @@ struct CommonCodableMacroTests {
             extension Person: CommonEncodable {
                 public func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -607,9 +607,9 @@ struct CommonCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var age: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -673,7 +673,7 @@ struct CommonCodableMacroTests {
             }
 
             extension Direction {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case north
                     case south
 
@@ -687,7 +687,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "north":
                             .north
@@ -704,18 +704,18 @@ struct CommonCodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .north:
-                        try encoder.encodeEnumCase(CodingFields.north)
+                        try encoder.encodeEnumCase(CommonCodingFields.north)
                     case .south:
-                        try encoder.encodeEnumCase(CodingFields.south)
+                        try encoder.encodeEnumCase(CommonCodingFields.south)
                     }
                 }
             }
 
             extension Direction: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Direction {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .north:
@@ -747,7 +747,7 @@ struct CommonCodableMacroTests {
             }
 
             extension Shape {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case circle
                     case point
 
@@ -761,7 +761,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "circle":
                             .circle
@@ -816,24 +816,24 @@ struct CommonCodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .circle(let radius):
-                        try encoder.encodeEnumCase(CodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.CircleFields.radius, value: radius)
+                        try encoder.encodeEnumCase(CommonCodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CommonCodingFields.CircleFields.radius, value: radius)
                         }
                     case .point:
-                        try encoder.encodeEnumCase(CodingFields.point)
+                        try encoder.encodeEnumCase(CommonCodingFields.point)
                     }
                 }
             }
 
             extension Shape: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .circle:
-                            try CodingFields.CircleFields.decode(from: &valuesDecoder)
+                            try CommonCodingFields.CircleFields.decode(from: &valuesDecoder)
                         case .point:
                             .point
                         }
@@ -861,7 +861,7 @@ struct CommonCodableMacroTests {
             }
 
             extension Wrapper {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case single
                     case pair
 
@@ -875,7 +875,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "single":
                             .single
@@ -976,13 +976,13 @@ struct CommonCodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .single(let _0):
-                        try encoder.encodeEnumCase(CodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.SingleFields._0, value: _0)
+                        try encoder.encodeEnumCase(CommonCodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CommonCodingFields.SingleFields._0, value: _0)
                         }
                     case .pair(let _0, let _1):
-                        try encoder.encodeEnumCase(CodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.PairFields._0, value: _0)
-                            try valueEncoder.encode(field: CodingFields.PairFields._1, value: _1)
+                        try encoder.encodeEnumCase(CommonCodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CommonCodingFields.PairFields._0, value: _0)
+                            try valueEncoder.encode(field: CommonCodingFields.PairFields._1, value: _1)
                         }
                     }
                 }
@@ -990,15 +990,15 @@ struct CommonCodableMacroTests {
 
             extension Wrapper: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .single:
-                            try CodingFields.SingleFields.decode(from: &valuesDecoder)
+                            try CommonCodingFields.SingleFields.decode(from: &valuesDecoder)
                         case .pair:
-                            try CodingFields.PairFields.decode(from: &valuesDecoder)
+                            try CommonCodingFields.PairFields.decode(from: &valuesDecoder)
                         }
                     }
                 }
@@ -1024,7 +1024,7 @@ struct CommonCodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case inProgress
                     case done
 
@@ -1038,7 +1038,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "in_progress":
                             .inProgress
@@ -1055,18 +1055,18 @@ struct CommonCodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .inProgress:
-                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                        try encoder.encodeEnumCase(CommonCodingFields.inProgress)
                     case .done:
-                        try encoder.encodeEnumCase(CodingFields.done)
+                        try encoder.encodeEnumCase(CommonCodingFields.done)
                     }
                 }
             }
 
             extension Status: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Status {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .inProgress:
@@ -1098,7 +1098,7 @@ struct CommonCodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: StaticStringCodingField {
+                enum CommonCodingFields: StaticStringCodingField {
                     case inProgress
                     case done
 
@@ -1112,7 +1112,7 @@ struct CommonCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "in_progress":
                             .inProgress
@@ -1131,18 +1131,18 @@ struct CommonCodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .inProgress:
-                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                        try encoder.encodeEnumCase(CommonCodingFields.inProgress)
                     case .done:
-                        try encoder.encodeEnumCase(CodingFields.done)
+                        try encoder.encodeEnumCase(CommonCodingFields.done)
                     }
                 }
             }
 
             extension Status: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Status {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .inProgress:

--- a/Tests/NewCodableMacrosTests/CommonDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonDecodableMacroTests.swift
@@ -20,7 +20,7 @@ import NewCodableMacros
 struct CommonDecodableMacroTests {
 
     @Test func basicStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Person {
@@ -99,7 +99,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func optionalProperty() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Item {
@@ -175,7 +175,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func allOptionalProperties() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Preferences {
@@ -248,7 +248,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func customCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Post {
@@ -327,7 +327,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func computedPropertySkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Thing {
@@ -399,7 +399,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func staticPropertySkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Config {
@@ -467,7 +467,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func lazyVarSkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Cached {
@@ -535,7 +535,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func emptyStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Empty {
@@ -558,7 +558,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func errorOnNonStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             class NotAStruct {
@@ -578,7 +578,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func propertyWithoutTypeAnnotation() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Bad {
@@ -598,7 +598,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func defaultValue() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Config {
@@ -684,7 +684,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func allDefaultValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Defaults {
@@ -757,7 +757,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func defaultWithCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Setting {
@@ -820,7 +820,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func defaultOnOptionalProperty() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct Prefs {
@@ -883,7 +883,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func defaultWithArbitraryExpression() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct WithExpr {
@@ -946,7 +946,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func aliasBasic() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct User {
@@ -1027,7 +1027,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func aliasCombinedWithCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct User {
@@ -1095,7 +1095,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func aliasMultiple() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             struct User {
@@ -1167,7 +1167,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func publicStructEmitsPublicMembers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             public struct Person {
@@ -1235,7 +1235,7 @@ struct CommonDecodableMacroTests {
     // MARK: - Enum Tests
 
     @Test func enumNoAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             enum Direction {
@@ -1298,7 +1298,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func enumWithAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             enum Shape {
@@ -1399,7 +1399,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func enumWithUnlabeledAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             enum Wrapper {
@@ -1546,7 +1546,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func enumWithCustomCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             enum Status {
@@ -1609,7 +1609,7 @@ struct CommonDecodableMacroTests {
     }
 
     @Test func enumWithDecodableAlias() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonDecodable
             enum Status {

--- a/Tests/NewCodableMacrosTests/CommonDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonDecodableMacroTests.swift
@@ -35,7 +35,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case name
                     case age
                     case unknown
@@ -52,7 +52,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -70,9 +70,9 @@ struct CommonDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var age: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -114,7 +114,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Item {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case name
                     case rating
                     case unknown
@@ -131,7 +131,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -149,9 +149,9 @@ struct CommonDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var rating: Double?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -190,7 +190,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Preferences {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case theme
                     case fontSize
                     case unknown
@@ -207,7 +207,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "theme":
                             .theme
@@ -225,9 +225,9 @@ struct CommonDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var theme: String?
                         var fontSize: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .theme:
@@ -263,7 +263,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Post {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case publishDate
                     case title
                     case unknown
@@ -280,7 +280,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "date_published":
                             .publishDate
@@ -298,9 +298,9 @@ struct CommonDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var publishDate: String?
                         var title: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .publishDate:
@@ -346,7 +346,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Thing {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case name
                     case unknown
 
@@ -360,7 +360,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -375,9 +375,9 @@ struct CommonDecodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Thing {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -414,7 +414,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Config {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case name
                     case unknown
 
@@ -428,7 +428,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -443,9 +443,9 @@ struct CommonDecodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Config {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -482,7 +482,7 @@ struct CommonDecodableMacroTests {
             }
             
             extension Cached {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case name
                     case unknown
 
@@ -496,7 +496,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -511,9 +511,9 @@ struct CommonDecodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Cached {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -615,7 +615,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Config {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case name
                     case locale
                     case retryCount
@@ -635,7 +635,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -656,9 +656,9 @@ struct CommonDecodableMacroTests {
                         var name: String?
                         var locale: String?
                         var retryCount: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -699,7 +699,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Defaults {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case greeting
                     case verbose
                     case unknown
@@ -716,7 +716,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "greeting":
                             .greeting
@@ -734,9 +734,9 @@ struct CommonDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var greeting: String?
                         var verbose: Bool?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .greeting:
@@ -770,7 +770,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Setting {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case maxRetries
                     case unknown
 
@@ -784,7 +784,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "max_retries":
                             .maxRetries
@@ -799,9 +799,9 @@ struct CommonDecodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Setting {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var maxRetries: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .maxRetries:
@@ -833,7 +833,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Prefs {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case locale
                     case unknown
 
@@ -847,7 +847,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "locale":
                             .locale
@@ -862,9 +862,9 @@ struct CommonDecodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Prefs {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var locale: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .locale:
@@ -896,7 +896,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension WithExpr {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case tags
                     case unknown
 
@@ -910,7 +910,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "tags":
                             .tags
@@ -925,9 +925,9 @@ struct CommonDecodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> WithExpr {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var tags: [String]?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .tags:
@@ -961,7 +961,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension User {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case userName
                     case age
                     case unknown
@@ -978,7 +978,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "userName":
                             .userName
@@ -998,9 +998,9 @@ struct CommonDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var userName: String?
                         var age: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .userName:
@@ -1040,7 +1040,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension User {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case userName
                     case unknown
 
@@ -1054,7 +1054,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "user_name":
                             .userName
@@ -1071,9 +1071,9 @@ struct CommonDecodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> User {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var userName: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .userName:
@@ -1108,7 +1108,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension User {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case name
                     case unknown
 
@@ -1122,7 +1122,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -1143,9 +1143,9 @@ struct CommonDecodableMacroTests {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> User {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -1180,7 +1180,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case name
                     case unknown
 
@@ -1194,7 +1194,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -1209,9 +1209,9 @@ struct CommonDecodableMacroTests {
                 public static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Person {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: CommonCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -1250,7 +1250,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Direction {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case north
                     case south
 
@@ -1264,7 +1264,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "north":
                             .north
@@ -1279,9 +1279,9 @@ struct CommonDecodableMacroTests {
 
             extension Direction: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Direction {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .north:
@@ -1313,7 +1313,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Shape {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case circle
                     case point
 
@@ -1327,7 +1327,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "circle":
                             .circle
@@ -1380,13 +1380,13 @@ struct CommonDecodableMacroTests {
 
             extension Shape: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Shape {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .circle:
-                            try CodingFields.CircleFields.decode(from: &valuesDecoder)
+                            try CommonCodingFields.CircleFields.decode(from: &valuesDecoder)
                         case .point:
                             .point
                         }
@@ -1414,7 +1414,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Wrapper {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case single
                     case pair
 
@@ -1428,7 +1428,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "single":
                             .single
@@ -1527,15 +1527,15 @@ struct CommonDecodableMacroTests {
 
             extension Wrapper: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .single:
-                            try CodingFields.SingleFields.decode(from: &valuesDecoder)
+                            try CommonCodingFields.SingleFields.decode(from: &valuesDecoder)
                         case .pair:
-                            try CodingFields.PairFields.decode(from: &valuesDecoder)
+                            try CommonCodingFields.PairFields.decode(from: &valuesDecoder)
                         }
                     }
                 }
@@ -1561,7 +1561,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case inProgress
                     case done
 
@@ -1575,7 +1575,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "in_progress":
                             .inProgress
@@ -1590,9 +1590,9 @@ struct CommonDecodableMacroTests {
 
             extension Status: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Status {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .inProgress:
@@ -1624,7 +1624,7 @@ struct CommonDecodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: StaticStringDecodingField {
+                enum CommonCodingFields: StaticStringDecodingField {
                     case inProgress
                     case done
 
@@ -1638,7 +1638,7 @@ struct CommonDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "in_progress":
                             .inProgress
@@ -1655,9 +1655,9 @@ struct CommonDecodableMacroTests {
 
             extension Status: CommonDecodable {
                 static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Status {
-                    var _codingField: CodingFields?
+                    var _codingField: CommonCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(CommonCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .inProgress:

--- a/Tests/NewCodableMacrosTests/CommonEncodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonEncodableMacroTests.swift
@@ -41,7 +41,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case name
                     case age
 
@@ -60,8 +60,8 @@ struct CommonEncodableMacroTests {
             extension Person: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -86,7 +86,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Post {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case publishDate
                     case title
 
@@ -105,8 +105,8 @@ struct CommonEncodableMacroTests {
             extension Post: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.publishDate, value: self.publishDate)
-                        try structEncoder.encode(field: CodingFields.title, value: self.title)
+                        try structEncoder.encode(field: CommonCodingFields.publishDate, value: self.publishDate)
+                        try structEncoder.encode(field: CommonCodingFields.title, value: self.title)
                     }
                 }
             }
@@ -131,7 +131,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Item {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case name
                     case rating
 
@@ -150,8 +150,8 @@ struct CommonEncodableMacroTests {
             extension Item: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.rating, value: self.rating)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.rating, value: self.rating)
                     }
                 }
             }
@@ -180,7 +180,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Thing {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case name
 
                     @_transparent
@@ -196,7 +196,7 @@ struct CommonEncodableMacroTests {
             extension Thing: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -221,7 +221,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Config {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case name
 
                     @_transparent
@@ -237,7 +237,7 @@ struct CommonEncodableMacroTests {
             extension Config: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -304,7 +304,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Cached {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case name
 
                     @_transparent
@@ -320,7 +320,7 @@ struct CommonEncodableMacroTests {
             extension Cached: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -345,7 +345,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension WithDefault {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case name
                     case age
 
@@ -364,8 +364,8 @@ struct CommonEncodableMacroTests {
             extension WithDefault: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -390,7 +390,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension User {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case userName
                     case age
 
@@ -409,8 +409,8 @@ struct CommonEncodableMacroTests {
             extension User: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.userName, value: self.userName)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: CommonCodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: CommonCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -439,7 +439,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Observed {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case count
                     case name
 
@@ -458,8 +458,8 @@ struct CommonEncodableMacroTests {
             extension Observed: CommonEncodable {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.count, value: self.count)
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.count, value: self.count)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -482,7 +482,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case name
 
                     @_transparent
@@ -498,7 +498,7 @@ struct CommonEncodableMacroTests {
             extension Person: CommonEncodable {
                 public func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -525,7 +525,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Direction {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case north
                     case south
 
@@ -545,9 +545,9 @@ struct CommonEncodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .north:
-                        try encoder.encodeEnumCase(CodingFields.north)
+                        try encoder.encodeEnumCase(CommonCodingFields.north)
                     case .south:
-                        try encoder.encodeEnumCase(CodingFields.south)
+                        try encoder.encodeEnumCase(CommonCodingFields.south)
                     }
                 }
             }
@@ -572,7 +572,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Shape {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case circle
                     case point
 
@@ -604,11 +604,11 @@ struct CommonEncodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .circle(let radius):
-                        try encoder.encodeEnumCase(CodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.CircleFields.radius, value: radius)
+                        try encoder.encodeEnumCase(CommonCodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CommonCodingFields.CircleFields.radius, value: radius)
                         }
                     case .point:
-                        try encoder.encodeEnumCase(CodingFields.point)
+                        try encoder.encodeEnumCase(CommonCodingFields.point)
                     }
                 }
             }
@@ -633,7 +633,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Wrapper {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case single
                     case pair
 
@@ -680,13 +680,13 @@ struct CommonEncodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .single(let _0):
-                        try encoder.encodeEnumCase(CodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.SingleFields._0, value: _0)
+                        try encoder.encodeEnumCase(CommonCodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CommonCodingFields.SingleFields._0, value: _0)
                         }
                     case .pair(let _0, let _1):
-                        try encoder.encodeEnumCase(CodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.PairFields._0, value: _0)
-                            try valueEncoder.encode(field: CodingFields.PairFields._1, value: _1)
+                        try encoder.encodeEnumCase(CommonCodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: CommonCodingFields.PairFields._0, value: _0)
+                            try valueEncoder.encode(field: CommonCodingFields.PairFields._1, value: _1)
                         }
                     }
                 }
@@ -712,7 +712,7 @@ struct CommonEncodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: StaticStringEncodingField {
+                enum CommonCodingFields: StaticStringEncodingField {
                     case inProgress
                     case done
 
@@ -732,9 +732,9 @@ struct CommonEncodableMacroTests {
                 func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
                     switch self {
                     case .inProgress:
-                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                        try encoder.encodeEnumCase(CommonCodingFields.inProgress)
                     case .done:
-                        try encoder.encodeEnumCase(CodingFields.done)
+                        try encoder.encodeEnumCase(CommonCodingFields.done)
                     }
                 }
             }

--- a/Tests/NewCodableMacrosTests/CommonEncodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonEncodableMacroTests.swift
@@ -26,7 +26,7 @@ let commonTestMacros: [String: Macro.Type] = [
 struct CommonEncodableMacroTests {
 
     @Test func basicStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct Person {
@@ -71,7 +71,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func customCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct Post {
@@ -116,7 +116,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func optionalProperty() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct Item {
@@ -161,7 +161,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func computedPropertySkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct Thing {
@@ -206,7 +206,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func staticPropertySkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct Config {
@@ -247,7 +247,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func errorOnNonStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             class NotAStruct {
@@ -267,7 +267,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func emptyStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct Empty {
@@ -289,7 +289,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func lazyVarSkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct Cached {
@@ -330,7 +330,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func propertyWithDefaultValue() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct WithDefault {
@@ -375,7 +375,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func decodableAliasIgnoredForEncodingOnly() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct User {
@@ -420,7 +420,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func propertyWithObservers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             struct Observed {
@@ -469,7 +469,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func publicStructEmitsPublicMembers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             public struct Person {
@@ -510,7 +510,7 @@ struct CommonEncodableMacroTests {
     // MARK: - Enum Tests
 
     @Test func enumNoAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             enum Direction {
@@ -557,7 +557,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func enumWithAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             enum Shape {
@@ -618,7 +618,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func enumWithUnlabeledAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             enum Wrapper {
@@ -697,7 +697,7 @@ struct CommonEncodableMacroTests {
     }
 
     @Test func enumWithCustomCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @CommonEncodable
             enum Status {

--- a/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
@@ -35,7 +35,7 @@ struct JSONCodableMacroTests {
             }
             
             extension Person {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case name
                     case age
                     case unknown
@@ -52,7 +52,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -68,8 +68,8 @@ struct JSONCodableMacroTests {
             extension Person: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -79,9 +79,9 @@ struct JSONCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var age: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -123,7 +123,7 @@ struct JSONCodableMacroTests {
             }
             
             extension Item {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case name
                     case rating
                     case unknown
@@ -140,7 +140,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -156,8 +156,8 @@ struct JSONCodableMacroTests {
             extension Item: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.rating, value: self.rating)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.rating, value: self.rating)
                     }
                 }
             }
@@ -167,9 +167,9 @@ struct JSONCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var rating: Double?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -208,7 +208,7 @@ struct JSONCodableMacroTests {
             }
             
             extension Post {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case publishDate
                     case title
                     case unknown
@@ -225,7 +225,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "date_published":
                             .publishDate
@@ -241,8 +241,8 @@ struct JSONCodableMacroTests {
             extension Post: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.publishDate, value: self.publishDate)
-                        try structEncoder.encode(field: CodingFields.title, value: self.title)
+                        try structEncoder.encode(field: JSONCodingFields.publishDate, value: self.publishDate)
+                        try structEncoder.encode(field: JSONCodingFields.title, value: self.title)
                     }
                 }
             }
@@ -252,9 +252,9 @@ struct JSONCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var publishDate: String?
                         var title: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .publishDate:
@@ -326,7 +326,7 @@ struct JSONCodableMacroTests {
             }
             
             extension Config {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case name
                     case locale
                     case unknown
@@ -343,7 +343,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -359,8 +359,8 @@ struct JSONCodableMacroTests {
             extension Config: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.locale, value: self.locale)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.locale, value: self.locale)
                     }
                 }
             }
@@ -370,9 +370,9 @@ struct JSONCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var locale: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -409,7 +409,7 @@ struct JSONCodableMacroTests {
             }
             
             extension User {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case userName
                     case unknown
 
@@ -423,7 +423,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "userName":
                             .userName
@@ -439,7 +439,7 @@ struct JSONCodableMacroTests {
             extension User: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: JSONCodingFields.userName, value: self.userName)
                     }
                 }
             }
@@ -448,9 +448,9 @@ struct JSONCodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> User {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var userName: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .userName:
@@ -485,7 +485,7 @@ struct JSONCodableMacroTests {
             }
             
             extension User {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case userName
                     case unknown
 
@@ -499,7 +499,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "user_name":
                             .userName
@@ -515,7 +515,7 @@ struct JSONCodableMacroTests {
             extension User: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: JSONCodingFields.userName, value: self.userName)
                     }
                 }
             }
@@ -524,9 +524,9 @@ struct JSONCodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> User {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var userName: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .userName:
@@ -563,7 +563,7 @@ struct JSONCodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case name
                     case age
                     case unknown
@@ -580,7 +580,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -596,8 +596,8 @@ struct JSONCodableMacroTests {
             extension Person: JSONEncodable {
                 public func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -607,9 +607,9 @@ struct JSONCodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var age: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -649,7 +649,7 @@ struct JSONCodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case name
                     case unknown
 
@@ -663,7 +663,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -677,7 +677,7 @@ struct JSONCodableMacroTests {
             extension Person: JSONEncodable {
                 package func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -686,9 +686,9 @@ struct JSONCodableMacroTests {
                 package static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -747,7 +747,7 @@ struct JSONCodableMacroTests {
             }
 
             extension Direction {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case north
                     case south
 
@@ -761,7 +761,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "north":
                             .north
@@ -778,18 +778,18 @@ struct JSONCodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .north:
-                        try encoder.encodeEnumCase(CodingFields.north)
+                        try encoder.encodeEnumCase(JSONCodingFields.north)
                     case .south:
-                        try encoder.encodeEnumCase(CodingFields.south)
+                        try encoder.encodeEnumCase(JSONCodingFields.south)
                     }
                 }
             }
 
             extension Direction: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Direction {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .north:
@@ -821,7 +821,7 @@ struct JSONCodableMacroTests {
             }
 
             extension Shape {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case circle
                     case point
 
@@ -835,7 +835,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "circle":
                             .circle
@@ -890,24 +890,24 @@ struct JSONCodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .circle(let radius):
-                        try encoder.encodeEnumCase(CodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.CircleFields.radius, value: radius)
+                        try encoder.encodeEnumCase(JSONCodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.CircleFields.radius, value: radius)
                         }
                     case .point:
-                        try encoder.encodeEnumCase(CodingFields.point)
+                        try encoder.encodeEnumCase(JSONCodingFields.point)
                     }
                 }
             }
 
             extension Shape: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Shape {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .circle:
-                            try CodingFields.CircleFields.decode(from: &valuesDecoder)
+                            try JSONCodingFields.CircleFields.decode(from: &valuesDecoder)
                         case .point:
                             .point
                         }
@@ -935,7 +935,7 @@ struct JSONCodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case inProgress
                     case done
 
@@ -949,7 +949,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "in_progress":
                             .inProgress
@@ -966,18 +966,18 @@ struct JSONCodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .inProgress:
-                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                        try encoder.encodeEnumCase(JSONCodingFields.inProgress)
                     case .done:
-                        try encoder.encodeEnumCase(CodingFields.done)
+                        try encoder.encodeEnumCase(JSONCodingFields.done)
                     }
                 }
             }
 
             extension Status: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .inProgress:
@@ -1009,7 +1009,7 @@ struct JSONCodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: JSONOptimizedCodingField {
+                enum JSONCodingFields: JSONOptimizedCodingField {
                     case inProgress
                     case done
 
@@ -1023,7 +1023,7 @@ struct JSONCodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "in_progress":
                             .inProgress
@@ -1042,18 +1042,18 @@ struct JSONCodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .inProgress:
-                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                        try encoder.encodeEnumCase(JSONCodingFields.inProgress)
                     case .done:
-                        try encoder.encodeEnumCase(CodingFields.done)
+                        try encoder.encodeEnumCase(JSONCodingFields.done)
                     }
                 }
             }
 
             extension Status: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .inProgress:

--- a/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONCodableMacroTests.swift
@@ -20,7 +20,7 @@ import NewCodableMacros
 struct JSONCodableMacroTests {
 
     @Test func basicStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             struct Person {
@@ -108,7 +108,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func optionalProperty() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             struct Item {
@@ -193,7 +193,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func customCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             struct Post {
@@ -281,7 +281,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func emptyStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             struct Empty {
@@ -311,7 +311,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func defaultValue() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             struct Config {
@@ -396,7 +396,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func aliasFullRoundtrip() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             struct User {
@@ -472,7 +472,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func aliasCombinedWithCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             struct User {
@@ -548,7 +548,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func publicStructEmitsPublicMembers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             public struct Person {
@@ -636,7 +636,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func packageStructEmitsPackageMembers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             package struct Person {
@@ -710,7 +710,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func errorOnNonStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             class NotAStruct {
@@ -732,7 +732,7 @@ struct JSONCodableMacroTests {
     // MARK: - Enum Tests
 
     @Test func enumNoAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             enum Direction {
@@ -806,7 +806,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func enumWithAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             enum Shape {
@@ -920,7 +920,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func enumWithCustomCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             enum Status {
@@ -994,7 +994,7 @@ struct JSONCodableMacroTests {
     }
 
     @Test func enumWithDecodableAlias() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONCodable
             enum Status {

--- a/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
@@ -35,7 +35,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case name
                     case age
                     case unknown
@@ -52,7 +52,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -70,9 +70,9 @@ struct JSONDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var age: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -114,7 +114,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Item {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case name
                     case rating
                     case unknown
@@ -131,7 +131,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -149,9 +149,9 @@ struct JSONDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
                         var rating: Double?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -190,7 +190,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Preferences {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case theme
                     case fontSize
                     case unknown
@@ -207,7 +207,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "theme":
                             .theme
@@ -225,9 +225,9 @@ struct JSONDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var theme: String?
                         var fontSize: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .theme:
@@ -263,7 +263,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Post {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case publishDate
                     case title
                     case unknown
@@ -280,7 +280,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "date_published":
                             .publishDate
@@ -298,9 +298,9 @@ struct JSONDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var publishDate: String?
                         var title: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .publishDate:
@@ -346,7 +346,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Thing {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case name
                     case unknown
 
@@ -360,7 +360,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -375,9 +375,9 @@ struct JSONDecodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Thing {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -414,7 +414,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Config {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case name
                     case unknown
 
@@ -428,7 +428,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -443,9 +443,9 @@ struct JSONDecodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Config {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -482,7 +482,7 @@ struct JSONDecodableMacroTests {
             }
             
             extension Cached {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case name
                     case unknown
 
@@ -496,7 +496,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -511,9 +511,9 @@ struct JSONDecodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Cached {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -615,7 +615,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Config {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case name
                     case locale
                     case retryCount
@@ -635,7 +635,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -656,9 +656,9 @@ struct JSONDecodableMacroTests {
                         var name: String?
                         var locale: String?
                         var retryCount: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -699,7 +699,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Defaults {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case greeting
                     case verbose
                     case unknown
@@ -716,7 +716,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "greeting":
                             .greeting
@@ -734,9 +734,9 @@ struct JSONDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var greeting: String?
                         var verbose: Bool?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .greeting:
@@ -770,7 +770,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Setting {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case maxRetries
                     case unknown
 
@@ -784,7 +784,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "max_retries":
                             .maxRetries
@@ -799,9 +799,9 @@ struct JSONDecodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Setting {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var maxRetries: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .maxRetries:
@@ -833,7 +833,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Prefs {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case locale
                     case unknown
 
@@ -847,7 +847,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "locale":
                             .locale
@@ -862,9 +862,9 @@ struct JSONDecodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Prefs {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var locale: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .locale:
@@ -896,7 +896,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension WithExpr {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case tags
                     case unknown
 
@@ -910,7 +910,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "tags":
                             .tags
@@ -925,9 +925,9 @@ struct JSONDecodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> WithExpr {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var tags: [String]?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .tags:
@@ -961,7 +961,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension User {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case userName
                     case age
                     case unknown
@@ -978,7 +978,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "userName":
                             .userName
@@ -998,9 +998,9 @@ struct JSONDecodableMacroTests {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var userName: String?
                         var age: Int?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .userName:
@@ -1040,7 +1040,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension User {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case userName
                     case unknown
 
@@ -1054,7 +1054,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "user_name":
                             .userName
@@ -1071,9 +1071,9 @@ struct JSONDecodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> User {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var userName: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .userName:
@@ -1108,7 +1108,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension User {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case name
                     case unknown
 
@@ -1122,7 +1122,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -1143,9 +1143,9 @@ struct JSONDecodableMacroTests {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> User {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -1180,7 +1180,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case name
                     case unknown
 
@@ -1194,7 +1194,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "name":
                             .name
@@ -1209,9 +1209,9 @@ struct JSONDecodableMacroTests {
                 public static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Person {
                     try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
                         var name: String?
-                        var _codingField: CodingFields?
+                        var _codingField: JSONCodingFields?
                         try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
-                            _codingField = try fieldDecoder.decode(CodingFields.self)
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                         } andValue: { valueDecoder throws(CodingError.Decoding) in
                             switch _codingField! {
                             case .name:
@@ -1254,7 +1254,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Direction {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case north
                     case south
                     case east
@@ -1274,7 +1274,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "north":
                             .north
@@ -1293,9 +1293,9 @@ struct JSONDecodableMacroTests {
 
             extension Direction: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Direction {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .north:
@@ -1331,7 +1331,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Shape {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case circle
                     case rectangle
 
@@ -1345,7 +1345,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "circle":
                             .circle
@@ -1444,15 +1444,15 @@ struct JSONDecodableMacroTests {
 
             extension Shape: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Shape {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .circle:
-                            try CodingFields.CircleFields.decode(from: &valuesDecoder)
+                            try JSONCodingFields.CircleFields.decode(from: &valuesDecoder)
                         case .rectangle:
-                            try CodingFields.RectangleFields.decode(from: &valuesDecoder)
+                            try JSONCodingFields.RectangleFields.decode(from: &valuesDecoder)
                         }
                     }
                 }
@@ -1478,7 +1478,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Result {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case success
                     case failure
 
@@ -1492,7 +1492,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "success":
                             .success
@@ -1545,13 +1545,13 @@ struct JSONDecodableMacroTests {
 
             extension Result: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Result {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .success:
-                            try CodingFields.SuccessFields.decode(from: &valuesDecoder)
+                            try JSONCodingFields.SuccessFields.decode(from: &valuesDecoder)
                         case .failure:
                             .failure
                         }
@@ -1579,7 +1579,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Wrapper {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case single
                     case pair
 
@@ -1593,7 +1593,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "single":
                             .single
@@ -1692,15 +1692,15 @@ struct JSONDecodableMacroTests {
 
             extension Wrapper: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Wrapper {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .single:
-                            try CodingFields.SingleFields.decode(from: &valuesDecoder)
+                            try JSONCodingFields.SingleFields.decode(from: &valuesDecoder)
                         case .pair:
-                            try CodingFields.PairFields.decode(from: &valuesDecoder)
+                            try JSONCodingFields.PairFields.decode(from: &valuesDecoder)
                         }
                     }
                 }
@@ -1726,7 +1726,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case inProgress
                     case done
 
@@ -1740,7 +1740,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "in_progress":
                             .inProgress
@@ -1755,9 +1755,9 @@ struct JSONDecodableMacroTests {
 
             extension Status: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .inProgress:
@@ -1789,7 +1789,7 @@ struct JSONDecodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: JSONOptimizedDecodingField {
+                enum JSONCodingFields: JSONOptimizedDecodingField {
                     case inProgress
                     case done
 
@@ -1803,7 +1803,7 @@ struct JSONDecodableMacroTests {
                         }
                     }
 
-                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CodingFields {
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
                         switch UTF8SpanComparator(key) {
                         case "in_progress":
                             .inProgress
@@ -1820,9 +1820,9 @@ struct JSONDecodableMacroTests {
 
             extension Status: JSONDecodable {
                 static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
-                    var _codingField: CodingFields?
+                    var _codingField: JSONCodingFields?
                     return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
-                        _codingField = try fieldDecoder.decode(CodingFields.self)
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
                     } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
                         return switch _codingField! {
                         case .inProgress:

--- a/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONDecodableMacroTests.swift
@@ -20,7 +20,7 @@ import NewCodableMacros
 struct JSONDecodableMacroTests {
 
     @Test func basicStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Person {
@@ -99,7 +99,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func optionalProperty() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Item {
@@ -175,7 +175,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func allOptionalProperties() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Preferences {
@@ -248,7 +248,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func customCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Post {
@@ -327,7 +327,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func computedPropertySkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Thing {
@@ -399,7 +399,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func staticPropertySkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Config {
@@ -467,7 +467,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func lazyVarSkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Cached {
@@ -535,7 +535,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func emptyStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Empty {
@@ -558,7 +558,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func errorOnNonStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             class NotAStruct {
@@ -578,7 +578,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func propertyWithoutTypeAnnotation() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Bad {
@@ -598,7 +598,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func defaultValue() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Config {
@@ -684,7 +684,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func allDefaultValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Defaults {
@@ -757,7 +757,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func defaultWithCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Setting {
@@ -820,7 +820,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func defaultOnOptionalProperty() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct Prefs {
@@ -883,7 +883,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func defaultWithArbitraryExpression() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct WithExpr {
@@ -946,7 +946,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func aliasBasic() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct User {
@@ -1027,7 +1027,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func aliasCombinedWithCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct User {
@@ -1095,7 +1095,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func aliasMultiple() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             struct User {
@@ -1167,7 +1167,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func publicStructEmitsPublicMembers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             public struct Person {
@@ -1235,7 +1235,7 @@ struct JSONDecodableMacroTests {
     // MARK: - Enum Tests
 
     @Test func enumNoAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             enum Direction {
@@ -1316,7 +1316,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func enumWithLabeledAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             enum Shape {
@@ -1463,7 +1463,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func enumMixedCases() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             enum Result {
@@ -1564,7 +1564,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func enumWithUnlabeledAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             enum Wrapper {
@@ -1711,7 +1711,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func enumWithCustomCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             enum Status {
@@ -1774,7 +1774,7 @@ struct JSONDecodableMacroTests {
     }
 
     @Test func enumWithDecodableAlias() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONDecodable
             enum Status {

--- a/Tests/NewCodableMacrosTests/JSONEncodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONEncodableMacroTests.swift
@@ -41,7 +41,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case name
                     case age
 
@@ -60,8 +60,8 @@ struct JSONEncodableMacroTests {
             extension Person: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -86,7 +86,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Post {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case publishDate
                     case title
 
@@ -105,8 +105,8 @@ struct JSONEncodableMacroTests {
             extension Post: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.publishDate, value: self.publishDate)
-                        try structEncoder.encode(field: CodingFields.title, value: self.title)
+                        try structEncoder.encode(field: JSONCodingFields.publishDate, value: self.publishDate)
+                        try structEncoder.encode(field: JSONCodingFields.title, value: self.title)
                     }
                 }
             }
@@ -131,7 +131,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Item {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case name
                     case rating
 
@@ -150,8 +150,8 @@ struct JSONEncodableMacroTests {
             extension Item: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.rating, value: self.rating)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.rating, value: self.rating)
                     }
                 }
             }
@@ -180,7 +180,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Thing {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case name
 
                     @_transparent
@@ -196,7 +196,7 @@ struct JSONEncodableMacroTests {
             extension Thing: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -221,7 +221,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Config {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case name
 
                     @_transparent
@@ -237,7 +237,7 @@ struct JSONEncodableMacroTests {
             extension Config: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -304,7 +304,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Cached {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case name
 
                     @_transparent
@@ -320,7 +320,7 @@ struct JSONEncodableMacroTests {
             extension Cached: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -345,7 +345,7 @@ struct JSONEncodableMacroTests {
             }
             
             extension WithDefault {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case name
                     case age
 
@@ -364,8 +364,8 @@ struct JSONEncodableMacroTests {
             extension WithDefault: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -390,7 +390,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension User {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case userName
                     case age
 
@@ -409,8 +409,8 @@ struct JSONEncodableMacroTests {
             extension User: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.userName, value: self.userName)
-                        try structEncoder.encode(field: CodingFields.age, value: self.age)
+                        try structEncoder.encode(field: JSONCodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: JSONCodingFields.age, value: self.age)
                     }
                 }
             }
@@ -439,7 +439,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Observed {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case count
                     case name
 
@@ -458,8 +458,8 @@ struct JSONEncodableMacroTests {
             extension Observed: JSONEncodable {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.count, value: self.count)
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.count, value: self.count)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -482,7 +482,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Person {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case name
 
                     @_transparent
@@ -498,7 +498,7 @@ struct JSONEncodableMacroTests {
             extension Person: JSONEncodable {
                 public func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     try encoder.encodeStructFields(count: 1) { structEncoder throws(CodingError.Encoding) in
-                        try structEncoder.encode(field: CodingFields.name, value: self.name)
+                        try structEncoder.encode(field: JSONCodingFields.name, value: self.name)
                     }
                 }
             }
@@ -529,7 +529,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Direction {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case north
                     case south
                     case east
@@ -555,13 +555,13 @@ struct JSONEncodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .north:
-                        try encoder.encodeEnumCase(CodingFields.north)
+                        try encoder.encodeEnumCase(JSONCodingFields.north)
                     case .south:
-                        try encoder.encodeEnumCase(CodingFields.south)
+                        try encoder.encodeEnumCase(JSONCodingFields.south)
                     case .east:
-                        try encoder.encodeEnumCase(CodingFields.east)
+                        try encoder.encodeEnumCase(JSONCodingFields.east)
                     case .west:
-                        try encoder.encodeEnumCase(CodingFields.west)
+                        try encoder.encodeEnumCase(JSONCodingFields.west)
                     }
                 }
             }
@@ -586,7 +586,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Shape {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case circle
                     case rectangle
 
@@ -633,13 +633,13 @@ struct JSONEncodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .circle(let radius):
-                        try encoder.encodeEnumCase(CodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.CircleFields.radius, value: radius)
+                        try encoder.encodeEnumCase(JSONCodingFields.circle, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.CircleFields.radius, value: radius)
                         }
                     case .rectangle(let width, let height):
-                        try encoder.encodeEnumCase(CodingFields.rectangle, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.RectangleFields.width, value: width)
-                            try valueEncoder.encode(field: CodingFields.RectangleFields.height, value: height)
+                        try encoder.encodeEnumCase(JSONCodingFields.rectangle, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.RectangleFields.width, value: width)
+                            try valueEncoder.encode(field: JSONCodingFields.RectangleFields.height, value: height)
                         }
                     }
                 }
@@ -665,7 +665,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Result {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case success
                     case failure
 
@@ -697,11 +697,11 @@ struct JSONEncodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .success(let value):
-                        try encoder.encodeEnumCase(CodingFields.success, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.SuccessFields.value, value: value)
+                        try encoder.encodeEnumCase(JSONCodingFields.success, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.SuccessFields.value, value: value)
                         }
                     case .failure:
-                        try encoder.encodeEnumCase(CodingFields.failure)
+                        try encoder.encodeEnumCase(JSONCodingFields.failure)
                     }
                 }
             }
@@ -726,7 +726,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Wrapper {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case single
                     case pair
 
@@ -773,13 +773,13 @@ struct JSONEncodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .single(let _0):
-                        try encoder.encodeEnumCase(CodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.SingleFields._0, value: _0)
+                        try encoder.encodeEnumCase(JSONCodingFields.single, associatedValueCount: 1) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.SingleFields._0, value: _0)
                         }
                     case .pair(let _0, let _1):
-                        try encoder.encodeEnumCase(CodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
-                            try valueEncoder.encode(field: CodingFields.PairFields._0, value: _0)
-                            try valueEncoder.encode(field: CodingFields.PairFields._1, value: _1)
+                        try encoder.encodeEnumCase(JSONCodingFields.pair, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.PairFields._0, value: _0)
+                            try valueEncoder.encode(field: JSONCodingFields.PairFields._1, value: _1)
                         }
                     }
                 }
@@ -805,7 +805,7 @@ struct JSONEncodableMacroTests {
             }
 
             extension Status {
-                enum CodingFields: JSONOptimizedEncodingField {
+                enum JSONCodingFields: JSONOptimizedEncodingField {
                     case inProgress
                     case done
 
@@ -825,9 +825,9 @@ struct JSONEncodableMacroTests {
                 func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
                     switch self {
                     case .inProgress:
-                        try encoder.encodeEnumCase(CodingFields.inProgress)
+                        try encoder.encodeEnumCase(JSONCodingFields.inProgress)
                     case .done:
-                        try encoder.encodeEnumCase(CodingFields.done)
+                        try encoder.encodeEnumCase(JSONCodingFields.done)
                     }
                 }
             }

--- a/Tests/NewCodableMacrosTests/JSONEncodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/JSONEncodableMacroTests.swift
@@ -26,7 +26,7 @@ let testMacros: [String: Macro.Type] = [
 struct JSONEncodableMacroTests {
 
     @Test func basicStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct Person {
@@ -71,7 +71,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func customCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct Post {
@@ -116,7 +116,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func optionalProperty() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct Item {
@@ -161,7 +161,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func computedPropertySkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct Thing {
@@ -206,7 +206,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func staticPropertySkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct Config {
@@ -247,7 +247,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func errorOnNonStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             class NotAStruct {
@@ -267,7 +267,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func emptyStruct() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct Empty {
@@ -289,7 +289,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func lazyVarSkipped() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct Cached {
@@ -330,7 +330,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func propertyWithDefaultValue() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct WithDefault {
@@ -375,7 +375,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func decodableAliasIgnoredForEncodingOnly() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct User {
@@ -420,7 +420,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func propertyWithObservers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             struct Observed {
@@ -469,7 +469,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func publicStructEmitsPublicMembers() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             public struct Person {
@@ -510,7 +510,7 @@ struct JSONEncodableMacroTests {
     // MARK: - Enum Tests
 
     @Test func enumNoAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             enum Direction {
@@ -571,7 +571,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func enumWithLabeledAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             enum Shape {
@@ -650,7 +650,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func enumMixedCases() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             enum Result {
@@ -711,7 +711,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func enumWithUnlabeledAssociatedValues() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             enum Wrapper {
@@ -790,7 +790,7 @@ struct JSONEncodableMacroTests {
     }
 
     @Test func enumWithCustomCodingKey() {
-        assertMacroExpansion(
+        AssertMacroExpansion(
             """
             @JSONEncodable
             enum Status {

--- a/Tests/NewCodableMacrosTests/MacroTestUtilities.swift
+++ b/Tests/NewCodableMacrosTests/MacroTestUtilities.swift
@@ -1,0 +1,37 @@
+import SwiftSyntax
+import SwiftSyntaxMacrosGenericTestSupport
+import SwiftSyntaxMacros
+import SwiftSyntaxMacroExpansion
+import Testing
+
+func AssertMacroExpansion(
+    _ originalSource: String,
+    expandedSource expectedExpandedSource: String,
+    diagnostics: [DiagnosticSpec] = [],
+    macros: [String: any Macro.Type],
+    applyFixIts: [String]? = nil,
+    fixedSource expectedFixedSource: String? = nil,
+    testModuleName: String = "TestModule",
+    testFileName: String = "test.swift",
+    indentationWidth: Trivia = .spaces(4),
+    sourceLocation: Testing.SourceLocation = #_sourceLocation) {
+    let macroSpecs = macros.mapValues { MacroSpec(type: $0) }
+    SwiftSyntaxMacrosGenericTestSupport.assertMacroExpansion(
+        originalSource,
+        expandedSource: expectedExpandedSource,
+        diagnostics: diagnostics,
+        macroSpecs: macroSpecs,
+        applyFixIts: applyFixIts,
+        fixedSource: expectedFixedSource,
+        testModuleName: testModuleName,
+        testFileName: testFileName,
+        indentationWidth: indentationWidth,
+        failureHandler: {
+            Issue.record(Comment(rawValue: $0.message), sourceLocation: sourceLocation)
+        },
+        fileID: "",
+        filePath: "",
+        line: UInt(sourceLocation.line),
+        column: UInt(sourceLocation.column)
+    )
+}

--- a/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
@@ -350,3 +350,103 @@ struct JSONCodableMacroIntegrationTests {
         #expect(decoded2 == pair)
     }
 }
+
+// MARK: - Combined @JSONCodable + @CommonCodable Integration Tests
+
+/// A type annotated with both @JSONCodable and @CommonCodable to verify
+/// that both conformances are generated correctly when macros are stacked.
+@JSONCodable @CommonCodable
+struct DualCodableStruct: Equatable {
+    let name: String
+    let count: Int
+    let active: Bool
+    let nickname: String?
+
+    @CodingKey("created_at")
+    let createdAt: String
+
+    @CodableDefault("unknown")
+    let source: String
+
+    @DecodableAlias("colour")
+    let color: String
+}
+
+@Suite("Combined @JSONCodable + @CommonCodable Integration")
+struct CombinedMacroIntegrationTests {
+
+    static let expectedJSON = #"{"name":"Widget","count":42,"active":true,"nickname":"W","created_at":"2026-01-01","source":"api","color":"red"}"#
+
+    static func makeSample() -> DualCodableStruct {
+        DualCodableStruct(
+            name: "Widget",
+            count: 42,
+            active: true,
+            nickname: "W",
+            createdAt: "2026-01-01",
+            source: "api",
+            color: "red"
+        )
+    }
+
+    @Test func jsonRoundTrip() throws {
+        let original = Self.makeSample()
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == Self.expectedJSON)
+        let decoded = try NewJSONDecoder().decode(DualCodableStruct.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func commonRoundTrip() throws {
+        let original = Self.makeSample()
+        let data = try encodeViaCommon(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == Self.expectedJSON)
+        let decoded: DualCodableStruct = try decodeViaCommon(from: data)
+        #expect(decoded == original)
+    }
+
+    private func encodeViaCommon(_ value: borrowing some CommonEncodable) throws -> Data {
+        try NewJSONEncoder().encode(value)
+    }
+
+    private func decodeViaCommon<T: CommonDecodable>(from data: Data) throws -> T {
+        try NewJSONDecoder().decode(T.self, from: data)
+    }
+
+    @Test func optionalNilRoundTrip() throws {
+        let original = DualCodableStruct(
+            name: "X", count: 0, active: false,
+            nickname: nil, createdAt: "2026-01-01", source: "test", color: "blue"
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"nickname\":null"))
+        let decoded = try NewJSONDecoder().decode(DualCodableStruct.self, from: data)
+        #expect(decoded.nickname == nil)
+    }
+
+    @Test func defaultValueWhenKeyAbsent() throws {
+        let json = Data(#"{"name":"X","count":0,"active":false,"nickname":null,"created_at":"2026-01-01","color":"blue"}"#.utf8)
+        let decoded = try NewJSONDecoder().decode(DualCodableStruct.self, from: json)
+        #expect(decoded.source == "unknown")
+    }
+
+    @Test func aliasDecoding() throws {
+        let json = Data(#"{"name":"X","count":0,"active":false,"nickname":null,"created_at":"2026-01-01","source":"web","colour":"green"}"#.utf8)
+        let decoded = try NewJSONDecoder().decode(DualCodableStruct.self, from: json)
+        #expect(decoded.color == "green")
+    }
+
+    @Test func reversedAttributeOrder() throws {
+        // Verifying the same type works — DualCodableStruct has @JSONCodable @CommonCodable.
+        // This test confirms both paths produce the same JSON regardless of which path encodes.
+        let original = Self.makeSample()
+        let jsonData = try NewJSONEncoder().encode(original)
+        let commonData = try encodeViaCommon(original)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let commonString = String(data: commonData, encoding: .utf8)!
+        #expect(jsonString == commonString)
+    }
+}


### PR DESCRIPTION
This PR enables combining multiple Codable macros on a single type

### Motivation:

At present it isn't actually possible to add `@JSONCodable` and `@CommonCodable` to a single type. It isn't even possible to add `@JSONEncodable` and `@JSONDecodable` separately. The core restriction lies in the fact that each macro takes upon itself the responsibility to generate the `CodingFields` type and its implementation. We need to make the macros "share" that responsibility.

### Modifications:

We're working with limited information in a macro, especially regarding other macros attached to the same type—basically just its name.

* We use "Codable", "Encodable", and "Decodable" suffixes on the macros as hints for the intention of the macro.
* We allow only the first (lexically) codable macro to generate a CodingFields "base" type.
* If there's only one format being implemented, that CodingFields type also becomes the type that will be used directly by the implementation. If there are multiple, then separate "wrapper" structs will be created that defer to that core type. This is to allow each format macro to conform to separate CodingField protocols like `JSONOptimizedCodingField`.

### Result:

`@JSONCodable` and `@CommonCodable` can now be combined in any order. Same for `@JSONEncodable` and `@JSONDecodable` (for a result identical to just `@JSONCodable`).

The important parts I care about most are the shared macro interfaces and the resulting output. The actual implementation of the macros could be improved and deduplicated a fair bit. That's not my top priority right now though.

### Testing:

Macro expansion verification, including improved diagnostics in swift testing.
Macro integration testing to ensure the generated code works correctly.