### PR TITLE
Calendar.RecurrenceRule: respect `firstWeekday` for ordinal weekday matching

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -720,9 +720,8 @@ extension Calendar {
         // few seconds can give us the last day in the interval
         lazy var lastWeekday = component(.weekday, from: interval.end.addingTimeInterval(-0.1))
         let calendarFirstWeekday = self.firstWeekday
-        // Convert an absolute weekday (Sun=1...Sat=7) to its position within the
-        // calendar's week (firstWeekday → 0). Used to decide whether two weekdays
-        // fall in the same week given a non-Sunday firstWeekday.
+        /// Convert an absolute weekday (Sun=1...Sat=7) to an index within the
+        /// calendar's week, which can start on an arbitrary weekday.
         func positionInWeek(_ weekday: Int) -> Int {
             (weekday - calendarFirstWeekday + 7) % 7
         }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -719,7 +719,14 @@ extension Calendar {
         // it falls on the day after the last day in the interval. Subtracting a
         // few seconds can give us the last day in the interval
         lazy var lastWeekday = component(.weekday, from: interval.end.addingTimeInterval(-0.1))
-        
+        let calendarFirstWeekday = self.firstWeekday
+        // Convert an absolute weekday (Sun=1...Sat=7) to its position within the
+        // calendar's week (firstWeekday → 0). Used to decide whether two weekdays
+        // fall in the same week given a non-Sunday firstWeekday.
+        func positionInWeek(_ weekday: Int) -> Int {
+            (weekday - calendarFirstWeekday + 7) % 7
+        }
+
         for (weekday, occurences) in map {
             let weekdayIdx = weekday.icuIndex
             if occurences == [] {
@@ -728,8 +735,8 @@ extension Calendar {
                 components.weekday = weekdayIdx
                 result.append(components)
             } else {
-                lazy var firstWeek = weekRange.lowerBound + (weekdayIdx < firstWeekday ? 1 : 0)
-                lazy var lastWeek  = weekRange.upperBound - (weekdayIdx > lastWeekday  ? 1 : 0)
+                lazy var firstWeek = weekRange.lowerBound + (positionInWeek(weekdayIdx) < positionInWeek(firstWeekday) ? 1 : 0)
+                lazy var lastWeek  = weekRange.upperBound - (positionInWeek(weekdayIdx) > positionInWeek(lastWeekday)  ? 1 : 0)
                 for occurence in occurences {
                     var components = DateComponents()
                     if occurence > 0 {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -720,8 +720,8 @@ extension Calendar {
         // few seconds can give us the last day in the interval
         lazy var lastWeekday = component(.weekday, from: interval.end.addingTimeInterval(-0.1))
         let calendarFirstWeekday = self.firstWeekday
-        /// Convert an absolute weekday (Sun=1...Sat=7) to an index within the
-        /// calendar's week, which can start on an arbitrary weekday.
+
+        /// Convert an absolute weekday (Sun=1...Sat=7) to an index within the calendar's week, which can start on an arbitrary weekday.
         func positionInWeek(_ weekday: Int) -> Int {
             (weekday - calendarFirstWeekday + 7) % 7
         }

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -911,6 +911,33 @@ private struct GregorianCalendarRecurrenceRuleTests {
     }
 
     @available(FoundationPreview 6.3, *)
+    @Test func ordinalWeekdaysWithNonSundayFirstWeekday() {
+        // Regression test for https://github.com/swiftlang/swift-foundation/issues/1387
+        // Ordinal weekday calculations (.nth(...)) must produce the same dates regardless
+        // of the calendar's firstWeekday setting.
+        let jan2024 = Date(timeIntervalSince1970: 1704067200.0) // 2024-01-01T00:00:00Z (a Monday)
+        let feb2024 = Date(timeIntervalSince1970: 1706745600.0) // 2024-02-01T00:00:00Z
+
+        let firstSundayJan2024 = Date(timeIntervalSince1970: 1704585600.0) // 2024-01-07T00:00:00Z
+        let lastSundayJan2024  = Date(timeIntervalSince1970: 1706400000.0) // 2024-01-28T00:00:00Z
+
+        for firstWeekday in 1...7 {
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = .gmt
+            calendar.firstWeekday = firstWeekday
+
+            var firstSundayRule = Calendar.RecurrenceRule(calendar: calendar, frequency: .monthly)
+            firstSundayRule.weekdays = [.nth(1, .sunday)]
+            let firstResults = Array(firstSundayRule.recurrences(of: jan2024, in: jan2024..<feb2024))
+            #expect(firstResults == [firstSundayJan2024], "firstWeekday=\(firstWeekday) returned \(firstResults) for 1st Sunday")
+
+            var lastSundayRule = Calendar.RecurrenceRule(calendar: calendar, frequency: .monthly)
+            lastSundayRule.weekdays = [.nth(-1, .sunday)]
+            let lastResults = Array(lastSundayRule.recurrences(of: jan2024, in: jan2024..<feb2024))
+            #expect(lastResults == [lastSundayJan2024], "firstWeekday=\(firstWeekday) returned \(lastResults) for last Sunday")
+        }
+    }
+
     @Test func partialRangeFrom() {
         let rule = Calendar.RecurrenceRule(calendar: gregorian, frequency: .daily, end: .never)
         

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -912,7 +912,6 @@ private struct GregorianCalendarRecurrenceRuleTests {
 
     @available(FoundationPreview 6.3, *)
     @Test func ordinalWeekdaysWithNonSundayFirstWeekday() {
-        // Regression test for https://github.com/swiftlang/swift-foundation/issues/1387
         // Ordinal weekday calculations (.nth(...)) must produce the same dates regardless
         // of the calendar's firstWeekday setting.
         let jan2024 = Date(timeIntervalSince1970: 1704067200.0) // 2024-01-01T00:00:00Z (a Monday)

--- a/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarRecurrenceRuleTests.swift
@@ -912,8 +912,7 @@ private struct GregorianCalendarRecurrenceRuleTests {
 
     @available(FoundationPreview 6.3, *)
     @Test func ordinalWeekdaysWithNonSundayFirstWeekday() {
-        // Ordinal weekday calculations (.nth(...)) must produce the same dates regardless
-        // of the calendar's firstWeekday setting.
+        // Ordinal weekday calculations (.nth(...)) must produce the same dates regardless of the calendar's firstWeekday setting.
         let jan2024 = Date(timeIntervalSince1970: 1704067200.0) // 2024-01-01T00:00:00Z (a Monday)
         let feb2024 = Date(timeIntervalSince1970: 1706745600.0) // 2024-02-01T00:00:00Z
 


### PR DESCRIPTION
Fixes #1387 (the hard-coded assumption in Calendar.RecuranceRule that Sunday is the first day of the week).

### Motivation:

Some locales use a different day of the week as the start of the week (e.g. Monday).

### Modifications:

The fix is to compare positions inside the calendar's week, with `firstWeekday` at position 0, so "comes before in the week" is well-defined for every `firstWeekday` setting.

### Result:

Per the original example in #1387, with `calendar.firstWeekday = 2` (Monday) and January 2024 (that starts on a Monday):

  * Previously "first Sunday [of the month]" was erroneously reported as Jan 14, now it's correctly Jan 7.
  * Previously "last Sunday [of the month]" returned no result at all (the code looked in week 5, Jan 29-31, which has no Sunday).  Now it correctly returns Jan 28.

### Testing:

A new unit test, `ordinalWeekdaysWithNonSundayFirstWeekday`, is included with this patch (also based on that specific example from the original GitHub Issue).  I think it covers the essentials (and checks all seven days as `firstWeekday` settings), though I haven't thought deeply about other possibly important cases.