### PR TITLE
OpenBSD does not have strtod_l or strtof_l.

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -415,7 +415,7 @@ extension Platform {
     public static func strtod_clocale(_ nptr: UnsafePointer<UInt8>, _ endptr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?) -> Double {
         #if os(Windows)
         return _strtod_l(nptr, endptr, Self.cLocale)
-        #elseif NO_LOCALIZATION
+        #elseif NO_LOCALIZATION || os(OpenBSD)
         return strtod(nptr, endptr);
         #else
         return strtod_l(nptr, endptr, Self.cLocale)
@@ -425,7 +425,7 @@ extension Platform {
     public static func strtof_clocale(_ nptr: UnsafePointer<UInt8>, _ endptr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?) -> Float {
         #if os(Windows)
         return _strtof_l(nptr, endptr, Self.cLocale)
-        #elseif NO_LOCALIZATION
+        #elseif NO_LOCALIZATION || os(OpenBSD)
         return strtof(nptr, endptr);
         #else
         return strtof_l(nptr, endptr, Self.cLocale)


### PR DESCRIPTION
Just special-case these for the platform, since I don't know where the NO_LOCALIZATION symbol is coming from; these functions all just use the C locale anyway, and strncasecmp_l unilaterally defaults to using the C locale (per strncasecmp(3)).

### Motivation:

Buildfix for OpenBSD.

### Modifications:

As above: use `strtod` and `strtof` instead of `strtod_l` and `strtof_l` introduced in #1943 which do not exist on the platform.

### Result:

Foundation builds on OpenBSD at HEAD.

### Testing:

Will run CI.
