### PR TITLE
Add File List Validation to CMake CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,10 +35,24 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Dependencies
         shell: bash
-        run: apt update && apt install -y cmake ninja-build
+        run: apt update && apt install -y cmake ninja-build jq
       - name: Configure Project
         shell: bash
-        run: cmake -G 'Ninja' -B build -S . -DCMAKE_C_COMPILER=clang -DCMAKE_Swift_COMPILER=swiftc -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=YES
+        run: |
+          mkdir -p build/.cmake/api/v1/query
+          touch build/.cmake/api/v1/query/codemodel-v2
+          cmake -G 'Ninja' -B build -S . -DCMAKE_C_COMPILER=clang -DCMAKE_Swift_COMPILER=swiftc -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=YES
+      - name: Validate CMake File Lists Match SwiftPM
+        shell: bash
+        run: |
+          swift package describe --type json | jq '.targets[] | select(.name == "FoundationEssentials") | .sources[]' | sort > /tmp/swiftpm-essentials
+          cat build/.cmake/api/v1/reply/target-FoundationEssentials-*.json | jq '.sources[].path[29:]' | sort > /tmp/cmake-essentials
+          swift package describe --type json | jq '.targets[] | select(.name == "FoundationInternationalization") | .sources[]' | sort > /tmp/swiftpm-internationalization
+          cat build/.cmake/api/v1/reply/target-FoundationInternationalization-*.json | jq '.sources[].path[39:]' | sort > /tmp/cmake-internationalization
+          exit_code=0
+          diff -u0 -L "SwiftPM" -L "CMake" /tmp/swiftpm-essentials /tmp/cmake-essentials && echo "::notice::FoundationEssentials CMakeLists.txt matches SwiftPM" || { echo "::error::FoundationEssentials CMakeLists.txt does not match SwiftPM"; exit_code=1; }
+          diff -u0 -L "SwiftPM" -L "CMake" /tmp/swiftpm-internationalization /tmp/cmake-internationalization  && echo "::notice::FoundationInternationalization CMakeLists.txt matches SwiftPM" || { echo "::error::FoundationInternationalization CMakeLists.txt does not match SwiftPM"; exit_code=1; }
+          exit $exit_code
       - name: Build Project
         shell: bash
         run: cmake --build build

--- a/Sources/FoundationEssentials/Data/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Data/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(FoundationEssentials PRIVATE
     Representations/Data+Inline.swift
     Representations/Data+InlineSlice.swift
     Representations/Data+LargeSlice.swift
+    Representations/Data+LegacyRepresentation.swift
     Representations/Data+Representation.swift
     Representations/DataStorage.swift
     

--- a/Sources/FoundationEssentials/URL/CMakeLists.txt
+++ b/Sources/FoundationEssentials/URL/CMakeLists.txt
@@ -15,6 +15,11 @@
 target_sources(FoundationEssentials PRIVATE
     URL.swift
     URL_Bridge.swift
+    URL_C+Encoding.swift
+    URL_C+File.swift
+    URL_C+Parsing.swift
+    URL_C+Resolution.swift
+    URL_C+Spans.swift
     URL_File.swift
     URL_Impl.swift
     URL_Info.swift

--- a/Sources/FoundationInternationalization/ICU/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/ICU/CMakeLists.txt
@@ -20,4 +20,5 @@ target_sources(FoundationInternationalization PRIVATE
     ICU+FieldPositer.swift
     ICU+Foundation.swift
     ICU+ResourceBundle.swift
+    ICU+StringConverter.swift
     ICUPatternGenerator.swift)

--- a/Sources/FoundationInternationalization/String/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/String/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(FoundationInternationalization PRIVATE .)
 target_sources(FoundationInternationalization PRIVATE
     KeyPathComparator.swift
     SortDescriptor.swift
+    String+Comparison_ICU.swift
     String+Locale.swift
     String+SortComparator.swift
     StringProtocol+Locale.swift)


### PR DESCRIPTION
Validates that the list of files built by CMake is the same as the list built by SwiftPM

### Motivation:

In order to prevent issues like https://github.com/swiftlang/swift-foundation/pull/1939 from happening in the future, we can validate that the list of files built by CMake is the same as the list built by SwiftPM

### Modifications:

Update the CMake CI to use `swift package describe` and the CMake API to produce a list of files for FoundationEssentials and FoundationInternationalization, and then diff the list of files

### Result:



### Testing:

Validated via CI
