### PR TITLE
Add CodableNaming: compile-time key naming conventions for codable macros

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,4 +20,4 @@
 # overrides, and makes uncharted parts of the repository easier to pin down.
 
 # Default code owner of everything.
-* @swiftlang/swift-foundation-codeowners
+* @kperryua

--- a/Sources/NewCodable/Macros.swift
+++ b/Sources/NewCodable/Macros.swift
@@ -15,28 +15,91 @@
 /// The macro spellings in this file are provisional and may evolve with the
 /// macro-based Codable design. The per-property marker macros below are
 /// especially likely to change as the feature set is refined.
+///
+/// Explicit `@CodingKey` attributes on individual members override naming conventions.
+
+// MARK: - JSONEncodable
+
 @attached(extension, conformances: JSONEncodable, names: named(CodingFields), named(JSONCodingFields), named(encode))
 public macro JSONEncodable() = #externalMacro(module: "NewCodableMacros", type: "JSONEncodableMacro")
 
-/// Experimental macro that synthesizes `JSONDecodable` conformance.
+/// Synthesizes `JSONEncodable` with a field naming convention (structs only).
+@attached(extension, conformances: JSONEncodable, names: named(CodingFields), named(JSONCodingFields), named(encode))
+public macro JSONEncodable(fieldNaming: CodableNaming) = #externalMacro(module: "NewCodableMacros", type: "JSONEncodableMacro")
+
+/// Synthesizes `JSONEncodable` with case/associated-value naming conventions (enums only).
+@attached(extension, conformances: JSONEncodable, names: named(CodingFields), named(JSONCodingFields), named(encode))
+public macro JSONEncodable(caseNaming: CodableNaming = .default, associatedValueLabelNaming: CodableNaming = .default) = #externalMacro(module: "NewCodableMacros", type: "JSONEncodableMacro")
+
+// MARK: - JSONDecodable
+
+/// Synthesizes `JSONDecodable` conformance.
 @attached(extension, conformances: JSONDecodable, names: named(CodingFields), named(JSONCodingFields), named(decode))
 public macro JSONDecodable() = #externalMacro(module: "NewCodableMacros", type: "JSONDecodableMacro")
 
-/// Experimental macro that synthesizes both `JSONEncodable` and `JSONDecodable`.
+/// Synthesizes `JSONDecodable` with a field naming convention (structs only).
+@attached(extension, conformances: JSONDecodable, names: named(CodingFields), named(JSONCodingFields), named(decode))
+public macro JSONDecodable(fieldNaming: CodableNaming) = #externalMacro(module: "NewCodableMacros", type: "JSONDecodableMacro")
+
+/// Synthesizes `JSONDecodable` with case/associated-value naming conventions (enums only).
+@attached(extension, conformances: JSONDecodable, names: named(CodingFields), named(JSONCodingFields), named(decode))
+public macro JSONDecodable(caseNaming: CodableNaming = .default, associatedValueLabelNaming: CodableNaming = .default) = #externalMacro(module: "NewCodableMacros", type: "JSONDecodableMacro")
+
+// MARK: - JSONCodable
+
+/// Synthesizes both `JSONEncodable` and `JSONDecodable`.
 @attached(extension, conformances: JSONEncodable, JSONDecodable, names: named(CodingFields), named(JSONCodingFields), named(encode), named(decode))
 public macro JSONCodable() = #externalMacro(module: "NewCodableMacros", type: "JSONCodableMacro")
 
-/// Experimental macro that synthesizes `CommonEncodable` conformance.
+/// Synthesizes both `JSONEncodable` and `JSONDecodable` with a field naming convention (structs only).
+@attached(extension, conformances: JSONEncodable, JSONDecodable, names: named(CodingFields), named(JSONCodingFields), named(encode), named(decode))
+public macro JSONCodable(fieldNaming: CodableNaming) = #externalMacro(module: "NewCodableMacros", type: "JSONCodableMacro")
+
+/// Synthesizes both `JSONEncodable` and `JSONDecodable` with case/associated-value naming conventions (enums only).
+@attached(extension, conformances: JSONEncodable, JSONDecodable, names: named(CodingFields), named(JSONCodingFields), named(encode), named(decode))
+public macro JSONCodable(caseNaming: CodableNaming = .default, associatedValueLabelNaming: CodableNaming = .default) = #externalMacro(module: "NewCodableMacros", type: "JSONCodableMacro")
+
+// MARK: - CommonEncodable
+
+/// Synthesizes `CommonEncodable` conformance.
 @attached(extension, conformances: CommonEncodable, names: named(CodingFields), named(CommonCodingFields), named(encode))
 public macro CommonEncodable() = #externalMacro(module: "NewCodableMacros", type: "CommonEncodableMacro")
 
-/// Experimental macro that synthesizes `CommonDecodable` conformance.
+/// Synthesizes `CommonEncodable` with a field naming convention (structs only).
+@attached(extension, conformances: CommonEncodable, names: named(CodingFields), named(CommonCodingFields), named(encode))
+public macro CommonEncodable(fieldNaming: CodableNaming) = #externalMacro(module: "NewCodableMacros", type: "CommonEncodableMacro")
+
+/// Synthesizes `CommonEncodable` with case/associated-value naming conventions (enums only).
+@attached(extension, conformances: CommonEncodable, names: named(CodingFields), named(CommonCodingFields), named(encode))
+public macro CommonEncodable(caseNaming: CodableNaming = .default, associatedValueLabelNaming: CodableNaming = .default) = #externalMacro(module: "NewCodableMacros", type: "CommonEncodableMacro")
+
+// MARK: - CommonDecodable
+
+/// Synthesizes `CommonDecodable` conformance.
 @attached(extension, conformances: CommonDecodable, names: named(CodingFields), named(CommonCodingFields), named(decode))
 public macro CommonDecodable() = #externalMacro(module: "NewCodableMacros", type: "CommonDecodableMacro")
 
-/// Experimental macro that synthesizes both `CommonEncodable` and `CommonDecodable`.
+/// Synthesizes `CommonDecodable` with a field naming convention (structs only).
+@attached(extension, conformances: CommonDecodable, names: named(CodingFields), named(CommonCodingFields), named(decode))
+public macro CommonDecodable(fieldNaming: CodableNaming) = #externalMacro(module: "NewCodableMacros", type: "CommonDecodableMacro")
+
+/// Synthesizes `CommonDecodable` with case/associated-value naming conventions (enums only).
+@attached(extension, conformances: CommonDecodable, names: named(CodingFields), named(CommonCodingFields), named(decode))
+public macro CommonDecodable(caseNaming: CodableNaming = .default, associatedValueLabelNaming: CodableNaming = .default) = #externalMacro(module: "NewCodableMacros", type: "CommonDecodableMacro")
+
+// MARK: - CommonCodable
+
+/// Synthesizes both `CommonEncodable` and `CommonDecodable`.
 @attached(extension, conformances: CommonEncodable, CommonDecodable, names: named(CodingFields), named(CommonCodingFields), named(encode), named(decode))
 public macro CommonCodable() = #externalMacro(module: "NewCodableMacros", type: "CommonCodableMacro")
+
+/// Synthesizes both `CommonEncodable` and `CommonDecodable` with a field naming convention (structs only).
+@attached(extension, conformances: CommonEncodable, CommonDecodable, names: named(CodingFields), named(CommonCodingFields), named(encode), named(decode))
+public macro CommonCodable(fieldNaming: CodableNaming) = #externalMacro(module: "NewCodableMacros", type: "CommonCodableMacro")
+
+/// Synthesizes both `CommonEncodable` and `CommonDecodable` with case/associated-value naming conventions (enums only).
+@attached(extension, conformances: CommonEncodable, CommonDecodable, names: named(CodingFields), named(CommonCodingFields), named(encode), named(decode))
+public macro CommonCodable(caseNaming: CodableNaming = .default, associatedValueLabelNaming: CodableNaming = .default) = #externalMacro(module: "NewCodableMacros", type: "CommonCodableMacro")
 
 /// Experimental per-property marker macro for overriding the serialized key.
 @attached(peer)
@@ -49,3 +112,85 @@ public macro CodableDefault<T>(_ value: T) = #externalMacro(module: "NewCodableM
 /// Experimental per-property marker macro for accepting alternate decoding keys.
 @attached(peer)
 public macro DecodableAlias(_ names: String...) = #externalMacro(module: "NewCodableMacros", type: "DecodableAliasMacro")
