### PR TITLE
Round ISO8601 fractional seconds to the nearest millisecond

### DIFF
--- a/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
@@ -357,13 +357,35 @@ extension Date.ISO8601FormatStyle : FormatStyle {
             }
         }
 
+        // When fractional seconds are included, the output's finest unit is the millisecond, so
+        // the sub-millisecond part is the remainder we are about to drop. Round the date to the
+        // nearest millisecond here, at the Date entry point, before extracting components. This
+        // lets the calendar carry any overflow correctly across seconds, minutes, hours, days, and
+        // the time zone boundary. Coarser fields keep truncating, so date-only and whole-second
+        // formatting are unchanged.
+        var value = value
+        if includingFractionalSeconds {
+            let interval = value.timeIntervalSinceReferenceDate
+            value = Date(timeIntervalSinceReferenceDate: (interval * 1000.0).rounded() / 1000.0)
+        }
+
         let secondsFromGMT: Int?
-        let components = componentsFormatStyle._calendar._dateComponents(whichComponents, from: value)
+        var components = componentsFormatStyle._calendar._dateComponents(whichComponents, from: value)
         if fields.contains(.timeZone) {
             secondsFromGMT = timeZone.secondsFromGMT(for: value)
         } else {
             secondsFromGMT = nil
         }
+
+        // The date is already rounded to the nearest millisecond above, but the calendar extracts
+        // the nanosecond from a `Double` fraction, so it lands a hair off the exact millisecond
+        // (e.g. 122999906 for .123). Snap the nanosecond onto the nearest millisecond so the shared
+        // formatter can truncate it back to the right value. The cross-second carry already happened
+        // on the date, so this only cleans up the float error and never reaches a full second.
+        if includingFractionalSeconds, let ns = components.nanosecond {
+            components.nanosecond = Int((Double(ns) / 1_000_000.0).rounded()) * 1_000_000
+        }
+
         return format(components, appendingTimeZoneOffset: secondsFromGMT)
     }
 

--- a/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
@@ -365,14 +365,9 @@ extension Date.ISO8601FormatStyle : FormatStyle {
             secondsFromGMT = nil
         }
 
-        // A `Date` built from a fractional `TimeInterval` cannot represent that fraction exactly, so
-        // the calendar extracts a nanosecond that sits just below the intended value (.123 arrives
-        // as 122999906). Truncating that to milliseconds reads back .122. Rounding to the nearest
-        // millisecond recovers .123, which is the value the caller asked for.
+        // A `Date` built from a fractional `TimeInterval` cannot represent that fraction exactly, so the calendar extracts a nanosecond that sits just below the intended value (.123 arrives as 122999906). Truncating that to milliseconds reads back .122. Rounding to the nearest millisecond recovers .123, which is the value the caller asked for.
         //
-        // The rounding is clamped so it can never carry into the next second. Correcting
-        // representation error is the goal, and a fraction genuinely close to a full second (45.9999)
-        // should still format as 45.999 rather than advancing the second, minute, or day.
+        // The rounding is clamped so it can never carry into the next second. Correcting representation error is the goal, and a fraction genuinely close to a full second (45.9999) should still format as 45.999 rather than advancing the second, minute, or day.
         if includingFractionalSeconds, let ns = components.nanosecond {
             let milliseconds = min(Int((Double(ns) / 1_000_000.0).rounded()), 999)
             components.nanosecond = milliseconds * 1_000_000

--- a/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
@@ -357,18 +357,6 @@ extension Date.ISO8601FormatStyle : FormatStyle {
             }
         }
 
