### PR TITLE
Move URL.FormatStyle and URL.ParseStrategy to swift-foundation 

### DIFF
--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -19,9 +19,9 @@ add_library(FoundationInternationalization
     RangeExpression.swift
     TimeInterval+Utils.swift
     URL+UnicodeLookalikeTable.swift
-    URLFormatStyle.swift
+    Formatting/URLFormatStyle.swift
     URLParser+ICU.swift
-    URLParseStrategy.swift)
+    Formatting/URLParseStrategy.swift)
 
 add_subdirectory(Calendar)
 add_subdirectory(Formatting)

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -18,7 +18,10 @@ add_library(FoundationInternationalization
     Duration+Utils.swift
     RangeExpression.swift
     TimeInterval+Utils.swift
-    URLParser+ICU.swift)
+    URL+UnicodeLookalikeTable.swift
+    URLFormatStyle.swift
+    URLParser+ICU.swift
+    URLParseStrategy.swift)
 
 add_subdirectory(Calendar)
 add_subdirectory(Formatting)

--- a/Sources/FoundationInternationalization/Formatting/URLFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/URLFormatStyle.swift
@@ -1,0 +1,756 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+internal import _ForSwiftFoundation
+#endif
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+extension URL {
+    /// A structure that converts between URL instances and their textual representations.
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    public struct FormatStyle : Codable, Hashable, Sendable {
+        /// The strategy to display the `scheme` component.
+        var scheme: ComponentDisplayOption
+        /// The strategy to display the `user` component.
+        var user: ComponentDisplayOption
+        /// The strategy to display the `password` component.
+        var password: ComponentDisplayOption
+        /// The strategy to display the `host` component.
+        var host: HostDisplayOption
+        /// The strategy to display the `port` component.
+        var port: ComponentDisplayOption
+        /// The strategy to display the `path` component.
+        var path: ComponentDisplayOption
+        /// The strategy to display the `query` component.
+        var query: ComponentDisplayOption
+        /// The strategy to display the `fragment` component.
+        var fragment: ComponentDisplayOption
+
+        /// Creates a new `FormatStyle` with the given configurations.
+        /// - Parameters:
+        ///   - scheme: The strategy to use for formatting the `scheme`.
+        ///   - user: The strategy to use for formatting the `user`.
+        ///   - password: The strategy to use for formatting the `password`.
+        ///   - host: The strategy to use for formatting the `host`.
+        ///   - port: The strategy to use for formatting the `port`.
+        ///   - path: The strategy to use for formatting the `path`.
+        ///   - query: The strategy to use for formatting the `query`.
+        ///   - fragment: The strategy to use for formatting the `fragment`.
+        public init(
+            scheme: ComponentDisplayOption = .always,
+            user: ComponentDisplayOption = .never,
+            password: ComponentDisplayOption = .never,
+            host: HostDisplayOption = .always,
+            port: ComponentDisplayOption = .omitIfHTTPFamily,
+            path: ComponentDisplayOption = .always,
+            query: ComponentDisplayOption = .never,
+            fragment: ComponentDisplayOption = .never) {
+                self.scheme = scheme
+                self.user = user
+                self.password = password
+                self.host = host
+                self.port = port
+                self.path = path
+                self.query = query
+                self.fragment = fragment
+        }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.FormatStyle {
+    /// An enumeration of the components of a URL, for use in creating format style options that depend on a component's value.
+    ///
+    /// You use this type with style-modifying methods like ``URL/FormatStyle/ComponentDisplayOption/displayWhen(_:matches:)`` in ``URL/FormatStyle/ComponentDisplayOption`` and ``URL/FormatStyle/HostDisplayOption/omitWhen(_:matches:)`` in ``URL/FormatStyle/HostDisplayOption``.
+    public enum Component : Int, Codable, Hashable, Sendable, CustomStringConvertible {
+        // These raw values MUST match _CFURLRequiredComponents
+        /// The URL format style scheme component.
+        case scheme   = 0b00000001 // 1 << 0
+        /// The URL format style user component.
+        case user     = 0b00000010 // 1 << 1
+        /// The URL format style password component.
+        case password = 0b00000100 // 1 << 2
+        /// The URL format style host component.
+        case host     = 0b00001000 // 1 << 3
+        /// The URL format style port component.
+        case port     = 0b00010000 // 1 << 4
+        /// The URL format style path component.
+        case path     = 0b00100000 // 1 << 5
+        /// The URL format style query component.
+        case query    = 0b01000000 // 1 << 6
+        /// The URL format style fragment component.
+        case fragment = 0b10000000 // 1 << 7
+
+        public var description: String {
+            switch self {
+            case .scheme: return "scheme"
+            case .user: return "username"
+            case .password: return "password"
+            case .host: return "host"
+            case .port: return "port"
+            case .path: return "path"
+            case .query: return "query"
+            case .fragment: return "fragment"
+            }
+        }
+
+        internal func getComponentValue<T>(from url: URL) -> T? {
+            switch self {
+            case .scheme: return url.scheme as? T
+            case .user: return url.user as? T
+            case .password: return url.password as? T
+            case .host: return url.host as? T
+            case .port: return url.port as? T
+            case .path: return url.path as? T
+            case .query: return url.query as? T
+            case .fragment: return url.fragment as? T
+            }
+        }
+
+        internal func hasComponentValue(in url: URL) -> Bool {
+            switch self {
+            case .scheme: return url.scheme != nil
+            case .user: return url.user != nil
+            case .password: return url.password != nil
+            case .host: return url.host != nil
+            case .port: return url.port != nil
+            case .path: return !url.path.isEmpty
+            case .query: return url.query != nil
+            case .fragment: return url.fragment != nil
+            }
+        }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.FormatStyle {
+    /// Specifies the condition to display a component
+    internal struct ComponentDisplayCondition : Codable, Hashable, CustomStringConvertible, Sendable {
+        let component: URL.FormatStyle.Component
+        let requirements: Set<String>
+
+        var description: String {
+            return "if \(component) matches \(requirements)"
+        }
+    }
+
+    /// Specifies the display option for a component, including whether to display or omit the
+    /// component and the condition to do so.
+    public struct ComponentDisplayOption : Codable, Hashable, CustomStringConvertible, Sendable {
+        enum Option : Int, Codable, Hashable {
+            case omitted
+            case displayed
+        }
+
+        var option: Option
+        var condition: ComponentDisplayCondition?
+
+        public var description: String {
+            switch self.option {
+            case .omitted:
+                if let condition = condition {
+                    return "omitted(condition: \(condition))"
+                }
+                return "never"
+            case .displayed:
+                if let condition = condition {
+                    return "displayed(condition: \(condition))"
+                }
+                return "always"
+            }
+        }
+
+        /// Creates a display option to always display the component.
+        public static var always: Self {
+            .init(option: .displayed, condition: nil)
+        }
+
+        /// Creates a display option to always omit the component.
+        public static var never: Self {
+            .init(option: .omitted, condition: nil)
+        }
+
+        /// Creates a display option to display the component if the given condition is met.
+        public static func displayWhen(_ component: URL.FormatStyle.Component, matches requirements: Set<String>) -> Self {
+            .init(option: .displayed, condition: .init(component: component, requirements: requirements))
+        }
+
+        /// Creates a display option to omit the component if the given condition is met.
+        public static func omitWhen(_ component: URL.FormatStyle.Component, matches requirements: Set<String>) -> Self {
+            .init(option: .omitted, condition: .init(component: component, requirements: requirements))
+        }
+
+        /// Creates a display option to omit the component if the URL's scheme
+        /// is `http` or `https`.
+        public static var omitIfHTTPFamily: Self {
+            .init(option: .omitted, condition: .init(component: .scheme, requirements: ["http", "https"]))
+        }
+    }
+
+    /// Specifies the display option for displaying the host component
+    public struct HostDisplayOption : Codable, Hashable, CustomStringConvertible, Sendable {
+        enum Option : Codable, Hashable, Sendable {
+            case omitted
+            case displayed
+
+            private typealias OmittedCodingKeys = EmptyCodingKeys
+            private typealias DisplayedCodingKeys = EmptyCodingKeys
+        }
+
+        var option: Option
+        var condition: ComponentDisplayCondition?
+        /// Whether deep (more than three) subdomains should be omitted
+        /// For example: `api.docs.code.example.com` will be
+        /// shorten to `code.example.com`
+        var omitMultiLevelSubdomains: Bool
+        /// A set of specific subdomains to omit.
+        var omitSpecificSubdomains: Set<String>?
+
+        public var description: String {
+            switch self.option {
+            case .omitted:
+                if let condition = condition {
+                    return "omitted(condition: \(condition))"
+                }
+                return "never"
+            case .displayed:
+                var conditionString = "no condition"
+                if let condition = condition {
+                    conditionString = String(describing: condition)
+                }
+                return "displayed(omitMultiLevelSubdomains: \(self.omitMultiLevelSubdomains), omitSpecificSubdomains: \(self.omitSpecificSubdomains ?? Set()), condition: \(conditionString)"
+            }
+        }
+
+        private init(option: Option, condition: ComponentDisplayCondition?, omitMultiLevelSubdomains: Bool = false, omitSpecificSubdomains: Set<String>? = nil) {
+            self.option = option
+            self.condition = condition
+            self.omitMultiLevelSubdomains = omitMultiLevelSubdomains
+            self.omitSpecificSubdomains = omitSpecificSubdomains
+        }
+
+        /// Creates a display option to always display the host.
+        public static var always: Self {
+            .init(option: .displayed, condition: nil)
+        }
+
+        /// Creates a display option to always omit the host.
+        public static var never: Self {
+            .init(option: .omitted, condition: nil)
+        }
+
+        /// Creates a display option to display the host if the given condition is met.
+        public static func displayWhen(_ component: URL.FormatStyle.Component, matches requirements: Set<String>) -> Self {
+            .init(option: .displayed, condition: .init(component: component, requirements: requirements))
+        }
+
+        /// Creates a display option to omit the host if the given condition is met.
+        public static func omitWhen(_ component: URL.FormatStyle.Component, matches requirements: Set<String>) -> Self {
+            .init(option: .omitted, condition: .init(component: component, requirements: requirements))
+        }
+
+        /// Creates a display option to omit the host if the URL's scheme
+        /// is `http` or `https`.
+        public static var omitIfHTTPFamily: Self {
+            .init(option: .omitted, condition: .init(component: .scheme, requirements: ["http", "https"]))
+        }
+
+        /// Creates a display option to manipulate the subdomains of a host
+        /// - Parameters:
+        ///   - subdomainsToOmit: specifies a set of subdomains to omit
+        ///   - omitMultiLevelSubdomains: if `true`, multi-level subdomains
+        ///     (more than two subdomains beyond the TLDs)  will be omitted.
+        public static func omitSpecificSubdomains(
+            _ subdomainsToOmit: Set<String> = Set(),
+            includeMultiLevelSubdomains omitMultiLevelSubdomains: Bool = false) -> Self {
+            .init(option: .displayed, condition: nil, omitMultiLevelSubdomains: omitMultiLevelSubdomains, omitSpecificSubdomains: subdomainsToOmit)
+        }
+
+        /// Creates a display option to manipulate the subdomains of a host
+        /// - Parameters:
+        ///   - subdomainsToOmit: specifies a set of subdomains to omit
+        ///   - omitMultiLevelSubdomains: if `true`, multi-level subdomains
+        ///     (more than two subdomains beyond the TLDs)  will be omitted.
+        ///   - component: the component to test for condition.
+        ///   - requirements: the requirements for the component.
+        public static func omitSpecificSubdomains(
+            _ subdomainsToOmit: Set<String> = Set(),
+            includeMultiLevelSubdomains omitMultiLevelSubdomains: Bool = false,
+            when component: URL.FormatStyle.Component, matches requirements: Set<String>) -> Self {
+            .init(option: .displayed,
+                  condition: .init(component: component, requirements: requirements),
+                  omitMultiLevelSubdomains: omitMultiLevelSubdomains,
+                  omitSpecificSubdomains: subdomainsToOmit)
+        }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.FormatStyle {
+    /// Modifies a format style to display a URL's scheme component in accordance with the provided option.
+    ///
+    /// - Parameter strategy: A component display option that indicates when, if ever, to display the scheme.
+    /// - Returns: A modified ``URL/FormatStyle`` that incorporates the specified behavior.
+    public func scheme(_ strategy: ComponentDisplayOption = .always) -> Self {
+        var new = self
+        new.scheme = strategy
+        return new
+    }
+
+    /// Modifies a format style to display a URL's user component in accordance with the provided option.
+    ///
+    /// - Parameter strategy: A component display option that indicates when, if ever, to display the user component.
+    /// - Returns: A modified ``URL/FormatStyle`` that incorporates the specified behavior.
+    public func user(_ strategy: ComponentDisplayOption = .never) -> Self {
+        var new = self
+        new.user = strategy
+        return new
+    }
+
+    /// Modifies a format style to display a URL's password component in accordance with the provided option.
+    ///
+    /// - Parameter strategy: A component display option that indicates when, if ever, to display the password component.
+    /// - Returns: A modified ``URL/FormatStyle`` that incorporates the specified behavior.
+    public func password(_ strategy: ComponentDisplayOption = .never) -> Self {
+        var new = self
+        new.password = strategy
+        return new
+    }
+
+    /// Modifies a format style to display a URL's host component in accordance with the provided option.
+    ///
+    /// - Parameter strategy: A host display option that indicates when, if ever, to display the host component.
+    /// - Returns: A modified ``URL/FormatStyle`` that incorporates the specified behavior.
+    public func host(_ strategy: HostDisplayOption = .always) -> Self {
+        var new = self
+        new.host = strategy
+        return new
+    }
+
+    /// Modifies a format style to display a URL's port component in accordance with the provided option.
+    ///
+    /// - Parameter strategy: A component display option that indicates when, if ever, to display the port component.
+    /// - Returns: A modified ``URL/FormatStyle`` that incorporates the specified behavior.
+    public func port(_ strategy: ComponentDisplayOption = .omitIfHTTPFamily) -> Self {
+        var new = self
+        new.port = strategy
+        return new
+    }
+
+    /// Modifies a format style to display a URL's path component in accordance with the provided option.
+    ///
+    /// - Parameter strategy: A component display option that indicates when, if ever, to display the path component.
+    /// - Returns: A modified ``URL/FormatStyle`` that incorporates the specified behavior.
+    public func path(_ strategy: ComponentDisplayOption = .always) -> Self {
+        var new = self
+        new.path = strategy
+        return new
+    }
+
+    /// Modifies a format style to display a URL's query component in accordance with the provided option.
+    ///
+    /// - Parameter strategy: A component display option that indicates when, if ever, to display the query component.
+    /// - Returns: A modified ``URL/FormatStyle`` that incorporates the specified behavior.
+    public func query(_ strategy: ComponentDisplayOption = .never) -> Self {
+        var new = self
+        new.query = strategy
+        return new
+    }
+
+    /// Modifies a format style to display a URL's fragment component in accordance with the provided option.
+    ///
+    /// - Parameter strategy: A component display option that indicates when, if ever, to display the fragment component.
+    /// - Returns: A modified ``URL/FormatStyle`` that incorporates the specified behavior.
+    public func fragment(_ strategy: ComponentDisplayOption = .never) -> Self {
+        var new = self
+        new.fragment = strategy
+        return new
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.FormatStyle : ParseableFormatStyle {
+    /// The parse strategy used by this format style.
+    public var parseStrategy: URL.ParseStrategy {
+        .init(format: self, lenient: false)
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.FormatStyle : FormatStyle {
+    @inline(__always)
+    private func url(_ url: URL, satisfies condition: ComponentDisplayCondition?) -> Bool {
+        guard let condition = condition else {
+            return true
+        }
+        if condition.component == .port {
+            guard let port: Int = condition.component.getComponentValue(from: url) else {
+                return false
+            }
+            return condition.requirements.contains(String(port))
+        }
+        guard let value: String = condition.component.getComponentValue(from: url) else {
+            return false
+        }
+        return condition.requirements.contains(value)
+    }
+
+    @inline(__always)
+    private func shouldDisplayComponent(from url: URL, basedOn strategy: ComponentDisplayOption) -> Bool {
+        let componentSatisfiesCondition = self.url(url, satisfies: strategy.condition)
+        return (componentSatisfiesCondition && strategy.option == .displayed) ||
+            (!componentSatisfiesCondition && strategy.option == .omitted)
+    }
+
+    @inline(__always)
+    private func exists(_ value: String?) -> Bool {
+        guard let value = value else {
+            return false
+        }
+        return !value.isEmpty
+    }
+
+    private func isIPv4(_ hostString: String) -> Bool {
+        let components = hostString.split(separator: ".")
+        guard components.count == 4 else {
+            return false
+        }
+        for component in components {
+            guard let intValue = Int(component), intValue >= 0 && intValue < 256 else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func isIPv6(_ hostString: String) -> Bool {
+        var host = hostString
+        // IPv6 addresses must be enclosed with `[]` as part of the URL
+        guard host.hasPrefix("[") && host.hasSuffix("]") else {
+            return false
+        }
+        // Remove the brackets for parsing
+        host.removeFirst()
+        host.removeLast()
+
+        // Since IPv6 can be shortened to arbitrary groups, we won't check
+        // how many groups are there; instead, we will check each group is
+        // either empty or a valid hex string
+        let groups = host.split(separator: ":")
+        for group in groups {
+            guard !group.isEmpty else {
+                // It's okay to have empty groups such as `::1`
+                continue
+            }
+            guard let intValue = Int(String(group), radix: 16),
+                  intValue >= 0, intValue <= 0xFFFF else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func generateFormattedString(from urlComponents: URLComponents, useEncodedHost: Bool) -> String {
+        // We can't use urlComponents.string directly because URLComponents uses encoded
+        // components (rightfully so) to compute the string. For a user-facing formatted
+        // string, we should use all raw components instead
+        var urlString = ""
+        // Append scheme
+        if let scheme = urlComponents.scheme {
+            urlString.append("\(scheme):")
+            // Append "//" if there's a host
+            if urlComponents.host != nil {
+                urlString.append("//")
+            }
+        }
+        // Append user
+        if let user = urlComponents.user {
+            urlString.append(user)
+        }
+        // Append password
+        if let password = urlComponents.password {
+            if urlComponents.user != nil {
+                // Append `:` between user and password
+                urlString.append(":")
+            }
+            urlString.append(password)
+        }
+        // Append host
+        let hostString = useEncodedHost ? urlComponents.encodedHost : urlComponents.host
+        if let host = hostString {
+            if urlComponents.user != nil || urlComponents.password != nil {
+                // Append `@` between authority and host
+                urlString.append("@")
+            }
+            urlString.append(host)
+        }
+        // Append port
+        if let port = urlComponents.port {
+            if urlComponents.host != nil {
+                // Append `:` between host and port
+                urlString.append(":")
+            }
+            urlString.append("\(port)")
+        }
+        // Append path
+        if !urlComponents.path.isEmpty {
+            // Remove the path trailing slash if path
+            // is the last component displayed
+            var path = urlComponents.path
+            if path.hasSuffix("/") &&
+                urlComponents.query == nil &&
+                urlComponents.fragment == nil {
+                path.removeLast()
+            }
+            urlString.append(path)
+        }
+        // Append query
+        if let query = urlComponents.query {
+            urlString.append("?\(query)")
+        }
+        // Append fragment
+        if let fragment = urlComponents.fragment {
+            urlString.append("#\(fragment)")
+        }
+
+        return urlString
+    }
+
+    private func formatMultiLevelSubdomains(from subdomains: inout [Substring], forHost hostString: String) {
+        // Remove all "extra" subdomains from a host beyond TLDs + 2 subdomains
+        // For example:
+        // developer.source.apple.com -> source.apple.com (TLD: com)
+        // developer.source.apple.com.cn -> source.apple.com.cn (TLD: com.cn)
+#if FOUNDATION_FRAMEWORK
+        guard let tlds = __NSURLGetTopLevelDomain(hostString, true) else {
+            // If the host string does not contain a valid TLD, do nothing
+            return
+        }
+        let numberOfTLDs = tlds.split(separator: ".").count
+        guard subdomains.count > numberOfTLDs + 2 else {
+            // Nothing to do. The hostString does not have any extra subdomains
+            return
+        }
+        subdomains.removeFirst(subdomains.count - (numberOfTLDs + 2))
+#endif
+    }
+
+    /// Formats a URL, using this style.
+    ///
+    /// Use this method when you want to create a single style instance, and then
+    /// use it to format multiple URL instances. The following example creates a
+    /// custom format style and then uses it to format a variety of URLs in an array:
+    ///
+    /// ```swift
+    /// let style = URL.FormatStyle(
+    ///     scheme: .never,
+    ///     user: .never,
+    ///     password: .never,
+    ///     host: .omitSpecificSubdomains(["www", "mobile", "m."],
+    ///                                   includeMultiLevelSubdomains: true),
+    ///     port: .never,
+    ///     path: .always,
+    ///     query: .never,
+    ///     fragment: .never)
+    /// let urls = [
+    ///     URL(string: "https://www.example.com/path/one")!,
+    ///     URL(string: "https://beta.example.com/path/two")!,
+    ///     URL(string: "https://beta.staging.west.example.com/three")!,
+    ///     URL(string: "https://query.example.com/four?key4=value4")!
+    /// ]
+    /// let formatted = urls.map { $0.formatted(style) }
+    /// // ["example.com/path/one", "beta.example.com/path/two", "west.example.com/three", "query.example.com/four"]
+    /// ```
+    ///
+    /// To format a single URL value, use the ``URL`` instance method
+    /// ``URL/formatted(_:)`` passing in an instance of ``URL/FormatStyle``,
+    /// or ``URL/formatted()`` to use a default style.
+    ///
+    /// - Parameter value: The URL to format.
+    /// - Returns: A string representation of `value`, formatted according to the style's configuration.
+    public func format(_ value: URL) -> String {
+        // URL(NSURL)'s old parser doesn't play well with Unicode
+        // characters. Use an `URLComponents` (which has the updated
+        // parser) to access all the decoded components instead of
+        // accessing them via URL directly
+        guard let decoder = URLComponents(
+            url: value, resolvingAgainstBaseURL: false) else {
+            return value.absoluteString
+        }
+        var urlComponents = URLComponents()
+        // Format scheme
+        if shouldDisplayComponent(from: value, basedOn: scheme) {
+            urlComponents.scheme = decoder.scheme
+        }
+        // Format user
+        if shouldDisplayComponent(from: value, basedOn: user) {
+            urlComponents.user = decoder.user
+        }
+        // Format password
+        if shouldDisplayComponent(from: value, basedOn: password) {
+            urlComponents.password = decoder.password
+        }
+        // Format host
+        var hostContainsLookalikeCharacters = false
+        if let hostString = decoder.host, !hostString.isEmpty {
+            let hostSatisfiesCondition = self.url(value, satisfies: self.host.condition)
+            // Determine whether the host is an IP address:
+            // - For ipv6, we need to add an additional `[]` around the host
+            // - For both ipv6 and ipv4, we shouldn't modify the host in anyway
+            let isIPv4 = self.isIPv4(hostString)
+            let isIPv6 = self.isIPv6(hostString)
+            let isIPAddress = isIPv4 || isIPv6
+            // Determine if the hostString contains lookalike characters.
+            // If the host contains lookalike characters, use the Punycode
+            // encoded host instead
+            hostContainsLookalikeCharacters = URL.UnicodeLookalikeTable.default.shouldDisplayEncodedHost(for: hostString)
+
+            switch self.host.option {
+            case .displayed:
+                var componentsModified = false
+                var formattedHost: String? = nil
+                if hostContainsLookalikeCharacters {
+                    // If the host contains lookalike characters, use the raw,
+                    // unprocessed hostString instead. `URLComponents` will
+                    // automatically encode the host
+                    formattedHost = hostString
+                } else {
+                    var hostComponents = hostString.split(separator: ".")
+                    // Format each subdomains
+                    if self.host.omitMultiLevelSubdomains && hostComponents.count > 3 && !isIPAddress {
+                        self.formatMultiLevelSubdomains(from: &hostComponents, forHost: hostString)
+                        componentsModified = true
+                    }
+                    if let subdomainsToOmit = self.host.omitSpecificSubdomains,
+                       hostComponents.count > 2,
+                       !isIPAddress,
+                       subdomainsToOmit.contains(String(hostComponents[0])) {
+                        // Remove the first subdomain if it's one of the subdomainsToOmit
+                        hostComponents.removeFirst()
+                        componentsModified = true
+                    }
+                    // Prepare `formattedHost`
+                    if isIPAddress {
+                        // Don't modify IP address
+                        formattedHost = hostString
+                    } else {
+                        formattedHost = hostComponents.joined(separator: ".")
+                    }
+                }
+
+                if hostSatisfiesCondition {
+                    urlComponents.host = formattedHost
+                } else if componentsModified {
+                    // If the host does not satisfy the condition, do not
+                    // omit subdomains
+                    urlComponents.host = hostString
+                }
+            case .omitted:
+                if !hostSatisfiesCondition {
+                    urlComponents.host = hostString
+                }
+            }
+        }
+        // Format port
+        if shouldDisplayComponent(from: value, basedOn: port) {
+            urlComponents.port = decoder.port
+        }
+        // Format path
+        if shouldDisplayComponent(from: value, basedOn: path) {
+            urlComponents.path = decoder.path
+        }
+        // Format query
+        if shouldDisplayComponent(from: value, basedOn: query) {
+            urlComponents.query = decoder.query
+        }
+        // Format fragment
+        if shouldDisplayComponent(from: value, basedOn: fragment) {
+            urlComponents.fragment = decoder.fragment
+        }
+
+        return self.generateFormattedString(
+            from: urlComponents,
+            useEncodedHost: hostContainsLookalikeCharacters)
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL {
+
+    /// Formats the URL, using the provided format style.
+    ///
+    /// Use this method when you want to format a single URL value with a
+    /// specific format style, or call it repeatedly with different format
+    /// styles.
+    ///
+    /// - Parameter format: The format style to apply when formatting the URL.
+    /// - Returns: A formatted string representation of the URL.
+#if FOUNDATION_FRAMEWORK
+    public func formatted<F: Foundation.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == URL {
+        format.format(self)
+    }
+#else
+    public func formatted<F: FoundationEssentials.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == URL {
+        format.format(self)
+    }
+#endif
+
+    /// Formats the URL using a default format style.
+    ///
+    /// Use this method to create a string representation of a URL using the
+    /// default ``URL/FormatStyle`` configuration. The default style creates a
+    /// string with the scheme, host, and path, but not the port or query.
+    ///
+    /// To customize formatting of the URL, use ``URL/formatted(_:)``, passing
+    /// in a customized ``FormatStyle``.
+    ///
+    /// - Returns: A string representation of the URL, formatted according to
+    ///   the default format style.
+    public func formatted() -> String {
+        self.formatted(.url)
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+public extension FormatStyle where Self == URL.FormatStyle {
+    /// A style for formatting a URL.
+    ///
+    /// Use the dot-notation form of this type property when the call point allows the use of
+    /// ``URL/FormatStyle``. You typically do this when calling the ``URL/formatted(_:)`` method
+    /// of ``URL``.
+    ///
+    /// The format style provided by this static accessor provides a default behavior. To
+    /// customize formatting behavior, use the modifiers in Customizing style behavior.
+    ///
+    /// The following example shows the use of a customized URL format style, created by
+    /// modifying the default style. The custom style strips the scheme and port and omits the
+    /// `www` subdomain, but leaves the path intact. This produces a simplified URL
+    /// representation that a browser could use as a window title.
+    ///
+    /// ```swift
+    /// let url = URL(string: "http://www.example.com:8080/path/to/file.txt")!
+    /// let formatted = url.formatted(.url
+    ///     .scheme(.never)
+    ///     .host(.omitSpecificSubdomains(["www"]))
+    ///     .port(.never)) // "example.com/path/to/file.txt"
+    /// ```
+    static var url: Self { .init() }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+public extension ParseableFormatStyle where Self == URL.FormatStyle {
+    static var url: Self { .init() }
+}

--- a/Sources/FoundationInternationalization/Formatting/URLParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/URLParseStrategy.swift
@@ -1,0 +1,463 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+extension URL {
+    fileprivate typealias Component = URL.FormatStyle.Component
+
+    /// A parse strategy for creating URLs from formatted strings.
+    ///
+    /// Create an explicit ``URL/ParseStrategy`` to parse multiple strings according to the same parse strategy. The following example creates a customized strategy, then applies it to multiple URL candidate strings.
+    ///
+    /// ```swift
+    /// let strategy = URL.ParseStrategy(
+    /// scheme: .defaultValue("https"),
+    /// user: .optional,
+    /// password: .optional,
+    /// host: .required,
+    /// port: .optional,
+    /// path: .required,
+    /// query: .required,
+    /// fragment: .optional)
+    /// let urlStrings = [
+    /// "example.com?key1=value1", // no scheme or path
+    /// "https://example.com?key2=value2", // no path
+    /// "https://example.com", // no query
+    /// "https://example.com/path?key4=value4", // complete
+    /// "//example.com/path?key5=value5" // complete except for default-able scheme
+    /// ]
+    /// let urls = urlStrings.map { try? strategy.parse($0) } // [nil, nil, nil, Optional(https://example.com/path?key4=value4), Optional(https://example.com/path?key5=value5)]
+    /// ```
+    ///
+    ///
+    /// You don't need to instantiate a parse strategy instance to parse a single string. Instead, use the URL initializer ``URL/init(_:strategy:)``, passing in a string to parse and a customized strategy, typically created with one of the static accessors. The following example parses a URL string, with a custom strategy that provides a default value for the port component if the source string doesn't specify one.
+    ///
+    /// ```swift
+    /// let urlString = "https://internal.example.com/path/to/endpoint?key=value"
+    /// let url = try? URL(urlString, strategy: .url
+    /// .port(.defaultValue(8080))) // https://internal.example.com:8080/path/to/endpoint?key=value
+    ///
+    /// ```
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    public struct ParseStrategy : Codable, Hashable, Sendable {
+        /// The strategy to parse the `scheme` component.
+        var scheme: ComponentParseStrategy<String>
+        /// The strategy to parse the `user` component.
+        var user: ComponentParseStrategy<String>
+        /// The strategy to parse the `password` component.
+        var password: ComponentParseStrategy<String>
+        /// The strategy to parse the `host` component.
+        var host: ComponentParseStrategy<String>
+        /// The strategy to parse the `port` component.
+        var port: ComponentParseStrategy<Int>
+        /// The strategy to parse the `path` component.
+        var path: ComponentParseStrategy<String>
+        /// The strategy to parse the `query` component.
+        var query: ComponentParseStrategy<String>
+        /// The strategy to parse the `fragment` component.
+        var fragment: ComponentParseStrategy<String>
+
+        private var requiredComponentsValue: UInt {
+            var value = 0
+            value |= (scheme == .required) ? Component.scheme.rawValue : 0
+            value |= (user == .required) ? Component.user.rawValue : 0
+            value |= (password == .required) ? Component.password.rawValue : 0
+            value |= (host == .required) ? Component.host.rawValue : 0
+            value |= (port == .required) ? Component.port.rawValue : 0
+            value |= (path == .required) ? Component.path.rawValue : 0
+            value |= (query == .required) ? Component.query.rawValue : 0
+            value |= (fragment == .required) ? Component.fragment.rawValue : 0
+            return UInt(value)
+        }
+
+        var defaultValues: [Int : String] {
+            var values: [Int : String] = [:]
+            if case .defaultValue(let value) = scheme {
+                values[Component.scheme.rawValue] = value
+            }
+            if case .defaultValue(let value) = user {
+                values[Component.user.rawValue] = value
+            }
+            if case .defaultValue(let value) = password {
+                values[Component.password.rawValue] = value
+            }
+            if case .defaultValue(let value) = host {
+                values[Component.host.rawValue] = value
+            }
+            if case .defaultValue(let value) = port {
+                values[Component.port.rawValue] = String(value)
+            }
+            if case .defaultValue(let value) = path {
+                values[Component.path.rawValue] = value
+            }
+            if case .defaultValue(let value) = query {
+                values[Component.query.rawValue] = value
+            }
+            if case .defaultValue(let value) = fragment {
+                values[Component.fragment.rawValue] = value
+            }
+            return values
+        }
+
+        /// Creates a new `ParseStrategy` with the given configurations.
+        /// - Parameters:
+        ///   - scheme: The strategy to use for parsing the `scheme`.
+        ///   - user: The strategy to use for parsing the `user`.
+        ///   - password: The strategy to use for parsing the `password`.
+        ///   - host: The strategy to use for parsing the `host`.
+        ///   - port: The strategy to use for parsing the `port`.
+        ///   - path: The strategy to use for parsing the `path`.
+        ///   - query: The strategy to use for parsing the `query`.
+        ///   - fragment: The strategy to use for parsing the `fragment`.
+        public init(
+            scheme: ComponentParseStrategy<String> = .required,
+            user: ComponentParseStrategy<String> = .optional,
+            password: ComponentParseStrategy<String> = .optional,
+            host: ComponentParseStrategy<String> = .required,
+            port: ComponentParseStrategy<Int> = .optional,
+            path: ComponentParseStrategy<String> = .optional,
+            query: ComponentParseStrategy<String> = .optional,
+            fragment: ComponentParseStrategy<String> = .optional) {
+                self.scheme = scheme
+                self.user = user
+                self.password = password
+                self.host = host
+                self.port = port
+                self.path = path
+                self.query = query
+                self.fragment = fragment
+        }
+
+        internal init(format: URL.FormatStyle, lenient: Bool) {
+            @inline(__always)
+            func isComponentRequired(_ component: URL.FormatStyle.ComponentDisplayOption) -> Bool {
+                return component.option == .displayed && component.condition == .none
+            }
+
+            self.scheme = isComponentRequired(format.scheme) ? .required : .optional
+            self.user = isComponentRequired(format.user) ? .required : .optional
+            self.password = isComponentRequired(format.password) ? .required : .optional
+            let hostRequired = format.host.option == .displayed && format.host.condition == .none
+            self.host = hostRequired ? .required : .optional
+            self.port = isComponentRequired(format.port) ? .required : .optional
+            self.path = isComponentRequired(format.path) ? .required : .optional
+            self.query = isComponentRequired(format.query) ? .required : .optional
+            self.fragment = isComponentRequired(format.fragment) ? .required : .optional
+        }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.ParseStrategy {
+    /// The strategy used to parse one component of a URL.
+    ///
+    /// Use this type with the ``URL/ParseStrategy`` initializer and static accessors, or its modifier methods, to specify behavior for parsing components of a URL. This allows you to reject URL candidate strings that lack required components — such as a scheme, host, or path — or to fill in default values while parsing.
+    public enum ComponentParseStrategy<Component : Codable & Hashable & Sendable> : Codable, Hashable, CustomStringConvertible, Sendable {
+        /// Denotes that the component is required to exists in order to consider the URL valid
+        case required
+        /// Denotes that the component is optional
+        case optional
+        /// If the component is missing, assume it has the attached default value
+        case defaultValue(Component)
+
+        private typealias RequiredCodingKeys = EmptyCodingKeys
+        private typealias OptionalCodingKeys = EmptyCodingKeys
+        private typealias DefaultValueCodingKeys = DefaultAssociatedValueCodingKeys1
+
+        public var description: String {
+            switch self {
+            case .required:
+                return "required"
+            case .optional:
+                return "optional"
+            case .defaultValue(let value):
+                return "assumeValueIfMissing(\(String(describing: value))"
+            }
+        }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.ParseStrategy {
+    /// Modifies a parse strategy to parse a URL's scheme component in accordance with the provided behavior.
+    ///
+    /// - Parameter strategy: A strategy for parsing the scheme component.
+    /// - Returns: A modified ``URL/ParseStrategy`` that incorporates the specified behavior.
+    public func scheme(_ strategy: ComponentParseStrategy<String> = .required) -> Self {
+        var new = self
+        new.scheme = strategy
+        return new
+    }
+
+    /// Modifies a parse strategy to parse a URL's user component in accordance with the provided behavior.
+    ///
+    /// - Parameter strategy: A strategy for parsing the user component.
+    /// - Returns: A modified ``URL/ParseStrategy`` that incorporates the specified behavior.
+    public func user(_ strategy: ComponentParseStrategy<String> = .optional) -> Self {
+        var new = self
+        new.user = strategy
+        return new
+    }
+
+    /// Modifies a parse strategy to parse a URL's password component in accordance with the provided behavior.
+    ///
+    /// - Parameter strategy: A strategy for parsing the password component.
+    /// - Returns: A modified ``URL/ParseStrategy`` that incorporates the specified behavior.
+    public func password(_ strategy: ComponentParseStrategy<String> = .optional) -> Self {
+        var new = self
+        new.password = strategy
+        return new
+    }
+
+    /// Modifies a parse strategy to parse a URL's host component in accordance with the provided behavior.
+    ///
+    /// - Parameter strategy: A strategy for parsing the host component.
+    /// - Returns: A modified ``URL/ParseStrategy`` that incorporates the specified behavior.
+    public func host(_ strategy: ComponentParseStrategy<String> = .required) -> Self {
+        var new = self
+        new.host = strategy
+        return new
+    }
+
+    /// Modifies a parse strategy to parse a URL's port component in accordance with the provided behavior.
+    ///
+    /// - Parameter strategy: A strategy for parsing the port component.
+    /// - Returns: A modified ``URL/ParseStrategy`` that incorporates the specified behavior.
+    public func port(_ strategy: ComponentParseStrategy<Int> = .optional) -> Self {
+        var new = self
+        new.port = strategy
+        return new
+    }
+
+    /// Modifies a parse strategy to parse a URL's path component in accordance with the provided behavior.
+    ///
+    /// - Parameter strategy: A strategy for parsing the path component.
+    /// - Returns: A modified ``URL/ParseStrategy`` that incorporates the specified behavior.
+    public func path(_ strategy: ComponentParseStrategy<String> = .optional) -> Self {
+        var new = self
+        new.path = strategy
+        return new
+    }
+
+    /// Modifies a parse strategy to parse a URL's query component in accordance with the provided behavior.
+    ///
+    /// - Parameter strategy: A strategy for parsing the query component.
+    /// - Returns: A modified ``URL/ParseStrategy`` that incorporates the specified behavior.
+    public func query(_ strategy: ComponentParseStrategy<String> = .optional) -> Self {
+        var new = self
+        new.query = strategy
+        return new
+    }
+
+    /// Modifies a parse strategy to parse a URL's fragment component in accordance with the provided behavior.
+    ///
+    /// - Parameter strategy: A strategy for parsing the fragment component.
+    /// - Returns: A modified ``URL/ParseStrategy`` that incorporates the specified behavior.
+    public func fragment(_ strategy: ComponentParseStrategy<String> = .optional) -> Self {
+        var new = self
+        new.fragment = strategy
+        return new
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.ParseStrategy : ParseStrategy {
+    fileprivate typealias Component = URL.FormatStyle.Component
+
+    internal func formatStyle() -> URL.FormatStyle {
+        // Simply construct a FormatStyle that displays everything
+        // since we can't infer when a component *should not* be
+        // displayed based on `ComponentParseStrategy`.
+        return URL.FormatStyle(
+            scheme: .always,
+            user: .always,
+            password: .always,
+            host: .always,
+            port: .always,
+            path: .always,
+            query: .always,
+            fragment: .always)
+    }
+
+    private func validate(_ components: URLComponents) -> Bool {
+        func isRequired(_ component: Component) -> Bool {
+            return requiredComponentsValue & UInt(component.rawValue) != 0
+        }
+        let invalid = (
+            (isRequired(.scheme) && components.scheme == nil) ||
+            (isRequired(.user) && components.user == nil) ||
+            (isRequired(.password) && components.password == nil) ||
+            (isRequired(.host) && components.host == nil) ||
+            (isRequired(.port) && components.port == nil) ||
+            (isRequired(.path) && components.path.isEmpty) ||
+            (isRequired(.query) && components.query == nil) ||
+            (isRequired(.fragment) && components.fragment == nil)
+        )
+        return !invalid
+    }
+
+    private func fillDefaultValues(for component: inout URLComponents) {
+        if component.scheme?.isEmpty ?? true {
+            component.scheme = defaultValues[Component.scheme.rawValue]
+        }
+        if component.user?.isEmpty ?? true {
+            component.user = defaultValues[Component.user.rawValue]
+        }
+        if component.password?.isEmpty ?? true {
+            component.password = defaultValues[Component.password.rawValue]
+        }
+        if component.host?.isEmpty ?? true {
+            component.host = defaultValues[Component.host.rawValue]
+        }
+        if component.port == nil,
+           let defaultPort = defaultValues[Component.port.rawValue] {
+            component.port = Int(defaultPort)
+        }
+        if component.path.isEmpty {
+            component.path = defaultValues[Component.path.rawValue] ?? ""
+        }
+        if component.query?.isEmpty ?? true {
+            component.query = defaultValues[Component.query.rawValue]
+        }
+        if component.fragment?.isEmpty ?? true {
+            component.fragment = defaultValues[Component.fragment.rawValue]
+        }
+    }
+
+    internal func matchURL(in string: some StringProtocol, url: inout URL?) -> Range<String.Index>? {
+        let endIndex = string.firstIndex { $0.isWhitespace } ?? string.endIndex
+        let matchRange = string.startIndex..<endIndex
+        let urlString = String(string[matchRange])
+        guard var components = URLComponents(string: urlString) else {
+            url = nil
+            return nil
+        }
+        guard validate(components) else {
+            url = nil
+            return nil
+        }
+        fillDefaultValues(for: &components)
+        url = components.url
+        return matchRange
+    }
+
+    /// Parses a URL string in accordance with this strategy and returns the parsed value.
+    ///
+    /// Use this method to repeatedly parse URL strings with the same
+    /// ``URL/ParseStrategy``. To parse a single URL string, use the URL
+    /// initializer ``URL/init(_:strategy:)``.
+    ///
+    /// This method throws an error if the parse strategy can't parse the
+    /// provided string.
+    ///
+    /// - Parameter value: The string to parse.
+    /// - Returns: The parsed URL value.
+    public func parse(_ value: String) throws -> URL {
+        var url: URL?
+        let result = matchURL(in: value, url: &url)
+        guard result != nil, let url else {
+            let url = URL(string: "https://user:password@www.example.com/path?color=red#name")!
+            throw parseError(value, exampleFormattedString: self.formatStyle().format(url))
+        }
+        return url
+    }
+
+    private static func match(url: inout URL?, inString string: String, defaultValues: [Int: String], requiredComponentsValue: UInt) {
+        if defaultValues.isEmpty { return }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension ParseStrategy where Self == URL.ParseStrategy {
+    /// A parse strategy for URLs.
+    ///
+    /// Use the dot-notation form of this type property when the call point allows the use of
+    /// ``URL/ParseStrategy``. Typically, you use this with the URL initializer ``URL/init(_:strategy:)``.
+    public static var url: Self {
+        .init()
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL {
+    /// Creates a new `URL` by parsing the given representation.
+    /// - Parameters:
+    ///   - value: A representation of a URL. The type of the representation is specified
+    ///     by `ParseStrategy.ParseInput`.
+    ///   - strategy: The parse strategy to parse `value` whose `ParseInput` is `URL`.
+#if FOUNDATION_FRAMEWORK
+    public init<T: Foundation.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
+        self = try strategy.parse(value)
+    }
+#else
+    public init<T: FoundationEssentials.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
+        self = try strategy.parse(value)
+    }
+#endif
+}
+
+// MARK: - Regex
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension URL.ParseStrategy : CustomConsumingRegexComponent {
+    /// The type returned when capturing matching substrings with this strategy.
+    ///
+    /// This strategy returns the ``URL`` type when performing regex capture.
+    public typealias RegexOutput = URL
+
+    /// Processes the input string within the specified bounds, beginning at the given index, and returns the end position of the match and the produced output.
+    ///
+    /// Don't call this method directly. Regular expression matching and capture
+    /// calls it automatically when matching substrings.
+    ///
+    /// - Parameters:
+    ///   - input: An input string to match against.
+    ///   - index: The index within `input` at which to begin searching.
+    ///   - bounds: The bounds within `input` in which to search.
+    /// - Returns: The upper bound where the match terminates and a matched instance, or `nil` if there isn't a match.
+    public func consuming(_ input: String, startingAt index: String.Index, in bounds: Range<String.Index>) throws -> (upperBound: String.Index, output: URL)? {
+        guard index < bounds.upperBound else {
+            return nil
+        }
+        let urlString = input[index ..< bounds.upperBound]
+        var url: URL?
+        let result = matchURL(in: urlString, url: &url)
+        guard let result, let url else {
+            return nil
+        }
+        return (upperBound: result.upperBound, output: url)
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+extension RegexComponent where Self == URL.ParseStrategy {
+    public static func url(scheme: URL.ParseStrategy.ComponentParseStrategy<String> = .required,
+       user: URL.ParseStrategy.ComponentParseStrategy<String> = .optional,
+       password: URL.ParseStrategy.ComponentParseStrategy<String> = .optional,
+       host: URL.ParseStrategy.ComponentParseStrategy<String> = .required,
+       port: URL.ParseStrategy.ComponentParseStrategy<Int> = .optional,
+       path: URL.ParseStrategy.ComponentParseStrategy<String> = .optional,
+       query: URL.ParseStrategy.ComponentParseStrategy<String> = .optional,
+       fragment: URL.ParseStrategy.ComponentParseStrategy<String> = .optional) -> Self {
+        return URL.ParseStrategy(
+            scheme: scheme,
+            user: user,
+            password: password,
+            host: host,
+            port: port,
+            path: path,
+            query: query,
+            fragment: fragment)
+    }
+}

--- a/Sources/FoundationInternationalization/URL+UnicodeLookalikeTable.swift
+++ b/Sources/FoundationInternationalization/URL+UnicodeLookalikeTable.swift
@@ -1,0 +1,702 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+internal import _FoundationICU
+
+extension URL {
+    final class UnicodeLookalikeTable : Sendable {
+        static let `default` = UnicodeLookalikeTable()
+
+        static let IDNScriptAllowedList: Set<Int> = {
+            func allowIDNScript(_ scriptName: String, to allowList: inout Set<Int>) {
+                let scriptCode = scriptName.withCString {
+                    return Int(u_getPropertyValueEnum(UCHAR_SCRIPT, $0))
+                }
+
+                if scriptCode >= 0 && scriptCode < UScriptCode.codeLimit.rawValue {
+                    allowList.insert(scriptCode)
+                }
+            }
+
+            var allowList: Set<Int> = Set()
+            // Populate the allow list
+            allowIDNScript("Common", to: &allowList)
+            allowIDNScript("Inherited", to: &allowList)
+            allowIDNScript("Arabic", to: &allowList)
+            allowIDNScript("Armenian", to: &allowList)
+            allowIDNScript("Bopomofo", to: &allowList)
+            allowIDNScript("Canadian_Aboriginal", to: &allowList)
+            allowIDNScript("Devanagari", to: &allowList)
+            allowIDNScript("Deseret", to: &allowList)
+            allowIDNScript("Gujarati", to: &allowList)
+            allowIDNScript("Gurmukhi", to: &allowList)
+            allowIDNScript("Hangul", to: &allowList)
+            allowIDNScript("Han", to: &allowList)
+            allowIDNScript("Hebrew", to: &allowList)
+            allowIDNScript("Hiragana", to: &allowList)
+            allowIDNScript("Katakana_Or_Hiragana", to: &allowList)
+            allowIDNScript("Katakana", to: &allowList)
+            allowIDNScript("Latin", to: &allowList)
+            allowIDNScript("Tamil", to: &allowList)
+            allowIDNScript("Thai", to: &allowList)
+            allowIDNScript("Yi", to: &allowList)
+
+            return allowList
+        }()
+
+        func shouldDisplayEncodedHost(for hostString: String) -> Bool {
+            if self.allCharactersInIDNScriptAllowList(in: hostString) {
+                return false
+            }
+            return !self.allCharactersAllowedByTLDRules(in: hostString)
+        }
+
+        private init() {}
+    }
+}
+
+extension Unicode.Scalar {
+    var ucharValue: UChar32 {
+        UChar32(value)
+    }
+}
+
+// MARK: - Lookalike Table
+extension URL.UnicodeLookalikeTable {
+    /// This function treats the following as unsafe, lookalike characters:
+    /// - any non-printable character, any character considered as whitespace,
+    /// - any ignorable character, and emoji characters related to locks.
+    /// We also considered the characters Mozilla disallows <http://kb.mozillazine.org/Network.IDN.blacklist_chars>.
+    private func isLookalikeScalar(_ scalar: Unicode.Scalar, withPreviousScalar previousScalar: Unicode.Scalar?) -> Bool {
+        if !u_isprint(scalar.ucharValue).boolValue ||
+            u_isUWhiteSpace(scalar.ucharValue).boolValue ||
+            u_hasBinaryProperty(scalar.ucharValue, UCHAR_DEFAULT_IGNORABLE_CODE_POINT).boolValue {
+            return true
+        }
+        let blockCode = ublock_getCode(scalar.ucharValue)
+        if blockCode == UBLOCK_IPA_EXTENSIONS || blockCode == UBLOCK_DESERET {
+            return true
+        }
+
+        switch (scalar.value) {
+        case 0x00BC: fallthrough /* VULGAR FRACTION ONE QUARTER */
+        case 0x00BD: fallthrough /* VULGAR FRACTION ONE HALF */
+        case 0x00BE: fallthrough /* VULGAR FRACTION THREE QUARTERS */
+        /* 0x0131 LATIN SMALL LETTER DOTLESS I is intentionally not considered a lookalike character because
+        it is visually distinguishable from i and it has legitimate use in the Turkish language */
+        case 0x01C0: fallthrough /* LATIN LETTER DENTAL CLICK */
+        case 0x01C3: fallthrough /* LATIN LETTER RETROFLEX CLICK */
+        case 0x1E9C: fallthrough /* LATIN SMALL LETTER LONG S WITH DIAGONAL STROKE */
+        case 0x1E9D: fallthrough /* LATIN SMALL LETTER LONG S WITH HIGH STROKE */
+        case 0x1EFE: fallthrough /* LATIN CAPITAL LETTER Y WITH LOOP */
+        case 0x1EFF: fallthrough /* LATIN SMALL LETTER Y WITH LOOP */
+        case 0x0237: fallthrough /* LATIN SMALL LETTER DOTLESS J */
+        case 0x0251: fallthrough /* LATIN SMALL LETTER ALPHA */
+        case 0x0261: fallthrough /* LATIN SMALL LETTER SCRIPT G */
+        case 0x02D0: fallthrough /* MODIFIER LETTER TRIANGULAR COLON */
+        case 0x0335: fallthrough /* COMBINING SHORT STROKE OVERLAY */
+        case 0x0337: fallthrough /* COMBINING SHORT SOLIDUS OVERLAY */
+        case 0x0338: fallthrough /* COMBINING LONG SOLIDUS OVERLAY */
+        case 0x0589: fallthrough /* ARMENIAN FULL STOP */
+        case 0x05B4: fallthrough /* HEBREW POINT HIRIQ */
+        case 0x05B9: fallthrough /* HEBREW POINT HOLAM */
+        case 0x05BA: fallthrough /* HEBREW POINT HOLAM HASER FOR VAV */
+        case 0x05BC: fallthrough /* HEBREW POINT DAGESH OR MAPIQ */
+        case 0x05C1: fallthrough /* HEBREW POINT SHIN DOT */
+        case 0x05C2: fallthrough /* HEBREW POINT SIN DOT */
+        case 0x05C3: fallthrough /* HEBREW PUNCTUATION SOF PASUQ */
+        case 0x05C4: fallthrough /* HEBREW MARK UPPER DOT */
+        case 0x05F4: fallthrough /* HEBREW PUNCTUATION GERSHAYIM */
+        case 0x0609: fallthrough /* ARABIC-INDIC PER MILLE SIGN */
+        case 0x060A: fallthrough /* ARABIC-INDIC PER TEN THOUSAND SIGN */
+        case 0x0650: fallthrough /* ARABIC KASRA */
+        case 0x0660: fallthrough /* ARABIC INDIC DIGIT ZERO */
+        case 0x066A: fallthrough /* ARABIC PERCENT SIGN */
+        case 0x06D4: fallthrough /* ARABIC FULL STOP */
+        case 0x06F0: fallthrough /* EXTENDED ARABIC INDIC DIGIT ZERO */
+        case 0x0701: fallthrough /* SYRIAC SUPRALINEAR FULL STOP */
+        case 0x0702: fallthrough /* SYRIAC SUBLINEAR FULL STOP */
+        case 0x0703: fallthrough /* SYRIAC SUPRALINEAR COLON */
+        case 0x0704: fallthrough /* SYRIAC SUBLINEAR COLON */
+        case 0x1735: fallthrough /* PHILIPPINE SINGLE PUNCTUATION */
+        case 0x1D04: fallthrough /* LATIN LETTER SMALL CAPITAL C */
+        case 0x1D0F: fallthrough /* LATIN LETTER SMALL CAPITAL O */
+        case 0x1D1C: fallthrough /* LATIN LETTER SMALL CAPITAL U */
+        case 0x1D20: fallthrough /* LATIN LETTER SMALL CAPITAL V */
+        case 0x1D21: fallthrough /* LATIN LETTER SMALL CAPITAL W */
+        case 0x1D22: fallthrough /* LATIN LETTER SMALL CAPITAL Z */
+        case 0x2010: fallthrough /* HYPHEN */
+        case 0x2011: fallthrough /* NON-BREAKING HYPHEN */
+        case 0x2024: fallthrough /* ONE DOT LEADER */
+        case 0x2027: fallthrough /* HYPHENATION POINT */
+        case 0x2039: fallthrough /* SINGLE LEFT-POINTING ANGLE QUOTATION MARK */
+        case 0x203A: fallthrough /* SINGLE RIGHT-POINTING ANGLE QUOTATION MARK */
+        case 0x2041: fallthrough /* CARET INSERTION POINT */
+        case 0x2044: fallthrough /* FRACTION SLASH */
+        case 0x2052: fallthrough /* COMMERCIAL MINUS SIGN */
+        case 0x2153: fallthrough /* VULGAR FRACTION ONE THIRD */
+        case 0x2154: fallthrough /* VULGAR FRACTION TWO THIRDS */
+        case 0x2155: fallthrough /* VULGAR FRACTION ONE FIFTH */
+        case 0x2156: fallthrough /* VULGAR FRACTION TWO FIFTHS */
+        case 0x2157: fallthrough /* VULGAR FRACTION THREE FIFTHS */
+        case 0x2158: fallthrough /* VULGAR FRACTION FOUR FIFTHS */
+        case 0x2159: fallthrough /* VULGAR FRACTION ONE SIXTH */
+        case 0x215A: fallthrough /* VULGAR FRACTION FIVE SIXTHS */
+        case 0x215B: fallthrough /* VULGAR FRACTION ONE EIGHT */
+        case 0x215C: fallthrough /* VULGAR FRACTION THREE EIGHTHS */
+        case 0x215D: fallthrough /* VULGAR FRACTION FIVE EIGHTHS */
+        case 0x215E: fallthrough /* VULGAR FRACTION SEVEN EIGHTHS */
+        case 0x215F: fallthrough /* FRACTION NUMERATOR ONE */
+        case 0x2212: fallthrough /* MINUS SIGN */
+        case 0x2215: fallthrough /* DIVISION SLASH */
+        case 0x2216: fallthrough /* SET MINUS */
+        case 0x2236: fallthrough /* RATIO */
+        case 0x233F: fallthrough /* APL FUNCTIONAL SYMBOL SLASH BAR */
+        case 0x23AE: fallthrough /* INTEGRAL EXTENSION */
+        case 0x244A: fallthrough /* OCR DOUBLE BACKSLASH */
+        case 0x2571: fallthrough /* BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT */
+        case 0x2572: fallthrough /* BOX DRAWINGS LIGHT DIAGONAL UPPER LEFT TO LOWER RIGHT */
+        case 0x29F6: fallthrough /* SOLIDUS WITH OVERBAR */
+        case 0x29F8: fallthrough /* BIG SOLIDUS */
+        case 0x2AFB: fallthrough /* TRIPLE SOLIDUS BINARY RELATION */
+        case 0x2AFD: fallthrough /* DOUBLE SOLIDUS OPERATOR */
+        case 0x2FF0: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT */
+        case 0x2FF1: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER ABOVE TO BELOW */
+        case 0x2FF2: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO MIDDLE AND RIGHT */
+        case 0x2FF3: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER ABOVE TO MIDDLE AND BELOW */
+        case 0x2FF4: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER FULL SURROUND */
+        case 0x2FF5: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM ABOVE */
+        case 0x2FF6: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM BELOW */
+        case 0x2FF7: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM LEFT */
+        case 0x2FF8: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM UPPER LEFT */
+        case 0x2FF9: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM UPPER RIGHT */
+        case 0x2FFA: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM LOWER LEFT */
+        case 0x2FFB: fallthrough /* IDEOGRAPHIC DESCRIPTION CHARACTER OVERLAID */
+        case 0x3002: fallthrough /* IDEOGRAPHIC FULL STOP */
+        case 0x3008: fallthrough /* LEFT ANGLE BRACKET */
+        case 0x3014: fallthrough /* LEFT TORTOISE SHELL BRACKET */
+        case 0x3015: fallthrough /* RIGHT TORTOISE SHELL BRACKET */
+        case 0x3033: fallthrough /* VERTICAL KANA REPEAT MARK UPPER HALF */
+        case 0x3035: fallthrough /* VERTICAL KANA REPEAT MARK LOWER HALF */
+        case 0x321D: fallthrough /* PARENTHESIZED KOREAN CHARACTER OJEON */
+        case 0x321E: fallthrough /* PARENTHESIZED KOREAN CHARACTER O HU */
+        case 0x33AE: fallthrough /* SQUARE RAD OVER S */
+        case 0x33AF: fallthrough /* SQUARE RAD OVER S SQUARED */
+        case 0x33C6: fallthrough /* SQUARE C OVER KG */
+        case 0x33DF: fallthrough /* SQUARE A OVER M */
+        case 0xA731: fallthrough /* LATIN LETTER SMALL CAPITAL S */
+        case 0xA771: fallthrough /* LATIN SMALL LETTER DUM */
+        case 0xA789: fallthrough /* MODIFIER LETTER COLON */
+        case 0xFE14: fallthrough /* PRESENTATION FORM FOR VERTICAL SEMICOLON */
+        case 0xFE15: fallthrough /* PRESENTATION FORM FOR VERTICAL EXCLAMATION MARK */
+        case 0xFE3F: fallthrough /* PRESENTATION FORM FOR VERTICAL LEFT ANGLE BRACKET */
+        case 0xFE5D: fallthrough /* SMALL LEFT TORTOISE SHELL BRACKET */
+        case 0xFE5E: fallthrough /* SMALL RIGHT TORTOISE SHELL BRACKET */
+        case 0xFF0E: fallthrough /* FULLWIDTH FULL STOP */
+        case 0xFF0F: fallthrough /* FULL WIDTH SOLIDUS */
+        case 0xFF61: fallthrough /* HALFWIDTH IDEOGRAPHIC FULL STOP */
+        case 0xFFFC: fallthrough /* OBJECT REPLACEMENT CHARACTER */
+        case 0xFFFD: fallthrough /* REPLACEMENT CHARACTER */
+        case 0x1F50F: fallthrough /* LOCK WITH INK PEN */
+        case 0x1F510: fallthrough /* CLOSED LOCK WITH KEY */
+        case 0x1F511: fallthrough /* KEY */
+        case 0x1F512: fallthrough /* LOCK */
+        case 0x1F513:             /* OPEN LOCK */
+            return true;
+        case 0x0307: /* COMBINING DOT ABOVE */
+            guard let previousScalar = previousScalar else {
+                return false
+            }
+
+            return previousScalar.value == 0x0237 /* LATIN SMALL LETTER DOTLESS J */
+                || previousScalar.value == 0x0131 /* LATIN SMALL LETTER DOTLESS I */
+                || previousScalar.value == 0x05D5 /* HEBREW LETTER VAV */
+        case 0x002E: /* FULL STOP */
+            return false;
+        default:
+            return isLookalikeSequence(
+                withScalar: scalar,
+                previousScalar: previousScalar,
+                ofScriptType: .armenian) ||
+            isLookalikeSequence(
+                withScalar: scalar,
+                previousScalar: previousScalar,
+                ofScriptType: .tamil) ||
+            isLookalikeSequence(
+                withScalar: scalar,
+                previousScalar: previousScalar,
+                ofScriptType: .canadianAboriginal) ||
+            isLookalikeSequence(
+                withScalar: scalar,
+                previousScalar: previousScalar,
+                ofScriptType: .thai) ||
+            isLookalikeSequence(
+                withScalar: scalar,
+                previousScalar: previousScalar,
+                ofScriptType: .arabic)
+        }
+    }
+
+    private func isLookalikeSequence(withScalar scalar: Unicode.Scalar, previousScalar: Unicode.Scalar?, ofScriptType scriptType: UScriptCode) -> Bool {
+        guard let previousScalar = previousScalar,
+              previousScalar != "/" else {
+            return false
+        }
+
+        if scriptType == .arabic {
+            return isLookalikeSequenceOfArabic(withScalar: scalar, previousScalar: previousScalar)
+        }
+
+        let isLookalikePair = { (first: Unicode.Scalar, second: Unicode.Scalar) -> Bool in
+            return first.isLookalikeScalarOfScriptType(scriptType) && !(second.isOfScriptType(scriptType) || second.isASCIIDigitOrValidHostCharacter())
+        }
+        return isLookalikePair(scalar, previousScalar) ||
+            isLookalikePair(previousScalar, scalar)
+    }
+
+    private func isLookalikeSequenceOfArabic(withScalar scalar: Unicode.Scalar, previousScalar: Unicode.Scalar?) -> Bool {
+        return scalar.isArabicDiacritic() && !(previousScalar?.isArabicCodePoint() ?? false)
+    }
+}
+
+// MARK: - IDN Script Allow List / TLD Rules
+extension URL.UnicodeLookalikeTable {
+    private func allCharactersInIDNScriptAllowList(in string: String) -> Bool {
+        var previousScalar: Unicode.Scalar? = nil
+        for scalar in string.unicodeScalars {
+            if !self.isScalarInIDNScriptAllowList(scalar) {
+                return false
+            }
+            if self.isLookalikeScalar(scalar, withPreviousScalar: previousScalar) {
+                return false
+            }
+            previousScalar = scalar
+        }
+        return true
+    }
+
+    private func isScalarInIDNScriptAllowList(_ scalar: Unicode.Scalar) -> Bool {
+        var status = U_ZERO_ERROR
+        let scriptCode = uscript_getScript(UChar32(scalar.value), &status)
+        guard status.isSuccess else { return false }
+
+        return URL.UnicodeLookalikeTable.IDNScriptAllowedList.contains(Int(scriptCode.rawValue))
+    }
+
+    private func allCharactersAllowedByTLDRules(in string: String) -> Bool {
+        var buffer = string
+        // Skip trailing dot for root domain.
+        if buffer.hasSuffix(".") {
+            buffer.removeLast(1)
+        }
+
+        // http://cctld.ru/files/pdf/docs/rules_ru-rf.pdf
+        let cyrillicRF: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x0440, // CYRILLIC SMALL LETTER ER
+            0x0444  // CYRILLIC SMALL LETTER EF
+        ])
+        if buffer.count > cyrillicRF.count && buffer.unicodeScalars.hasSuffix(cyrillicRF) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicRF.count),
+                allowedBy: { $0.isRussianDomainNameCharacter() })
+        }
+
+        // http://rusnames.ru/rules.pl
+        let cyrillicRUS: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x0440, // CYRILLIC SMALL LETTER ER
+            0x0443, // CYRILLIC SMALL LETTER U
+            0x0441  // CYRILLIC SMALL LETTER ES
+        ])
+        if buffer.count > cyrillicRUS.count && buffer.unicodeScalars.hasSuffix(cyrillicRUS) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicRUS.count),
+                allowedBy: { $0.isRussianDomainNameCharacter() })
+        }
+
+        // http://ru.faitid.org/projects/moscow/documents/moskva/idn
+        let cyrillicMOSKVA: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x043C, // CYRILLIC SMALL LETTER EM
+            0x043E, // CYRILLIC SMALL LETTER O
+            0x0441, // CYRILLIC SMALL LETTER ES
+            0x043A, // CYRILLIC SMALL LETTER KA
+            0x0432, // CYRILLIC SMALL LETTER VE
+            0x0430  // CYRILLIC SMALL LETTER A
+        ])
+        if buffer.count > cyrillicMOSKVA.count && buffer.unicodeScalars.hasSuffix(cyrillicMOSKVA) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicMOSKVA.count),
+                allowedBy: { $0.isRussianDomainNameCharacter() })
+        }
+
+        // http://www.dotdeti.ru/foruser/docs/regrules.php
+        let cyrillicDETI: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x0434, // CYRILLIC SMALL LETTER DE
+            0x0435, // CYRILLIC SMALL LETTER IE
+            0x0442, // CYRILLIC SMALL LETTER TE
+            0x0438  // CYRILLIC SMALL LETTER I
+        ])
+        if buffer.count > cyrillicDETI.count && buffer.unicodeScalars.hasSuffix(cyrillicDETI) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicDETI.count),
+                allowedBy: { $0.isRussianDomainNameCharacter() })
+        }
+
+        // http://corenic.org - rules not published. The word is Russian,
+        // so only allowing Russian at this time, although we may need to
+        // revise the checks if this ends up being used with other languages
+        // spoken in Russia.
+        let cyrillicONLAYN: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x043E, // CYRILLIC SMALL LETTER O
+            0x043D, // CYRILLIC SMALL LETTER EN
+            0x043B, // CYRILLIC SMALL LETTER EL
+            0x0430, // CYRILLIC SMALL LETTER A
+            0x0439, // CYRILLIC SMALL LETTER SHORT I
+            0x043D  // CYRILLIC SMALL LETTER EN
+        ])
+        if buffer.count > cyrillicONLAYN.count && buffer.unicodeScalars.hasSuffix(cyrillicONLAYN) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicONLAYN.count),
+                allowedBy: { $0.isRussianDomainNameCharacter() })
+        }
+
+        // http://corenic.org - same as above.
+        let cyrillicSAYT: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x0441, // CYRILLIC SMALL LETTER ES
+            0x0430, // CYRILLIC SMALL LETTER A
+            0x0439, // CYRILLIC SMALL LETTER SHORT I
+            0x0442  // CYRILLIC SMALL LETTER TE
+        ])
+        if buffer.count > cyrillicSAYT.count && buffer.unicodeScalars.hasSuffix(cyrillicSAYT) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicSAYT.count),
+                allowedBy: { $0.isRussianDomainNameCharacter() })
+        }
+
+        // http://pir.org/products/opr-domain/ - rules not published.
+        // According to the registry site, the intended audience is
+        // "Russian and other Slavic-speaking markets".
+        // Chrome appears to only allow Russian, so sticking with that for now.
+        let cyrillicORG: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x043E, // CYRILLIC SMALL LETTER O
+            0x0440, // CYRILLIC SMALL LETTER ER
+            0x0433  // CYRILLIC SMALL LETTER GHE
+        ])
+        if buffer.count > cyrillicORG.count && buffer.unicodeScalars.hasSuffix(cyrillicORG) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicORG.count),
+                allowedBy: { $0.isRussianDomainNameCharacter() })
+        }
+
+        // http://cctld.by/rules.html
+        let cyrillicBEL: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x0431, // CYRILLIC SMALL LETTER BE
+            0x0435, // CYRILLIC SMALL LETTER IE
+            0x043B  // CYRILLIC SMALL LETTER EL
+        ])
+        if buffer.count > cyrillicBEL.count && buffer.unicodeScalars.hasSuffix(cyrillicBEL) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicBEL.count),
+                allowedBy: {
+                    // Russian and Byelorussian letters, digits and dashes are allowed.
+                    return ($0.value >= 0x0430 && $0.value <= 0x044f) || $0.value == 0x0451 ||
+                        $0.value == 0x0456 || $0.value == 0x045E || $0.value == 0x2019 ||
+                        $0.isASCIIDigit() || $0 == "-"
+                })
+        }
+
+        // http://www.nic.kz/docs/poryadok_vnedreniya_kaz_ru.pdf
+        let cyrillicKAZ: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x049B, // CYRILLIC SMALL LETTER KA WITH DESCENDER
+            0x0430, // CYRILLIC SMALL LETTER A
+            0x0437  // CYRILLIC SMALL LETTER ZE
+        ])
+        if buffer.count > cyrillicKAZ.count && buffer.unicodeScalars.hasSuffix(cyrillicKAZ) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicKAZ.count),
+                allowedBy: {
+                    // Kazakh letters, digits and dashes are allowed.
+                    return ($0.value >= 0x0430 && $0.value <= 0x044f) || $0.value == 0x0451 ||
+                        $0.value == 0x04D9 || $0.value == 0x0493 || $0.value == 0x049B ||
+                        $0.value == 0x04A3 || $0.value == 0x04E9 || $0.value == 0x04B1 ||
+                        $0.value == 0x04AF || $0.value == 0x04BB || $0.value == 0x0456 ||
+                        $0.isASCIIDigit() || $0 == "-"
+                })
+        }
+
+        // http://uanic.net/docs/documents-ukr/Rules%20of%20UKR_v4.0.pdf
+        let cyrillicUKR: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x0443, // CYRILLIC SMALL LETTER U
+            0x043A, // CYRILLIC SMALL LETTER KA
+            0x0440  // CYRILLIC SMALL LETTER ER
+        ])
+        if buffer.count > cyrillicUKR.count && buffer.unicodeScalars.hasSuffix(cyrillicUKR) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicUKR.count),
+                allowedBy: {
+                    // Russian and Ukrainian letters, digits and dashes are allowed.
+                    return ($0.value >= 0x0430 && $0.value <= 0x044f) || $0.value == 0x0451 ||
+                        $0.value == 0x0491 || $0.value == 0x0404 || $0.value == 0x0456 ||
+                        $0.value == 0x0457 || $0.isASCIIDigit() || $0 == "-"
+                })
+        }
+
+        // http://www.rnids.rs/data/DOKUMENTI/idn-srb-policy-termsofuse-v1.4-eng.pdf
+        let cyrillicSRB: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x0441, // CYRILLIC SMALL LETTER ES
+            0x0440, // CYRILLIC SMALL LETTER ER
+            0x0431  // CYRILLIC SMALL LETTER BE
+        ])
+        if buffer.count > cyrillicSRB.count && buffer.unicodeScalars.hasSuffix(cyrillicSRB) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicSRB.count),
+                allowedBy: {
+                    // Serbian letters, digits and dashes are allowed.
+                    return ($0.value >= 0x0430 && $0.value <= 0x0438) || ($0.value >= 0x043A && $0.value <= 0x0448) ||
+                        $0.value == 0x0452 || $0.value == 0x0458 || $0.value == 0x0459 ||
+                        $0.value == 0x045A || $0.value == 0x045B || $0.value == 0x045F ||
+                        $0.isASCIIDigit() || $0 == "-"
+                })
+        }
+
+        // http://marnet.mk/doc/pravilnik-mk-mkd.pdf
+        let cyrillicMKD: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x043C, // CYRILLIC SMALL LETTER EM
+            0x043A, // CYRILLIC SMALL LETTER KA
+            0x0434  // CYRILLIC SMALL LETTER DE
+        ])
+        if buffer.count > cyrillicMKD.count && buffer.unicodeScalars.hasSuffix(cyrillicMKD) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicMKD.count),
+                allowedBy: {
+                    // Macedonian letters, digits and dashes are allowed.
+                    return ($0.value >= 0x0430 && $0.value <= 0x0438) || ($0.value >= 0x043A && $0.value <= 0x0448) ||
+                        $0.value == 0x0453 || $0.value == 0x0455 || $0.value == 0x0458 ||
+                        $0.value == 0x0459 || $0.value == 0x045A || $0.value == 0x045C ||
+                        $0.value == 0x045F || $0.isASCIIDigit() || $0 == "-"
+                })
+        }
+
+        // https://www.mon.mn/cs/
+        let cyrillicMON: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x043C, // CYRILLIC SMALL LETTER EM
+            0x043E, // CYRILLIC SMALL LETTER O
+            0x043D  // CYRILLIC SMALL LETTER EN
+        ])
+        if buffer.count > cyrillicMON.count && buffer.unicodeScalars.hasSuffix(cyrillicMON) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicMON.count),
+                allowedBy: {
+                    // Mongolian letters, digits and dashes are allowed.
+                    return ($0.value >= 0x0430 && $0.value <= 0x044f) || $0.value == 0x0451 ||
+                        $0.value == 0x04E9 || $0.value == 0x04AF || $0.isASCIIDigit() ||
+                        $0 == "-"
+                })
+        }
+
+        // https://www.icann.org/sites/default/files/packages/lgr/lgr-second-level-bulgarian-30aug16-en.html
+        let cyrillicBG: String.UnicodeScalarView = .init([
+            0x002E, // '.' FULL STOP
+            0x0431, // CYRILLIC SMALL LETTER BE
+            0x0433 // CYRILLIC SMALL LETTER GHE
+        ])
+        if buffer.count > cyrillicBG.count && buffer.unicodeScalars.hasSuffix(cyrillicBG) {
+            return self.secondLevelDomain(
+                buffer.unicodeScalars.dropLast(cyrillicBG.count),
+                allowedBy: {
+                    return ($0.value >= 0x0430 && $0.value <= 0x044A) || $0.value == 0x044C ||
+                        ($0.value >= 0x044E && $0.value <= 0x0450) || $0.value == 0x045D ||
+                        $0.isASCIIDigit() || $0 == "-"
+                })
+        }
+
+        // Not a known top level domain with special rules.
+        return false
+    }
+
+    private func secondLevelDomain(_ secondLevelDomain: String.UnicodeScalarView.SubSequence, allowedBy filterFunc: (Unicode.Scalar) -> Bool) -> Bool {
+        for scalar in secondLevelDomain.reversed() {
+            if filterFunc(scalar) {
+                continue
+            }
+            // Only check the second level domain. Lower level registrars may have different rules.
+            if scalar == "." {
+                break
+            }
+            return false
+        }
+        return true
+    }
+}
+
+// MARK: - Unicode Scalar Extensions
+extension Unicode.Scalar {
+    fileprivate func isOfScriptType(_ type: UScriptCode) -> Bool {
+        var status = U_ZERO_ERROR
+        let scriptCode = uscript_getScript(UChar32(self.value), &status)
+        return scriptCode == type
+    }
+
+    fileprivate func isLookalikeScalarOfScriptType(_ scriptType: UScriptCode) -> Bool {
+        switch scriptType {
+        case .armenian:
+            return self.isLookalikeScalarOfArmenianScript()
+        case .tamil:
+            return self.isLookalikeScalarOfTamilScript()
+        case .thai:
+            return self.isLookalikeScalarOfThai()
+        case .canadianAboriginal:
+            return self.isLookalikeScalarOfCanadianAboriginal()
+        case .codeLimit:
+            return false
+        default:
+            return false
+        }
+    }
+
+    fileprivate func isLookalikeScalarOfTamilScript() -> Bool {
+        switch self.value {
+        case 0x0BE6: /* TAMIL DIGIT ZERO */
+            return true
+        default:
+            return false
+        }
+    }
+
+    fileprivate func isLookalikeScalarOfArmenianScript() -> Bool {
+        switch self.value {
+        case 0x0548: fallthrough /* ARMENIAN CAPITAL LETTER VO */
+        case 0x054D: fallthrough /* ARMENIAN CAPITAL LETTER SEH */
+        case 0x0551: fallthrough /* ARMENIAN CAPITAL LETTER CO */
+        case 0x0555: fallthrough /* ARMENIAN CAPITAL LETTER OH */
+        case 0x0578: fallthrough /* ARMENIAN SMALL LETTER VO */
+        case 0x057D: fallthrough /* ARMENIAN SMALL LETTER SEH */
+        case 0x0581: fallthrough /* ARMENIAN SMALL LETTER CO */
+        case 0x0585:             /* ARMENIAN SMALL LETTER OH */
+            return true
+        default:
+            return false
+        }
+    }
+
+    fileprivate func isLookalikeScalarOfCanadianAboriginal() -> Bool {
+        switch self.value {
+        case 0x146D: fallthrough /* CANADIAN SYLLABICS KI */
+        case 0x146F: fallthrough /* CANADIAN SYLLABICS KO */
+        case 0x1472: fallthrough /* CANADIAN SYLLABICS KA */
+        case 0x14AA: fallthrough /* CANADIAN SYLLABICS MA */
+        case 0x157C: fallthrough /* CANADIAN SYLLABICS NUNAVUT H */
+        case 0x1587: fallthrough /* CANADIAN SYLLABICS TLHI */
+        case 0x15AF: fallthrough /* CANADIAN SYLLABICS AIVILIK B */
+        case 0x15B4: fallthrough /* CANADIAN SYLLABICS BLACKFOOT WE */
+        case 0x15C5: fallthrough /* CANADIAN SYLLABICS CARRIER GHO */
+        case 0x15DE: fallthrough /* CANADIAN SYLLABICS CARRIER THE */
+        case 0x15E9: fallthrough /* CANADIAN SYLLABICS CARRIER PO */
+        case 0x15F1: fallthrough /* CANADIAN SYLLABICS CARRIER GE */
+        case 0x15F4: fallthrough /* CANADIAN SYLLABICS CARRIER GA */
+        case 0x166D: fallthrough /* CANADIAN SYLLABICS CHI SIGN */
+        case 0x166E:             /* CANADIAN SYLLABICS FULL STOP */
+            return true
+        default:
+            return false
+        }
+    }
+
+    fileprivate func isLookalikeScalarOfThai() -> Bool {
+        switch self.value {
+        case 0x0E01:             /* THAI CHARACTER KO KAI */
+            return true
+        default:
+            return false
+        }
+    }
+
+    fileprivate func isASCIIDigitOrValidHostCharacter() -> Bool {
+        if !self.isASCIIDigitOrPunctuation() {
+            return false
+        }
+        return self.isValidHostCharacter()
+    }
+
+    fileprivate func isRussianDomainNameCharacter() -> Bool {
+        // Only modern Russian letters, digits and dashes are allowed.
+        return (self.value >= 0x0430 && self.value <= 0x044f) ||
+            self.value == 0x0451 || self.isASCIIDigit() ||
+            self == "-"
+    }
+
+    fileprivate func isASCIIDigit() -> Bool {
+        return self >= "0" && self <= "9"
+    }
+
+    fileprivate func isArabicDiacritic() -> Bool {
+        return 0x064B <= self.value && self.value <= 0x065F
+    }
+
+    fileprivate func isArabicCodePoint() -> Bool {
+        return ublock_getCode(self.ucharValue) == UBLOCK_ARABIC
+    }
+
+    private func isASCIIDigitOrPunctuation() -> Bool {
+        return (self >= "!" && self <= "@") ||
+            (self >= "[" && self <= "`") ||
+            (self >= "{" && self <= "~")
+    }
+
+    private func isValidHostCharacter() -> Bool {
+        switch self {
+        case "#": fallthrough
+        case "%": fallthrough
+        case "/": fallthrough
+        case ":": fallthrough
+        case "?": fallthrough
+        case "@": fallthrough
+        case "[": fallthrough
+        case "\\": fallthrough
+        case "]":
+            return false
+        default:
+            return true
+        }
+    }
+}
+
+extension String.UnicodeScalarView {
+    fileprivate init<S>(_ elements: S) where S : Sequence, S.Element == UInt32 {
+        self.init(elements.map { Unicode.Scalar($0)! })
+    }
+
+    fileprivate func hasSuffix(_ suffix: String.UnicodeScalarView) -> Bool {
+        guard suffix.count < self.count else {
+            return false
+        }
+
+        let target = self[self.index(self.endIndex, offsetBy: -suffix.count) ..< self.endIndex]
+        return String.UnicodeScalarView(target).elementsEqual(suffix)
+    }
+}

