### PR TITLE
Benchmarks: bump to swift-tools-version 6.1, support disabling jemalloc, fix Swift 6 concurrency

### DIFF
--- a/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
+++ b/Benchmarks/Benchmarks/AttributedString/BenchmarkAttributedString.swift
@@ -56,7 +56,7 @@ class AttributedStringBox {
     }
 }
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.warmupIterations = 0
     Benchmark.defaultConfiguration.maxDuration = .seconds(1)
     Benchmark.defaultConfiguration.scalingFactor = .kilo
@@ -456,7 +456,7 @@ let benchmarks = {
     }
     
     struct TestAttribute : AttributedStringKey {
-        static var name = "0"
+        nonisolated(unsafe) static var name = "0"
         typealias Value = Int
     }
     var hashAttributeContainer = AttributeContainer()

--- a/Benchmarks/Benchmarks/Base64/Base64.swift
+++ b/Benchmarks/Benchmarks/Base64/Base64.swift
@@ -30,7 +30,7 @@ private func autoreleasepool<T>(_ block: () -> T) -> T { block() }
 import Darwin
 #endif
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark(
         "base64-encode-jwtHeader-toString-noOptions",
         configuration: Benchmark.Configuration(

--- a/Benchmarks/Benchmarks/CharacterSet/BenchmarkCharacterSet.swift
+++ b/Benchmarks/Benchmarks/CharacterSet/BenchmarkCharacterSet.swift
@@ -20,7 +20,7 @@ import FoundationInternationalization
 import Foundation
 #endif
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     #if FOUNDATION_FRAMEWORK
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)

--- a/Benchmarks/Benchmarks/Data/BenchmarkData.swift
+++ b/Benchmarks/Benchmarks/Data/BenchmarkData.swift
@@ -19,7 +19,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo

--- a/Benchmarks/Benchmarks/DataIO/BenchmarkDataIO.swift
+++ b/Benchmarks/Benchmarks/DataIO/BenchmarkDataIO.swift
@@ -66,7 +66,7 @@ extension Benchmark.Configuration {
     }
 }
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo

--- a/Benchmarks/Benchmarks/Essentials/BenchmarkEssentials.swift
+++ b/Benchmarks/Benchmarks/Essentials/BenchmarkEssentials.swift
@@ -19,7 +19,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo

--- a/Benchmarks/Benchmarks/Formatting/BenchmarkFormatting.swift
+++ b/Benchmarks/Benchmarks/Formatting/BenchmarkFormatting.swift
@@ -21,7 +21,7 @@ import FoundationInternationalization
 import Foundation
 #endif
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.maxIterations = 1_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo

--- a/Benchmarks/Benchmarks/Internationalization/BenchmarkCalendar.swift
+++ b/Benchmarks/Benchmarks/Internationalization/BenchmarkCalendar.swift
@@ -22,7 +22,7 @@ import Foundation
 
 #if FOUNDATION_FRAMEWORK
 // FOUNDATION_FRAMEWORK has a scheme per benchmark file, so only include one benchmark here.
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     calendarBenchmarks()
 }
 #endif

--- a/Benchmarks/Benchmarks/Internationalization/BenchmarkLocale.swift
+++ b/Benchmarks/Benchmarks/Internationalization/BenchmarkLocale.swift
@@ -22,7 +22,7 @@ import Foundation
 
 #if FOUNDATION_FRAMEWORK
 // FOUNDATION_FRAMEWORK has a scheme per benchmark file, so only include one benchmark here.
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     localeBenchmarks()
 }
 #endif

--- a/Benchmarks/Benchmarks/Internationalization/BenchmarkTimeZone.swift
+++ b/Benchmarks/Benchmarks/Internationalization/BenchmarkTimeZone.swift
@@ -22,7 +22,7 @@ import Foundation
 
 #if FOUNDATION_FRAMEWORK
 // FOUNDATION_FRAMEWORK has a scheme per benchmark file, so only include one benchmark here.
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     timeZoneBenchmarks()
 }
 #endif
