### PR TITLE
Add JSON specialization build flag

### DIFF
--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -214,6 +214,8 @@ extension UInt8 {
     }
 }
 
+#if !NO_JSON_FOUNDATION_SPECIALIZATION
+
 //===----------------------------------------------------------------------===//
 // Date parsing conveniences
 //===----------------------------------------------------------------------===//
@@ -338,6 +340,8 @@ internal extension Date {
         return (y, m, d)
     }
 }
+
+#endif
 
 //===----------------------------------------------------------------------===//
 // Integer parsing conveniences

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -12,8 +12,17 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Glibc)
 @preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif os(Windows)
+import CRT
+import WinSDK
+#elseif os(WASI)
+@preconcurrency import WASILibc
 #elseif canImport(string_h)
 import string_h
 #endif

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -14,9 +14,9 @@
 import Darwin
 #elseif canImport(Glibc)
 @preconcurrency import Glibc
+#elseif canImport(string_h)
+import string_h
 #endif
-
-internal import _FoundationCShims
 
 internal struct JSON5Scanner {
     let options: Options

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -16,8 +16,9 @@ import Darwin
 @preconcurrency import Glibc
 #endif
 
-internal import _FoundationCShims
+#if !NO_JSON_FOUNDATION_SPECIALIZATION
 internal import Synchronization
+#endif
 
 /// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
 /// containing `Decodable` values (in which case it should be exempt from key conversion strategies).
@@ -72,6 +73,7 @@ extension Dictionary : _JSONStringDictionaryDecodableMarker where Key == String,
 open class JSONDecoder {
     // MARK: Options
 
+    #if !NO_JSON_FOUNDATION_SPECIALIZATION
     /// The strategies available for formatting dates when decoding them from JSON.
     public enum DateDecodingStrategy : Sendable {
         /// Defer to `Date` for decoding. This is the default strategy.
@@ -96,6 +98,7 @@ open class JSONDecoder {
         @preconcurrency
         case custom(@Sendable (_ decoder: Decoder) throws -> Date)
     }
+    #endif
 
     /// The strategies for decoding raw data.
     public enum DataDecodingStrategy : Sendable {
@@ -129,6 +132,7 @@ open class JSONDecoder {
         /// Use the keys specified by each type. This is the default strategy.
         case useDefaultKeys
 
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         /// Convert from "snake_case_keys" to "camelCaseKeys" before attempting to match a key with the one specified by each type.
         ///
         /// The conversion to upper case uses `Locale.system`, also known as the ICU "root" locale. This means the result is consistent regardless of the current user's locale and language preferences.
@@ -141,6 +145,7 @@ open class JSONDecoder {
         ///
         /// - Note: Using a key decoding strategy has a nominal performance cost, as each string key has to be inspected for the `_` character.
         case convertFromSnakeCase
+        #endif
 
         /// Provide a custom conversion from the key in the encoded JSON to the keys specified by the decoded types.
         /// The full path to the current decoding position is provided for context (in case you need to locate this key within the payload). The returned key is used in place of the last component in the coding path before decoding.
@@ -148,6 +153,7 @@ open class JSONDecoder {
         @preconcurrency
         case custom(@Sendable (_ codingPath: [CodingKey]) -> CodingKey)
 
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         fileprivate static func _convertFromSnakeCase(_ stringKey: String) -> String {
             guard !stringKey.isEmpty else { return stringKey }
 
@@ -192,8 +198,10 @@ open class JSONDecoder {
             }
             return result
         }
+        #endif
     }
 
+    #if !NO_JSON_FOUNDATION_SPECIALIZATION
     /// The strategy used when decoding dates from part of a JSON object.
     open var dateDecodingStrategy: DateDecodingStrategy {
         get {
@@ -216,6 +224,7 @@ open class JSONDecoder {
             options.dateDecodingStrategy = newValue
         }
     }
+    #endif
 
     /// The strategy that a decoder uses to decode raw data.
     ///
@@ -346,7 +355,9 @@ open class JSONDecoder {
 
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
     fileprivate struct _Options {
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
+        #endif
         var dataDecodingStrategy: DataDecodingStrategy = .base64
         var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
         var keyDecodingStrategy: KeyDecodingStrategy = .useDefaultKeys
@@ -444,6 +455,9 @@ open class JSONDecoder {
         return try jsonData.withBufferView {
             [length = jsonData.count] bytes in
             assert(bytes.count == length)
+            #if NO_JSON_FOUNDATION_SPECIALIZATION
+            return try closure(bytes)
+            #else
             // RFC4627 section 3
             // The first two characters of a JSON text will always be ASCII. We can determine encoding by looking at the first four bytes.
             let byte0 = (length > 0) ? bytes[uncheckedOffset: 0] : nil
@@ -508,6 +522,7 @@ open class JSONDecoder {
                     try closure(BufferView(unsafeBufferPointer: $0)!)
                 }
             }
+            #endif
         }
     }
 }
@@ -553,6 +568,9 @@ fileprivate class JSONDecoderImpl {
     // In either case, we need to copy-in the input buffer since it's about to go out of scope.
     func takeOwnershipOfBackingDataIfNeeded(selfIsUniquelyReferenced: Bool) {
         if !selfIsUniquelyReferenced || !isKnownUniquelyReferenced(&jsonMap) {
+            #if NO_JSON_FOUNDATION_SPECIALIZATION
+            fatalError("Cannot have multiple references to a JSONDecoder implementation")
+            #endif
             jsonMap.copyInBuffer()
         }
     }
@@ -638,11 +656,12 @@ extension JSONDecoderImpl: Decoder {
     }
 
     func unwrap<T: Decodable>(_ mapValue: JSONMap.Value, as type: T.Type, for codingPathNode: _CodingPathNode, _ additionalKey: (some CodingKey)? = nil) throws -> T {
-        if type == Date.self {
-            return try self.unwrapDate(from: mapValue, for: codingPathNode, additionalKey) as! T
-        }
         if type == Data.self {
             return try self.unwrapData(from: mapValue, for: codingPathNode, additionalKey) as! T
+        }
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
+        if type == Date.self {
+            return try self.unwrapDate(from: mapValue, for: codingPathNode, additionalKey) as! T
         }
         if type == URL.self {
             return try self.unwrapURL(from: mapValue, for: codingPathNode, additionalKey) as! T
@@ -650,6 +669,7 @@ extension JSONDecoderImpl: Decoder {
         if type == Decimal.self {
             return try self.unwrapDecimal(from: mapValue, for: codingPathNode, additionalKey) as! T
         }
+        #endif
         if !options.keyDecodingStrategy.isDefault, T.self is _JSONStringDictionaryDecodableMarker.Type {
             return try self.unwrapDictionary(from: mapValue, as: type, for: codingPathNode, additionalKey)
         }
@@ -665,6 +685,7 @@ extension JSONDecoderImpl: Decoder {
         }
     }
 
+    #if !NO_JSON_FOUNDATION_SPECIALIZATION
     private func unwrapDate<K: CodingKey>(from mapValue: JSONMap.Value, for codingPathNode: _CodingPathNode, _ additionalKey: K? = nil) throws -> Date {
         try checkNotNull(mapValue, expectedType: Date.self, for: codingPathNode, additionalKey)
 
@@ -702,6 +723,7 @@ extension JSONDecoderImpl: Decoder {
             }
         }
     }
+    #endif
 
     private func unwrapData(from mapValue: JSONMap.Value, for codingPathNode: _CodingPathNode, _ additionalKey: (some CodingKey)? = nil) throws -> Data {
         try checkNotNull(mapValue, expectedType: Data.self, for: codingPathNode, additionalKey)
@@ -740,6 +762,7 @@ extension JSONDecoderImpl: Decoder {
         }
     }
 
+    #if !NO_JSON_FOUNDATION_SPECIALIZATION
     private func unwrapURL(from mapValue: JSONMap.Value, for codingPathNode: _CodingPathNode, _ additionalKey: (some CodingKey)? = nil) throws -> URL {
         try checkNotNull(mapValue, expectedType: URL.self, for: codingPathNode, additionalKey)
 
@@ -805,6 +828,7 @@ extension JSONDecoderImpl: Decoder {
             }
         }
     }
+    #endif
 
     private func unwrapDictionary<T: Decodable>(from mapValue: JSONMap.Value, as type: T.Type, for codingPathNode: _CodingPathNode, _ additionalKey: (some CodingKey)? = nil) throws -> T {
         try checkNotNull(mapValue, expectedType: [String:Any].self, for: codingPathNode, additionalKey)
@@ -1058,6 +1082,7 @@ extension JSONDecoderImpl: Decoder {
             }
         }
 
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         let decimalParseResult = Decimal._decimal(from: numberBuffer, matchEntireString: true).asOptional
         if let decimal = decimalParseResult.result {
             guard let value = T(decimal) else {
@@ -1065,6 +1090,7 @@ extension JSONDecoderImpl: Decoder {
             }
             return value
         }
+        #endif
         // Maybe it was just an unreadable sequence?
         if json5 {
             throw JSON5Scanner.validateNumber(from: numberBuffer.suffix(from: digitBeginning), fullSource: fullSource)
@@ -1081,6 +1107,7 @@ extension JSONDecoderImpl: Decoder {
     }
 }
 
+#if !NO_JSON_FOUNDATION_SPECIALIZATION
 extension FixedWidthInteger {
     init?(_ decimal: Decimal) {
         let isNegative = decimal._isNegative != 0
@@ -1133,6 +1160,7 @@ extension FixedWidthInteger {
         }
     }
 }
+#endif
 
 extension JSONDecoderImpl : SingleValueDecodingContainer {
     func decodeNil() -> Bool {
@@ -1247,6 +1275,7 @@ extension JSONDecoderImpl {
                     let key = try impl.unwrapString(from: keyValue, for: codingPathNode, _CodingKey?.none)
                     result[key]._setIfNil(to: value)
                 }
+            #if !NO_JSON_FOUNDATION_SPECIALIZATION
             case .convertFromSnakeCase:
                 while let (keyValue, value) = iter.next() {
                     // We know these values are keys, but UTF-8 decoding could still fail.
@@ -1257,6 +1286,7 @@ extension JSONDecoderImpl {
                     // Effectively an undefined behavior with JSON dictionaries.
                     result[JSONDecoder.KeyDecodingStrategy._convertFromSnakeCase(key)]._setIfNil(to: value)
                 }
+            #endif
             case .custom(let converter):
                 let codingPathForCustomConverter = codingPathNode.path
                 while let (keyValue, value) = iter.next() {
@@ -1906,5 +1936,9 @@ fileprivate extension JSONDecoder.KeyDecodingStrategy {
     }
 }
 
+#if NO_JSON_FOUNDATION_SPECIALIZATION
+@available(*, unavailable)
+#else
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+#endif
 extension JSONDecoder : @unchecked Sendable {}

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !NO_JSON_FOUNDATION_SPECIALIZATION
 internal import Synchronization
+#endif
 
 //===----------------------------------------------------------------------===//
 // JSON Encoder
@@ -82,6 +84,7 @@ open class JSONEncoder {
         public static let withoutEscapingSlashes = OutputFormatting(rawValue: 1 << 3)
     }
 
+    #if !NO_JSON_FOUNDATION_SPECIALIZATION
     /// The formatting strategies available for formatting dates when encoding a date as JSON.
     public enum DateEncodingStrategy : Sendable {
         /// The strategy that uses formatting from the Date structure.
@@ -108,7 +111,8 @@ open class JSONEncoder {
         @preconcurrency
         case custom(@Sendable (Date, Encoder) throws -> Void)
     }
-    
+    #endif
+
     /// The strategies for encoding raw data.
     public enum DataEncodingStrategy : Sendable {
         /// The strategy that encodes data using the encoding specified by the data instance itself.
@@ -143,6 +147,7 @@ open class JSONEncoder {
         /// Use the keys specified by each type. This is the default strategy.
         case useDefaultKeys
 
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         /// Convert from "camelCaseKeys" to "snake_case_keys" before writing a key to JSON payload.
         ///
         /// Capital characters are determined by testing membership in Unicode General Categories Lu and Lt.
@@ -158,6 +163,7 @@ open class JSONEncoder {
         ///
         /// - Note: Using a key encoding strategy has a nominal performance cost, as each string key has to be converted.
         case convertToSnakeCase
+        #endif
 
         /// Provide a custom conversion to the key in the encoded JSON from the keys specified by the encoded types.
         /// The full path to the current encoding position is provided for context (in case you need to locate this key within the payload). The returned key is used in place of the last component in the coding path before encoding.
@@ -165,6 +171,7 @@ open class JSONEncoder {
         @preconcurrency
         case custom(@Sendable (_ codingPath: [CodingKey]) -> CodingKey)
 
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         fileprivate static func _convertToSnakeCase(_ stringKey: String) -> String {
             guard !stringKey.isEmpty else { return stringKey }
 
@@ -213,6 +220,7 @@ open class JSONEncoder {
             }).joined(separator: "_")
             return result
         }
+        #endif
     }
 
     /// A value that determines the readability, size, and element order of the encoded JSON object.
@@ -240,6 +248,7 @@ open class JSONEncoder {
         }
     }
 
+    #if !NO_JSON_FOUNDATION_SPECIALIZATION
     /// The strategy used when encoding dates as part of a JSON object.
     ///
     /// Defaults to `.deferredToDate`.
@@ -264,6 +273,7 @@ open class JSONEncoder {
             options.dateEncodingStrategy = newValue
         }
     }
+    #endif
 
     /// The strategy that an encoder uses to encode raw data.
     ///
@@ -367,7 +377,9 @@ open class JSONEncoder {
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
     fileprivate struct _Options {
         var outputFormatting: OutputFormatting = []
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         var dateEncodingStrategy: DateEncodingStrategy = .deferredToDate
+        #endif
         var dataEncodingStrategy: DataEncodingStrategy = .base64
         var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy = .throw
         var keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys
@@ -828,9 +840,11 @@ private struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContain
         switch encoder.options.keyEncodingStrategy {
         case .useDefaultKeys:
             return key.stringValue
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         case .convertToSnakeCase:
             let newKeyString = JSONEncoder.KeyEncodingStrategy._convertToSnakeCase(key.stringValue)
             return newKeyString
+        #endif
         case .custom(let converter):
             var path = codingPath
             path.append(key)
@@ -1173,6 +1187,7 @@ private extension __JSONEncoder {
         try .number(from: double, encoder: self, additionalKey)
     }
 
+    #if !NO_JSON_FOUNDATION_SPECIALIZATION
     func wrap(_ date: Date, for additionalKey: (some CodingKey)? = _CodingKey?.none) throws -> JSONEncoderValue {
         switch self.options.dateEncodingStrategy {
         case .deferredToDate:
@@ -1206,6 +1221,7 @@ private extension __JSONEncoder {
             return encoder.takeValue() ?? .object([:])
         }
     }
+    #endif
 
     func wrap(_ data: Data, for additionalKey: (some CodingKey)? = _CodingKey?.none) throws -> JSONEncoderValue {
         switch self.options.dataEncodingStrategy {
@@ -1248,18 +1264,21 @@ private extension __JSONEncoder {
     }
 
     func wrapGeneric<T: Encodable>(_ value: T, for additionalKey: (some CodingKey)? = _CodingKey?.none) throws -> JSONEncoderValue? {
-
+        #if !NO_JSON_FOUNDATION_SPECIALIZATION
         if let date = value as? Date {
             // Respect Date encoding strategy
             return try self.wrap(date, for: additionalKey)
-        } else if let data = value as? Data {
-            // Respect Data encoding strategy
-            return try self.wrap(data, for: additionalKey)
         } else if let url = value as? URL {
             // Encode URLs as single strings.
             return self.wrap(url.absoluteString)
         } else if let decimal = value as? Decimal {
             return .number(decimal.description)
+        }
+        #endif
+
+        if let data = value as? Data {
+            // Respect Data encoding strategy
+            return try self.wrap(data, for: additionalKey)
         } else if !options.keyEncodingStrategy.isDefault, let encodable = value as? _JSONStringDictionaryEncodableMarker {
             return try self.wrap(encodable as! [String:Encodable], for: additionalKey)
         } else if let array = _asDirectArrayEncodable(value) {
@@ -1440,7 +1459,11 @@ extension EncodingError {
     }
 }
 
+#if NO_JSON_FOUNDATION_SPECIALIZATION
+@available(*, unavailable)
+#else
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+#endif
 extension JSONEncoder : @unchecked Sendable {}
 
 //===----------------------------------------------------------------------===//
@@ -1557,8 +1580,9 @@ fileprivate extension JSONEncoder.KeyEncodingStrategy {
         switch self {
         case .useDefaultKeys:
             return true
-        case .custom, .convertToSnakeCase:
+        default:
             return false
+
         }
     }
 }

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -59,8 +59,9 @@ import Darwin
 @preconcurrency import Glibc
 #endif // canImport(Darwin)
 
-internal import _FoundationCShims
+#if !NO_JSON_FOUNDATION_SPECIALIZATION
 internal import Synchronization
+#endif
 
 internal class JSONMap {
     enum TypeDescriptor : Int {


### PR DESCRIPTION
Adds a new build flag around some of Foundation-specific specialization of JSON coders

### Motivation:

Allows for building JSON coders without some of Foundation's specializations when necessary

### Modifications:

- Adds a new build flag surrounding some of the specializations in Foundation's JSON coders
- Updates some imports to be more specific

### Result:

No direct impact to the build at this time

### Testing:

Covered by existing JSON tests
