### PR TITLE
Treat null as nil in keyed decodeIfPresent with configuration

### DIFF
--- a/Sources/FoundationEssentials/CodableWithConfiguration.swift
+++ b/Sources/FoundationEssentials/CodableWithConfiguration.swift
@@ -114,7 +114,7 @@ public extension KeyedDecodingContainer {
         forKey key: Self.Key,
         configuration: C.Type
     ) throws -> T? where T.DecodingConfiguration == C.DecodingConfiguration {
-        if contains(key) {
+        if contains(key), try !decodeNil(forKey: key) {
             return try self.decode(T.self, forKey: key, configuration: configuration)
         } else {
             return nil
@@ -133,7 +133,7 @@ public extension KeyedDecodingContainer {
         forKey key: Self.Key,
         configuration: T.DecodingConfiguration
     ) throws -> T? {
-        if contains(key) {
+        if contains(key), try !decodeNil(forKey: key) {
             return try self.decode(T.self, forKey: key, configuration: configuration)
         } else {
             return nil

--- a/Tests/FoundationEssentialsTests/CodableConfiguration/CodableConfigurationTests.swift
+++ b/Tests/FoundationEssentialsTests/CodableConfiguration/CodableConfigurationTests.swift
@@ -38,6 +38,39 @@ struct CodableConfigurationTests {
         let sut = try decoder.decode(UsingCodableConfiguration.self, from: jsonData)
         #expect(sut.testObject == nil)
     }
+
+    @Test
+    func decodeIfPresentKeyed_succeedsForNull() async throws {
+        let json = "{\"testObject\":null,\"testObject2\":null}"
+        let jsonData = try #require(json.data(using: .utf8))
+
+        let decoder = JSONDecoder()
+        let sut = try decoder.decode(UsingDecodeIfPresent.self, from: jsonData)
+        #expect(sut.testObject == nil)
+        #expect(sut.testObject2 == nil)
+    }
+
+    @Test
+    func decodeIfPresentKeyed_succeedsForMissingKey() async throws {
+        let json = "{}"
+        let jsonData = try #require(json.data(using: .utf8))
+
+        let decoder = JSONDecoder()
+        let sut = try decoder.decode(UsingDecodeIfPresent.self, from: jsonData)
+        #expect(sut.testObject == nil)
+        #expect(sut.testObject2 == nil)
+    }
+
+    @Test
+    func decodeIfPresentKeyed_succeedsForValue() async throws {
+        let json = "{\"testObject\":\"Hello There\",\"testObject2\":\"General Kenobi\"}"
+        let jsonData = try #require(json.data(using: .utf8))
+
+        let decoder = JSONDecoder()
+        let sut = try decoder.decode(UsingDecodeIfPresent.self, from: jsonData)
+        #expect(sut.testObject?.value == "Hello There")
+        #expect(sut.testObject2?.value == "General Kenobi")
+    }
 }
 
 private extension CodableConfigurationTests {
@@ -49,6 +82,26 @@ private extension CodableConfigurationTests {
     struct UsingCodableConfiguration: Codable {
         @CodableConfiguration(wrappedValue: nil, from: CustomConfig.self)
         var testObject: NonCodableType?
+    }
+
+    /// Type that decodes optional values by calling the keyed
+    /// `decodeIfPresent(_:forKey:configuration:)` APIs directly, covering both
+    /// the `DecodingConfigurationProviding` overload and the overload that takes
+    /// a configuration instance.
+    struct UsingDecodeIfPresent: Decodable {
+        let testObject: NonCodableType?
+        let testObject2: NonCodableType?
+
+        enum CodingKeys: String, CodingKey {
+            case testObject
+            case testObject2
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            testObject = try container.decodeIfPresent(NonCodableType.self, forKey: .testObject, configuration: CustomConfig.self)
+            testObject2 = try container.decodeIfPresent(NonCodableType.self, forKey: .testObject2, configuration: CustomConfig.decodingConfiguration)
+        }
     }
 
     /// Helper object allowing to decode Date using ISO8601 scheme


### PR DESCRIPTION
The two `KeyedDecodingContainer.decodeIfPresent(_:forKey:configuration:)` overloads decided whether a value was present by checking only `contains(key)`. When a key is present but its value is an explicit `null`, that check passes and the value is forwarded to `decode(_:forKey:configuration:)`, which hands it to the configuration's decoder. For an optional property backed by a non-optional decoder (for example a `String`), that throws `valueNotFound` instead of returning `nil`.

This is inconsistent with three sibling code paths that all treat `null` as `nil`:

- The standard library's `decodeIfPresent(_:forKey:)`, which checks `contains(key) && !decodeNil(forKey:)`.
- The `UnkeyedDecodingContainer` configuration overloads, which already guard with `decodeNil()`.
- The `@CodableConfiguration` property wrapper, whose `null` handling was fixed in #1631.

The root cause is the missing `decodeNil(forKey:)` check on the keyed overloads. #1631 closed the same class of inconsistency reported in #1630 for the property-wrapper path but left these public APIs unchanged. The fix adds `try !decodeNil(forKey: key)` to the guard so a present-but-null value yields `nil`, matching the missing-key behavior and the rest of the API surface.

Verification: added regression tests in `CodableConfigurationTests` that decode optional values through both keyed `decodeIfPresent` overloads for a null value, a missing key, and a present value. The null case failed before the change with `valueNotFound` and passes after it. The full `CodableConfiguration`, `AttributedString`, `JSONEncoderTests`, and `PropertyListEncoderTests` suites pass.

Fixes #1630