-        // When fractional seconds are included, the output's finest unit is the millisecond, so
-        // the sub-millisecond part is the remainder we are about to drop. Round the date to the
-        // nearest millisecond here, at the Date entry point, before extracting components. This
-        // lets the calendar carry any overflow correctly across seconds, minutes, hours, days, and
-        // the time zone boundary. Coarser fields keep truncating, so date-only and whole-second
-        // formatting are unchanged.
-        var value = value
-        if includingFractionalSeconds {
-            let interval = value.timeIntervalSinceReferenceDate
-            value = Date(timeIntervalSinceReferenceDate: (interval * 1000.0).rounded() / 1000.0)
-        }
-
         let secondsFromGMT: Int?
         var components = componentsFormatStyle._calendar._dateComponents(whichComponents, from: value)
         if fields.contains(.timeZone) {
@@ -377,13 +365,17 @@ extension Date.ISO8601FormatStyle : FormatStyle {
             secondsFromGMT = nil
         }
 
-        // The date is already rounded to the nearest millisecond above, but the calendar extracts
-        // the nanosecond from a `Double` fraction, so it lands a hair off the exact millisecond
-        // (e.g. 122999906 for .123). Snap the nanosecond onto the nearest millisecond so the shared
-        // formatter can truncate it back to the right value. The cross-second carry already happened
-        // on the date, so this only cleans up the float error and never reaches a full second.
+        // A `Date` built from a fractional `TimeInterval` cannot represent that fraction exactly, so
+        // the calendar extracts a nanosecond that sits just below the intended value (.123 arrives
+        // as 122999906). Truncating that to milliseconds reads back .122. Rounding to the nearest
+        // millisecond recovers .123, which is the value the caller asked for.
+        //
+        // The rounding is clamped so it can never carry into the next second. Correcting
+        // representation error is the goal, and a fraction genuinely close to a full second (45.9999)
+        // should still format as 45.999 rather than advancing the second, minute, or day.
         if includingFractionalSeconds, let ns = components.nanosecond {
-            components.nanosecond = Int((Double(ns) / 1_000_000.0).rounded()) * 1_000_000
+            let milliseconds = min(Int((Double(ns) / 1_000_000.0).rounded()), 999)
+            components.nanosecond = milliseconds * 1_000_000
         }
 
         return format(components, appendingTimeZoneOffset: secondsFromGMT)

--- a/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
@@ -346,13 +346,14 @@ extension DateComponents.ISO8601FormatStyle : FormatStyle {
                 
                 if includingFractionalSeconds {
                     let ns = components.nanosecond ?? 0
-                    // Round to the nearest millisecond rather than truncating. A `Date` created from a
-                    // fractional `TimeInterval` such as `1674036251.123` cannot represent the value
-                    // exactly, so the extracted nanosecond is often slightly below the intended value
-                    // (e.g. 122999906 instead of 123000000). Truncating that toward zero produces an
-                    // off-by-one in the milliseconds field (".122" instead of ".123"). Clamp to 999 so
-                    // a value that rounds up to 1000 does not overflow the three-digit field.
-                    let ms = min(Int((Double(ns) / 1_000_000.0).rounded()), 999)
+                    // Format the milliseconds field by truncating the nanosecond toward zero. The
+                    // `Date` entry point already rounds to the nearest millisecond and carries any
+                    // overflow across the second boundary through the calendar, then hands this layer
+                    // a nanosecond that sits exactly on a millisecond, so truncation reads it back
+                    // correctly and can never overflow the three-digit field. A bare `DateComponents`
+                    // formatted directly has no anchoring `Date` to carry through, so it keeps the
+                    // original truncating behavior here unchanged.
+                    let ms = Int((Double(ns) / 1_000_000.0).rounded(.towardZero))
                     buffer.appendElement(asciiPeriod)
                     buffer.append(ms, zeroPad: 3)
                 }

--- a/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
@@ -346,7 +346,13 @@ extension DateComponents.ISO8601FormatStyle : FormatStyle {
                 
                 if includingFractionalSeconds {
                     let ns = components.nanosecond ?? 0
-                    let ms = Int((Double(ns) / 1_000_000.0).rounded(.towardZero))
+                    // Round to the nearest millisecond rather than truncating. A `Date` created from a
+                    // fractional `TimeInterval` such as `1674036251.123` cannot represent the value
+                    // exactly, so the extracted nanosecond is often slightly below the intended value
+                    // (e.g. 122999906 instead of 123000000). Truncating that toward zero produces an
+                    // off-by-one in the milliseconds field (".122" instead of ".123"). Clamp to 999 so
+                    // a value that rounds up to 1000 does not overflow the three-digit field.
+                    let ms = min(Int((Double(ns) / 1_000_000.0).rounded()), 999)
                     buffer.appendElement(asciiPeriod)
                     buffer.append(ms, zeroPad: 3)
                 }

--- a/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
@@ -346,13 +346,7 @@ extension DateComponents.ISO8601FormatStyle : FormatStyle {
                 
                 if includingFractionalSeconds {
                     let ns = components.nanosecond ?? 0
-                    // Format the milliseconds field by truncating the nanosecond toward zero. The
-                    // `Date` entry point already rounds to the nearest millisecond and carries any
-                    // overflow across the second boundary through the calendar, then hands this layer
-                    // a nanosecond that sits exactly on a millisecond, so truncation reads it back
-                    // correctly and can never overflow the three-digit field. A bare `DateComponents`
-                    // formatted directly has no anchoring `Date` to carry through, so it keeps the
-                    // original truncating behavior here unchanged.
+                    // Format the milliseconds field by truncating the nanosecond toward zero. The `Date` entry point already rounds to the nearest millisecond and carries any overflow across the second boundary through the calendar, then hands this layer a nanosecond that sits exactly on a millisecond, so truncation reads it back correctly and can never overflow the three-digit field. A bare `DateComponents` formatted directly has no anchoring `Date` to carry through, so it keeps the original truncating behavior here unchanged.
                     let ms = Int((Double(ns) / 1_000_000.0).rounded(.towardZero))
                     buffer.appendElement(asciiPeriod)
                     buffer.append(ms, zeroPad: 3)

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
@@ -212,4 +212,27 @@ private struct ISO8601FormatStyleFormattingTests {
         let str = Date.ISO8601FormatStyle().timeZone(separator: .colon).time(includingFractionalSeconds: true).timeSeparator(.colon).format(date)
         #expect(str == "15:35:45.999Z")
     }
+
+    @Test func fractionalSecondsRoundToNearestMillisecond() throws {
+        // A `Date` built from a fractional `TimeInterval` at a present-day magnitude cannot represent
+        // the value exactly, so the extracted nanosecond lands just below the intended value (e.g.
+        // 122999906 for .123). The milliseconds field must round to the nearest millisecond rather
+        // than truncating toward zero, otherwise it is reported one millisecond too low.
+        let style = Date.ISO8601FormatStyle.iso8601.year().month().day().time(includingFractionalSeconds: true)
+
+        // 1674036251.123 -> "2023-01-18T10:04:11.123" (previously ".122")
+        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_251.123)) == "2023-01-18T10:04:11.123")
+
+        // Every millisecond from a present-day base must round-trip through the formatted string.
+        let base = 1_674_036_251.0
+        for ms in 0..<1000 {
+            let formatted = style.format(Date(timeIntervalSince1970: base + Double(ms) / 1000.0))
+            let padded = "00\(ms)".suffix(3)
+            let suffix = ".\(padded)"
+            #expect(formatted.hasSuffix(suffix), "ms=\(ms) formatted as \(formatted)")
+        }
+
+        // A sub-millisecond remainder that rounds up to 1000 must clamp to .999, never overflow to ".1000".
+        #expect(style.format(Date(timeIntervalSince1970: base + 0.9996)) == "2023-01-18T10:04:11.999")
+    }
 }

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
@@ -235,4 +235,16 @@ private struct ISO8601FormatStyleFormattingTests {
         // A sub-millisecond remainder that rounds up to 1000 must clamp to .999, never overflow to ".1000".
         #expect(style.format(Date(timeIntervalSince1970: base + 0.9996)) == "2023-01-18T10:04:11.999")
     }
+
+    @Test func fractionalSecondsClampAtSecondBoundary() throws {
+        // parkera's scenario from issue #963: a time like HH:MM:59.9999 formatted with three
+        // fractional digits and round-nearest must not read HH:MM:59.000. The min(..., 999)
+        // clamp keeps it at .999 rather than wrapping the rounded-up millisecond to zero or
+        // silently carrying into the seconds field, which this format layer does not do.
+        let style = Date.ISO8601FormatStyle.iso8601.year().month().day().time(includingFractionalSeconds: true)
+
+        // 1674036299.0 is 2023-01-18T10:04:59. The sub-millisecond remainder rounds up to 1000
+        // and clamps to .999, so the second stays 59 and never reads .000.
+        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_299.0 + 0.9996)) == "2023-01-18T10:04:59.999")
+    }
 }

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
@@ -207,10 +207,12 @@ private struct ISO8601FormatStyleFormattingTests {
     }
     
     @Test func rounding() {
-        // Date is: "1970-01-01 15:35:45.9999"
+        // Date is: "1970-01-01 15:35:45.9999". Rounding the fractional seconds to the nearest
+        // millisecond rounds .9999 up to a full second, which carries through the calendar, so the
+        // output is the next whole second 15:35:46.000, not the truncated 15:35:45.999.
         let date = Date(timeIntervalSinceReferenceDate: -978251054.0 - 0.0001)
         let str = Date.ISO8601FormatStyle().timeZone(separator: .colon).time(includingFractionalSeconds: true).timeSeparator(.colon).format(date)
-        #expect(str == "15:35:45.999Z")
+        #expect(str == "15:35:46.000Z")
     }
 
     @Test func fractionalSecondsRoundToNearestMillisecond() throws {
@@ -232,19 +234,46 @@ private struct ISO8601FormatStyleFormattingTests {
             #expect(formatted.hasSuffix(suffix), "ms=\(ms) formatted as \(formatted)")
         }
 
-        // A sub-millisecond remainder that rounds up to 1000 must clamp to .999, never overflow to ".1000".
-        #expect(style.format(Date(timeIntervalSince1970: base + 0.9996)) == "2023-01-18T10:04:11.999")
+        // A sub-millisecond remainder that rounds up to a full millisecond carries into the
+        // seconds field through the calendar, so .9996 at second 11 reads as the next whole second.
+        #expect(style.format(Date(timeIntervalSince1970: base + 0.9996)) == "2023-01-18T10:04:12.000")
     }
 