+
+/// Naming convention for serialized keys.
+///
+/// When applied to a codable macro, transforms Swift property or case names
+/// into serialized key strings according to the selected convention.
+/// Explicit `@CodingKey` attributes on individual properties or enum cases
+/// override the naming convention.
+///
+/// ## Algorithm
+///
+/// The transformation has two phases:
+///
+/// **1. Word splitting.** The Swift identifier is decomposed into words using
+/// the following rules (applied left-to-right):
+///
+/// - Interior underscores are treated as explicit word separators and are
+///   consumed (not included in any word).
+/// - A transition from a lowercase or digit character to an uppercase
+///   character starts a new word.
+///   Example: `myProperty` → `["my", "Property"]`
+/// - A run of multiple uppercase characters followed by a lowercase character
+///   splits before the last uppercase character (preserving the acronym as
+///   its own word).
+///   Example: `parseHTTPResponse` → `["parse", "HTTP", "Response"]`
+/// - Digits do **not** trigger a word boundary on their own; they remain
+///   attached to the preceding letters.
+///   Example: `version4Thing` → `["version4", "Thing"]`
+///
+/// **2. Reassembly.** The words are joined according to the target convention:
+///
+/// | Convention              | Join rule                                         | Example output        |
+/// |-------------------------|---------------------------------------------------|-----------------------|
+/// | `.camelCase`            | First word lowercased, rest capitalized, no separator | `parseHttpResponse` |
+/// | `.PascalCase`           | Each word capitalized, no separator               | `ParseHttpResponse`   |
+/// | `.snake_case`           | Each word lowercased, joined with `_`             | `parse_http_response` |
+/// | `.SCREAMING_SNAKE_CASE` | Each word uppercased, joined with `_`             | `PARSE_HTTP_RESPONSE` |
+/// | `.kebab_case`           | Each word lowercased, joined with `-`             | `parse-http-response` |
+/// | `.SCREAMING_KEBAB_CASE` | Each word uppercased, joined with `-`             | `PARSE-HTTP-RESPONSE` |
+/// | `.lowercase`            | Each word lowercased, no separator                | `parsehttpresponse`   |
+/// | `.UPPERCASE`            | Each word uppercased, no separator                | `PARSEHTTPRESPONSE`   |
+///
+/// "Capitalized" means the first character is uppercased and the remaining
+/// characters are lowercased — acronyms like `HTTP` become `Http` in
+/// camelCase/PascalCase output.
+///
+/// ## Compile-Time Key Generation
+///
+/// This transformation is applied at compile time during macro expansion. The
+/// macro embeds the resulting string as a literal in the generated
+/// `CodingFields` enum, and that literal is the **only** serialized key that
+/// will match the property during both encoding and decoding. (Additional
+/// aliases can be declared with `@DecodableAlias` to accept alternative keys
+/// during decoding.)
+///
+/// This design eliminates the round-tripping problems inherent in runtime key
+/// conversion strategies such as `JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`.
+/// With the runtime approach, encoding and decoding apply independent
+/// transformations that are not always inverses of each other — for example,
+/// `imageURL` encodes to `image_url`, but decoding `image_url` back produces
+/// `imageUrl`, which no longer matches the original property name. Because
+/// `CodableNaming` generates a single deterministic key at compile time, this
+/// class of mismatch cannot occur.
+public enum CodableNaming: Sendable {
+    /// Use the Swift name unchanged (default).
+    case `default`
+    /// `camelCase` — first letter lowercased, subsequent word-initial letters uppercased (Swift's native convention).
+    case camelCase
+    /// `PascalCase` — each word starts with an uppercase letter, no separators.
+    case PascalCase
+    /// `snake_case` — lowercase words separated by underscores.
+    case snake_case
+    /// `SCREAMING_SNAKE_CASE` — uppercase words separated by underscores.
+    case SCREAMING_SNAKE_CASE
+    /// `kebab-case` — lowercase words separated by hyphens.
+    case kebab_case
+    /// `SCREAMING-KEBAB-CASE` — uppercase words separated by hyphens.
+    case SCREAMING_KEBAB_CASE
+    /// `lowercase` — all lowercase, no separators.
+    case lowercase
+    /// `UPPERCASE` — all uppercase, no separators.
+    case UPPERCASE
+}

--- a/Sources/NewCodableMacros/CodableNaming.swift
+++ b/Sources/NewCodableMacros/CodableNaming.swift
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftDiagnostics
+
+/// Mirror of the user-facing `CodableNaming` enum, used within the macro plugin
+/// to apply name transformations at compile time.
+enum CodableNamingConvention: String {
+    case `default`
+    case camelCase
+    case PascalCase
+    case snake_case
+    case SCREAMING_SNAKE_CASE
+    case kebab_case
+    case SCREAMING_KEBAB_CASE
+    case lowercase
+    case UPPERCASE
+}
+
+/// Holds the naming conventions parsed from a codable macro attribute.
+struct NamingConventions {
+    /// Naming for struct fields (only applicable to structs).
+    var fieldNaming: CodableNamingConvention = .default
+    /// Naming for enum case names (only applicable to enums).
+    var caseNaming: CodableNamingConvention = .default
+    /// Naming for enum associated value labels (only applicable to enums).
+    var associatedValueLabelNaming: CodableNamingConvention = .default
+}
+
+/// Parses naming convention arguments from a codable macro attribute.
+///
+/// Recognizes `fieldNaming:`, `caseNaming:`, and `associatedValueLabelNaming:` labeled arguments
+/// whose values are member access expressions (e.g., `.snake_case`).
+func parseNamingConventions(from node: AttributeSyntax) -> NamingConventions {
+    var conventions = NamingConventions()
+    guard let arguments = node.arguments?.as(LabeledExprListSyntax.self) else {
+        return conventions
+    }
+
+    for argument in arguments {
+        guard let label = argument.label?.text,
+              let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil else {
+            continue
+        }
+        let conventionName = memberAccess.declName.baseName.text
+        guard let convention = CodableNamingConvention(rawValue: conventionName) else {
+            continue
+        }
+
+        switch label {
+        case "fieldNaming":
+            conventions.fieldNaming = convention
+        case "caseNaming":
+            conventions.caseNaming = convention
+        case "associatedValueLabelNaming":
+            conventions.associatedValueLabelNaming = convention
+        default:
+            continue
+        }
+    }
+
+    return conventions
+}
+
+// MARK: - Name Transformation
+
+/// Splits a camelCase, PascalCase, or sanke case identifier into its constituent words.
+///
+/// Handles transitions like:
+/// - lowercase → uppercase: `myProperty` → `["my", "Property"]`
+/// - uppercase → uppercase+lowercase (acronyms): `parseHTTPResponse` → `["parse", "HTTP", "Response"]`
+/// - underscore separators: `my_property` → `["my", "property"]`
+internal func splitIntoWords(_ name: String) -> [String] {
+    var words: [String] = []
+    var currentWord = ""
+
+    let chars = Array(name)
+    for i in chars.indices {
+        let char = chars[i]
+
+        if char == "_" {
+            // Separator: flush current word and skip
+            if !currentWord.isEmpty {
+                words.append(currentWord)
+                currentWord = ""
+            }
+            continue
+        }
+
+        if char.isUppercase {
+            if !currentWord.isEmpty {
+                let prevIsUpper = currentWord.last?.isUppercase ?? false
+                if prevIsUpper {
+                    // We're in an acronym run. Check if the next character is lowercase,
+                    // which means this uppercase letter starts a new word.
+                    let nextIsLower = (i + 1 < chars.count) && chars[i + 1].isLowercase
+                    if nextIsLower {
+                        words.append(currentWord)
+                        currentWord = String(char)
+                    } else {
+                        currentWord.append(char)
+                    }
+                } else {
+                    // Transition from lowercase to uppercase: start new word
+                    words.append(currentWord)
+                    currentWord = String(char)
+                }
+            } else {
+                currentWord.append(char)
+            }
+        } else {
+            currentWord.append(char)
+        }
+    }
+
+    if !currentWord.isEmpty {
+        words.append(currentWord)
+    }
+
+    return words
+}
+
+/// Capitalizes the first character of a word and lowercases the rest.
+private func capitalizeWord(_ word: String) -> String {
+    guard let first = word.first else { return word }
+    return first.uppercased() + word.dropFirst().lowercased()
+}
+
+/// Applies a naming convention to a Swift identifier.
+///
+/// Leading and trailing underscores are preserved in the output (e.g., `_myField` with
+/// `.snake_case` becomes `_my_field`). This matches the behavior of Foundation's
+/// `JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`.
+///
+/// - Parameters:
+///   - name: The original Swift identifier name.
+///   - convention: The target naming convention.
+/// - Returns: The transformed name, or the original name if convention is `.default`.
+func applyNamingConvention(_ name: String, convention: CodableNamingConvention) -> String {
+    guard convention != .default else { return name }
+
+    // Preserve leading and trailing underscores.
+    let leadingUnderscores = String(name.prefix(while: { $0 == "_" }))
+    let trailingCount = name.reversed().prefix(while: { $0 == "_" }).count
+    let trailingUnderscores = String(repeating: "_", count: trailingCount)
+
+    let stripped: String
+    if leadingUnderscores.count + trailingUnderscores.count >= name.count {
+        // The entire string is underscores — nothing to transform.
+        return name
+    } else {
+        let start = name.index(name.startIndex, offsetBy: leadingUnderscores.count)
+        let end = name.index(name.endIndex, offsetBy: -trailingUnderscores.count)
+        stripped = String(name[start..<end])
+    }
+
+    let words = splitIntoWords(stripped)
+    guard !words.isEmpty else { return name }
+
+    let transformed: String
+    switch convention {
+    case .default:
+        return name
+
+    case .camelCase:
+        transformed = words.enumerated().map { index, word in
+            index == 0 ? word.lowercased() : capitalizeWord(word)
+        }.joined()
+
+    case .PascalCase:
+        transformed = words.map { capitalizeWord($0) }.joined()
+
+    case .snake_case:
+        transformed = words.map { $0.lowercased() }.joined(separator: "_")
+
+    case .SCREAMING_SNAKE_CASE:
+        transformed = words.map { $0.uppercased() }.joined(separator: "_")
+
+    case .kebab_case:
+        transformed = words.map { $0.lowercased() }.joined(separator: "-")
+
+    case .SCREAMING_KEBAB_CASE:
+        transformed = words.map { $0.uppercased() }.joined(separator: "-")
+
+    case .lowercase:
+        transformed = words.map { $0.lowercased() }.joined()
+
+    case .UPPERCASE:
+        transformed = words.map { $0.uppercased() }.joined()
+    }
+
+    return leadingUnderscores + transformed + trailingUnderscores
+}

--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -234,14 +234,16 @@ enum CodableTypeDeclaration {
         } else {
             typeName = TokenSyntax(.identifier(type.trimmedDescription), presence: .present)
         }
