### PR TITLE
Temporarily remove Data OutputSpan append functions

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -636,9 +636,10 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///     - Parameters:
     ///       - span: An `OutputRawSpan` covering uninitialized memory with
     ///         space for the specified number of additional bytes.
+    // TODO: Make public pending SE-0527 naming discussion
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
-    public mutating func append<E: Error>(
+    internal mutating func append<E: Error>(
         addingRawCapacity uninitializedCount: Int,
         initializingWith initializer: (_ span: inout OutputRawSpan) throws(E) -> Void
     ) throws(E) {
@@ -665,9 +666,10 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///     - Parameters:
     ///       - span: An `OutputSpan` covering uninitialized memory with
     ///         space for the specified number of additional elements.
+    // TODO: Make public pending SE-0527 naming discussion
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
-    public mutating func append<E: Error>(
+    internal mutating func append<E: Error>(
         addingCapacity uninitializedCount: Int,
         initializingWith initializer: (_ span: inout OutputSpan<UInt8>) throws(E) -> Void
     ) throws(E) {


### PR DESCRIPTION
Removes `Data.append(addingCapacity:initializingWith:)` and `Data.append(addingRawCapacity:initializingWith:)` while naming is under discussion

### Motivation:

In [the discussion for SE-0525](https://forums.swift.org/t/accepted-with-modifications-se-0525-safe-loading-api-for-rawspan/86329/10) we have decided to defer the naming of `Output(Raw)Span.append(addingCapacity:initializingWith:)` to SE-0527 (UniqueArray and RigidArray) which will define a standard naming convention for this shape of API. Therefore, `append(addingCapacity:initializingWith:)` was removed from SE-0525.

Similarly, we previously approved a `Data.append(addingCapacity:initializingWith:)` and  `Data.append(addingRawCapacity:initializingWith:)`. `Data` should similar naming conventions as `Output(Raw)Span` and `UniqueArray`/`RigidArray`. As of right now, according to GitHub search, we have no clients adopting this function. For the time being, this removes the function from the public API until we have solidified the naming convention to avoid needing to deprecate and slowly transition clients when the name changes (which is likely).

### Modifications:

Removes `Data.append(addingCapacity:initializingWith:)` and `Data.append(addingRawCapacity:initializingWith:)` while naming is under discussion

### Result:

APIs are for use within Foundation only, external adoption is prevented until naming stabilizes

### Testing:

Existing tests still exercise these now-internal APIs
