### PR TITLE
Create _FoundationInternationalizationData library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -175,10 +175,17 @@ let package = Package(
 
         // FoundationInternationalization
         .target(
+            name: "_FoundationInternationalizationData",
+            dependencies: [
+                "_FoundationCShims"
+            ]
+        ),
+        .target(
             name: "FoundationInternationalization",
             dependencies: [
                 .target(name: "FoundationEssentials"),
                 .target(name: "_FoundationCShims"),
+                .target(name: "_FoundationInternationalizationData"),
                 .product(name: "_FoundationICU", package: "swift-foundation-icu")
             ],
             exclude: [

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -13,5 +13,6 @@
 ##===----------------------------------------------------------------------===##
 
 add_subdirectory(_FoundationCShims)
+add_subdirectory(_FoundationInternationalizationData)
 add_subdirectory(FoundationEssentials)
 add_subdirectory(FoundationInternationalization)

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -45,7 +45,8 @@ target_compile_options(FoundationInternationalization PRIVATE -package-name "Swi
 target_link_libraries(FoundationInternationalization PUBLIC
     FoundationEssentials
     _FoundationCShims
-    _FoundationICU)
+    _FoundationICU
+    _FoundationInternationalizationData)
 target_link_libraries(FoundationInternationalization PUBLIC ${_SwiftFoundation_wasi_libc_libraries})
 
 if(NOT BUILD_SHARED_LIBS)
@@ -53,6 +54,8 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCShims>")
     target_compile_options(FoundationInternationalization PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
+    target_compile_options(FoundationInternationalization PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationInternationalizationData>")
     target_compile_options(FoundationEssentials PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend $<$<PLATFORM_ID:Windows>:${CMAKE_STATIC_LIBRARY_PREFIX_Swift}>swiftSynchronization>")
 endif()

--- a/Sources/_FoundationInternationalizationData/CMakeLists.txt
+++ b/Sources/_FoundationInternationalizationData/CMakeLists.txt
@@ -1,0 +1,50 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_library(_FoundationInternationalizationData STATIC
+    ListFormatData.c)
+
+target_include_directories(_FoundationInternationalizationData PUBLIC include)
+
+target_compile_options(_FoundationInternationalizationData INTERFACE
+  "$<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap>>")
+
+set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS _FoundationInternationalizationData)
+
+if(BUILD_SHARED_LIBS)
+    set(install_directory swift)
+else()
+    set(install_directory swift_static)
+endif()
+
+# Copy Headers to known directory for direct client (XCTest) test builds
+file(COPY
+        include/
+    DESTINATION
+        ${CMAKE_BINARY_DIR}/_CModulesForClients/_FoundationInternationalizationData)
+
+# Install headers
+install(DIRECTORY
+            include/
+        DESTINATION
+            lib/${install_directory}/_FoundationInternationalizationData)
+
+if(NOT BUILD_SHARED_LIBS)
+    get_swift_host_os(swift_os)
+    install(TARGETS _FoundationInternationalizationData
+        ARCHIVE DESTINATION lib/${install_directory}/${swift_os}
+        LIBRARY DESTINATION lib/${install_directory}/${swift_os}
+        RUNTIME DESTINATION bin)
+endif()
+

--- a/Sources/_FoundationInternationalizationData/ListFormatData.c
+++ b/Sources/_FoundationInternationalizationData/ListFormatData.c
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+const char * const _ListFormatPatterns[] = {};

--- a/Sources/_FoundationInternationalizationData/ListFormatData.c
+++ b/Sources/_FoundationInternationalizationData/ListFormatData.c
@@ -10,4 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-const char * const _ListFormatPatterns[] = {};
+#include "ListFormatData.h"
+#include <stddef.h>
+
+const char * const * _ListFormatPatterns = NULL;

--- a/Sources/_FoundationInternationalizationData/include/InternationalizationDataMacros.h
+++ b/Sources/_FoundationInternationalizationData/include/InternationalizationDataMacros.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Note: This is copied from _FoundationCShims/_CShimsMacros.h. In the future, we should determine how to import this from _FoundationCShims directly instead of duplicating the header.
+
+#ifndef _INTERNATIONALIZATION_DATA_MACROS_H
+#define _INTERNATIONALIZATION_DATA_MACROS_H
+
+#if FOUNDATION_FRAMEWORK
+// This macro prevents the symbol from being exported from the framework, where library evolution is enabled.
+#define INTERNAL __attribute__((__visibility__("hidden")))
+#else
+// This macro makes the symbol available for package users. With library evolution disabled, it is possible for clients to end up referencing these normally-internal symbols.
+#define INTERNAL extern
+#endif
+
+#endif

--- a/Sources/_FoundationInternationalizationData/include/ListFormatData.h
+++ b/Sources/_FoundationInternationalizationData/include/ListFormatData.h
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <_FoundationCShims/_CShimsMacros.h>
+
+// Stub for data that will be populated
+INTERNAL const char * const _ListFormatPatterns[];

--- a/Sources/_FoundationInternationalizationData/include/ListFormatData.h
+++ b/Sources/_FoundationInternationalizationData/include/ListFormatData.h
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
 #include "_CShimsMacros.h"
-#else
-#import <_FoundationCShims/_CShimsMacros.h>
-#endif
 
 // Stub for data that will be populated
 INTERNAL const char * const * _ListFormatPatterns;

--- a/Sources/_FoundationInternationalizationData/include/ListFormatData.h
+++ b/Sources/_FoundationInternationalizationData/include/ListFormatData.h
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "_CShimsMacros.h"
+#include "InternationalizationDataMacros.h"
 
 // Stub for data that will be populated
 INTERNAL const char * const * _ListFormatPatterns;

--- a/Sources/_FoundationInternationalizationData/include/ListFormatData.h
+++ b/Sources/_FoundationInternationalizationData/include/ListFormatData.h
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
+#include "_CShimsMacros.h"
+#else
 #import <_FoundationCShims/_CShimsMacros.h>
+#endif
 
 // Stub for data that will be populated
-INTERNAL const char * const _ListFormatPatterns[];
+INTERNAL const char * const * _ListFormatPatterns;

--- a/Sources/_FoundationInternationalizationData/include/module.modulemap
+++ b/Sources/_FoundationInternationalizationData/include/module.modulemap
@@ -1,4 +1,5 @@
 module _FoundationInternationalizationData {
+    header "InternationalizationDataMacros.h"
     header "ListFormatData.h"
 
     export *

--- a/Sources/_FoundationInternationalizationData/include/module.modulemap
+++ b/Sources/_FoundationInternationalizationData/include/module.modulemap
@@ -1,0 +1,5 @@
+module _FoundationInternationalizationData {
+    header "ListFormatData.h"
+
+    export *
+}


### PR DESCRIPTION
Creates a library named `_FoundationInternationalizationData` to hold CLDR data that Foundation uses directly for its native implementations of ICU functionality

### Motivation:

This is a precursor to https://github.com/swiftlang/swift-foundation/pull/1991 which will introduce the first set of data to this library and begin using it.

### Modifications:

- Create a new `_FoundationInternationalizationData` static library
- Statically link it into the `FoundationInternationalization` dynamic library for dynamic builds, or install the library for static builds (mirroring the behavior of `_FoundationCShims`)

### Result:

`_FoundationInternationalizationData` library is created

### Testing:

Will test via this repo's CI as well as full toolchain testing alongside the modification to the windows installer script to include the new header
