### PR TITLE
new-codable: Fix GrowableEncodingBytes discard error on Embedded Swift

### DIFF
--- a/Sources/NewCodable/GrowableEncodingBytes.swift
+++ b/Sources/NewCodable/GrowableEncodingBytes.swift
@@ -14,7 +14,7 @@
 // MARK: - GrowableEncodingBytes
 
 // TODO: Temporarily public
-@safe
+@safe @frozen
 public struct GrowableEncodingBytes: ~Copyable {
     @usableFromInline
     internal var _pointer: UnsafeMutableRawPointer?


### PR DESCRIPTION
Fixes a `discard`-related Embedded build error.

### Motivation:

Building `NewCodable` on Embedded Swift fails with the following error:
```- error: 'discard' statement cannot be used in an embedded function not marked '@export(interface)' inside of type 'GrowableEncodingBytes', which is not '@frozen'```
I'm only using the compiler's suggestion here, feel free to address this issue more appropriately.

### Modifications:

Marked `GrowableEncodingBytes` as frozen.

### Result:

Resolves a build error on Embedded Swift (#1960).