-    @Test func fractionalSecondsClampAtSecondBoundary() throws {
-        // parkera's scenario from issue #963: a time like HH:MM:59.9999 formatted with three
-        // fractional digits and round-nearest must not read HH:MM:59.000. The min(..., 999)
-        // clamp keeps it at .999 rather than wrapping the rounded-up millisecond to zero or
-        // silently carrying into the seconds field, which this format layer does not do.
+    @Test func fractionalSecondsCarryAtSecondBoundary() throws {
+        // parkera's scenario from issue #963: a time like HH:MM:59.9996 formatted with three
+        // fractional digits and round-nearest must not read HH:MM:59.999, which keeps the wrong
+        // value at the boundary. Because the rounding now happens at the Date entry point, the
+        // sub-millisecond remainder rounds up and the calendar carries it across the second.
         let style = Date.ISO8601FormatStyle.iso8601.year().month().day().time(includingFractionalSeconds: true)
 
-        // 1674036299.0 is 2023-01-18T10:04:59. The sub-millisecond remainder rounds up to 1000
-        // and clamps to .999, so the second stays 59 and never reads .000.
-        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_299.0 + 0.9996)) == "2023-01-18T10:04:59.999")
+        // 1674036299.0 is 2023-01-18T10:04:59. The .9996 remainder rounds up to a full second, so
+        // the output carries to the next whole second: 10:05:00.000, never 10:04:59.999.
+        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_299.0 + 0.9996)) == "2023-01-18T10:05:00.000")
+
+        // 0.9999s also carries to the next whole second.
+        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_251.0 + 0.9999)) == "2023-01-18T10:04:12.000")
+    }
+
+    @Test func fractionalSecondsCarryAcrossDSTBoundary() throws {
+        // Carrying a rounded-up millisecond across a second can also cross a daylight saving time
+        // transition. Use US Pacific, where 2023-03-12 01:59:59.9996 local rounds up into the
+        // 03:00 wall-clock jump (02:00 does not exist). The calendar must produce a consistent
+        // wall-clock time and time zone offset for the rounded Date.
+        guard let pacific = TimeZone(identifier: "America/Los_Angeles") else { return }
+        let style = Date.ISO8601FormatStyle(timeZone: pacific).year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .colon)
+
+        // 1678615199.0 is 2023-03-12T01:59:59 Pacific (PST, -08:00), the last second before the
+        // spring-forward gap. Rounding .9996 up carries the wall clock to 03:00:00 PDT (-07:00).
+        let formatted = style.format(Date(timeIntervalSince1970: 1_678_615_199.0 + 0.9996))
+        #expect(formatted == "2023-03-12T03:00:00.000-07:00")
+    }
+
+    @Test func fractionalSecondsRoundTripParseThenFormat() throws {
+        // Parsing a millisecond-precision string and formatting it back must be stable: the
+        // formatted value should match the parsed input, not drift by a millisecond.
+        let style = Date.ISO8601FormatStyle.iso8601.year().month().day().time(includingFractionalSeconds: true)
+        let input = "2023-01-18T10:04:11.123"
+        let date = try style.parse(input)
+        #expect(style.format(date) == input)
     }
 }

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
@@ -207,12 +207,12 @@ private struct ISO8601FormatStyleFormattingTests {
     }
     
     @Test func rounding() {
-        // Date is: "1970-01-01 15:35:45.9999". Rounding the fractional seconds to the nearest
-        // millisecond rounds .9999 up to a full second, which carries through the calendar, so the
-        // output is the next whole second 15:35:46.000, not the truncated 15:35:45.999.
+        // Date is: "1970-01-01 15:35:45.9999". Rounding to the nearest millisecond is clamped so it
+        // never carries into the next second, so a fraction this close to a full second still
+        // formats as .999 rather than advancing to 15:35:46.000.
         let date = Date(timeIntervalSinceReferenceDate: -978251054.0 - 0.0001)
         let str = Date.ISO8601FormatStyle().timeZone(separator: .colon).time(includingFractionalSeconds: true).timeSeparator(.colon).format(date)
-        #expect(str == "15:35:46.000Z")
+        #expect(str == "15:35:45.999Z")
     }
 
     @Test func fractionalSecondsRoundToNearestMillisecond() throws {
@@ -234,38 +234,35 @@ private struct ISO8601FormatStyleFormattingTests {
             #expect(formatted.hasSuffix(suffix), "ms=\(ms) formatted as \(formatted)")
         }
 
-        // A sub-millisecond remainder that rounds up to a full millisecond carries into the
-        // seconds field through the calendar, so .9996 at second 11 reads as the next whole second.
-        #expect(style.format(Date(timeIntervalSince1970: base + 0.9996)) == "2023-01-18T10:04:12.000")
+        // A sub-millisecond remainder close enough to a full second is clamped rather than carried,
+        // so .9996 at second 11 still reads as second 11 with the largest representable fraction.
+        #expect(style.format(Date(timeIntervalSince1970: base + 0.9996)) == "2023-01-18T10:04:11.999")
     }
 
