### PR TITLE
new-codable: Use string interpolation instead of the reflection-backed String interfaces

### DIFF
--- a/Sources/NewCodable/CodingError.swift
+++ b/Sources/NewCodable/CodingError.swift
@@ -136,8 +136,8 @@ extension CodingError {
         sourceLocation: CodingError._Decoding.SourceLocation? = nil
     ) -> _Decoding {
         typeMismatch(
-            expectedTypeDescription: String(describing: Expected.self),
-            actualValueDescription: String(describing: actualValue),
+            expectedTypeDescription: "\(Expected.self)",
+            actualValueDescription: "\(actualValue)",
             at: codingPath,
             sourceLocation: sourceLocation)
     }
@@ -211,7 +211,7 @@ extension CodingError {
         sourceLocation: CodingError._Decoding.SourceLocation? = nil
     ) -> _Decoding {
         valueNotFound(
-            expectedTypeDescription: String(describing: Expected.self),
+            expectedTypeDescription: "\(Expected.self)",
             at: codingPath,
             debugDescription: debugDescription,
             sourceLocation: sourceLocation

--- a/Sources/NewCodable/JSON/JSONParserDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONParserDecoder.swift
@@ -1300,10 +1300,10 @@ extension JSONParserDecoder {
                 print("root")
             case .array(_, let parent):
                 parent.pointee.printCodingPathAddrs()
-                print("array:", parent)
+                print("array: \(parent)")
             case .dictionary(_, let parent):
                 parent.pointee.printCodingPathAddrs()
-                print("dict:", parent)
+                print("dict: \(parent)")
             }
         }
         

--- a/Sources/NewCodable/JSON/JSONPrimitiveDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONPrimitiveDecoder.swift
@@ -755,17 +755,17 @@ extension JSONPrimitive {
         case .array(let array): CodingError.typeMismatch(expectedType: expectedType, actualValue: array, at: path)
         case .dictionary(let dict): CodingError.typeMismatch(expectedType: expectedType, actualValue: dict, at: path)
         case .bool(let bool): CodingError.typeMismatch(expectedType: expectedType, actualValue: bool, at: path)
-        case .number(let number): CodingError.typeMismatch(expectedTypeDescription: String(describing: expectedType), actualValueDescription: number.extendedPrecisionRepresentation)
-        case .string(let string): CodingError.typeMismatch(expectedTypeDescription: String(describing: expectedType), actualValueDescription: "\"\(string)\"")
-        case .null: CodingError.typeMismatch(expectedTypeDescription: String(describing: expectedType), actualValueDescription: "null")
+        case .number(let number): CodingError.typeMismatch(expectedTypeDescription: "\(expectedType)", actualValueDescription: number.extendedPrecisionRepresentation)
+        case .string(let string): CodingError.typeMismatch(expectedTypeDescription: "\(expectedType)", actualValueDescription: "\"\(string)\"")
+        case .null: CodingError.typeMismatch(expectedTypeDescription: "\(expectedType)", actualValueDescription: "null")
         }
     }
     
     @usableFromInline
     func typeMismatchError(expectedTypeDescription: String, at path: CodingPath) -> CodingError.Decoding {
         switch self {
-        case .array(let array): CodingError.typeMismatch(expectedTypeDescription: expectedTypeDescription, actualValueDescription: array.description, at: path)
-        case .dictionary(let dict): CodingError.typeMismatch(expectedTypeDescription: expectedTypeDescription, actualValueDescription: dict.description, at: path)
+        case .array(let array): CodingError.typeMismatch(expectedTypeDescription: expectedTypeDescription, actualValueDescription: "\(array)", at: path)
+        case .dictionary(let dict): CodingError.typeMismatch(expectedTypeDescription: expectedTypeDescription, actualValueDescription: "\(dict)", at: path)
         case .bool(let bool): CodingError.typeMismatch(expectedTypeDescription: expectedTypeDescription, actualValueDescription: bool.description, at: path)
         case .number(let number): CodingError.typeMismatch(expectedTypeDescription: expectedTypeDescription, actualValueDescription: number.extendedPrecisionRepresentation)
         case .string(let string): CodingError.typeMismatch(expectedTypeDescription: expectedTypeDescription, actualValueDescription: "\"\(string)\"")

--- a/Sources/NewCodable/JSON/NewJSONEncoder.swift
+++ b/Sources/NewCodable/JSON/NewJSONEncoder.swift
@@ -190,10 +190,10 @@ public struct JSONDirectEncoder: CommonEncoder, ~Copyable, ~Escapable {
                 print("root")
             case .array(_, let parent):
                 parent.pointee.printCodingPathAddrs()
-                print("array:", parent)
+                print("array: \(parent)")
             case .dictionary(_, let parent):
                 parent.pointee.printCodingPathAddrs()
-                print("dict:", parent)
+                print("dict: \(parent)")
             }
         }
         


### PR DESCRIPTION
Replaces string representation conversions with Embedded-friendly interpolations.

### Motivation:

`String(describing:)` is unavailable on Embedded Swift, as well as `.description` on array and dictionaries.

### Modifications:

Replaced all failing string interfaces with interpolations.

### Result:

Resolves some of the build errors on Embedded Swift (#1960).