--- a/Tests/FoundationInternationalizationTests/Formatting/URLFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/URLFormatStyleTests.swift
@@ -1,0 +1,461 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+#if canImport(FoundationInternationalization)
+@testable import FoundationEssentials
+@testable import FoundationInternationalization
+#else
+@testable import Foundation
+#endif
+
+@Suite("URL.FormatStyle")
+private struct URLFormatStyleTests {
+    @Test func defaultFormatStyle() {
+        let style = URL.FormatStyle()
+        // Scheme is always visible
+        verify("https://www.pomegranate.com", matches: "https://www.pomegranate.com", withStyle: style)
+        verify("http://www.peach.com", matches: "http://www.peach.com", withStyle: style)
+        verify("ssh://www.banana.com", matches: "ssh://www.banana.com", withStyle: style)
+        // Authoirty is always omitted
+        verify("https://charles:pswd@cherry.com", matches: "https://cherry.com", withStyle: style)
+        verify("http://tim:pssd@orange.com", matches: "http://orange.com", withStyle: style)
+        verify("ftp://dev:pswd@strawberry.com", matches: "ftp://strawberry.com", withStyle: style)
+        // Host is always visible
+        verify("https://docs.code.lychee.com", matches: "https://docs.code.lychee.com", withStyle: style)
+        verify("ftp://vault.kiwi.com", matches: "ftp://vault.kiwi.com", withStyle: style)
+        // Port is omitted for HTTP family
+        verify("https://www.blueberry.com:1234", matches: "https://www.blueberry.com", withStyle: style)
+        verify("http://www.raspberry.com:4242", matches: "http://www.raspberry.com", withStyle: style)
+        verify("safari://www.pineapple.com:9876", matches: "safari://www.pineapple.com:9876", withStyle: style)
+        // Path is always visible
+        verify("https://www.lemon.com/api/v2", matches: "https://www.lemon.com/api/v2", withStyle: style)
+        verify("music://www.lime.com/api/v3", matches: "music://www.lime.com/api/v3", withStyle: style)
+        // Query is always omitted
+        verify("https://mango.com/search?color=red", matches: "https://mango.com/search", withStyle: style)
+        verify("photos://melon.com/find?size=large", matches: "photos://melon.com/find", withStyle: style)
+        // Fragment is always omitted
+        verify("https://grapes.com/path#history", matches: "https://grapes.com/path", withStyle: style)
+        verify("apps://plums.com/path#development", matches: "apps://plums.com/path", withStyle: style)
+        // Put everything together
+        verify("https://charles:pswd@apple.com/search?name=iMac#specs", matches: "https://apple.com/search", withStyle: style)
+    }
+
+    @Test func hostFormatting() {
+        // Test displayed style
+        var style = URL.FormatStyle().scheme(.omitIfHTTPFamily).host(.always)
+        verify("https://www.apple.com", matches: "www.apple.com", withStyle: style)
+        style = style.host(.displayWhen(.scheme, matches: ["http", "https"]))
+        verify("ftp://www.apple.com", matches: "ftp:", withStyle: style)
+        // Test omitted style
+        style = style.host(.never)
+        verify("ftp://www.apple.com", matches: "ftp:", withStyle: style)
+        style = style.host(.omitIfHTTPFamily)
+        verify("ftp://www.apple.com", matches: "ftp://www.apple.com", withStyle: style)
+        // Default style for scheme is .omitIfHTTPFamily
+        verify("https://www.apple.com/path", matches: "/path", withStyle: style)
+        // Test omitMultiLevelSubdomains (requires TLD detection, framework only)
+#if FOUNDATION_FRAMEWORK
+        style = style.host(.omitSpecificSubdomains([], includeMultiLevelSubdomains: true))
+        verify("https://docs.api.code.apple.com.cn", matches: "code.apple.com.cn", withStyle: style)
+#endif
+        style = style.host(.omitSpecificSubdomains([], includeMultiLevelSubdomains: true, when: .scheme, matches: ["http", "https"]))
+        verify("ftp://a.b.c.d.apple.com", matches: "ftp://a.b.c.d.apple.com", withStyle: style)
+        // Test omitSpecificDomains
+        style = style.host(.omitSpecificSubdomains(["www", "mobile", "m"]))
+        verify("https://mobile.apple.com", matches: "apple.com", withStyle: style)
+        verify("https://www.apple.com", matches: "apple.com", withStyle: style)
+        verify("https://m.apple.com", matches: "apple.com", withStyle: style)
+        verify("https://mobile.com", matches: "mobile.com", withStyle: style)
+        verify("https://m.mobile.apple.com", matches: "mobile.apple.com", withStyle: style)
+        verify("https://dev.apple.com", matches: "dev.apple.com", withStyle: style)
+        style = style.host(.omitSpecificSubdomains(["www", "charles", "mobile"], when: .scheme, matches: ["http", "https"]))
+        verify("https://charles.hu.codes", matches: "hu.codes", withStyle: style)
+        verify("ftp://mobile.apple.com", matches: "ftp://mobile.apple.com", withStyle: style)
+        // Test ip addresses
+        verify("https://192.168.0.30", matches: "192.168.0.30", withStyle: style)
+        verify("https://[2620:100:e000::8001]/search", matches: "[2620:100:e000::8001]/search", withStyle: style)
+        style = style.host(.omitSpecificSubdomains(["192", "168"], includeMultiLevelSubdomains: true))
+        // IP address should not be modified
+        verify("https://192.168.0.255/path", matches: "192.168.0.255/path", withStyle: style)
+        style = style.host(.omitSpecificSubdomains(["2620", "100"], includeMultiLevelSubdomains: true))
+        verify("https://[2620:100:e000::8001]/search", matches: "[2620:100:e000::8001]/search", withStyle: style)
+    }
+
+    @Test func componentCondition() {
+        // When there's no condition, the ComponentStyle is applied as it is
+        var style: URL.FormatStyle = .init(scheme: .never)
+        verify("https://www.apple.com", matches: "www.apple.com", withStyle: style)
+        verify("ssh://www.pear.com", matches: "www.pear.com", withStyle: style)
+        style = .init(scheme: .always)
+        verify("https://www.plums.com", matches: "https://www.plums.com", withStyle: style)
+        verify("ftp://www.melon.com", matches: "ftp://www.melon.com", withStyle: style)
+        // Constraint the style to only apply to HTTP family of URLs
+        style = .init(scheme: .omitIfHTTPFamily)
+        verify("https://www.mango.com", matches: "www.mango.com", withStyle: style)
+        verify("http://www.cherry.com", matches: "www.cherry.com", withStyle: style)
+        verify("ftp://www.kiwi.com", matches: "ftp://www.kiwi.com", withStyle: style)
+        style = .init(scheme: .displayWhen(.scheme, matches: ["http", "https"]))
+        verify("https://www.lemon.com", matches: "https://www.lemon.com", withStyle: style)
+        verify("http://www.lime.com", matches: "http://www.lime.com", withStyle: style)
+        verify("mailto://www.pinapple.com", matches: "www.pinapple.com", withStyle: style)
+        // Contraint the style to specific schemes
+        style = .init(scheme: .omitWhen(.scheme, matches: ["music", "tv", "chocolate"]))
+        verify("https://www.peach.com", matches: "https://www.peach.com", withStyle: style)
+        verify("music://www.banana.com", matches: "www.banana.com", withStyle: style)
+        verify("tv://www.watermelon.com", matches: "www.watermelon.com", withStyle: style)
+        verify("chocolate://www.strawberry.com", matches: "www.strawberry.com", withStyle: style)
+        style = .init(scheme: .displayWhen(.scheme, matches: ["music", "tv", "chocolate"]))
+        verify("https://www.blueberry.com", matches: "www.blueberry.com", withStyle: style)
+        verify("music://www.raspberry.com", matches: "music://www.raspberry.com", withStyle: style)
+        verify("tv://www.orange.com", matches: "tv://www.orange.com", withStyle: style)
+        verify("chocolate://www.lychee.com", matches: "chocolate://www.lychee.com", withStyle: style)
+    }
+
+    @Test func formatStyleFromLinkPresentation() {
+        // Tests stolen from LinkPresentation to make sure we produce the same result
+        let standard: URL.FormatStyle = .init(
+            scheme: .omitWhen(.scheme, matches: ["http"]), query: .never, fragment: .never)
+        verify("http://www.apple.com", matches: "www.apple.com", withStyle: standard)
+        verify("http://www.apple.com/", matches: "www.apple.com", withStyle: standard)
+        verify("http://apple.com/", matches: "apple.com", withStyle: standard);
+        verify("http://www.apple.com/iPhone/", matches: "www.apple.com/iPhone", withStyle: standard)
+        verify("https://www.apple.com", matches: "https://www.apple.com", withStyle: standard)
+        verify("https://www.apple.com/", matches: "https://www.apple.com", withStyle: standard)
+        verify("https://www.apple.com/iPhone/", matches: "https://www.apple.com/iPhone", withStyle: standard)
+        verify("ftp:/", matches: "ftp:", withStyle: standard)
+        verify("ftp:/Volumes/", matches: "ftp:/Volumes", withStyle: standard)
+
+        var style = standard.scheme(.omitIfHTTPFamily)
+        verify("https://www.apple.com/", matches: "www.apple.com", withStyle: style)
+
+        style = style.scheme(.always)
+            .user(.always)
+            .host(.omitSpecificSubdomains(["www"]))
+        verify("http://www.apple.com/", matches: "http://apple.com", withStyle: style);
+        verify("http://m.cnn.com/", matches: "http://m.cnn.com", withStyle: style);
+        verify("ftp://www.apple.com/", matches: "ftp://apple.com", withStyle: style);
+        verify("http://www.@apple.com/", matches: "http://www.@apple.com", withStyle: style);
+        verify("http://www.com/", matches: "http://www.com", withStyle: style);
+
+        style = style.scheme(.always)
+            .host(.always)
+            .path(.omitIfHTTPFamily)
+            .query(.omitIfHTTPFamily)
+            .fragment(.omitIfHTTPFamily)
+        verify("http://www.apple.com/mac", matches: "http://www.apple.com", withStyle: style);
+        verify("file:/", matches: "file:", withStyle: style);
+        verify("file:/etc/asl", matches: "file:/etc/asl", withStyle: style);
+
+        style = style.user(.always)
+            .password(.always)
+            .port(.omitIfHTTPFamily)
+            .path(.always)
+        verify(
+            "http://www.apple.com:81/imac",
+            matches: "http://www.apple.com/imac", withStyle: style)
+        verify(
+            "feed://www.apple.com:81/imac",
+            matches: "feed://www.apple.com:81/imac", withStyle: style)
+        verify(
+            "http://[2620:100:e000::8001]:81/US",
+            matches: "http://[2620:100:e000::8001]/US", withStyle: style)
+        verify(
+            "http://[2620:100:e000::8001]/US",
+            matches: "http://[2620:100:e000::8001]/US", withStyle: style)
+        verify(
+            "http://someone:something@[2620:100:e000::8001]/US",
+            matches: "http://someone:something@[2620:100:e000::8001]/US", withStyle: style)
+
+        style = style.host(.omitSpecificSubdomains(["m"], when: .scheme, matches: ["http", "https"]))
+        verify("http://www.apple.com/", matches: "http://www.apple.com", withStyle: style);
+        verify("http://m.cnn.com/", matches: "http://cnn.com", withStyle: style);
+        verify("ftp://m.cnn.com/", matches: "ftp://m.cnn.com", withStyle: style);
+        verify("http://m.@cnn.com/", matches: "http://m.@cnn.com", withStyle: style);
+        verify("http://m.edu/", matches: "http://m.edu", withStyle: style);
+
+        style = style.host(.omitSpecificSubdomains(["m", "mobile", "www"], when: .scheme, matches: ["http", "https"]))
+        verify("http://www.m.cnn.com/", matches: "http://m.cnn.com", withStyle: style)
+        verify("http://mobile.twitter.com/", matches: "http://twitter.com", withStyle: style)
+        verify("http://www.twitter.com/", matches: "http://twitter.com", withStyle: style)
+        verify("http://mobile.twitter.com/", matches: "http://twitter.com", withStyle: style)
+        verify("ftp://mobile.twitter.com/", matches: "ftp://mobile.twitter.com", withStyle: style)
+        verify("http://mobile.@cnn.com/", matches: "http://mobile.@cnn.com", withStyle: style)
+        verify("http://mobile.edu/", matches: "http://mobile.edu", withStyle: style)
+        verify("http://www.mobile.twitter.com/", matches: "http://mobile.twitter.com", withStyle: style)
+        verify("http://m.mobile.twitter.com/", matches: "http://mobile.twitter.com", withStyle: style)
+        verify("http://mobile.m.twitter.com/", matches: "http://m.twitter.com", withStyle: style)
+
+        style = style.host(.always)
+            .path(.never).query(.never).fragment(.never)
+        verify("http://www.youtube.com/", matches: "http://www.youtube.com", withStyle: style)
+        verify("http://www.youtube.com/?", matches: "http://www.youtube.com", withStyle: style)
+        verify("http://www.youtube.com/?v=", matches: "http://www.youtube.com", withStyle: style)
+        verify("http://www.youtube.com/?#", matches: "http://www.youtube.com", withStyle: style)
+        verify("http://www.youtube.com/?#fragment", matches: "http://www.youtube.com", withStyle: style)
+        verify("http://www.youtube.com/#fragment", matches: "http://www.youtube.com", withStyle: style)
+
+        style = style.scheme(.always)
+            .user(.omitIfHTTPFamily)
+            .password(.omitIfHTTPFamily)
+            .path(.always)
+            .port(.omitIfHTTPFamily)
+        verify("http://apple.com................@google.com/", matches: "http://google.com", withStyle: style)
+        verify("http://apple.com................@google.com", matches: "http://google.com", withStyle: style)
+        verify("http://apple.com@google.com/", matches: "http://google.com", withStyle: style)
+        verify("http://someone:something@[2620:100:e000::8001]/US", matches: "http://[2620:100:e000::8001]/US", withStyle: style)
+        verify("http://someone:something@192.168.1.1/US", matches: "http://192.168.1.1/US", withStyle: style)
+        verify("http://someone@", matches: "http:", withStyle: style)
+        verify("http://someone:something@", matches: "http:", withStyle: style)
+        verify("http://@google.com", matches: "http://google.com", withStyle: style)
+
+        // Multi-level subdomain stripping requires TLD detection (framework only)
+#if FOUNDATION_FRAMEWORK
+        style = standard.host(.omitSpecificSubdomains(["m", "mobile", "www"], includeMultiLevelSubdomains: true))
+        verify("http://a.b.c.d.e.com", matches: "d.e.com", withStyle: style)
+        verify("http://apple.com.a.a.a.a.a.a.a.a.a.a.evil.com", matches: "a.evil.com", withStyle: style)
+        verify("http://g.com", matches: "g.com", withStyle: style)
+        verify("http://f.g.com", matches: "f.g.com", withStyle: style)
+        verify("http://e.f.g.com", matches: "f.g.com", withStyle: style)
+        verify("http://www.com", matches: "www.com", withStyle: style)
+        verify("http://www.a.com", matches: "a.com", withStyle: style)
+        verify("http://www.a.b.com", matches: "a.b.com", withStyle: style)
+        verify("http://a.www.b.com", matches: "b.com", withStyle: style)
+        verify("http://a.www.B.com", matches: "B.com", withStyle: style)
+        verify("http://m.com", matches: "m.com", withStyle: style)
+        verify("http://m.a.com", matches: "a.com", withStyle: style)
+        verify("http://m.a.b.com", matches: "a.b.com", withStyle: style)
+        verify("http://a.m.b.com", matches: "b.com", withStyle: style)
+        verify("http://m.www.apple.com", matches: "apple.com", withStyle: style)
+        verify("http://www.m.apple.com", matches: "apple.com", withStyle: style)
+        verify("http://www.mobile.twitter.com", matches: "twitter.com", withStyle: style)
+        verify("http://m.mobile.twitter.com", matches: "twitter.com", withStyle: style)
+        verify("http://mobile.m.twitter.com", matches: "twitter.com", withStyle: style)
+        verify("http://mobile.com", matches: "mobile.com", withStyle: style)
+#endif
+    }
+
+    @Test func lookalikeCharacters() {
+        // Display all components
+        let style = URL.FormatStyle(
+            scheme: .always, user: .always, password: .always,
+            host: .always, port: .always, path: .always,
+            query: .always, fragment: .always)
+        // "Normal" (not lookalike) Unicode characters
+        // should be displayed verbatim
+        verify(
+            "https://👁👄👁.fm",
+            matches: "https://👁👄👁.fm", withStyle: style)
+        verify(
+            "http://見.香港/热狗/🌭",
+            matches: "http://見.香港/热狗/🌭", withStyle: style)
+        verify(
+            "https://🤙🏻:🏳️‍🌈@🐮.臺灣.இலங்கை:1234/🥗?name=δοκιμή#😉",
+            matches: "https://🤙🏻:🏳️‍🌈@🐮.臺灣.இலங்கை:1234/🥗?name=δοκιμή#😉",
+            withStyle: style)
+        // If the host contains lookalike characters, we should
+        // display Punycode instead
+        verify(
+            "http://аррІе.com/", // NOT apple.com
+            matches: "http://xn--80ak6aa4i.com", withStyle: style)
+        verify(
+            "http://gooِgle.com/", // also NOT google.com
+            matches: "http://xn--google-yri.com", withStyle: style)
+
+        // Stolen from LinkPresentation:
+        // These strings contain lookalike characters, therefore
+        // we should display Punycode instead
+        let punycodeSpoofTests: [(url: String, output: String)] = [
+            (url: "https://ı̇/", output: "https://xn--cfa45g"),
+            (url: "https://ȷ̇/", output: "https://xn--tma03b"),
+            (url: "https://ᴄ/", output: "https://xn--u7f"),
+            (url: "https://ᴏ/", output: "https://xn--57f"),
+            (url: "https://ꜱ/", output: "https://xn--i38a"),
+            (url: "https://ᴜ/", output: "https://xn--j8f"),
+            (url: "https://ᴠ/", output: "https://xn--n8f"),
+            (url: "https://ᴡ/", output: "https://xn--o8f"),
+            (url: "https://ᴢ/", output: "https://xn--p8f"),
+            (url: "https://ɡ/", output: "https://xn--0na"),
+            (url: "https://cnո/", output: "https://xn--cn-ded"),
+            (url: "https://ոews.org/", output: "https://xn--ews-nfe.org"),
+            (url: "https://yoսtube/", output: "https://xn--yotube-qkh"),
+            (url: "https://սcla.edu/", output: "https://xn--cla-7fe.edu"),
+            (url: "https://ו̇/", output: "https://xn--rsa94l"),
+            (url: "https://וֹ/", output: "https://xn--hdb9c"),
+            (url: "https://וֺ/", output: "https://xn--idb7c"),
+            (url: "https://וׁ/", output: "https://xn--pdb3b"),
+            (url: "https://וׂ/", output: "https://xn--qdb1b"),
+            (url: "https://וׄ/", output: "https://xn--sdb7a"),
+            (url: "https://ɾ/", output: "https://xn--uoa"),
+            (url: "https://ǀ/", output: "https://xn--fja"),
+            (url: "https://ɴ/", output: "https://xn--koa"),
+            (url: "https://ȷ/", output: "https://xn--tma"),
+            (url: "https://օo/", output: "https://xn--o-pdc"),
+            (url: "https://oօ/", output: "https://xn--o-qdc"),
+            (url: "https://ցg/", output: "https://xn--g-hdc"),
+            (url: "https://gց/", output: "https://xn--g-idc"),
+            (url: "https://௦o/", output: "https://xn--o-00e"),
+            (url: "https://o௦/", output: "https://xn--o-10e"),
+            (url: "https://gotՑԵՃ.com", output: "https://xn--got-kde4e2d.com"),
+            (url: "mailto:someone@.xn--4dbacpta7bzbn3a.com", output: "mailto:someone@.xn--4dbacpta7bzbn3a.com"),
+            (url: "mailto:someone@.xn--4dbacpta7bzbn3a.com?subjectsomething", output: "mailto:someone@.xn--4dbacpta7bzbn3a.com?subjectsomething"),
+            (url: "http://xn--nwstrfn-5fg5byy.com", output: "http://xn--nwstrfn-5fg5byy.com"),
+            (url: "http://xn--google-yri.com", output: "http://xn--google-yri.com"),
+            (url: "https://xn--apple-gkh.com", output: "https://xn--apple-gkh.com"),
+            (url: "http://gooِgle.com", output: "http://xn--google-yri.com"),
+            (url: "http://xn--cfa45g", output: "http://xn--cfa45g"),
+            (url: "http://xn--tma03b", output: "http://xn--tma03b"),
+            (url: "http://xn--u7f", output: "http://xn--u7f"),
+            (url: "http://xn--57f", output: "http://xn--57f"),
+            (url: "http://xn--i38a", output: "http://xn--i38a"),
+            (url: "http://xn--j8f", output: "http://xn--j8f"),
+            (url: "http://xn--n8f", output: "http://xn--n8f"),
+            (url: "http://xn--o8f", output: "http://xn--o8f"),
+            (url: "http://xn--p8f", output: "http://xn--p8f"),
+            (url: "http://xn--0na", output: "http://xn--0na"),
+            (url: "http://xn--cn-ded", output: "http://xn--cn-ded"),
+            (url: "http://xn--ews-nfe.org", output: "http://xn--ews-nfe.org"),
+            (url: "http://xn--yotube-qkh", output: "http://xn--yotube-qkh"),
+            (url: "http://xn--cla-7fe.edu", output: "http://xn--cla-7fe.edu"),
+            (url: "http://nеwstаrfіn.com/", output: "http://xn--nwstrfn-5fg5byy.com"),
+            (url: "http://gooِgle.com/", output: "http://xn--google-yri.com"),
+            (url: "https://appِle.com/", output: "https://xn--apple-gkh.com"),
+            (url: "https://xn--a-g4i", output: "https://xn--a-g4i"),
+            (url: "https://xn--a-h4i", output: "https://xn--a-h4i"),
+            (url: "https://xn--a-80i", output: "https://xn--a-80i"),
+            (url: "https://xn--a-90i", output: "https://xn--a-90i"),
+            (url: "https://xn--a-0fj", output: "https://xn--a-0fj"),
+            (url: "https://xn--a-1fj", output: "https://xn--a-1fj"),
+            (url: "https://xn--a-2fj", output: "https://xn--a-2fj"),
+            (url: "https://xn--a-3fj", output: "https://xn--a-3fj"),
+            (url: "https://xn--a-rli", output: "https://xn--a-rli"),
+            (url: "https://xn--a-sli", output: "https://xn--a-sli"),
+            (url: "https://xn--a-vli", output: "https://xn--a-vli"),
+            (url: "https://xn--a-wli", output: "https://xn--a-wli"),
+            (url: "https://xn--a-1li", output: "https://xn--a-1li"),
+            (url: "https://xn--a-2li", output: "https://xn--a-2li"),
+            (url: "https://xn--a-8oi", output: "https://xn--a-8oi"),
+            (url: "https://xn--a-9oi", output: "https://xn--a-9oi"),
+            (url: "https://xn--a-v1i", output: "https://xn--a-v1i"),
+            (url: "https://xn--a-w1i", output: "https://xn--a-w1i"),
+            (url: "https://xn--a-f5i", output: "https://xn--a-f5i"),
+            (url: "https://xn--a-g5i", output: "https://xn--a-g5i"),
+            (url: "https://xn--a-u6i", output: "https://xn--a-u6i"),
+            (url: "https://xn--a-v6i", output: "https://xn--a-v6i"),
+            (url: "https://xn--a-h7i", output: "https://xn--a-h7i"),
+            (url: "https://xn--a-i7i", output: "https://xn--a-i7i"),
+            (url: "https://xn--a-x7i", output: "https://xn--a-x7i"),
+            (url: "https://xn--a-y7i", output: "https://xn--a-y7i"),
+            (url: "https://xn--a-37i", output: "https://xn--a-37i"),
+            (url: "https://xn--a-47i", output: "https://xn--a-47i"),
+            (url: "https://xn--n-twf", output: "https://xn--n-twf"),
+            (url: "https://xn--n-uwf", output: "https://xn--n-uwf"),
+            (url: "https://xn--jna", output: "https://xn--jna"),
+            (url: "https://xn--spa", output: "https://xn--spa"),
+            (url: "https://xn--8pa", output: "https://xn--8pa"),
+            (url: "https://xn--3hb112n", output: "https://xn--3hb112n"),
+            (url: "https://xn--a-ypc062v", output: "https://xn--a-ypc062v"),
+            (url: "https://xn--2j8c", output: "https://xn--2j8c"),  // U+1043D
+            (url: "https://xn--ikg", output: "https://xn--ikg"),    // U+1E9C
+            (url: "https://xn--jkg", output: "https://xn--jkg"),    // U+1E9D
+            (url: "https://xn--cng", output: "https://xn--cng")     // U+1EFE or U+1EFF
+        ]
+        for spoofTest in punycodeSpoofTests {
+            verify(spoofTest.url, matches: spoofTest.output, withStyle: style)
+        }
+
+        // These are valid Unicode characters. We should display
+        // them verbatim
+        let validUnicodeTests = [
+            "http://site.com",
+            "http://臺灣.இலங்கை",
+            "mailto:someone@example.org",
+            "mailto:someone@xn--4dbacpta7bzbn3a.com",
+            "mailto:someone@xn--4dbacpta7bzbn3a.com?subjectsomething",
+            "http://site.com/sub",
+            "http://site.com/sub#fragment",
+            "http://site.com#fragment/sub",
+            "https://en.wikipedia.org/wiki/.հայ",
+            "https://ճմո.հայ",
+            "https://ճ-1-մո.հայ",
+            "https://2ճ_մո.հայ",
+            "https://ճ_մ垃.հայ",
+            // Valid mixtures of Armenian and other scripts
+            "https://en.wikipedia.org/wiki/.հայ",
+            "https://ճմո.հայ",
+            "https://ճ-1-մո.հայ",
+            "https://2ճ_մո.հայ",
+            "https://ճ_մ垃.հայ",
+            "https://ցեճfans.net",
+            // Tamil
+            "https://௦௧௨௩count",
+            // Canadian aboriginal
+            "https://ᖯᐁabc",
+            "https://ᖴᐁabc",
+            "https://᙭ᐁabc",
+            "https://᙮ᐁabc",
+            "https://ᑭᐁabc",
+            "https://ᑯᐁabc",
+            "https://ᑲᐁabc",
+            "https://ᒪᐁabc",
+            "https://ᕼᐁabc",
+            "https://ᖇᐁabc",
+            "https://ᗅᐁabc",
+            "https://ᗞᐁabc",
+            "https://ᗩᐁabc",
+            "https://ᗱᐁabc",
+            "https://ᗴᐁabc",
+            "https://íabc",
+            // Thai
+            "https://กขabc",
+            // Arabic
+            "https://تفاح"
+        ]
+        for validTest in validUnicodeTests {
+            verify(validTest, matches: validTest, withStyle: style)
+        }
+
+        // These Unicode characters should still be displayed after
+        // some transformation
+        let validEncodedUnicodeTests = [
+            // Needs to be lower cased
+            (url: "https://ՑԵorյՃ.biz", output: "https://ցեorյճ.biz"),
+            (url: "https://ճԵorյՃ.biz", output: "https://ճեorյճ.biz"),
+            (url: "https://ձԵՃfans.net", output: "https://ձեճfans.net"),
+            (url: "https://ՑԵՃfans.net", output: "https://ցեճfans.net"),
+            // Needs to be decoded
+            (url: "http://%77ebsite.com", output: "http://website.com"),
+            (url: "http://xn--4dbacpta7bzbn3a.com", output: "http://אייפוןבארץ.com"),
+            (url: "http://xn--sailor-183m.com", output: "http://sailor月.com"),
+            (url: "http://xn--d1abbgf6aiiy.xn--p1ai", output: "http://президент.рф"),
+            (url: "http://xn--b1aaebccb4c.xn--d1abbgf6aiiy.xn--p1ai", output: "http://медведев.президент.рф"),
+            (url: "http://%E5%BC%95%E3%81%8D%E5%89%B2%E3%82%8A.jp", output: "http://引き割り.jp"),
+            (url: "https://maps.apple.com/?address=Carrer%20de%20Par%C3%ADs,%20114,%2008029%20Barcelona,%20Spain&auid=742406409215325628&ll=41.388445,2.146888&lsp=9902&q=Sant%20Jordi%20Swimming%20Pool&_ext=ChoKBQgEEM4BCgQIBRADCgUIBhCnAQoECAoQABIkKR6C/fovpkRAMUBsY44HNwBAOSzmKw09vURAQYCTnBGgIgJA&t=m", output: "https://maps.apple.com/?address=Carrer de París, 114, 08029 Barcelona, Spain&auid=742406409215325628&ll=41.388445,2.146888&lsp=9902&q=Sant Jordi Swimming Pool&_ext=ChoKBQgEEM4BCgQIBRADCgUIBhCnAQoECAoQABIkKR6C/fovpkRAMUBsY44HNwBAOSzmKw09vURAQYCTnBGgIgJA&t=m"),
+            (url: "https://en.wikipedia.org/wiki/Mission_San_Francisco_de_As%C3%ADs", output: "https://en.wikipedia.org/wiki/Mission_San_Francisco_de_Asís"),
+        ]
+        for encodedUnicodeTest in validEncodedUnicodeTests {
+            verify(encodedUnicodeTest.url, matches: encodedUnicodeTest.output, withStyle: style)
+        }
+    }
+
+    private func verify(_ urlString: String, matches expectedOutput: String, withStyle style: URL.FormatStyle, sourceLocation: SourceLocation = #_sourceLocation) {
+        // Use a URLComponents to create the URL in case it has Unicode characters
+        let urlComponents = URLComponents(string: urlString)
+        let url = urlComponents!.url!
+        let output = url.formatted(style)
+        #expect(
+            output == expectedOutput,
+            "Expecting [\(expectedOutput)], got [\(output)]",
+            sourceLocation: sourceLocation)
+    }
+}

