### PR TITLE
IndexPath: handle interior insertion into pair storage.

### DIFF
--- a/Sources/FoundationEssentials/IndexPath.swift
+++ b/Sources/FoundationEssentials/IndexPath.swift
@@ -313,6 +313,18 @@ public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCo
                         }
                     case (0, 2):
                         self = newValue
+                    case (1, 1):
+                        // Insert newValue between first and second, leaving the pair otherwise intact.
+                        switch newValue {
+                        case .empty:
+                            break
+                        case .single(let other):
+                            self = .array([first, other, second])
+                        case .pair(let otherFirst, let otherSecond):
+                            self = .array([first, otherFirst, otherSecond, second])
+                        case .array(let other):
+                            self = .array([first] + other + [second])
+                        }
                     case (1, 2):
                         switch newValue {
                         case .empty:

--- a/Sources/FoundationEssentials/IndexPath.swift
+++ b/Sources/FoundationEssentials/IndexPath.swift
@@ -300,6 +300,18 @@ public struct IndexPath : Equatable, Hashable, MutableCollection, RandomAccessCo
                         case .array(let other):
                             self = .array(other + [first, second])
                         }
+                    case (1, 1):
+                        // Insert newValue between first and second, leaving the pair otherwise intact.
+                        switch newValue {
+                        case .empty:
+                            break
+                        case .single(let other):
+                            self = .array([first, other, second])
+                        case .pair(let otherFirst, let otherSecond):
+                            self = .array([first, otherFirst, otherSecond, second])
+                        case .array(let other):
+                            self = .array([first] + other + [second])
+                        }
                     case (0, 1):
                         switch newValue {
                         case .empty:

--- a/Tests/FoundationEssentialsTests/IndexPathTests.swift
+++ b/Tests/FoundationEssentialsTests/IndexPathTests.swift
@@ -549,6 +549,24 @@ private struct TestIndexPath {
         #expect(ip1.count == 2)
     }
     
+    @Test func rangeReplacementPairInsertInMiddle() {
+        var ip = IndexPath(indexes: [1, 2])
+        ip[1..<1] = IndexPath(indexes: [10])
+        #expect(ip == IndexPath(indexes: [1, 10, 2]))
+
+        var ip2 = IndexPath(indexes: [1, 2])
+        ip2[1..<1] = IndexPath(indexes: [])
+        #expect(ip2 == IndexPath(indexes: [1, 2]))
+
+        var ip3 = IndexPath(indexes: [1, 2])
+        ip3[1..<1] = IndexPath(indexes: [10, 20])
+        #expect(ip3 == IndexPath(indexes: [1, 10, 20, 2]))
+
+        var ip4 = IndexPath(indexes: [1, 2])
+        ip4[1..<1] = IndexPath(indexes: [10, 20, 30])
+        #expect(ip4 == IndexPath(indexes: [1, 10, 20, 30, 2]))
+    }
+
     @Test func moreRanges() {
         var ip = IndexPath(indexes: [1, 2, 3])
         let ip2 = IndexPath(indexes: [5, 6, 7, 8, 9, 10])


### PR DESCRIPTION
Inserting at the interior position of a two-element IndexPath via `path[1..<1] = newValue` no longer crashes (from `fatalError`).

### Motivation:

Found through static analysis (as opposed to seeing it exhibited in the wild).  It seems pretty easy to trigger with the public API, but I do wonder if I'm missing something as to why this hasn't been caught before.

I know it's a bit weird to write `1..<1`, and maybe it's intentional that it crashes?  But it _doesn't_ crash in the other internal storage formats.  So it seems like either this is the correct solution, or the solution is to make it _also_ crash on the other paths?

### Modifications:

The internal `Storage` enum's range-replacement subscript-setter for the `.pair` case enumerated `(0, 0)`, `(0, 1)`, `(0, 2)`, `(1, 2)`, `(2, 2)` and trapped the default branch — but it never handled `(1, 1)`.  Now it does (following the pattern of the other cases.

### Result:

No more crash.

### Testing:

Added a new unit test, `rangeReplacementPairInsertInMiddle`, covering a few cases.