### PR TITLE
[6.3.x] Add Date+HTTPFormatStyle.swift to CMakeLists.txt

### DIFF
--- a/Sources/FoundationEssentials/Formatting/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Formatting/CMakeLists.txt
@@ -15,6 +15,7 @@
 target_sources(FoundationEssentials PRIVATE
     BinaryInteger+NumericStringRepresentation.swift
     Date+ISO8601FormatStyle.swift
+    Date+HTTPFormatStyle.swift
     DateComponents+ISO8601FormatStyle.swift
     DiscreteFormatStyle.swift
     FormatParsingUtilities.swift


### PR DESCRIPTION
- **Explanation**: Adds `Date+HTTPFormatStyle.swift` to the build so that `Date.HTTPFormatStyle` is included in the toolchain
- **Scope**: Only impacts CMake build of `Date.HTTPFormatStyle`
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-foundation/pull/1939
- **Risk**: Low - only impacts CMake build of a single file that already builds on Darwin platforms
- **Testing**: Tests for this file have already been running on all platforms via the SwiftPM build
- **Reviewers**: @jmschonfeld 
