### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/Sources/FoundationEssentials/Formatting/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Formatting/CMakeLists.txt
@@ -15,6 +15,7 @@
 target_sources(FoundationEssentials PRIVATE
     BinaryInteger+NumericStringRepresentation.swift
     Date+ISO8601FormatStyle.swift
+    Date+HTTPFormatStyle.swift
     DateComponents+ISO8601FormatStyle.swift
     DiscreteFormatStyle.swift
     FormatParsingUtilities.swift


### PR DESCRIPTION
Adds a file to CMakeLists.txt that was missing

### Motivation:

I tried to use HTTPFormatStyle on Linux and mysteriously the compiler didn't find it.

### Modifications:

Add the implementation file to CMakeLists.txt

### Result:

It works

Credit goes to @jmschonfeld since he immediately discovered why the code wasn't available on Linux even though the Swift file was there.