### PR TITLE
[6.4] Update dependency/CI versions to 6.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,21 +15,21 @@ jobs:
     name: Test (SwiftPM)
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
-      linux_swift_versions: '["nightly-6.4"]'
-      windows_swift_versions: '["nightly-6.4"]'
+      linux_swift_versions: '["nightly-6.4.x"]'
+      windows_swift_versions: '["nightly-6.4.x"]'
       enable_macos_checks: false
       macos_xcode_versions: '["16.3"]'
       macos_versions: '["tahoe"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["nightly-6.4"]'
+      wasm_sdk_versions: '["nightly-6.4.x"]'
       enable_cross_pr_testing: true
       enable_android_sdk_build: true
-      android_sdk_versions: '["nightly-6.4"]'
+      android_sdk_versions: '["nightly-6.4.x"]'
 
   cmake_build:
     name: Build (CMake)
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.4-noble
+    container: swiftlang/swift:nightly-6.4.x-noble
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v6

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,21 +15,21 @@ jobs:
     name: Test (SwiftPM)
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
-      linux_swift_versions: '["nightly-main"]'
-      windows_swift_versions: '["nightly-main"]'
+      linux_swift_versions: '["nightly-6.4"]'
+      windows_swift_versions: '["nightly-6.4"]'
       enable_macos_checks: false
       macos_xcode_versions: '["16.3"]'
       macos_versions: '["tahoe"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["nightly-main"]'
+      wasm_sdk_versions: '["nightly-6.4"]'
       enable_cross_pr_testing: true
       enable_android_sdk_build: true
-      android_sdk_versions: '["nightly-main"]'
+      android_sdk_versions: '["nightly-6.4"]'
 
   cmake_build:
     name: Build (CMake)
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-noble
+    container: swiftlang/swift:nightly-6.4-noble
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
     message(STATUS "_SwiftFoundationICU_SourceDIR not provided, checking out local copy of swift-foundation-icu")
     FetchContent_Declare(SwiftFoundationICU
         GIT_REPOSITORY https://github.com/apple/swift-foundation-icu.git
-        GIT_TAG main)
+        GIT_TAG release/6.4.x)
 endif()
 
 if (_SwiftCollections_SourceDIR)

--- a/Package.swift
+++ b/Package.swift
@@ -72,10 +72,10 @@ if let useLocalDepsEnv = Context.environment["SWIFTCI_USE_LOCAL_DEPS"], !useLoca
                 exact: "1.1.6"),
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
-                branch: "main"),
+                branch: "release/6.4.x"),
             .package(
                 url: "https://github.com/swiftlang/swift-syntax",
-                branch: "main")
+                branch: "release/6.4.x")
         ]
 }
 

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT SwiftSyntax_FOUND)
     # If building at desk, check out and link against the SwiftSyntax repo's targets
     FetchContent_Declare(SwiftSyntax
         GIT_REPOSITORY https://github.com/swiftlang/swift-syntax.git
-        GIT_TAG main)
+        GIT_TAG release/6.4.x)
     FetchContent_MakeAvailable(SwiftSyntax)
 else()
   message(STATUS "SwiftSyntax_DIR provided, using swift-syntax from ${SwiftSyntax_DIR}")


### PR DESCRIPTION
Update toolchain/dependency versions to 6.4 on the 6.4.x release branch

### Motivation:

This aligns the version of the toolchain/libraries used with those used during the full toolchain build

### Modifications:

- Update the workflows to use the 6.4 toolchain
- Update `Package.swift` and the CMake files to use the 6.4 branch of dependencies

### Result:

Project builds with the 6.4 toolchain and 6.4 dependencies

### Testing:

Validated via existing CI testing
