### PR TITLE
new-codable: Clean up Foundation dependency leftovers

### DIFF
--- a/Sources/NewCodable/JSON/JSONError.swift
+++ b/Sources/NewCodable/JSON/JSONError.swift
@@ -102,19 +102,6 @@ enum JSONError: Swift.Error, Equatable {
             return nil
         }
     }
-
-#if FOUNDATION_FRAMEWORK
-    @usableFromInline
-    var nsError: NSError {
-        var userInfo : [String: Any] = [
-            NSDebugDescriptionErrorKey : self.debugDescription
-        ]
-        if let location = self.sourceLocation {
-            userInfo["NSJSONSerializationErrorIndex"] = location.index
-        }
-        return .init(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: userInfo)
-    }
-#endif // FOUNDATION_FRAMEWORK
 }
 
 extension JSONError {


### PR DESCRIPTION
Removes unnecessary `nsError` property.

### Motivation:

This is likely a leftover from the original `JSONError` implementation. And it won't compile anyway now that all the imports are removed.

### Modifications:

Removes `nsError`.

### Result:

No more indirect Foundation references in the `NewCodable` target.