-    @Test func fractionalSecondsCarryAtSecondBoundary() throws {
-        // parkera's scenario from issue #963: a time like HH:MM:59.9996 formatted with three
-        // fractional digits and round-nearest must not read HH:MM:59.999, which keeps the wrong
-        // value at the boundary. Because the rounding now happens at the Date entry point, the
-        // sub-millisecond remainder rounds up and the calendar carries it across the second.
+    @Test func fractionalSecondsDoNotCarryAtSecondBoundary() throws {
+        // Rounding here exists to undo binary representation error, not to advance the instant. A
+        // time like HH:MM:59.9996 must stay in that second and format as HH:MM:59.999 rather than
+        // rolling the second, the minute, and potentially the day forward.
         let style = Date.ISO8601FormatStyle.iso8601.year().month().day().time(includingFractionalSeconds: true)
 
-        // 1674036299.0 is 2023-01-18T10:04:59. The .9996 remainder rounds up to a full second, so
-        // the output carries to the next whole second: 10:05:00.000, never 10:04:59.999.
-        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_299.0 + 0.9996)) == "2023-01-18T10:05:00.000")
+        // 1674036299.0 is 2023-01-18T10:04:59, so the .9996 remainder must not reach 10:05:00.000.
+        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_299.0 + 0.9996)) == "2023-01-18T10:04:59.999")
 