-        
+
+        let naming = parseNamingConventions(from: node)
+
         if declaration.is(EnumDeclSyntax.self) {
-            guard let cases = extractEnumCases(from: declaration.memberBlock, for: node, in: context) else {
+            guard let cases = extractEnumCases(from: declaration.memberBlock, for: node, in: context, naming: naming) else {
                 return nil
             }
             self = .enumDecl(typeName: typeName, cases: cases)
         } else if declaration.is(StructDeclSyntax.self) {
-            guard let properties = extractDetailedStoredProperties(from: declaration.memberBlock, for: node, in: context) else {
+            guard let properties = extractDetailedStoredProperties(from: declaration.memberBlock, for: node, in: context, naming: naming) else {
                 return nil
             }
             self = .structDecl(typeName: typeName, properties: properties)
@@ -292,7 +294,8 @@ enum CodableTypeDeclaration {
 func extractDetailedStoredProperties(
     from members: MemberBlockSyntax,
     for node: AttributeSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
+    naming: NamingConventions = NamingConventions()
 ) -> [DetailedStoredProperty]? {
     var properties: [DetailedStoredProperty] = []
 
@@ -347,7 +350,7 @@ func extractDetailedStoredProperties(
             }
 
             let propertyName = pattern.identifier.trimmedDescription
-            let key = customKey ?? propertyName
+            let key = customKey ?? applyNamingConvention(propertyName, convention: naming.fieldNaming)
 
             let type = typeAnnotation.type
             let isOptional: Bool
@@ -415,7 +418,8 @@ func accessLevel(of declaration: some DeclGroupSyntax) -> CodableDeclarationAcce
 func extractEnumCases(
     from members: MemberBlockSyntax,
     for node: AttributeSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
+    naming: NamingConventions = NamingConventions()
 ) -> [EnumCaseInfo]? {
     var cases: [EnumCaseInfo] = []
 
@@ -429,14 +433,19 @@ func extractEnumCases(
 
         for element in caseDecl.elements {
             let caseName = element.name.trimmedDescription
-            let key = customKey ?? caseName
+            let key = customKey ?? applyNamingConvention(caseName, convention: naming.caseNaming)
             var parameters: [EnumCaseAssociatedValue] = []
 
             if let paramClause = element.parameterClause {
                 for (index, param) in paramClause.parameters.enumerated() {
                     var label = param.firstName?.trimmedDescription
                     if label == "_" { label = nil }
-                    let encodedName = label ?? "_\(index)"
+                    let encodedName: String
+                    if let label {
+                        encodedName = applyNamingConvention(label, convention: naming.associatedValueLabelNaming)
+                    } else {
+                        encodedName = "_\(index)"
+                    }
                     let typeName = param.type.trimmedDescription
                     parameters.append(EnumCaseAssociatedValue(label: label, encodedName: encodedName, typeName: typeName))
                 }
@@ -1189,8 +1198,8 @@ private func generatePerCaseFieldEnums(
             let guardLetNames = enumCase.associatedValues.map { "let \($0.encodedName)" }.joined(separator: ", ")
 
             let args = enumCase.associatedValues.map { param -> String in
-                if param.label != nil {
-                    return "\(param.encodedName): \(param.encodedName)"
+                if let label = param.label {
+                    return "\(label): \(param.encodedName)"
                 } else {
                     return "\(param.encodedName)"
                 }
@@ -1291,8 +1300,8 @@ private func generatePerCaseFieldWrapperStructs(
             let guardLetNames = enumCase.associatedValues.map { "let \($0.encodedName)" }.joined(separator: ", ")
 
             let args = enumCase.associatedValues.map { param -> String in
-                if param.label != nil {
-                    return "\(param.encodedName): \(param.encodedName)"
+                if let label = param.label {
+                    return "\(label): \(param.encodedName)"
                 } else {
                     return "\(param.encodedName)"
                 }

--- a/Tests/NewCodableMacrosTests/CodableNamingExpansionTests.swift
+++ b/Tests/NewCodableMacrosTests/CodableNamingExpansionTests.swift
@@ -1,0 +1,630 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import SwiftSyntaxMacrosGenericTestSupport
+import Testing
+import NewCodableMacros
+
+@Suite("CodableNaming Macro Expansion")
+struct CodableNamingExpansionTests {
+
+    // MARK: - Struct fieldNaming Tests
+
+    @Test func structFieldNamingSnakeCase() {
+        AssertMacroExpansion(
+            """
+            @JSONCodable(fieldNaming: .snake_case)
+            struct User {
+                let userName: String
+                let imageURL: String
+                let parseHTTPResponse: Int
+            }
+            """,
+            expandedSource: """
+            struct User {
+                let userName: String
+                let imageURL: String
+                let parseHTTPResponse: Int
+            }
+
+            extension User {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case userName
+                    case imageURL
+                    case parseHTTPResponse
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .userName:
+                            "user_name"
+                        case .imageURL:
+                            "image_url"
+                        case .parseHTTPResponse:
+                            "parse_http_response"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "user_name":
+                            .userName
+                        case "image_url":
+                            .imageURL
+                        case "parse_http_response":
+                            .parseHTTPResponse
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension User: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 3) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: JSONCodingFields.imageURL, value: self.imageURL)
+                        try structEncoder.encode(field: JSONCodingFields.parseHTTPResponse, value: self.parseHTTPResponse)
+                    }
+                }
+            }
+
+            extension User: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> User {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var userName: String?
+                        var imageURL: String?
+                        var parseHTTPResponse: Int?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .userName:
+                                userName = try valueDecoder.decode(String.self)
+                            case .imageURL:
+                                imageURL = try valueDecoder.decode(String.self)
+                            case .parseHTTPResponse:
+                                parseHTTPResponse = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let userName else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'user_name'")
+                        }
+                        guard let imageURL else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'image_url'")
+                        }
+                        guard let parseHTTPResponse else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'parse_http_response'")
+                        }
+                        return User(userName: userName, imageURL: imageURL, parseHTTPResponse: parseHTTPResponse)
+                    }
+                }
+            }
+            """,
+            macros: namingTestMacros
+        )
+    }
+
+    @Test func structFieldNamingPascalCase() {
+        AssertMacroExpansion(
+            """
+            @JSONCodable(fieldNaming: .PascalCase)
+            struct User {
+                let userName: String
+                let imageURL: String
+                let parseHTTPResponse: Int
+            }
+            """,
+            expandedSource: """
+            struct User {
+                let userName: String
+                let imageURL: String
+                let parseHTTPResponse: Int
+            }
+
+            extension User {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case userName
+                    case imageURL
+                    case parseHTTPResponse
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .userName:
+                            "UserName"
+                        case .imageURL:
+                            "ImageUrl"
+                        case .parseHTTPResponse:
+                            "ParseHttpResponse"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "UserName":
+                            .userName
+                        case "ImageUrl":
+                            .imageURL
+                        case "ParseHttpResponse":
+                            .parseHTTPResponse
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension User: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 3) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: JSONCodingFields.imageURL, value: self.imageURL)
+                        try structEncoder.encode(field: JSONCodingFields.parseHTTPResponse, value: self.parseHTTPResponse)
+                    }
+                }
+            }
+
+            extension User: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> User {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var userName: String?
+                        var imageURL: String?
+                        var parseHTTPResponse: Int?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .userName:
+                                userName = try valueDecoder.decode(String.self)
+                            case .imageURL:
+                                imageURL = try valueDecoder.decode(String.self)
+                            case .parseHTTPResponse:
+                                parseHTTPResponse = try valueDecoder.decode(Int.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let userName else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'UserName'")
+                        }
+                        guard let imageURL else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'ImageUrl'")
+                        }
+                        guard let parseHTTPResponse else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'ParseHttpResponse'")
+                        }
+                        return User(userName: userName, imageURL: imageURL, parseHTTPResponse: parseHTTPResponse)
+                    }
+                }
+            }
+            """,
+            macros: namingTestMacros
+        )
+    }
+
+    // MARK: - Struct fieldNaming with @CodingKey Override
+
+    @Test func structFieldNamingWithCodingKeyOverride() {
+        AssertMacroExpansion(
+            """
+            @JSONCodable(fieldNaming: .snake_case)
+            struct User {
+                let userName: String
+                let imageURL: String
+                @CodingKey("custom_email") let emailAddress: String
+            }
+            """,
+            expandedSource: """
+            struct User {
+                let userName: String
+                let imageURL: String
+                let emailAddress: String
+            }
+
+            extension User {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case userName
+                    case imageURL
+                    case emailAddress
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .userName:
+                            "user_name"
+                        case .imageURL:
+                            "image_url"
+                        case .emailAddress:
+                            "custom_email"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "user_name":
+                            .userName
+                        case "image_url":
+                            .imageURL
+                        case "custom_email":
+                            .emailAddress
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension User: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 3) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: JSONCodingFields.imageURL, value: self.imageURL)
+                        try structEncoder.encode(field: JSONCodingFields.emailAddress, value: self.emailAddress)
+                    }
+                }
+            }
+
+            extension User: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> User {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var userName: String?
+                        var imageURL: String?
+                        var emailAddress: String?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .userName:
+                                userName = try valueDecoder.decode(String.self)
+                            case .imageURL:
+                                imageURL = try valueDecoder.decode(String.self)
+                            case .emailAddress:
+                                emailAddress = try valueDecoder.decode(String.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let userName else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'user_name'")
+                        }
+                        guard let imageURL else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'image_url'")
+                        }
+                        guard let emailAddress else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'custom_email'")
+                        }
+                        return User(userName: userName, imageURL: imageURL, emailAddress: emailAddress)
+                    }
+                }
+            }
+            """,
+            macros: namingTestMacros
+        )
+    }
+
+    // MARK: - Struct fieldNaming with @DecodableAlias
+
+    @Test func structFieldNamingWithDecodableAlias() {
+        AssertMacroExpansion(
+            """
+            @JSONCodable(fieldNaming: .snake_case)
+            struct User {
+                @DecodableAlias("legacyUserName") let userName: String
+                let imageURL: String
+            }
+            """,
+            expandedSource: """
+            struct User {
+                let userName: String
+                let imageURL: String
+            }
+
+            extension User {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case userName
+                    case imageURL
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .userName:
+                            "user_name"
+                        case .imageURL:
+                            "image_url"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "user_name":
+                            .userName
+                        case "legacyUserName":
+                            .userName
+                        case "image_url":
+                            .imageURL
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension User: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: JSONCodingFields.userName, value: self.userName)
+                        try structEncoder.encode(field: JSONCodingFields.imageURL, value: self.imageURL)
+                    }
+                }
+            }
+
+            extension User: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> User {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var userName: String?
+                        var imageURL: String?
+                        var _codingField: JSONCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .userName:
+                                userName = try valueDecoder.decode(String.self)
+                            case .imageURL:
+                                imageURL = try valueDecoder.decode(String.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let userName else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'user_name'")
+                        }
+                        guard let imageURL else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'image_url'")
+                        }
+                        return User(userName: userName, imageURL: imageURL)
+                    }
+                }
+            }
+            """,
+            macros: namingTestMacros
+        )
+    }
+
+    // MARK: - Enum caseNaming Tests
+
+    @Test func enumCaseNamingSnakeCase() {
+        AssertMacroExpansion(
+            """
+            @JSONCodable(caseNaming: .snake_case)
+            enum Status {
+                case inProgress
+                case parseHTTPError
+            }
+            """,
+            expandedSource: """
+            enum Status {
+                case inProgress
+                case parseHTTPError
+            }
+
+            extension Status {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case inProgress
+                    case parseHTTPError
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .inProgress:
+                            "in_progress"
+                        case .parseHTTPError:
+                            "parse_http_error"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "in_progress":
+                            .inProgress
+                        case "parse_http_error":
+                            .parseHTTPError
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+                }
+            }
+
+            extension Status: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .inProgress:
+                        try encoder.encodeEnumCase(JSONCodingFields.inProgress)
+                    case .parseHTTPError:
+                        try encoder.encodeEnumCase(JSONCodingFields.parseHTTPError)
+                    }
+                }
+            }
+
+            extension Status: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Status {
+                    var _codingField: JSONCodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .inProgress:
+                            .inProgress
+                        case .parseHTTPError:
+                            .parseHTTPError
+                        }
+                    }
+                }
+            }
+            """,
+            macros: namingTestMacros
+        )
+    }
+
+    // MARK: - Enum caseNaming + associatedValueLabelNaming
+
+    @Test func enumCaseAndAssociatedValueNaming() {
+        AssertMacroExpansion(
+            """
+            @JSONCodable(caseNaming: .snake_case, associatedValueLabelNaming: .snake_case)
+            enum Event {
+                case userLoggedIn(sessionID: String, Int)
+                case parseHTTPError
+            }
+            """,
+            expandedSource: """
+            enum Event {
+                case userLoggedIn(sessionID: String, Int)
+                case parseHTTPError
+            }
+
+            extension Event {
+                enum JSONCodingFields: JSONOptimizedCodingField {
+                    case userLoggedIn
+                    case parseHTTPError
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .userLoggedIn:
+                            "user_logged_in"
+                        case .parseHTTPError:
+                            "parse_http_error"
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> JSONCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "user_logged_in":
+                            .userLoggedIn
+                        case "parse_http_error":
+                            .parseHTTPError
+                        default:
+                            throw CodingError.unknownKey(key)
+                        }
+                    }
+
+                    enum UserLoggedInFields: JSONOptimizedCodingField {
+                        case session_id
+                        case _1
+
+                        @_transparent
+                        var staticString: StaticString {
+                            switch self {
+                            case .session_id:
+                                "session_id"
+                            case ._1:
+                                "_1"
+                            }
+                        }
+
+                        static func field(for key: UTF8Span) throws(CodingError.Decoding) -> UserLoggedInFields {
+                            switch UTF8SpanComparator(key) {
+                            case "session_id":
+                                .session_id
+                            case "_1":
+                                ._1
+                            default:
+                                throw CodingError.unknownKey(key)
+                            }
+                        }
+
+                        static func decode(from decoder: inout some JSONDictionaryDecoder & ~Escapable) throws(CodingError.Decoding) -> Event {
+                            var session_id: String?
+                            var _1: Int?
+                            var _field: UserLoggedInFields?
+                            try decoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                                _field = try fieldDecoder.decode(UserLoggedInFields.self)
+                            } andValue: { valueDecoder throws(CodingError.Decoding) in
+                                switch _field! {
+                                case .session_id:
+                                    session_id = try valueDecoder.decode(String.self)
+                                case ._1:
+                                    _1 = try valueDecoder.decode(Int.self)
+                                }
+                            }
+                            guard let session_id, let _1 else {
+                                throw CodingError.dataCorrupted(debugDescription: "Missing required fields")
+                            }
+                            return .userLoggedIn(sessionID: session_id, _1)
+                        }
+                    }
+                }
+            }
+
+            extension Event: JSONEncodable {
+                func encode(to encoder: inout JSONDirectEncoder) throws(CodingError.Encoding) {
+                    switch self {
+                    case .userLoggedIn(let session_id, let _1):
+                        try encoder.encodeEnumCase(JSONCodingFields.userLoggedIn, associatedValueCount: 2) { valueEncoder throws(CodingError.Encoding) in
+                            try valueEncoder.encode(field: JSONCodingFields.UserLoggedInFields.session_id, value: session_id)
+                            try valueEncoder.encode(field: JSONCodingFields.UserLoggedInFields._1, value: _1)
+                        }
+                    case .parseHTTPError:
+                        try encoder.encodeEnumCase(JSONCodingFields.parseHTTPError)
+                    }
+                }
+            }
+
+            extension Event: JSONDecodable {
+                static func decode(from decoder: inout some JSONDecoderProtocol & ~Escapable) throws(CodingError.Decoding) -> Event {
+                    var _codingField: JSONCodingFields?
+                    return try decoder.decodeEnumCase { fieldDecoder throws(CodingError.Decoding) in
+                        _codingField = try fieldDecoder.decode(JSONCodingFields.self)
+                    } associatedValues: { valuesDecoder throws(CodingError.Decoding) in
+                        return switch _codingField! {
+                        case .userLoggedIn:
+                            try JSONCodingFields.UserLoggedInFields.decode(from: &valuesDecoder)
+                        case .parseHTTPError:
+                            .parseHTTPError
+                        }
+                    }
+                }
+            }
+            """,
+            macros: namingTestMacros
+        )
+    }
+}
+
+private let namingTestMacros: [String: Macro.Type] = [
+    "JSONCodable": JSONCodableMacro.self,
+    "CodingKey": CodingKeyMacro.self,
+    "DecodableAlias": DecodableAliasMacro.self,
+]

--- a/Tests/NewCodableMacrosTests/CodableNamingTests.swift
+++ b/Tests/NewCodableMacrosTests/CodableNamingTests.swift
@@ -1,0 +1,628 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+@testable import NewCodableMacros
+
+// MARK: - splitIntoWords Tests
+
+@Suite("splitIntoWords")
+struct SplitIntoWordsTests {
+
+    // MARK: - camelCase inputs
+
+    @Test func camelCaseSimple() {
+        #expect(splitIntoWords("myProperty") == ["my", "Property"])
+    }
+
+    @Test func camelCaseMultipleWords() {
+        #expect(splitIntoWords("myLongPropertyName") == ["my", "Long", "Property", "Name"])
+    }
+
+    @Test func camelCaseSingleWord() {
+        #expect(splitIntoWords("name") == ["name"])
+    }
+
+    // MARK: - PascalCase inputs
+
+    @Test func pascalCaseSimple() {
+        #expect(splitIntoWords("MyProperty") == ["My", "Property"])
+    }
+
+    @Test func pascalCaseMultipleWords() {
+        #expect(splitIntoWords("MyLongPropertyName") == ["My", "Long", "Property", "Name"])
+    }
+
+    @Test func pascalCaseSingleWord() {
+        #expect(splitIntoWords("Name") == ["Name"])
+    }
+
+    // MARK: - Acronyms
+
+    @Test func acronymAtEnd() {
+        #expect(splitIntoWords("parseJSON") == ["parse", "JSON"])
+    }
+
+    @Test func acronymAtStart() {
+        #expect(splitIntoWords("HTTPResponse") == ["HTTP", "Response"])
+    }
+
+    @Test func acronymInMiddle() {
+        #expect(splitIntoWords("parseHTTPResponse") == ["parse", "HTTP", "Response"])
+    }
+
+    @Test func multipleAcronyms() {
+        #expect(splitIntoWords("convertXMLToJSON") == ["convert", "XML", "To", "JSON"])
+    }
+
+    @Test func acronymFollowedByAcronym() {
+        #expect(splitIntoWords("XMLHTTP") == ["XMLHTTP"])
+    }
+
+    @Test func singleCharacterAtEnd() {
+        #expect(splitIntoWords("singleCharacterAtEndX") == ["single", "Character", "At", "End", "X"])
+    }
+
+    @Test func twoCharacters() {
+        #expect(splitIntoWords("aA") == ["a", "A"])
+    }
+
+    @Test func partialCaps() {
+        #expect(splitIntoWords("partCAPS") == ["part", "CAPS"])
+    }
+
+    @Test func partialCapsSwitchBack() {
+        #expect(splitIntoWords("partCAPSLowerAGAIN") == ["part", "CAPS", "Lower", "AGAIN"])
+    }
+
+    @Test func thisIsAnXMLProperty() {
+        #expect(splitIntoWords("thisIsAnXMLProperty") == ["this", "Is", "An", "XML", "Property"])
+    }
+
+    // MARK: - snake_case inputs
+
+    @Test func snakeCaseSimple() {
+        #expect(splitIntoWords("my_property") == ["my", "property"])
+    }
+
+    @Test func snakeCaseMultipleWords() {
+        #expect(splitIntoWords("my_long_property_name") == ["my", "long", "property", "name"])
+    }
+
+    @Test func screamingSnakeCase() {
+        #expect(splitIntoWords("MY_LONG_PROPERTY") == ["MY", "LONG", "PROPERTY"])
+    }
+
+    // MARK: - Mixed inputs
+
+    @Test func camelCaseWithUnderscores() {
+        #expect(splitIntoWords("myProperty_name") == ["my", "Property", "name"])
+    }
+
+    // MARK: - Numerics
+
+    @Test func numbersInMiddle() {
+        #expect(splitIntoWords("property2Name") == ["property2", "Name"])
+    }
+
+    @Test func numbersAfterUnderscore() {
+        #expect(splitIntoWords("property_2_name") == ["property", "2", "name"])
+    }
+
+    @Test func version4Thing() {
+        #expect(splitIntoWords("version4Thing") == ["version4", "Thing"])
+    }
+
+    @Test func dataPoint22() {
+        #expect(splitIntoWords("dataPoint22") == ["data", "Point22"])
+    }
+
+    @Test func dataPoint22Word() {
+        #expect(splitIntoWords("dataPoint22Word") == ["data", "Point22", "Word"])
+    }
+
+    @Test func one2Three() {
+        #expect(splitIntoWords("one2Three") == ["one2", "Three"])
+    }
+
+    // MARK: - Diacritics
+
+    @Test func diacriticUppercaseTransition() {
+        #expect(splitIntoWords("asdfĆqer") == ["asdf", "Ćqer"])
+    }
+
+    @Test func snakeCaseDiacritic() {
+        #expect(splitIntoWords("snake_ćase") == ["snake", "ćase"])
+    }
+
+    @Test func snakeCaseCapitalizedDiacritic() {
+        #expect(splitIntoWords("snake_Ćase") == ["snake", "Ćase"])
+    }
+
+    // MARK: - Edge cases
+
+    @Test func emptyString() {
+        #expect(splitIntoWords("") == [])
+    }
+
+    @Test func singleCharacterLowercase() {
+        #expect(splitIntoWords("x") == ["x"])
+    }
+
+    @Test func singleCharacterUppercase() {
+        #expect(splitIntoWords("X") == ["X"])
+    }
+
+    @Test func allUppercase() {
+        #expect(splitIntoWords("URL") == ["URL"])
+    }
+
+    @Test func allLowercase() {
+        #expect(splitIntoWords("lowercase") == ["lowercase"])
+    }
+
+    @Test func consecutiveUnderscores() {
+        #expect(splitIntoWords("my__property") == ["my", "property"])
+    }
+
+    @Test func leadingUnderscore() {
+        #expect(splitIntoWords("_myProperty") == ["my", "Property"])
+    }
+
+    @Test func trailingUnderscore() {
+        #expect(splitIntoWords("myProperty_") == ["my", "Property"])
+    }
+
+    @Test func multipleLeadingUnderscores() {
+        #expect(splitIntoWords("__myProperty") == ["my", "Property"])
+    }
+
+    @Test func onlyUnderscores() {
+        #expect(splitIntoWords("___") == [])
+    }
+}
+
+// MARK: - applyNamingConvention Tests
+
+@Suite("applyNamingConvention")
+struct ApplyNamingConventionTests {
+
+    /// Each group represents the same conceptual words expressed in every valid Swift identifier format.
+    /// This ensures a true cross-product: every concept × every input format × every output convention.
+    ///
+    /// Inputs are limited to formats that are valid Swift identifiers:
+    /// camelCase, PascalCase, snake_case, and SCREAMING_SNAKE_CASE.
+    struct ConceptGroup {
+        let label: String
+        let camelCase: String
+        let pascalCase: String
+        let snakeCase: String
+        let screamingSnakeCase: String
+
+        // Expected outputs for this concept under each target convention
+        let toCamelCase: String
+        let toPascalCase: String
+        let toSnakeCase: String
+        let toScreamingSnakeCase: String
+        let toKebabCase: String
+        let toScreamingKebabCase: String
+        let toLowercase: String
+        let toUppercase: String
+
+        var allInputs: [(label: String, input: String)] {
+            [
+                ("\(label)/camelCase", camelCase),
+                ("\(label)/PascalCase", pascalCase),
+                ("\(label)/snake_case", snakeCase),
+                ("\(label)/SCREAMING_SNAKE_CASE", screamingSnakeCase),
+            ]
+        }
+    }
+
+    static let concepts: [ConceptGroup] = [
+        // Two simple words
+        ConceptGroup(label: "twoWords",
+            camelCase: "myProperty",
+            pascalCase: "MyProperty",
+            snakeCase: "my_property",
+            screamingSnakeCase: "MY_PROPERTY",
+
+            toCamelCase: "myProperty",
+            toPascalCase: "MyProperty",
+            toSnakeCase: "my_property",
+            toScreamingSnakeCase: "MY_PROPERTY",
+            toKebabCase: "my-property",
+            toScreamingKebabCase: "MY-PROPERTY",
+            toLowercase: "myproperty",
+            toUppercase: "MYPROPERTY"
+        ),
+        // Four words
+        ConceptGroup(label: "fourWords",
+            camelCase: "myLongPropertyName",
+            pascalCase: "MyLongPropertyName",
+            snakeCase: "my_long_property_name",
+            screamingSnakeCase: "MY_LONG_PROPERTY_NAME",
+
+            toCamelCase: "myLongPropertyName",
+            toPascalCase: "MyLongPropertyName",
+            toSnakeCase: "my_long_property_name",
+            toScreamingSnakeCase: "MY_LONG_PROPERTY_NAME",
+            toKebabCase: "my-long-property-name",
+            toScreamingKebabCase: "MY-LONG-PROPERTY-NAME",
+            toLowercase: "mylongpropertyname",
+            toUppercase: "MYLONGPROPERTYNAME"
+        ),
+        // Acronym in middle
+        ConceptGroup(label: "acronymMiddle",
+            camelCase: "parseHTTPResponse",
+            pascalCase: "ParseHTTPResponse",
+            snakeCase: "parse_http_response",
+            screamingSnakeCase: "PARSE_HTTP_RESPONSE",
+
+            toCamelCase: "parseHttpResponse",
+            toPascalCase: "ParseHttpResponse",
+            toSnakeCase: "parse_http_response",
+            toScreamingSnakeCase: "PARSE_HTTP_RESPONSE",
+            toKebabCase: "parse-http-response",
+            toScreamingKebabCase: "PARSE-HTTP-RESPONSE",
+            toLowercase: "parsehttpresponse",
+            toUppercase: "PARSEHTTPRESPONSE"
+        ),
+        // Acronym at end
+        ConceptGroup(label: "acronymEnd",
+            camelCase: "imageURL",
+            pascalCase: "ImageURL",
+            snakeCase: "image_url",
+            screamingSnakeCase: "IMAGE_URL",
+
+            toCamelCase: "imageUrl",
+            toPascalCase: "ImageUrl",
+            toSnakeCase: "image_url",
+            toScreamingSnakeCase: "IMAGE_URL",
+            toKebabCase: "image-url",
+            toScreamingKebabCase: "IMAGE-URL",
+            toLowercase: "imageurl",
+            toUppercase: "IMAGEURL"
+        ),
+        // Numeric in middle
+        ConceptGroup(label: "numericMiddle",
+            camelCase: "version4Thing",
+            pascalCase: "Version4Thing",
+            snakeCase: "version4_thing",
+            screamingSnakeCase: "VERSION4_THING",
+
+            toCamelCase: "version4Thing",
+            toPascalCase: "Version4Thing",
+            toSnakeCase: "version4_thing",
+            toScreamingSnakeCase: "VERSION4_THING",
+            toKebabCase: "version4-thing",
+            toScreamingKebabCase: "VERSION4-THING",
+            toLowercase: "version4thing",
+            toUppercase: "VERSION4THING"
+        ),
+        // Numeric at end
+        ConceptGroup(label: "numericEnd",
+            camelCase: "dataPoint22",
+            pascalCase: "DataPoint22",
+            snakeCase: "data_point22",
+            screamingSnakeCase: "DATA_POINT22",
+
+            toCamelCase: "dataPoint22",
+            toPascalCase: "DataPoint22",
+            toSnakeCase: "data_point22",
+            toScreamingSnakeCase: "DATA_POINT22",
+            toKebabCase: "data-point22",
+            toScreamingKebabCase: "DATA-POINT22",
+            toLowercase: "datapoint22",
+            toUppercase: "DATAPOINT22"
+        ),
+        // Acronym at start
+        ConceptGroup(label: "acronymStart",
+            camelCase: "httpResponse",
+            pascalCase: "HTTPResponse",
+            snakeCase: "http_response",
+            screamingSnakeCase: "HTTP_RESPONSE",
+
+            toCamelCase: "httpResponse",
+            toPascalCase: "HttpResponse",
+            toSnakeCase: "http_response",
+            toScreamingSnakeCase: "HTTP_RESPONSE",
+            toKebabCase: "http-response",
+            toScreamingKebabCase: "HTTP-RESPONSE",
+            toLowercase: "httpresponse",
+            toUppercase: "HTTPRESPONSE"
+        ),
+        // Longer acronym in middle of longer phrase
+        ConceptGroup(label: "xmlInPhrase",
+            camelCase: "thisIsAnXMLProperty",
+            pascalCase: "ThisIsAnXMLProperty",
+            snakeCase: "this_is_an_xml_property",
+            screamingSnakeCase: "THIS_IS_AN_XML_PROPERTY",
+
+            toCamelCase: "thisIsAnXmlProperty",
+            toPascalCase: "ThisIsAnXmlProperty",
+            toSnakeCase: "this_is_an_xml_property",
+            toScreamingSnakeCase: "THIS_IS_AN_XML_PROPERTY",
+            toKebabCase: "this-is-an-xml-property",
+            toScreamingKebabCase: "THIS-IS-AN-XML-PROPERTY",
+            toLowercase: "thisisanxmlproperty",
+            toUppercase: "THISISANXMLPROPERTY"
+        ),
+        // Single word
+        ConceptGroup(label: "singleWord",
+            camelCase: "single",
+            pascalCase: "Single",
+            snakeCase: "single",
+            screamingSnakeCase: "SINGLE",
+
+            toCamelCase: "single",
+            toPascalCase: "Single",
+            toSnakeCase: "single",
+            toScreamingSnakeCase: "SINGLE",
+            toKebabCase: "single",
+            toScreamingKebabCase: "SINGLE",
+            toLowercase: "single",
+            toUppercase: "SINGLE"
+        ),
+        // Single word that's an all-caps acronym
+        ConceptGroup(label: "singleWordAllCaps",
+            camelCase: "url",
+            pascalCase: "Url",
+            snakeCase: "url",
+            screamingSnakeCase: "URL",
+
+            toCamelCase: "url",
+            toPascalCase: "Url",
+            toSnakeCase: "url",
+            toScreamingSnakeCase: "URL",
+            toKebabCase: "url",
+            toScreamingKebabCase: "URL",
+            toLowercase: "url",
+            toUppercase: "URL"
+        ),
+        // Single character
+        ConceptGroup(label: "singleChar",
+            camelCase: "x",
+            pascalCase: "X",
+            snakeCase: "x",
+            screamingSnakeCase: "X",
+
+            toCamelCase: "x",
+            toPascalCase: "X",
+            toSnakeCase: "x",
+            toScreamingSnakeCase: "X",
+            toKebabCase: "x",
+            toScreamingKebabCase: "X",
+            toLowercase: "x",
+            toUppercase: "X"
+        ),
+        // Diacritic word boundary
+        ConceptGroup(label: "diacritic",
+            camelCase: "asdfĆqer",
+            pascalCase: "AsdfĆqer",
+            snakeCase: "asdf_ćqer",
+            screamingSnakeCase: "ASDF_ĆQER",
+
+            toCamelCase: "asdfĆqer",
+            toPascalCase: "AsdfĆqer",
+            toSnakeCase: "asdf_ćqer",
+            toScreamingSnakeCase: "ASDF_ĆQER",
+            toKebabCase: "asdf-ćqer",
+            toScreamingKebabCase: "ASDF-ĆQER",
+            toLowercase: "asdfćqer",
+            toUppercase: "ASDFĆQER"
+        ),
+        // Partial caps (word + all-caps tail)
+        ConceptGroup(label: "partialCaps",
+            camelCase: "partCAPS",
+            pascalCase: "PartCAPS",
+            snakeCase: "part_caps",
+            screamingSnakeCase: "PART_CAPS",
+
+            toCamelCase: "partCaps",
+            toPascalCase: "PartCaps",
+            toSnakeCase: "part_caps",
+            toScreamingSnakeCase: "PART_CAPS",
+            toKebabCase: "part-caps",
+            toScreamingKebabCase: "PART-CAPS",
+            toLowercase: "partcaps",
+            toUppercase: "PARTCAPS"
+        ),
+        // Partial caps switching back
+        ConceptGroup(label: "partialCapsSwitchBack",
+            camelCase: "partCAPSLowerAGAIN",
+            pascalCase: "PartCAPSLowerAGAIN",
+            snakeCase: "part_caps_lower_again",
+            screamingSnakeCase: "PART_CAPS_LOWER_AGAIN",
+
+            toCamelCase: "partCapsLowerAgain",
+            toPascalCase: "PartCapsLowerAgain",
+            toSnakeCase: "part_caps_lower_again",
+            toScreamingSnakeCase: "PART_CAPS_LOWER_AGAIN",
+            toKebabCase: "part-caps-lower-again",
+            toScreamingKebabCase: "PART-CAPS-LOWER-AGAIN",
+            toLowercase: "partcapsloweragain",
+            toUppercase: "PARTCAPSLOWERAGAIN"
+        ),
+    ]
+
+    // Flatten all concept inputs for parameterized tests.
+    // Each entry: (label, input, expected for that convention).
+    static let allCamelCaseCases: [(label: String, input: String, expected: String)] = concepts.flatMap { concept in
+        concept.allInputs.map { ($0.label, $0.input, concept.toCamelCase) }
+    }
+
+    static let allPascalCaseCases: [(label: String, input: String, expected: String)] = concepts.flatMap { concept in
+        concept.allInputs.map { ($0.label, $0.input, concept.toPascalCase) }
+    }
+
+    static let allSnakeCaseCases: [(label: String, input: String, expected: String)] = concepts.flatMap { concept in
+        concept.allInputs.map { ($0.label, $0.input, concept.toSnakeCase) }
+    }
+
+    static let allScreamingSnakeCaseCases: [(label: String, input: String, expected: String)] = concepts.flatMap { concept in
+        concept.allInputs.map { ($0.label, $0.input, concept.toScreamingSnakeCase) }
+    }
+
+    static let allKebabCaseCases: [(label: String, input: String, expected: String)] = concepts.flatMap { concept in
+        concept.allInputs.map { ($0.label, $0.input, concept.toKebabCase) }
+    }
+
+    static let allScreamingKebabCaseCases: [(label: String, input: String, expected: String)] = concepts.flatMap { concept in
+        concept.allInputs.map { ($0.label, $0.input, concept.toScreamingKebabCase) }
+    }
+
+    static let allLowercaseCases: [(label: String, input: String, expected: String)] = concepts.flatMap { concept in
+        concept.allInputs.map { ($0.label, $0.input, concept.toLowercase) }
+    }
+
+    static let allUppercaseCases: [(label: String, input: String, expected: String)] = concepts.flatMap { concept in
+        concept.allInputs.map { ($0.label, $0.input, concept.toUppercase) }
+    }
+
+    // MARK: - Full matrix tests
+
+    @Test(arguments: allCamelCaseCases)
+    func camelCase(label: String, input: String, expected: String) {
+        #expect(
+            applyNamingConvention(input, convention: .camelCase) == expected,
+            "\(label): \"\(input)\" → camelCase should be \"\(expected)\""
+        )
+    }
+
+    @Test(arguments: allPascalCaseCases)
+    func pascalCase(label: String, input: String, expected: String) {
+        #expect(
+            applyNamingConvention(input, convention: .PascalCase) == expected,
+            "\(label): \"\(input)\" → PascalCase should be \"\(expected)\""
+        )
+    }
+
+    @Test(arguments: allSnakeCaseCases)
+    func snakeCase(label: String, input: String, expected: String) {
+        #expect(
+            applyNamingConvention(input, convention: .snake_case) == expected,
+            "\(label): \"\(input)\" → snake_case should be \"\(expected)\""
+        )
+    }
+
+    @Test(arguments: allScreamingSnakeCaseCases)
+    func screamingSnakeCase(label: String, input: String, expected: String) {
+        #expect(
+            applyNamingConvention(input, convention: .SCREAMING_SNAKE_CASE) == expected,
+            "\(label): \"\(input)\" → SCREAMING_SNAKE_CASE should be \"\(expected)\""
+        )
+    }
+
+    @Test(arguments: allKebabCaseCases)
+    func kebabCase(label: String, input: String, expected: String) {
+        #expect(
+            applyNamingConvention(input, convention: .kebab_case) == expected,
+            "\(label): \"\(input)\" → kebab-case should be \"\(expected)\""
+        )
+    }
+
+    @Test(arguments: allScreamingKebabCaseCases)
+    func screamingKebabCase(label: String, input: String, expected: String) {
+        #expect(
+            applyNamingConvention(input, convention: .SCREAMING_KEBAB_CASE) == expected,
+            "\(label): \"\(input)\" → SCREAMING-KEBAB-CASE should be \"\(expected)\""
+        )
+    }
+
+    @Test(arguments: allLowercaseCases)
+    func lowercase(label: String, input: String, expected: String) {
+        #expect(
+            applyNamingConvention(input, convention: .lowercase) == expected,
+            "\(label): \"\(input)\" → lowercase should be \"\(expected)\""
+        )
+    }
+
+    @Test(arguments: allUppercaseCases)
+    func uppercase(label: String, input: String, expected: String) {
+        #expect(
+            applyNamingConvention(input, convention: .UPPERCASE) == expected,
+            "\(label): \"\(input)\" → UPPERCASE should be \"\(expected)\""
+        )
+    }
+
+    // MARK: - .default convention (pass-through)
+
+    @Test(arguments: concepts.flatMap(\.allInputs))
+    func defaultReturnsOriginal(label: String, input: String) {
+        #expect(applyNamingConvention(input, convention: .default) == input)
+    }
+
+    // MARK: - Leading/trailing underscore preservation
+
+    @Test func leadingUnderscoreSnakeCase() {
+        #expect(applyNamingConvention("_myProperty", convention: .snake_case) == "_my_property")
+    }
+
+    @Test func trailingUnderscoreSnakeCase() {
+        #expect(applyNamingConvention("myProperty_", convention: .snake_case) == "my_property_")
+    }
+
+    @Test func bothLeadingAndTrailingUnderscores() {
+        #expect(applyNamingConvention("_myProperty_", convention: .snake_case) == "_my_property_")
+    }
+
+    @Test func multipleLeadingUnderscores() {
+        #expect(applyNamingConvention("__myProperty", convention: .snake_case) == "__my_property")
+    }
+
+    @Test func multipleTrailingUnderscores() {
+        #expect(applyNamingConvention("myProperty__", convention: .snake_case) == "my_property__")
+    }
+
+    @Test func multipleLeadingAndTrailingUnderscores() {
+        #expect(applyNamingConvention("__myProperty__", convention: .snake_case) == "__my_property__")
+    }
+
+    @Test func leadingUnderscorePascalCase() {
+        #expect(applyNamingConvention("_myProperty", convention: .PascalCase) == "_MyProperty")
+    }
+
+    @Test func leadingUnderscoreCamelCase() {
+        #expect(applyNamingConvention("_MyProperty", convention: .camelCase) == "_myProperty")
+    }
+
+    @Test func leadingUnderscoreKebabCase() {
+        #expect(applyNamingConvention("_myProperty", convention: .kebab_case) == "_my-property")
+    }
+
+    @Test func leadingUnderscoreUppercase() {
+        #expect(applyNamingConvention("_myProperty", convention: .UPPERCASE) == "_MYPROPERTY")
+    }
+
+    @Test func leadingUnderscoreScreamingSnakeCase() {
+        #expect(applyNamingConvention("_oneTwoThree", convention: .SCREAMING_SNAKE_CASE) == "_ONE_TWO_THREE")
+    }
+
+    @Test func allUnderscoresReturnsOriginal() {
+        #expect(applyNamingConvention("___", convention: .snake_case) == "___")
+    }
+
+    @Test func singleUnderscoreReturnsOriginal() {
+        #expect(applyNamingConvention("_", convention: .snake_case) == "_")
+    }
+
+    @Test func doubleUnderscoreReturnsOriginal() {
+        #expect(applyNamingConvention("__", convention: .camelCase) == "__")
+    }
+
+    // MARK: - Edge cases
+
+    @Test func emptyString() {
+        #expect(applyNamingConvention("", convention: .snake_case) == "")
+    }
+}

--- a/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/JSONMacroIntegrationTests.swift
@@ -450,3 +450,502 @@ struct CombinedMacroIntegrationTests {
         #expect(jsonString == commonString)
     }
 }
+
+// MARK: - Naming Convention Integration Tests
+
+// Each struct below uses the same comprehensive set of field names to exercise
+// word splitting edge cases (single char, single word, all-caps, numerics,
+// leading underscores, diacritics, emoji) across every naming strategy.
+
+@JSONCodable(fieldNaming: .snake_case)
+struct SnakeCaseNamingChecks: Equatable {
+    let a: Int
+    let single: Int
+    let ALLCAPS: Int
+    let ALL_CAPS: Int
+    let userName: String
+    let parseHTTPResponse: Int
+    let one2Three: Int
+    let one2three: Int
+    let camelCaseField: String
+    let _myField: Int
+    let __doubleUnderscore: Int
+    let snake_ćase: String
+    let _one_two_three_: Int
+    let caféName: String
+    let data📦Size: Int
+}
+
+@JSONCodable(fieldNaming: .SCREAMING_SNAKE_CASE)
+struct ScreamingSnakeCaseNamingChecks: Equatable {
+    let a: Int
+    let single: Int
+    let ALLCAPS: Int
+    let ALL_CAPS: Int
+    let userName: String
+    let parseHTTPResponse: Int
+    let one2Three: Int
+    let one2three: Int
+    let camelCaseField: String
+    let _myField: Int
+    let __doubleUnderscore: Int
+    let snake_ćase: String
+    let _one_two_three_: Int
+    let caféName: String
+    let data📦Size: Int
+}
+
+@JSONCodable(fieldNaming: .kebab_case)
+struct KebabCaseNamingChecks: Equatable {
+    let a: Int
+    let single: Int
+    let ALLCAPS: Int
+    let ALL_CAPS: Int
+    let userName: String
+    let parseHTTPResponse: Int
+    let one2Three: Int
+    let one2three: Int
+    let camelCaseField: String
+    let _myField: Int
+    let __doubleUnderscore: Int
+    let snake_ćase: String
+    let _one_two_three_: Int
+    let caféName: String
+    let data📦Size: Int
+}
+
+@JSONCodable(fieldNaming: .SCREAMING_KEBAB_CASE)
+struct ScreamingKebabCaseNamingChecks: Equatable {
+    let a: Int
+    let single: Int
+    let ALLCAPS: Int
+    let ALL_CAPS: Int
+    let userName: String
+    let parseHTTPResponse: Int
+    let one2Three: Int
+    let one2three: Int
+    let camelCaseField: String
+    let _myField: Int
+    let __doubleUnderscore: Int
+    let snake_ćase: String
+    let _one_two_three_: Int
+    let caféName: String
+    let data📦Size: Int
+}
+
+@JSONCodable(fieldNaming: .PascalCase)
+struct PascalCaseNamingChecks: Equatable {
+    let a: Int
+    let single: Int
+    let ALLCAPS: Int
+    let ALL_CAPS: Int
+    let userName: String
+    let parseHTTPResponse: Int
+    let one2Three: Int
+    let one2three: Int
+    let camelCaseField: String
+    let _myField: Int
+    let __doubleUnderscore: Int
+    let snake_ćase: String
+    let _one_two_three_: Int
+    let caféName: String
+    let data📦Size: Int
+}
+
+@JSONCodable(fieldNaming: .camelCase)
+struct CamelCaseNamingChecks: Equatable {
+    let A: Int
+    let Single: Int
+    let ALLCAPS: Int
+    let ALL_CAPS: Int
+    let UserName: String
+    let ParseHTTPResponse: Int
+    let One2Three: Int
+    let One2three: Int
+    let CamelCaseField: String
+    let _MyField: Int
+    let __DoubleUnderscore: Int
+    let Snake_Ćase: String
+    let _One_Two_Three_: Int
+    let CaféName: String
+    let Data📦Size: Int
+}
+
+@JSONCodable(fieldNaming: .lowercase)
+struct LowercaseNamingChecks: Equatable {
+    let a: Int
+    let single: Int
+    let ALLCAPS: Int
+    let userName: String
+    let parseHTTPResponse: Int
+    let one2Three: Int
+    let camelCaseField: String
+    let _myField: Int
+    let __doubleUnderscore: Int
+    let snake_ćase: String
+    let _one_two_three_: Int
+    let caféName: String
+    let data📦Size: Int
+}
+
+@JSONCodable(fieldNaming: .UPPERCASE)
+struct UppercaseNamingChecks: Equatable {
+    let a: Int
+    let single: Int
+    let ALLCAPS: Int
+    let userName: String
+    let parseHTTPResponse: Int
+    let one2Three: Int
+    let camelCaseField: String
+    let _myField: Int
+    let __doubleUnderscore: Int
+    let snake_ćase: String
+    let _one_two_three_: Int
+    let caféName: String
+    let data📦Size: Int
+}
+
+@JSONCodable(fieldNaming: .snake_case)
+struct NamingWithCodingKeyOverride: Equatable {
+    let userName: String
+    @CodingKey("custom_email") let emailAddress: String
+}
+
+@JSONCodable(caseNaming: .snake_case)
+enum SnakeCaseEnum: Equatable {
+    case myCase
+    case anotherLongCase
+}
+
+@JSONCodable(caseNaming: .SCREAMING_SNAKE_CASE)
+enum ScreamingSnakeCaseEnum: Equatable {
+    case myCase
+    case anotherLongCase
+}
+
+@JSONCodable(caseNaming: .kebab_case)
+enum KebabCaseEnum: Equatable {
+    case myCase
+    case anotherLongCase
+}
+
+@JSONCodable(caseNaming: .snake_case, associatedValueLabelNaming: .snake_case)
+enum SnakeCaseEnumWithAssocValues: Equatable {
+    case userProfile(firstName: String, lastName: String)
+    case errorCode(Int)
+}
+
+@JSONCodable(caseNaming: .snake_case)
+enum SnakeCaseEnumWithCodingKeyOverride: Equatable {
+    @CodingKey("custom_case") case myCase
+    case anotherLongCase
+}
+
+@Suite("Naming Convention Integration")
+struct NamingConventionIntegrationTests {
+
+    // MARK: - Struct fieldNaming tests
+
+    @Test func structSnakeCase() throws {
+        let original = SnakeCaseNamingChecks(
+            a: 1, single: 2, ALLCAPS: 3, ALL_CAPS: 9, userName: "alice",
+            parseHTTPResponse: 200, one2Three: 4, one2three: 5,
+            camelCaseField: "x", _myField: 6, __doubleUnderscore: 7,
+            snake_ćase: "ć", _one_two_three_: 10, caféName: "Café", data📦Size: 8
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains(#""a":1"#))
+        #expect(json.contains(#""single":2"#))
+        #expect(json.contains(#""allcaps":3"#))
+        #expect(json.contains(#""all_caps":9"#))
+        #expect(json.contains(#""user_name":"alice""#))
+        #expect(json.contains(#""parse_http_response":200"#))
+        #expect(json.contains(#""one2_three":4"#))
+        #expect(json.contains(#""one2three":5"#))
+        #expect(json.contains(#""camel_case_field":"x""#))
+        #expect(json.contains(#""_my_field":6"#))
+        #expect(json.contains(#""__double_underscore":7"#))
+        #expect(json.contains(#""snake_ćase":"ć""#))
+        #expect(json.contains(#""_one_two_three_":10"#))
+        #expect(json.contains(#""café_name":"Café""#))
+        #expect(json.contains(#""data📦_size":8"#))
+        let decoded = try NewJSONDecoder().decode(SnakeCaseNamingChecks.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func structScreamingSnakeCase() throws {
+        let original = ScreamingSnakeCaseNamingChecks(
+            a: 1, single: 2, ALLCAPS: 3, ALL_CAPS: 9, userName: "alice",
+            parseHTTPResponse: 200, one2Three: 4, one2three: 5,
+            camelCaseField: "x", _myField: 6, __doubleUnderscore: 7,
+            snake_ćase: "ć", _one_two_three_: 10, caféName: "Café", data📦Size: 8
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains(#""A":1"#))
+        #expect(json.contains(#""SINGLE":2"#))
+        #expect(json.contains(#""ALLCAPS":3"#))
+        #expect(json.contains(#""ALL_CAPS":9"#))
+        #expect(json.contains(#""USER_NAME":"alice""#))
+        #expect(json.contains(#""PARSE_HTTP_RESPONSE":200"#))
+        #expect(json.contains(#""ONE2_THREE":4"#))
+        #expect(json.contains(#""ONE2THREE":5"#))
+        #expect(json.contains(#""CAMEL_CASE_FIELD":"x""#))
+        #expect(json.contains(#""_MY_FIELD":6"#))
+        #expect(json.contains(#""__DOUBLE_UNDERSCORE":7"#))
+        #expect(json.contains(#""SNAKE_ĆASE":"ć""#))
+        #expect(json.contains(#""_ONE_TWO_THREE_":10"#))
+        #expect(json.contains(#""CAFÉ_NAME":"Café""#))
+        #expect(json.contains(#""DATA📦_SIZE":8"#))
+        let decoded = try NewJSONDecoder().decode(ScreamingSnakeCaseNamingChecks.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func structKebabCase() throws {
+        let original = KebabCaseNamingChecks(
+            a: 1, single: 2, ALLCAPS: 3, ALL_CAPS: 9, userName: "alice",
+            parseHTTPResponse: 200, one2Three: 4, one2three: 5,
+            camelCaseField: "x", _myField: 6, __doubleUnderscore: 7,
+            snake_ćase: "ć", _one_two_three_: 10, caféName: "Café", data📦Size: 8
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains(#""a":1"#))
+        #expect(json.contains(#""single":2"#))
+        #expect(json.contains(#""allcaps":3"#))
+        #expect(json.contains(#""all-caps":9"#))
+        #expect(json.contains(#""user-name":"alice""#))
+        #expect(json.contains(#""parse-http-response":200"#))
+        #expect(json.contains(#""one2-three":4"#))
+        #expect(json.contains(#""one2three":5"#))
+        #expect(json.contains(#""camel-case-field":"x""#))
+        #expect(json.contains(#""_my-field":6"#))
+        #expect(json.contains(#""__double-underscore":7"#))
+        #expect(json.contains(#""snake-ćase":"ć""#))
+        #expect(json.contains(#""_one-two-three_":10"#))
+        #expect(json.contains(#""café-name":"Café""#))
+        #expect(json.contains(#""data📦-size":8"#))
+        let decoded = try NewJSONDecoder().decode(KebabCaseNamingChecks.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func structScreamingKebabCase() throws {
+        let original = ScreamingKebabCaseNamingChecks(
+            a: 1, single: 2, ALLCAPS: 3, ALL_CAPS: 9, userName: "alice",
+            parseHTTPResponse: 200, one2Three: 4, one2three: 5,
+            camelCaseField: "x", _myField: 6, __doubleUnderscore: 7,
+            snake_ćase: "ć", _one_two_three_: 10, caféName: "Café", data📦Size: 8
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains(#""A":1"#))
+        #expect(json.contains(#""SINGLE":2"#))
+        #expect(json.contains(#""ALLCAPS":3"#))
+        #expect(json.contains(#""ALL-CAPS":9"#))
+        #expect(json.contains(#""USER-NAME":"alice""#))
+        #expect(json.contains(#""PARSE-HTTP-RESPONSE":200"#))
+        #expect(json.contains(#""ONE2-THREE":4"#))
+        #expect(json.contains(#""ONE2THREE":5"#))
+        #expect(json.contains(#""CAMEL-CASE-FIELD":"x""#))
+        #expect(json.contains(#""_MY-FIELD":6"#))
+        #expect(json.contains(#""__DOUBLE-UNDERSCORE":7"#))
+        #expect(json.contains(#""SNAKE-ĆASE":"ć""#))
+        #expect(json.contains(#""_ONE-TWO-THREE_":10"#))
+        #expect(json.contains(#""CAFÉ-NAME":"Café""#))
+        #expect(json.contains(#""DATA📦-SIZE":8"#))
+        let decoded = try NewJSONDecoder().decode(ScreamingKebabCaseNamingChecks.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func structPascalCase() throws {
+        let original = PascalCaseNamingChecks(
+            a: 1, single: 2, ALLCAPS: 3, ALL_CAPS: 9, userName: "alice",
+            parseHTTPResponse: 200, one2Three: 4, one2three: 5,
+            camelCaseField: "x", _myField: 6, __doubleUnderscore: 7,
+            snake_ćase: "ć", _one_two_three_: 10, caféName: "Café", data📦Size: 8
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains(#""A":1"#))
+        #expect(json.contains(#""Single":2"#))
+        #expect(json.contains(#""Allcaps":3"#))
+        #expect(json.contains(#""AllCaps":9"#))
+        #expect(json.contains(#""UserName":"alice""#))
+        #expect(json.contains(#""ParseHttpResponse":200"#))
+        #expect(json.contains(#""One2Three":4"#))
+        #expect(json.contains(#""One2three":5"#))
+        #expect(json.contains(#""CamelCaseField":"x""#))
+        #expect(json.contains(#""_MyField":6"#))
+        #expect(json.contains(#""__DoubleUnderscore":7"#))
+        #expect(json.contains(#""SnakeĆase":"ć""#))
+        #expect(json.contains(#""_OneTwoThree_":10"#))
+        #expect(json.contains(#""CaféName":"Café""#))
+        #expect(json.contains(#""Data📦Size":8"#))
+        let decoded = try NewJSONDecoder().decode(PascalCaseNamingChecks.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func structCamelCase() throws {
+        let original = CamelCaseNamingChecks(
+            A: 1, Single: 2, ALLCAPS: 3, ALL_CAPS: 9, UserName: "alice",
+            ParseHTTPResponse: 200, One2Three: 4, One2three: 5,
+            CamelCaseField: "x", _MyField: 6, __DoubleUnderscore: 7,
+            Snake_Ćase: "ć", _One_Two_Three_: 10, CaféName: "Café", Data📦Size: 8
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains(#""a":1"#))
+        #expect(json.contains(#""single":2"#))
+        #expect(json.contains(#""allcaps":3"#))
+        #expect(json.contains(#""allCaps":9"#))
+        #expect(json.contains(#""userName":"alice""#))
+        #expect(json.contains(#""parseHttpResponse":200"#))
+        #expect(json.contains(#""one2Three":4"#))
+        #expect(json.contains(#""one2three":5"#))
+        #expect(json.contains(#""camelCaseField":"x""#))
+        #expect(json.contains(#""_myField":6"#))
+        #expect(json.contains(#""__doubleUnderscore":7"#))
+        #expect(json.contains(#""snakeĆase":"ć""#))
+        #expect(json.contains(#""_oneTwoThree_":10"#))
+        #expect(json.contains(#""caféName":"Café""#))
+        #expect(json.contains(#""data📦Size":8"#))
+        let decoded = try NewJSONDecoder().decode(CamelCaseNamingChecks.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func structLowercase() throws {
+        let original = LowercaseNamingChecks(
+            a: 1, single: 2, ALLCAPS: 3, userName: "alice",
+            parseHTTPResponse: 200, one2Three: 4,
+            camelCaseField: "x", _myField: 6, __doubleUnderscore: 7,
+            snake_ćase: "ć", _one_two_three_: 10, caféName: "Café", data📦Size: 8
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains(#""a":1"#))
+        #expect(json.contains(#""single":2"#))
+        #expect(json.contains(#""allcaps":3"#))
+        #expect(json.contains(#""username":"alice""#))
+        #expect(json.contains(#""parsehttpresponse":200"#))
+        #expect(json.contains(#""one2three":4"#))
+        #expect(json.contains(#""camelcasefield":"x""#))
+        #expect(json.contains(#""_myfield":6"#))
+        #expect(json.contains(#""__doubleunderscore":7"#))
+        #expect(json.contains(#""snakećase":"ć""#))
+        #expect(json.contains(#""_onetwothree_":10"#))
+        #expect(json.contains(#""caféname":"Café""#))
+        #expect(json.contains(#""data📦size":8"#))
+        let decoded = try NewJSONDecoder().decode(LowercaseNamingChecks.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func structUppercase() throws {
+        let original = UppercaseNamingChecks(
+            a: 1, single: 2, ALLCAPS: 3, userName: "alice",
+            parseHTTPResponse: 200, one2Three: 4,
+            camelCaseField: "x", _myField: 6, __doubleUnderscore: 7,
+            snake_ćase: "ć", _one_two_three_: 10, caféName: "Café", data📦Size: 8
+        )
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains(#""A":1"#))
+        #expect(json.contains(#""SINGLE":2"#))
+        #expect(json.contains(#""ALLCAPS":3"#))
+        #expect(json.contains(#""USERNAME":"alice""#))
+        #expect(json.contains(#""PARSEHTTPRESPONSE":200"#))
+        #expect(json.contains(#""ONE2THREE":4"#))
+        #expect(json.contains(#""CAMELCASEFIELD":"x""#))
+        #expect(json.contains(#""_MYFIELD":6"#))
+        #expect(json.contains(#""__DOUBLEUNDERSCORE":7"#))
+        #expect(json.contains(#""SNAKEĆASE":"ć""#))
+        #expect(json.contains(#""_ONETWOTHREE_":10"#))
+        #expect(json.contains(#""CAFÉNAME":"Café""#))
+        #expect(json.contains(#""DATA📦SIZE":8"#))
+        let decoded = try NewJSONDecoder().decode(UppercaseNamingChecks.self, from: data)
+        #expect(decoded == original)
+    }
+
+    // MARK: - CodingKey override
+
+    @Test func codingKeyOverridesNamingConvention() throws {
+        let original = NamingWithCodingKeyOverride(userName: "alice", emailAddress: "a@b.com")
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        // userName → snake_case → "user_name", but emailAddress has @CodingKey("custom_email")
+        #expect(json == #"{"user_name":"alice","custom_email":"a@b.com"}"#)
+        let decoded = try NewJSONDecoder().decode(NamingWithCodingKeyOverride.self, from: data)
+        #expect(decoded == original)
+    }
+
+    // MARK: - Enum caseNaming tests
+
+    @Test func enumSnakeCase() throws {
+        let original = SnakeCaseEnum.anotherLongCase
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"another_long_case":{}}"#)
+        let decoded = try NewJSONDecoder().decode(SnakeCaseEnum.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func enumScreamingSnakeCase() throws {
+        let original = ScreamingSnakeCaseEnum.anotherLongCase
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"ANOTHER_LONG_CASE":{}}"#)
+        let decoded = try NewJSONDecoder().decode(ScreamingSnakeCaseEnum.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func enumKebabCase() throws {
+        let original = KebabCaseEnum.anotherLongCase
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"another-long-case":{}}"#)
+        let decoded = try NewJSONDecoder().decode(KebabCaseEnum.self, from: data)
+        #expect(decoded == original)
+    }
+
+    // MARK: - Enum associatedValueLabelNaming tests
+
+    @Test func enumWithAssociatedValueNaming() throws {
+        let original = SnakeCaseEnumWithAssocValues.userProfile(firstName: "Alice", lastName: "Smith")
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        // Case name → snake_case: "user_profile", labels → snake_case: "first_name", "last_name"
+        #expect(json == #"{"user_profile":{"first_name":"Alice","last_name":"Smith"}}"#)
+        let decoded = try NewJSONDecoder().decode(SnakeCaseEnumWithAssocValues.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func enumWithUnlabeledAssociatedValueUnaffectedByNaming() throws {
+        // Unlabeled associated values use positional names (_0, _1) which should not be transformed
+        let original = SnakeCaseEnumWithAssocValues.errorCode(404)
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"error_code":{"_0":404}}"#)
+        let decoded = try NewJSONDecoder().decode(SnakeCaseEnumWithAssocValues.self, from: data)
+        #expect(decoded == original)
+    }
+
+    // MARK: - Enum CodingKey override
+
+    @Test func enumCodingKeyOverridesNamingConvention() throws {
+        let original = SnakeCaseEnumWithCodingKeyOverride.myCase
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        // myCase has @CodingKey("custom_case"), so it uses "custom_case" not "my_case"
+        #expect(json == #"{"custom_case":{}}"#)
+        let decoded = try NewJSONDecoder().decode(SnakeCaseEnumWithCodingKeyOverride.self, from: data)
+        #expect(decoded == original)
+
+        // anotherLongCase has no override, so caseNaming applies
+        let original2 = SnakeCaseEnumWithCodingKeyOverride.anotherLongCase
+        let data2 = try NewJSONEncoder().encode(original2)
+        let json2 = String(data: data2, encoding: .utf8)!
+        #expect(json2 == #"{"another_long_case":{}}"#)
+        let decoded2 = try NewJSONDecoder().decode(SnakeCaseEnumWithCodingKeyOverride.self, from: data2)
+        #expect(decoded2 == original2)
+    }
+}


### PR DESCRIPTION
A first attempt at specifying full-struct field/case/label naming patterns. Again, this mirrors the capabilities from other packages like serde. Please take note of the `CodableNaming` documentation, as this does behave significantly differently than `JSONEncoder/Decoder`'s snake case conversions.