### PR TITLE
new-codable: Address traditional Codable unavailability on Embedded Swift

### DIFF
--- a/Sources/NewCodable/CommonCodablePrimitive.swift
+++ b/Sources/NewCodable/CommonCodablePrimitive.swift
@@ -134,6 +134,7 @@ internal struct CommonPrimitiveVisitor: CommonDecodingVisitor {
     }
 }
 
+#if !hasFeature(Embedded)
 /// Conformance that allows decoding Decodable types in a CommonDecoder.
 extension CommonCodablePrimitive: AdaptableDecodableValue {
     typealias ArrayIterator = Array<CommonCodablePrimitive>.Iterator
@@ -508,3 +509,4 @@ extension CommonCodablePrimitive: AdaptableDecodableValue {
         throw CodingError.dataCorrupted(debugDescription: "Expected array but found \(self)")
     }
 }
+#endif

--- a/Sources/NewCodable/CommonDecodableProtocols.swift
+++ b/Sources/NewCodable/CommonDecodableProtocols.swift
@@ -172,6 +172,7 @@ public protocol CommonDecoder: ~Escapable {
     @_lifetime(self: copy self)
     mutating func decodeBytes<V: DecodingBytesVisitor>(visitor: V) throws(CodingError.Decoding) -> V.DecodedValue
     
+#if !hasFeature(Embedded)
     /// Decodes a value conforming to the standard `Decodable` protocol using `decodeAny` and an `AdaptorDecoder`.
     ///
     /// This method provides a bridge between the new `CommonDecoder` protocol and the existing `Decodable` protocol
@@ -183,6 +184,7 @@ public protocol CommonDecoder: ~Escapable {
     @_disfavoredOverload
     @_lifetime(self: copy self)
     mutating func decode<D: Decodable>(_: D.Type) throws(CodingError.Decoding) -> D
+#endif
     
     var codingPath: CodingPath { get }
 }
@@ -321,6 +323,7 @@ public extension CommonArrayDecoder where Self: ~Escapable {
         }
     }
     
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     @_alwaysEmitIntoClient
     @inline(__always)
@@ -340,6 +343,7 @@ public extension CommonArrayDecoder where Self: ~Escapable {
             try elementDecoder.decode(t)
         }
     }
+#endif
     
     var sizeHint: Int? { nil }
 }
@@ -506,6 +510,7 @@ public extension CommonDecodingVisitor where Self: ~Copyable & ~Escapable {
     }
 }
 
+#if !hasFeature(Embedded)
 public extension CommonDecoder where Self: ~Escapable {
     /// Default implementation for decoding standard `Decodable` types using `decodeAny` and `AdaptorDecoder`.
     ///
@@ -529,3 +534,4 @@ public extension CommonDecoder where Self: ~Escapable {
         }
     }
 }
+#endif

--- a/Sources/NewCodable/CommonEncodableProtocols.swift
+++ b/Sources/NewCodable/CommonEncodableProtocols.swift
@@ -293,9 +293,11 @@ public protocol CommonEncoder: ~Copyable, ~Escapable {
     @_lifetime(self: copy self)
     mutating func encodeEnumCase(_ name: UTF8Span, associatedValueCount: Int, _ associatedValueClosure: (inout StructEncoder) throws(CodingError.Encoding) -> Void) throws(CodingError.Encoding)
         
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     @_lifetime(self: copy self)
     mutating func encode(_ value: some Encodable) throws(CodingError.Encoding)
+#endif
     
     var codingPath: CodingPath { get }
 }