--- a/Tests/FoundationInternationalizationTests/Formatting/URLParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/URLParseStrategyTests.swift
@@ -1,0 +1,425 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import RegexBuilder
+import Testing
+
+#if canImport(FoundationInternationalization)
+@testable import FoundationEssentials
+@testable import FoundationInternationalization
+#else
+@testable import Foundation
+#endif
+
+typealias FullStringTestCase = (string: String, style: URL.ParseStrategy, expectMatch: Bool)
+
+@Suite("URL.ParseStrategy")
+private struct URLParseStrategyTests {
+
+    @Test func componentRequirements() {
+        let lenientTests: [FullStringTestCase] = [
+            (string: "https://www.example.com",
+             style: .init(),
+             expectMatch: true),
+            (string: "www.example.com",
+             style: .init(),
+             expectMatch: false),
+            // Missing scheme
+            (string: "www.example.com",
+             style: .init(scheme: .required),
+             expectMatch: false),
+            (string: "https://www.example.com",
+             style: .init(scheme: .required, host: .required),
+             expectMatch: true),
+            // Missing port
+            (string: "https://www.example.com",
+             style: .init(
+                scheme: .required,
+                host: .required,
+                port: .required),
+             expectMatch: false),
+            (string: "https://www.example.com:1234",
+             style: .init(
+                scheme: .required,
+                host: .required,
+                port: .required),
+             expectMatch: true),
+            // Missing username
+            (string: "https://www.example.com:1234",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                host: .required,
+                port: .required),
+             expectMatch: false),
+            (string: "https://charles@www.example.com:1234",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                host: .required,
+                port: .required),
+             expectMatch: true),
+            // Missing password
+            (string: "https://charles@www.example.com:1234",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                password: .required,
+                host: .required,
+                port: .required),
+             expectMatch: false),
+            (string: "https://charles:password@www.example.com:1234",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                password: .required,
+                host: .required,
+                port: .required),
+             expectMatch: true),
+            // Missing path
+            (string: "https://charles:password@www.example.com:1234",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                password: .required,
+                host: .required,
+                port: .required,
+                path: .required),
+             expectMatch: false),
+            (string: "https://charles:password@www.example.com:1234/search/v2",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                password: .required,
+                host: .required,
+                port: .required,
+                path: .required),
+             expectMatch: true),
+            // Missing query
+            (string: "https://charles:password@www.example.com:1234/search",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                password: .required,
+                host: .required,
+                port: .required,
+                path: .required,
+                query: .required),
+             expectMatch: false),
+            (string: "https://charles:password@www.example.com:1234/search?name=alexis",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                password: .required,
+                host: .required,
+                port: .required,
+                path: .required,
+                query: .required),
+             expectMatch: true),
+            // Missing fragment
+            (string: "https://charles:password@www.example.com:1234/search?name=alexis",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                password: .required,
+                host: .required,
+                port: .required,
+                path: .required,
+                query: .required,
+                fragment: .required),
+             expectMatch: false),
+            (string: "https://charles:password@www.example.com:1234/search?name=alexis#user-name",
+             style: .init(
+                scheme: .required,
+                user: .required,
+                password: .required,
+                host: .required,
+                port: .required,
+                path: .required,
+                query: .required,
+                fragment: .required),
+             expectMatch: true),
+        ]
+        for testCase in lenientTests {
+            _verifyParseStrategy(withCase: testCase)
+        }
+    }
+
+    @Test func defaultValueSubstitution() {
+        let tests: [FullStringTestCase] = [
+            // Substitute scheme
+            (string: "www.apple.com",
+             style: .init(scheme: .defaultValue("https"), host: .optional),
+             expectMatch: true),
+            (string: "ftp://www.orange.com",
+             style: .init(scheme: .defaultValue("https")),
+             expectMatch: true),
+            // Substitute user
+            (string: "https://www.watermelon.com",
+             style: .init(user: .defaultValue("Charles")),
+             expectMatch: true),
+            (string: "https://moria@www.peach.com",
+             style: .init(user: .defaultValue("Charles")),
+             expectMatch: true),
+            // Substitute password
+            (string: "https://charles:pa$$w0rd@www.mango.com",
+             style: .init(password: .defaultValue("guest")),
+             expectMatch: true),
+            (string: "https://lana@www.strawberry.com",
+             style: .init(password: .defaultValue("guest")),
+             expectMatch: true),
+            // Substitute host
+            (string: "https://www.kiwi.com",
+             style: .init(host: .defaultValue("www.apple.com")),
+             expectMatch: true),
+            (string: "https:",
+             style: .init(host: .defaultValue("www.apple.com")),
+             expectMatch: true),
+            // Substitute port
+            (string: "https://www.pineapple.com:1234",
+             style: .init(port: .defaultValue(8080)),
+             expectMatch: true),
+            (string: "https://www.lemon.com",
+             style: .init(port: .defaultValue(8080)),
+             expectMatch: true),
+            // Substitute path
+            (string: "https://www.lime.com/search",
+             style: .init(path: .defaultValue("/about")),
+             expectMatch: true),
+            (string: "https://www.blueberry.com",
+             style: .init(path: .defaultValue("/about")),
+             expectMatch: true),
+            // Substitute query
+            (string: "https://www.cherry.com?color=red",
+             style: .init(query: .defaultValue("color=blue")),
+             expectMatch: true),
+            (string: "https://www.blueberry.com",
+             style: .init(query: .defaultValue("color=blue")),
+             expectMatch: true),
+            // Substitute fragment
+            (string: "https://www.dragonfruit.com#description",
+             style: .init(fragment: .defaultValue("name")),
+             expectMatch: true),
+            (string: "https://www.lychee.com",
+             style: .init(fragment: .defaultValue("name")),
+             expectMatch: true),
+        ]
+
+        for testCase in tests {
+            _verifyDefaultValueSubstitution(withCase: testCase)
+        }
+    }
+
+    private func _verifyParseStrategy(withCase testCase: FullStringTestCase, sourceLocation: SourceLocation = #_sourceLocation) {
+        let expectedValue: URL? = testCase.expectMatch ? URL(string: testCase.string)! : nil
+        let output: URL? = try? testCase.style.parse(testCase.string)
+        #expect(
+            expectedValue == output,
+            "Expected [\(String(describing: expectedValue))], got [\(String(describing: output))]",
+            sourceLocation: sourceLocation)
+    }
+
+    private func _verifyDefaultValueSubstitution(withCase testCase: FullStringTestCase, sourceLocation: SourceLocation = #_sourceLocation) {
+        // Default value substitution cases always expect a match
+        // `originalURL` shouldn't have any substitutions. We can use it
+        // to check whether the default values are set correctly in the
+        // parsed URL
+        let originalURL = URL(string: testCase.string)!
+        let output: URL = try! testCase.style.parse(testCase.string)
+        testCase.style.defaultValues.forEach { (componentValue: Int, defaultValue: String) in
+            let component = URL.FormatStyle.Component(rawValue: componentValue)!
+            if !component.hasComponentValue(in: originalURL) {
+                // We should use the substituted value because the original
+                // url does not contain this value
+                if let stringValue: String = component.getComponentValue(from: output) {
+                    #expect(stringValue == defaultValue, sourceLocation: sourceLocation)
+                } else if let intValue: Int = component.getComponentValue(from: output) {
+                    let defaultIntValue = Int(defaultValue)
+                    #expect(defaultIntValue != nil, sourceLocation: sourceLocation)
+                    #expect(intValue == defaultIntValue, sourceLocation: sourceLocation)
+                } else {
+                    Issue.record("Unexpected component type", sourceLocation: sourceLocation)
+                }
+            } else {
+                // We should use the original value because it's present
+                // so no substitution needed
+                if let stringOriginalValue: String = component.getComponentValue(from: originalURL),
+                   let stringOutputValue: String = component.getComponentValue(from: output) {
+                    #expect(stringOriginalValue == stringOutputValue, sourceLocation: sourceLocation)
+                } else if let intOriginalValue: Int = component.getComponentValue(from: originalURL),
+                          let intOutputValue: Int = component.getComponentValue(from: output) {
+                    #expect(intOriginalValue == intOutputValue, sourceLocation: sourceLocation)
+                } else {
+                    Issue.record("Unexpected component type", sourceLocation: sourceLocation)
+                }
+            }
+        }
+    }
+}
+
+@Suite("URL.ParseStrategy (Pattern Matching)")
+private struct URLParseStrategyPatternMatchingTests {
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func webAddressPatternMatching() {
+        let webAddress: URL.ParseStrategy = .init()
+        let urlText = "https://www.example.com:1234/products"
+        let expectation = URL(string: urlText)
+        _verifyMatching(
+            urlText,
+            style: webAddress,
+            expectedUpperBound: urlText.endIndex,
+            expectedValue: expectation)
+        _verifyMatching(
+            "\(urlText) is an amazing website",
+            style: webAddress,
+            expectedUpperBound: urlText.endIndex,
+            expectedValue: expectation)
+        _verifyMatching(
+            "\(urlText) 🏳️‍🌈🤙🏻", style: webAddress,
+            expectedUpperBound: urlText.endIndex,
+            expectedValue: expectation)
+        // Test match custom range
+        let sentance = "Moria Rosé \(urlText) bébé"
+        let range = sentance.firstIndex(of: "h")! ..< sentance.endIndex
+        _verifyMatching(
+            sentance, style: webAddress, range: range,
+            expectedUpperBound: sentance.index(after: sentance.lastIndex(of: "s")!),
+            expectedValue: expectation)
+        // Match the first url
+        _verifyMatching(
+            "\(urlText) https://www.apple.com file:///var/mobile",
+            style: webAddress,
+            expectedUpperBound: urlText.endIndex,
+            expectedValue: expectation)
+        // Invalid urls
+        // The url does not start at the beginning of the sentance
+        _verifyMatching(
+            sentance, style: webAddress,
+            expectedUpperBound: nil,
+            expectedValue: nil)
+        _verifyMatching(
+            "htt ps://www.ex ple.com", style: webAddress,
+            expectedUpperBound: nil,
+            expectedValue: nil)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func nonConventionalURLPatternMatching() {
+        // Test "non-conventional" URLs. The host names of these URLs are encoded
+        // via `uidna_nameToASCII` and the paths are percent encoded.
+        let emojiURLText = "https://i❤️tacos.ws/🏳️‍🌈/冰淇淋"
+        let emojiURL = URL(string: "https://xn--itacos-i50d.ws/%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88/%E5%86%B0%E6%B7%87%E6%B7%8B")
+        _verifyMatching(
+            "\(emojiURLText) 🏳️‍🌈❤️",
+            style: .init(),
+            expectedUpperBound: emojiURLText.endIndex,
+            expectedValue: emojiURL)
+        let emojiSentance = "🤯🌝 🌭 \(emojiURLText) 🏁🌈 🏳️‍🌈🥗🤙🏻"
+        let emojiRange = emojiSentance.firstIndex(of: "h")! ..< emojiSentance.endIndex
+        _verifyMatching(
+            emojiSentance, style: .init(),
+            range: emojiRange,
+            expectedUpperBound: emojiSentance.index(after: emojiSentance.lastIndex(of: "淋")!),
+            expectedValue: emojiURL)
+        let chineseURLText = "http://見.香港/热狗/🌭"
+        let chineseURL = URL(string: "http://xn--nw2a.xn--j6w193g/%E7%83%AD%E7%8B%97/%F0%9F%8C%AD")
+        _verifyMatching(
+            "\(chineseURLText) 苹果手表", style: .init(),
+            expectedUpperBound: chineseURLText.endIndex,
+            expectedValue: chineseURL)
+        let chineseSentance = "这个网站 \(chineseURLText) 很有趣"
+        let chineseRange = chineseSentance.firstIndex(of: "h")! ..< chineseSentance.endIndex
+        _verifyMatching(
+            chineseSentance, style: .init(),
+            range: chineseRange,
+            expectedUpperBound: chineseSentance.index(after: chineseSentance.lastIndex(of: "🌭")!),
+            expectedValue: chineseURL)
+        // Match the first URL
+        _verifyMatching(
+            "\(emojiURLText) \(chineseURLText) file:///var/moblie",
+            style: .init(),
+            expectedUpperBound: emojiURLText.endIndex,
+            expectedValue: emojiURL)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func regexMatching() {
+        let header = """
+        HTTP/1.1 301 Redirect
+        Date: Wed, 16 Feb 2022 23:53:19 GMT
+        Connection: close
+        Location: https://www.apple.com/
+        Content-Type: text/html
+        Content-Language: en
+        """
+        let regex = Regex {
+            Capture {
+                .url()
+            }
+        }
+        guard let res = header.firstMatch(of: regex) else {
+            Issue.record()
+            return
+        }
+        let expectedURL = URL(string: "https://www.apple.com/")!
+        #expect(res.output.0 == "https://www.apple.com/")
+        #expect(res.output.1 == expectedURL)
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @Test func regexMatchingMultiple() {
+        let list = """
+        A   https://www.pomegranate.com         TYPE1
+        B   ftp://www.apple.com                 TYPE2
+        C   http://[2620:100:e000::8001]:81/US  TYPE3
+        D   www.noscheme.com                    TYPE4 // should not match
+        E   https://👁👄👁.fm/🐮                TYPE5
+        """
+        let regex = Regex {
+            Capture {
+                .url(scheme: .required, host: .required, port: .defaultValue(8080))
+            }
+        }
+        // port 8080 should have been insert to the URLs without a port
+        let expectedURLs = [
+            URL(string: "https://www.pomegranate.com:8080")!,
+            URL(string: "ftp://www.apple.com:8080")!,
+            URL(string: "http://[2620:100:e000::8001]:81/US")!,
+            URLComponents(string: "https://👁👄👁.fm:8080/🐮")!.url!
+        ]
+        let expectedStrings: [String] = [
+            "https://www.pomegranate.com",
+            "ftp://www.apple.com",
+            "http://[2620:100:e000::8001]:81/US",
+            "https://👁👄👁.fm/🐮"
+        ]
+        let result = list.matches(of: regex)
+        for index in 0 ..< expectedURLs.count {
+            #expect(String(result[index].output.0) == expectedStrings[index])
+            #expect(result[index].output.1 == expectedURLs[index])
+        }
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    private func _verifyMatching(_ str: String, style: URL.ParseStrategy, range: Range<String.Index>? = nil, expectedUpperBound: String.Index?, expectedValue: URL?, sourceLocation: SourceLocation = #_sourceLocation) {
+        let resolvedRange = range ?? str.startIndex ..< str.endIndex
+        let (upperBound, match) = (try? style.consuming(str, startingAt: resolvedRange.lowerBound, in: resolvedRange)) ?? (nil, nil)
+        let upperBoundDescription = upperBound?.utf16Offset(in: str)
+        let expectedUpperBoundDescription = expectedUpperBound?.utf16Offset(in: str)
+        #expect(
+            upperBound == expectedUpperBound,
+            "found upperBound: \(String(describing: upperBoundDescription)); expected: \(String(describing: expectedUpperBoundDescription))",
+            sourceLocation: sourceLocation)
+        #expect(match == expectedValue, sourceLocation: sourceLocation)
+    }
+}


### PR DESCRIPTION
1. Move URLFormatStyle.swift, URLParseStrategy.swift, and URL+UnicodeLookalikeTable.swift into FoundationInternationalization.

2. Migrate XCTest-based tests to Swift Testing.

Credit: @iCharlesHu


### Motivation:

issue #1919 

### Result:

The API is available everywhere

### Testing:

Added two test files for URL.FormatStyle and URL.ParseStrategy