@@ -62,14 +62,14 @@ func timeZoneBenchmarks() {
     }
 
     Benchmark("creatingTimeZones", configuration: .init(scalingFactor: .mega)) { benchmark in
-        for name in NSTimeZone.knownTimeZoneNames {
+        for name in TimeZone.knownTimeZoneIdentifiers {
             let t = TimeZone(identifier: name)
             blackHole(t)
         }
     }
 
     Benchmark("secondsFromGMT_manyTimeZones", configuration: .init(scalingFactor: .mega)) { benchmark in
-        for name in NSTimeZone.knownTimeZoneNames {
+        for name in TimeZone.knownTimeZoneIdentifiers {
             let t = TimeZone(identifier: name)!
             for d in testDates {
                 let s = t.secondsFromGMT(for: d)

--- a/Benchmarks/Benchmarks/Internationalization/InternationalizationBenchmark.swift
+++ b/Benchmarks/Benchmarks/Internationalization/InternationalizationBenchmark.swift
@@ -2,7 +2,7 @@ import Benchmark
 
 
 #if !FOUNDATION_FRAMEWORK
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     calendarBenchmarks()
     localeBenchmarks()
     timeZoneBenchmarks()

--- a/Benchmarks/Benchmarks/JSON/JSONBenchmark.swift
+++ b/Benchmarks/Benchmarks/JSON/JSONBenchmark.swift
@@ -72,7 +72,7 @@ func path(forResource name: String) -> _URL? {
     return _URL(fileURLWithPath: url.path)
 }
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo

--- a/Benchmarks/Benchmarks/Predicates/BenchmarkPredicates.swift
+++ b/Benchmarks/Benchmarks/Predicates/BenchmarkPredicates.swift
@@ -109,7 +109,7 @@ func registerPredicateTests() {
     #endif // USE_PACKAGE || !os(Windows)
 }
 
-let benchmarks : () -> Void = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo

--- a/Benchmarks/Benchmarks/String/BenchmarkString.swift
+++ b/Benchmarks/Benchmarks/String/BenchmarkString.swift
@@ -23,7 +23,7 @@ import Foundation
 private func autoreleasepool<T>(_ block: () -> T) -> T { block() }
 #endif
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo

--- a/Benchmarks/Benchmarks/URL/BenchmarkURL.swift
+++ b/Benchmarks/Benchmarks/URL/BenchmarkURL.swift
@@ -19,7 +19,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
 
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 
 import PackageDescription
 
@@ -6,7 +6,7 @@ enum UsePackage {
     /// Use a known package hash downloaded from GitHub. Set with env var `USE_PACKAGE`
     case useGitHubPackage
 
-    /// Use a local package, rooted at `String`. For example ".." to back up one directory from the Benchmark package. This is useful when testing local changes. 
+    /// Use a local package, rooted at `String`. For example ".." to back up one directory from the Benchmark package. This is useful when testing local changes.
     /// Set with env var `SWIFTCI_USE_LOCAL_DEPS=<path to root>`, for example `SWIFTCI_USE_LOCAL_DEPS=..`
     case useLocalPackage(String)
 
@@ -15,7 +15,7 @@ enum UsePackage {
 
     var description: String {
         switch self {
-            case .useGitHubPackage: 
+            case .useGitHubPackage:
                 return "Using GitHub package"
             case .useLocalPackage(let root):
                 #if os(macOS)
@@ -51,7 +51,11 @@ print("swift-foundation benchmarks: \(usePackage.description)")
 
 // ------------
 
-var packageDependency : [Package.Dependency] = [.package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.11.1")]
+var packageDependency : [Package.Dependency] = [
+    Context.environment["BENCHMARK_DISABLE_JEMALLOC"] != nil
+        ? .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.11.1", traits: [])
+        : .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.11.1")
+]
 var targetDependency : [Target.Dependency] = [.product(name: "Benchmark", package: "package-benchmark")]
 var i18nTargetDependencies : [Target.Dependency] = []
 var swiftSettings : [SwiftSetting] = [.unsafeFlags(["-Rmodule-loading"]), .enableUpcomingFeature("MemberImportVisibility")]
@@ -167,7 +171,7 @@ let package = Package(
             name: "JSONBenchmarks",
             dependencies: targetDependency,
             path: "Benchmarks/JSON",
-            resources: [.copy("Resources")],
+            resources: [.process("Resources")],
             swiftSettings: swiftSettings,
             plugins: [
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")

--- a/Foundation_Build_Process.md
+++ b/Foundation_Build_Process.md
@@ -122,11 +122,21 @@ The swift-foundation project is also built internally within Apple as part of th
 
 ## Benchmarks
 
-Benchmarks for `swift-foundation` are in a separate Swift Package in the `Benchmarks` subfolder of this repository. 
+Benchmarks for `swift-foundation` are in a separate Swift Package in the `Benchmarks` subfolder of this repository.
 They use the [`package-benchmark`](https://github.com/ordo-one/package-benchmark) plugin.
-Benchmarks depends on the [`jemalloc`](https://jemalloc.net) memory allocation library, which is used by `package-benchmark` to capture memory allocation statistics.
-An installation guide can be found in the [Getting Started article](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark/gettingstarted#Installing-Prerequisites-and-Platform-Support) of `package-benchmark`. 
+Benchmarks depends on the [`jemalloc`](https://jemalloc.net) memory allocation library, which is used by `package-benchmark` to capture memory allocation statistics. An installation guide can be found in the [Getting Started article](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark/gettingstarted#Installing-Prerequisites-and-Platform-Support) of `package-benchmark
+
+Install `jemalloc` before running benchmarks:
+- **macOS:** `brew install jemalloc`
+- **Ubuntu:** `sudo apt-get install -y libjemalloc-dev`
+
 Afterwards you can run the benchmarks from CLI by going to the `Benchmarks` subfolder (e.g. `cd Benchmarks`) and invoking:
 ```
 swift package benchmark
 ```
+
+If `jemalloc` is not available, disable it by setting `BENCHMARK_DISABLE_JEMALLOC=1`:
+```shell
+BENCHMARK_DISABLE_JEMALLOC=1 swift package benchmark
+```
+


### PR DESCRIPTION
# Motivation
`BENCHMARK_DISABLE_JEMALLOC=1 swift package benchmark` doesn't actually disable jemalloc when using swift 6+ toolchain


# Fix
- Bump Benchmarks/Package.swift to swift-tools-version 6.1 (required for SwiftPM traits API)
- Add `BENCHMARK_DISABLE_JEMALLOC` env var support: when set, package-benchmark is fetched with
  traits: [] to disable the default jemalloc trait, enabling builds in environments where
  jemalloc is unavailable.
- Fix JSONBenchmarks resource bundle: change `.copy("Resources")` to `.process("Resources")` so
  JSON test files land at `Contents/Resources/` rather than `Contents/Resources/Resources/`
- Fix Swift 6 strict concurrency in all 15 benchmark targets: annotate `let benchmarks` closures
  as `@Sendable () -> Void`
- Fix BenchmarkTimeZone.swift: replace `NSTimeZone.knownTimeZoneNames` with `TimeZone.knownTimeZoneIdentifiers`
- Fix BenchmarkAttributedString.swift: annotate TestAttribute.name with `nonisolated(unsafe)`
  (the mutation is intentional single-threaded benchmark setup creating 100k distinct entries)
- Document jemalloc install steps and BENCHMARK_DISABLE_JEMALLOC usage in Foundation_Build_Process.md
