### PR TITLE
Remove module specifier on FormatStyle within Date

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
+++ b/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
@@ -45,15 +45,9 @@ extension Date {
     ///
     /// - Parameter format: The format for formatting `self`.
     /// - Returns: A representation of `self` using the given `format`. The type of the representation is specified by `FormatStyle.FormatOutput`.
-#if FOUNDATION_FRAMEWORK
-    public func formatted<F: Foundation.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == Date {
+    public func formatted<F: FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == Date {
         format.format(self)
     }
-#else
-    public func formatted<F: FoundationEssentials.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == Date {
-        format.format(self)
-    }
-#endif // FOUNDATION_FRAMEWORK
     
     // Parsing
     /// Creates a new `Date` by parsing the given representation.
@@ -61,27 +55,15 @@ extension Date {
     /// - Parameters:
     ///   - value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
     ///   - strategy: The parse strategy to parse `value` whose `ParseOutput` is `Date`.
-#if FOUNDATION_FRAMEWORK
-    public init<T: Foundation.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
+    public init<T: ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
         self = try strategy.parse(value)
     }
-#else
-    public init<T: FoundationEssentials.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
-        self = try strategy.parse(value)
-    }
-#endif // FOUNDATION_FRAMEWORK
+
     /// Creates a new `Date` by parsing the given string representation.
-#if FOUNDATION_FRAMEWORK
     @_disfavoredOverload
-    public init<T: Foundation.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
+    public init<T: ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
         self = try strategy.parse(String(value))
     }
-#else
-    @_disfavoredOverload
-    public init<T: FoundationEssentials.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
-        self = try strategy.parse(String(value))
-    }
-#endif // FOUNDATION_FRAMEWORK
 }
 
 @available(FoundationPreview 6.2, *)


### PR DESCRIPTION
Remove extra unnecessary module qualification in `Date.FormatStyle`-related code

### Motivation:

This code currently `#if`'s around whether to reference `FormatStyle` as `Foundation.FormatStyle` or `FoundationEssentials.FormatStyle` resulting in duplicated code. However, when `protocol FormatStyle` is in the same module as the code, name lookup prefers the top level protocol over the sibling `struct Date.FormatStyle`. This means we can remove the extra qualification inside of FoundationEssentials.

Note that this lookup precedence rule only applies within `FoundationEssentials`. `Decimal+FormatStyle` has a similar workaround in `FoundationInternationalization`, but we cannot make this change there because the sibling `struct Decimal.FormatStyle` is preferred over the imported `protocol FormatStyle` from `FoundationEssentials`.

### Modifications:

Remove extra module qualification in `Date+FormatStyle.swift`

### Result:

Project builds without duplicated code

### Testing:

Verified that project still builds.