@@ -498,6 +500,7 @@ public extension CommonDictionaryEncoder where Self: ~Copyable & ~Escapable {
         try self.encode(key: key) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     @inline(__always)
     @_alwaysEmitIntoClient
@@ -505,6 +508,7 @@ public extension CommonDictionaryEncoder where Self: ~Copyable & ~Escapable {
     mutating func encode(key: String, value: some Encodable) throws(CodingError.Encoding) {
         try self.encode(key: key) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
+#endif
 }
 
 /// A type that can encode a struct type based on "common" data types into a native format for
@@ -564,6 +568,7 @@ public extension CommonStructEncoder where Self: ~Copyable & ~Escapable {
         try self.encode(key: key) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     @inline(__always)
     @_alwaysEmitIntoClient
@@ -581,6 +586,7 @@ public extension CommonStructEncoder where Self: ~Copyable & ~Escapable {
     mutating func encode(key: String, value: some Encodable) throws(CodingError.Encoding) {
         try self.encode(key: key) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
+#endif
 }
 
 // To avoid duplicate implementations for types that conform to both.
@@ -606,6 +612,7 @@ public extension CommonStructEncoder where Self: CommonDictionaryEncoder & ~Copy
         try self.encode(key: key) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     @inline(__always)
     @_alwaysEmitIntoClient
@@ -623,6 +630,7 @@ public extension CommonStructEncoder where Self: CommonDictionaryEncoder & ~Copy
     mutating func encode(key: String, value: some Encodable) throws(CodingError.Encoding) {
         try self.encode(key: key) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
+#endif
 }
 
 /// A type that can encode an array based on "common" data types into
@@ -649,6 +657,7 @@ extension CommonArrayEncoder where Self: ~Copyable & ~Escapable {
         try self.encodeElement { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
+#if !hasFeature(Embedded)
     /// Convenience: encode an Encodable value.
     @_disfavoredOverload
     @inline(__always)
@@ -657,6 +666,7 @@ extension CommonArrayEncoder where Self: ~Copyable & ~Escapable {
     public mutating func encode<T: Encodable>(_ value: T) throws(CodingError.Encoding) {
         try self.encodeElement { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
+#endif
 }
 
 
@@ -710,7 +720,9 @@ public extension CommonEncoder where Self: ~Copyable & ~Escapable {
     mutating func encodeEnumCase(_ name: UTF8Span) throws(CodingError.Encoding) { throw CodingError.unsupportedEncodingType("enum") }
     @_lifetime(self: copy self)
     mutating func encodeEnumCase(_ name: UTF8Span, associatedValueCount: Int, _ associatedValueClosure: (inout StructEncoder) throws(CodingError.Encoding) -> Void) throws(CodingError.Encoding) { throw CodingError.unsupportedEncodingType("enum") }
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     @_lifetime(self: copy self)
     mutating func encode(_ value: some Encodable) throws(CodingError.Encoding) { throw CodingError.unsupportedEncodingType("Encodable") }
+#endif
 }

--- a/Sources/NewCodable/JSON/AdaptorDecoder.swift
+++ b/Sources/NewCodable/JSON/AdaptorDecoder.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !hasFeature(Embedded)
 /// A type that provides context relevant for both the overall decoding operation, as well as the
 /// decoding of a specific value.
 public struct AdaptorDecodableValueContext<Value: AdaptableDecodableValue> {
@@ -547,4 +548,5 @@ extension AdaptorDecoder: SingleValueDecodingContainer {
     public func decode(_ type: UInt128.Type) throws -> UInt128 { try value.decode(type, context: context) }
     public func decode<T>(_ type: T.Type) throws -> T where T : Decodable { try value.decode(type, context: context) }
 }
+#endif
 

--- a/Sources/NewCodable/JSON/AdaptorEncoder.swift
+++ b/Sources/NewCodable/JSON/AdaptorEncoder.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 
+#if !hasFeature(Embedded)
 // TBD?
 public struct AdaptorEncodableValueContext<Value: AdaptorEncodableValue> {
     
@@ -803,3 +804,4 @@ extension AdaptorEncodableValue {
         return .init(array: array.map { .value($0) })
     }
 }
+#endif

--- a/Sources/NewCodable/JSON/JSONDecoderProtocols.swift
+++ b/Sources/NewCodable/JSON/JSONDecoderProtocols.swift
@@ -262,9 +262,11 @@ public protocol JSONDecoderProtocol: ~Escapable {
     @_lifetime(self: copy self)
     mutating func decode<T: CommonDecodable & ~Copyable>(_ t: T.Type) throws(CodingError.Decoding) -> T
     
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     @_lifetime(self: copy self)
     mutating func decode<T: Decodable>(_ t: T.Type) throws(CodingError.Decoding) -> T
+#endif
     
     var codingPath: CodingPath { get }
 }

--- a/Sources/NewCodable/JSON/JSONParserDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONParserDecoder.swift
@@ -1169,6 +1169,7 @@ extension JSONParserDecoder {
         return try decodeAny(JSONElementVisitor())
     }
     
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     @_lifetime(self: copy self)
     public mutating func decode<T: Decodable>(_ t: T.Type) throws(CodingError.Decoding) -> T {
@@ -1191,6 +1192,7 @@ extension JSONParserDecoder {
             fatalError("TODO: Convert/wrap error")
         }
     }
+#endif
 }
 
 extension JSONParserDecoder {

--- a/Sources/NewCodable/JSON/JSONPrimitive.swift
+++ b/Sources/NewCodable/JSON/JSONPrimitive.swift
@@ -303,10 +303,12 @@ extension JSONPrimitive {
         }
         return try number[type]
     }
+#if !hasFeature(Embedded)
     func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
         let decoder = _JSONValueDecoder(self)
         return try type.init(from: decoder)
     }
+#endif
 }
 
 internal class _JSONValueDecoder {
@@ -316,6 +318,7 @@ internal class _JSONValueDecoder {
     }
 }
 
+#if !hasFeature(Embedded)
 extension _JSONValueDecoder: Decoder {
     // TODO: Need to pass down decoding strategies.
     // TODO: Coding Paths
@@ -1024,4 +1027,5 @@ extension JSONPrimitive: AdaptorEncodableValue {
     
     
 }
+#endif
 

--- a/Sources/NewCodable/JSON/JSONPrimitiveDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONPrimitiveDecoder.swift
@@ -593,6 +593,7 @@ extension JSONPrimitiveDecoder {
         return try T.decode(from: &self)
     }
     
+#if !hasFeature(Embedded)
     @_disfavoredOverload
     public mutating func decode<T: Decodable>(_ t: T.Type) throws(CodingError.Decoding) -> T {
         // JSONPrimitiveDecoder already has a JSONPrimitive, so we can directly create an AdaptorDecoder
@@ -609,6 +610,7 @@ extension JSONPrimitiveDecoder {
             return try T(from: decoder)
         } catch { fatalError("TODO: Wrap/convert error" ) }
     }
+#endif
 }
 
 extension JSONPrimitiveDecoder: CommonDecoder {

--- a/Sources/NewCodable/JSON/NewJSONEncoder.swift
+++ b/Sources/NewCodable/JSON/NewJSONEncoder.swift
@@ -711,6 +711,7 @@ extension JSONDirectEncoder.DictionaryEncoder {
         try self.encode(field: field) { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
+#if !hasFeature(Embedded)
     /// Convenience: encode an Encodable value for a key.
     @_disfavoredOverload
     @inline(__always)
@@ -728,6 +729,7 @@ extension JSONDirectEncoder.DictionaryEncoder {
     public mutating func encode<T: Encodable>(key: String, value: T) throws(CodingError.Encoding) {
         try self.encode(key: key.utf8Span, checkForEscapes: true, value: value)
     }
+#endif
 }
 
 extension JSONDirectEncoder {
@@ -778,6 +780,7 @@ extension JSONDirectEncoder.ArrayEncoder {
         try self.encodeElement { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
     
+#if !hasFeature(Embedded)
     /// Convenience: encode an Encodable value.
         @_disfavoredOverload
     @inline(__always)
@@ -786,6 +789,7 @@ extension JSONDirectEncoder.ArrayEncoder {
     public mutating func encode<T: Encodable>(_ value: T) throws(CodingError.Encoding) {
         try self.encodeElement { encoder throws(CodingError.Encoding) in try encoder.encode(value) }
     }
+#endif
 }
 
 extension JSONDirectEncoder {
@@ -869,6 +873,7 @@ extension JSONDirectEncoder {
     }
 }
 
+#if !hasFeature(Embedded)
 // MARK: - Convenience Extension for Encodable support
 
 extension JSONDirectEncoder {
@@ -885,3 +890,4 @@ extension JSONDirectEncoder {
         }
     }
 }
+#endif

--- a/Sources/NewCodable/SharedTypes.swift
+++ b/Sources/NewCodable/SharedTypes.swift
@@ -815,6 +815,7 @@ extension CodingPath.Component {
         }
     }
 }
+#if !hasFeature(Embedded)
 extension CodingPath {
     /// Converts the coding path components to an array of `CodingKey` values
     /// for use with traditional `Decoder` APIs.
@@ -863,6 +864,7 @@ private struct _IntCodingKey: CodingKey {
         self._intValue = intValue
     }
 }
+#endif
 
 protocol JSONByteIterator: ~Copyable, ~Escapable {
     mutating func nextByte() throws(JSONError) -> UInt8?

--- a/Sources/NewCodable/Utilities.swift
+++ b/Sources/NewCodable/Utilities.swift
@@ -15,6 +15,7 @@
 // Shared Key Type
 //===----------------------------------------------------------------------===//
 
+#if !hasFeature(Embedded)
 @usableFromInline
 internal enum _CodingKey : CodingKey {
     case string(String)
@@ -68,6 +69,7 @@ internal enum _CodingKey : CodingKey {
 
     internal static let `super` = _CodingKey.string("super")
 }
+#endif
 
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Disables `Codable` adapters for Embedded Swift builds.

### Motivation:

Traditional `Codable` is unavailable on Embedded Swift, and using any of its interfaces (`CodingKey`, `Encodable`, `Decodable`, etc.) will result in compilation errors.

### Modifications:

Added conditional compilation checks for everything related to traditional Codable adapters.

### Result:

Resolves some of the build errors on Embedded Swift (#1960).
