### PR TITLE
new-codable: Remove dynamic casts of floating point values

### DIFF
--- a/Sources/NewCodable/JSON/JSONPrimitive.swift
+++ b/Sources/NewCodable/JSON/JSONPrimitive.swift
@@ -53,13 +53,10 @@ public enum JSONPrimitive {
                 }
             }
         }
-        public subscript<T: BinaryFloatingPoint>(_ : T.Type) -> T {
+        public subscript<T: BinaryFloatingPoint & LosslessStringConvertible>(_ : T.Type) -> T {
             get throws(JSONError) {
-                // TODO: Implement better.
-                if T.self == Double.self {
-                    return Double(string)! as! T
-                } else if T.self == Float.self {
-                    return Float(string)! as! T
+                if let value = T(string) {
+                    return value
                 }
                 fatalError()
             }


### PR DESCRIPTION
Reimplements floating point decoding with Embedded Swift in mind.

### Motivation:

Dynamic casts of value types can't be used on Embedded Swift. Both Double and Float conform to `LosslessStringConvertible`, so we can just add it as a generic constraint.

### Modifications:

Replaces dynamic casts with `LosslessStringConvertible`-based implementation.

### Result:

Resolves a build error on Embedded Swift (#1960).
