### PR TITLE
Fix a typo in proposal 0400

### DIFF
--- a/Proposals/0040-calendar-timezone-initializer.md
+++ b/Proposals/0040-calendar-timezone-initializer.md
@@ -86,7 +86,7 @@ init(identifier: Identifier) // existing
 init(identifier: Identifier, timeZone: TimeZone? = nil, locale: Locale? = nil, firstWeekday: Int? = nil, minimumDaysInFirstWeek: Int? = nil) // new
 ```
 
-When `timeZone`, `locale`, `firstWeekday`, or `minimumDaysInFirstWeek` are `nil`, which initializer does the compiler choose, as in the following code?
+When `timeZone`, `locale`, `firstWeekday`, and `minimumDaysInFirstWeek` are all `nil`, which initializer does the compiler choose, as in the following code?
 ```swift
 let calendar = Calendar(identifier: .gregorian)
 ```


### PR DESCRIPTION
Fixes a misleading typo in the "Source compatibility" section explaining which initialiser the compiler chooses when `timeZone`, `locale`, `firstWeekday`, and `minimumDaysInFirstWeek` are all omitted at the call site.