### PR TITLE
Remove _specializingCast from Foundation

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -314,9 +314,9 @@ extension AttributedString.CharacterView: RangeReplaceableCollection {
         let subrange = _guts.characterRange(roundingDown: subrange._bstringRange)
         
         // Prevent the BigString mutation below from falling back to Character-by-Character loops.
-        if let newElements = _specializingCast(newElements, to: Self.self) {
+        if let newElements = _specialize(newElements, for: Self.self) {
             _replaceSubrange(subrange, with: newElements._characters)
-        } else if let newElements = _specializingCast(newElements, to: Slice<Self>.self) {
+        } else if let newElements = _specialize(newElements, for: Slice<Self>.self) {
             _replaceSubrange(subrange, with: newElements._rebased._characters)
         } else {
             _replaceSubrange(subrange, with: newElements)
@@ -333,7 +333,7 @@ extension AttributedString.CharacterView: RangeReplaceableCollection {
         // don't need to touch string storage, but we still want to update attributes as if it was
         // a full edit.
         var hasStringChanges = true
-        if let newElements = _specializingCast(newElements, to: BigSubstring.self),
+        if let newElements = _specialize(newElements, for: BigSubstring.self),
            newElements.isIdentical(to: _characters[subrange]) {
             hasStringChanges = false
         }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -297,9 +297,9 @@ extension AttributedString.UnicodeScalarView: RangeReplaceableCollection {
         let subrange = _guts.unicodeScalarRange(roundingDown: subrange._bstringRange)
 
         // Prevent the BigString mutation below from falling back to Character-by-Character loops.
-        if let newElements = _specializingCast(newElements, to: Self.self) {
+        if let newElements = _specialize(newElements, for: Self.self) {
             _replaceSubrange(subrange, with: newElements._unicodeScalars)
-        } else if let newElements = _specializingCast(newElements, to: Slice<Self>.self) {
+        } else if let newElements = _specialize(newElements, for: Slice<Self>.self) {
             _replaceSubrange(subrange, with: newElements._rebased._unicodeScalars)
         } else {
             _replaceSubrange(subrange, with: newElements)
@@ -316,7 +316,7 @@ extension AttributedString.UnicodeScalarView: RangeReplaceableCollection {
         // don't need to touch string storage, but we still want to update attributes as if it was
         // a full edit.
         var hasStringChanges = true
-        if let newElements = _specializingCast(newElements, to: BigSubstring.UnicodeScalarView.self),
+        if let newElements = _specialize(newElements, for: BigSubstring.UnicodeScalarView.self),
            newElements.isIdentical(to: _unicodeScalars[subrange]) {
             hasStringChanges = false
         }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -143,9 +143,9 @@ extension AttributedString {
     }
 
     internal init(_ s: some AttributedStringProtocol) {
-        if let s = _specializingCast(s, to: AttributedString.self) {
+        if let s = _specialize(s, for: AttributedString.self) {
             self = s
-        } else if let s = _specializingCast(s, to: AttributedSubstring.self) {
+        } else if let s = _specialize(s, for: AttributedSubstring.self) {
             self = AttributedString(s)
         } else {
             // !!!: We don't expect or want this to happen.
@@ -251,17 +251,17 @@ extension AttributedString {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
     internal static func _bstring<S: Sequence<Character>>(from elements: S) -> BigString {
-        if let elements = _specializingCast(elements, to: String.self) {
+        if let elements = _specialize(elements, for: String.self) {
             return BigString(elements)
         }
-        if let elements = _specializingCast(elements, to: Substring.self) {
+        if let elements = _specialize(elements, for: Substring.self) {
             return BigString(elements)
         }
-        if let elements = _specializingCast(elements, to: AttributedString.CharacterView.self) {
+        if let elements = _specialize(elements, for: AttributedString.CharacterView.self) {
             return BigString(elements._characters)
         }
-        if let elements = _specializingCast(
-            elements, to: Slice<AttributedString.CharacterView>.self
+        if let elements = _specialize(
+            elements, for: Slice<AttributedString.CharacterView>.self
         ) {
             return BigString(elements._characters)
         }

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -162,9 +162,9 @@ extension AttributedStringProtocol {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedStringProtocol {
     internal var __guts: AttributedString.Guts {
-        if let s = _specializingCast(self, to: AttributedString.self) {
+        if let s = _specialize(self, for: AttributedString.self) {
             return s._guts
-        } else if let s = _specializingCast(self, to: AttributedSubstring.self) {
+        } else if let s = _specialize(self, for: AttributedSubstring.self) {
             return s._guts
         } else {
             return self.characters._guts

--- a/Sources/FoundationEssentials/AttributedString/Collection Stdlib Defaults.swift
+++ b/Sources/FoundationEssentials/AttributedString/Collection Stdlib Defaults.swift
@@ -113,9 +113,3 @@ extension BidirectionalCollection {
     return i
   }
 }
-
-@inline(__always)
-internal func _specializingCast<Input, Output>(_ value: Input, to type: Output.Type) -> Output? {
-    guard Input.self == Output.self else { return nil }
-    return _identityCast(value, to: type)
-}

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -1293,35 +1293,35 @@ private extension __JSONEncoder {
     }
 
     func _asDirectArrayEncodable<T: Encodable>(_ value: T) -> _JSONDirectArrayEncodable? {
-        return if let array = _specializingCast(value, to: [Int8].self) {
+        return if let array = _specialize(value, for: [Int8].self) {
             array
-        } else if let array = _specializingCast(value, to: [Int16].self) {
+        } else if let array = _specialize(value, for: [Int16].self) {
             array
-        } else if let array = _specializingCast(value, to: [Int32].self) {
+        } else if let array = _specialize(value, for: [Int32].self) {
             array
-        } else if let array = _specializingCast(value, to: [Int64].self) {
+        } else if let array = _specialize(value, for: [Int64].self) {
             array
-        } else if let array = _specializingCast(value, to: [Int128].self) {
+        } else if let array = _specialize(value, for: [Int128].self) {
             array
-        } else if let array = _specializingCast(value, to: [Int].self) {
+        } else if let array = _specialize(value, for: [Int].self) {
             array
-        } else if let array = _specializingCast(value, to: [UInt8].self) {
+        } else if let array = _specialize(value, for: [UInt8].self) {
             array
-        } else if let array = _specializingCast(value, to: [UInt16].self) {
+        } else if let array = _specialize(value, for: [UInt16].self) {
             array
-        } else if let array = _specializingCast(value, to: [UInt32].self) {
+        } else if let array = _specialize(value, for: [UInt32].self) {
             array
-        } else if let array = _specializingCast(value, to: [UInt64].self) {
+        } else if let array = _specialize(value, for: [UInt64].self) {
             array
-        } else if let array = _specializingCast(value, to: [UInt128].self) {
+        } else if let array = _specialize(value, for: [UInt128].self) {
             array
-        } else if let array = _specializingCast(value, to: [UInt].self) {
+        } else if let array = _specialize(value, for: [UInt].self) {
             array
-        } else if let array = _specializingCast(value, to: [String].self) {
+        } else if let array = _specialize(value, for: [String].self) {
             array
-        } else if let array = _specializingCast(value, to: [Float].self) {
+        } else if let array = _specialize(value, for: [Float].self) {
             array
-        } else if let array = _specializingCast(value, to: [Double].self) {
+        } else if let array = _specialize(value, for: [Double].self) {
             array
         } else {
             nil

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -33,7 +33,7 @@ extension StringProtocol {
         // Standardize the path to use forward slashes before processing for consistency
         return self.replacing(._backslash, with: ._slash)
         #else
-        if let str = _specializingCast(self, to: String.self) {
+        if let str = _specialize(self, for: String.self) {
             return str
         } else {
             return String(self)

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -415,10 +415,10 @@ extension StringProtocol {
         // `Substring`. Note that we're only ever calling `_lineBounds` on a `Substring`; this is
         // to reduce the code size overhead of having to specialize it multiple times (at a slight
         // cost to runtime performance).
-        if let s = _specializingCast(self, to: String.self) {
+        if let s = _specialize(self, for: String.self) {
             let range = s.unicodeScalars._boundaryAlignedRange(range)
             return s[...].utf8._lineBounds(around: range)
-        } else if let s = _specializingCast(self, to: Substring.self) {
+        } else if let s = _specialize(self, for: Substring.self) {
             let range = s.unicodeScalars._boundaryAlignedRange(range)
             return s.utf8._lineBounds(around: range)
         } else {
@@ -454,10 +454,10 @@ extension StringProtocol {
         // `Substring`. Note that we're only ever calling `_paragraphBounds` on a `Substring`; this is
         // to reduce the code size overhead of having to specialize it multiple times (at a slight
         // cost to runtime performance).
-        if let s = _specializingCast(self, to: String.self) {
+        if let s = _specialize(self, for: String.self) {
             let range = s.unicodeScalars._boundaryAlignedRange(range)
             return s[...].utf8._paragraphBounds(around: range) // Note: We use [...] to get a Substring
-        } else if let s = _specializingCast(self, to: Substring.self) {
+        } else if let s = _specialize(self, for: Substring.self) {
             let range = s.unicodeScalars._boundaryAlignedRange(range)
             return s.utf8._paragraphBounds(around: range)
         } else {

--- a/Sources/FoundationEssentials/URL/URLEncoder.swift
+++ b/Sources/FoundationEssentials/URL/URLEncoder.swift
@@ -758,7 +758,7 @@ extension StringProtocol {
         }
         #endif
 
-        let string = _specializingCast(self, to: String.self) ?? String(self)
+        let string = _specialize(self, for: String.self) ?? String(self)
         if allowedCharacters.hasIdenticalSwiftStorage(to: .urlPathAllowed) {
             return URLEncoder.percentEncode(path: string)
         } else if allowedCharacters.hasIdenticalSwiftStorage(to: .urlHostAllowed) {
@@ -788,7 +788,7 @@ extension StringProtocol {
         }
         #endif
         return URLEncoder.percentDecode(
-            string: _specializingCast(self, to: String.self) ?? String(self)
+            string: _specialize(self, for: String.self) ?? String(self)
         )
     }
 }


### PR DESCRIPTION
Removes `_specializingCast` in favor of `_specialize`

### Motivation:

We added `_specializingCast` to Foundation, but now the stdlib offers `_specialize` so we can just use that instead and remove our implementation

### Modifications:

Removes `_specializingCast` and replaces all uses with `_specialize`

### Result:

All code uses `_specialize` from the stdlib instead of our own implementation

### Testing:

All code still builds and tests still pass