-        // 0.9999s also carries to the next whole second.
-        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_251.0 + 0.9999)) == "2023-01-18T10:04:12.000")
+        // 0.9999s is likewise clamped instead of carrying.
+        #expect(style.format(Date(timeIntervalSince1970: 1_674_036_251.0 + 0.9999)) == "2023-01-18T10:04:11.999")
     }
 
-    @Test func fractionalSecondsCarryAcrossDSTBoundary() throws {
-        // Carrying a rounded-up millisecond across a second can also cross a daylight saving time
-        // transition. Use US Pacific, where 2023-03-12 01:59:59.9996 local rounds up into the
-        // 03:00 wall-clock jump (02:00 does not exist). The calendar must produce a consistent
-        // wall-clock time and time zone offset for the rounded Date.
+    @Test func fractionalSecondsDoNotCarryAcrossDSTBoundary() throws {
+        // Because rounding never carries across a second, it also cannot push a time across a
+        // daylight saving transition. Use US Pacific, where 2023-03-12 01:59:59.9996 local sits in
+        // the last second before the spring-forward gap and must stay there.
         guard let pacific = TimeZone(identifier: "America/Los_Angeles") else { return }
         let style = Date.ISO8601FormatStyle(timeZone: pacific).year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .colon)
 
-        // 1678615199.0 is 2023-03-12T01:59:59 Pacific (PST, -08:00), the last second before the
-        // spring-forward gap. Rounding .9996 up carries the wall clock to 03:00:00 PDT (-07:00).
+        // 1678615199.0 is 2023-03-12T01:59:59 Pacific (PST, -08:00). The output keeps that wall
+        // clock and offset instead of jumping to 03:00:00 PDT.
         let formatted = style.format(Date(timeIntervalSince1970: 1_678_615_199.0 + 0.9996))
-        #expect(formatted == "2023-03-12T03:00:00.000-07:00")
+        #expect(formatted == "2023-03-12T01:59:59.999-08:00")
     }
 
     @Test func fractionalSecondsRoundTripParseThenFormat() throws {

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleFormattingTests.swift
@@ -207,19 +207,14 @@ private struct ISO8601FormatStyleFormattingTests {
     }
     
     @Test func rounding() {
-        // Date is: "1970-01-01 15:35:45.9999". Rounding to the nearest millisecond is clamped so it
-        // never carries into the next second, so a fraction this close to a full second still
-        // formats as .999 rather than advancing to 15:35:46.000.
+        // Date is: "1970-01-01 15:35:45.9999". Rounding to the nearest millisecond is clamped so it never carries into the next second, so a fraction this close to a full second still formats as .999 rather than advancing to 15:35:46.000.
         let date = Date(timeIntervalSinceReferenceDate: -978251054.0 - 0.0001)
         let str = Date.ISO8601FormatStyle().timeZone(separator: .colon).time(includingFractionalSeconds: true).timeSeparator(.colon).format(date)
         #expect(str == "15:35:45.999Z")
     }
 
     @Test func fractionalSecondsRoundToNearestMillisecond() throws {
-        // A `Date` built from a fractional `TimeInterval` at a present-day magnitude cannot represent
-        // the value exactly, so the extracted nanosecond lands just below the intended value (e.g.
-        // 122999906 for .123). The milliseconds field must round to the nearest millisecond rather
-        // than truncating toward zero, otherwise it is reported one millisecond too low.
+        // A `Date` built from a fractional `TimeInterval` at a present-day magnitude cannot represent the value exactly, so the extracted nanosecond lands just below the intended value (e.g. 122999906 for .123). The milliseconds field must round to the nearest millisecond rather than truncating toward zero, otherwise it is reported one millisecond too low.
         let style = Date.ISO8601FormatStyle.iso8601.year().month().day().time(includingFractionalSeconds: true)
 
         // 1674036251.123 -> "2023-01-18T10:04:11.123" (previously ".122")
@@ -234,15 +229,12 @@ private struct ISO8601FormatStyleFormattingTests {
             #expect(formatted.hasSuffix(suffix), "ms=\(ms) formatted as \(formatted)")
         }
 
-        // A sub-millisecond remainder close enough to a full second is clamped rather than carried,
-        // so .9996 at second 11 still reads as second 11 with the largest representable fraction.
+        // A sub-millisecond remainder close enough to a full second is clamped rather than carried, so .9996 at second 11 still reads as second 11 with the largest representable fraction.
         #expect(style.format(Date(timeIntervalSince1970: base + 0.9996)) == "2023-01-18T10:04:11.999")
     }
 
     @Test func fractionalSecondsDoNotCarryAtSecondBoundary() throws {
-        // Rounding here exists to undo binary representation error, not to advance the instant. A
-        // time like HH:MM:59.9996 must stay in that second and format as HH:MM:59.999 rather than
-        // rolling the second, the minute, and potentially the day forward.
+        // Rounding here exists to undo binary representation error, not to advance the instant. A time like HH:MM:59.9996 must stay in that second and format as HH:MM:59.999 rather than rolling the second, the minute, and potentially the day forward.
         let style = Date.ISO8601FormatStyle.iso8601.year().month().day().time(includingFractionalSeconds: true)
 
         // 1674036299.0 is 2023-01-18T10:04:59, so the .9996 remainder must not reach 10:05:00.000.


### PR DESCRIPTION
`Date.ISO8601FormatStyle` with `includingFractionalSeconds` reports the milliseconds field one millisecond too low for many values. For example:

```swift
let date = Date(timeIntervalSince1970: 1_674_036_251.123)
let style = Date.ISO8601FormatStyle.iso8601.year().month().day().time(includingFractionalSeconds: true)
style.format(date) // "2023-01-18T10:04:11.122", expected "...11.123"
```

The same off-by-one drops the last millisecond for a large fraction of inputs at present-day magnitudes, e.g. `.001` formats as `.000` and `.011` formats as `.010`.

Root cause: the milliseconds field is derived from the nanosecond component by truncating toward zero.

```swift
let ms = Int((Double(ns) / 1_000_000.0).rounded(.towardZero))
```

A `Date` built from a fractional `TimeInterval` at a current-date magnitude cannot represent the value exactly, and the nanosecond the calendar extracts lands just below the intended value. For the example above the nanosecond component is `122999906` rather than `123000000`, so truncating gives `122`. This only shows up at large magnitudes: the existing `665076946.011` test case happens to land on a nanosecond at or above `11000000`, so truncation still produced `.011` there, which is why it was not caught.

The fix rounds to the nearest millisecond instead of truncating, and clamps the result to `999` so a value that would round up to `1000` does not overflow the three-digit field. That clamp keeps the behavior already asserted by the existing `rounding()` test, where `15:35:45.9999` formats as `15:35:45.999`.

Parsing is unaffected: it already maps `.123` back to `123000000` ns exactly, so the formatted output now matches what the parser expects for the displayable resolution.

Verification: added a regression test that fails before this change and passes after. It checks the reported `.123` case, asserts that every millisecond `0..<1000` from a present-day base round-trips through the formatted string, and checks the `1000` overflow clamp. The full `ISO8601FormatStyle`, `Date.FormatStyle`, and HTTP format style suites pass (the only failure in the wider `FoundationEssentialsTests` run is `fileExtendedAttributes`, which also fails on a clean checkout and is unrelated).

Fixes #963.

Happy to retarget this at an active release branch if that fits the merge-forward strategy better.