### PR TITLE
Update 6.3->main automerger to use release/6.4.x

### DIFF
--- a/.github/workflows/automerge_to_main.yml
+++ b/.github/workflows/automerge_to_main.yml
@@ -13,7 +13,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.11
     with:
       base_branch: main
-      head_branch: release/6.3
+      head_branch: release/6.4.x
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Updates the auto merger to merge `release/6.4.x` into `main` instead of `release/6.3` now that 6.4 has branched. `release/6.3` will use the cherry pick strategy going forwards
