### PR TITLE
Enable ICUResourceTimeZone_feature to match FOUNDATION_FRAMEWORK

### DIFF
--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -48,7 +48,7 @@ internal func foundation_swift_ICUResourceTimeZone_feature_enabled() -> Bool {
     _foundation_swift_ICUResourceTimeZone_feature_enabled()
 }
 #else
-internal func foundation_swift_ICUResourceTimeZone_feature_enabled() -> Bool { return false }
+internal func foundation_swift_ICUResourceTimeZone_feature_enabled() -> Bool { return true }
 #endif
 
 final class _TimeZoneICU: _TimeZoneProtocol, Sendable {


### PR DESCRIPTION
Enable ICUResourceTimeZone_feature to match FOUNDATION_FRAMEWORK