### PR TITLE
[Windows] Atomic write: clear READONLY on destination and retry rename

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -447,17 +447,51 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
                     wcscpy_s($0, cchLength + 1, pwszPath)
                 }
 
-                if !SetFileInformationByHandle(hFile, FileRenameInfoEx, pInfo, dwSize) {
-                    let dwError = GetLastError()
+                var renameOk = SetFileInformationByHandle(hFile, FileRenameInfoEx, pInfo, dwSize)
+
+                if !renameOk {
+                    var dwError = GetLastError()
+
+                    // FileRenameInfoEx with POSIX_SEMANTICS + REPLACE_IF_EXISTS
+                    // returns ERROR_ACCESS_DENIED (mapped from NTSTATUS STATUS_CANNOT_DELETE)
+                    // when the destination has FILE_ATTRIBUTE_READONLY.
+                    // Clear it on the destination (in line with POSIX semantics)
+                    // and retry once before falling through.
+                    if dwError == ERROR_ACCESS_DENIED {
+                        let dwAttributes = GetFileAttributesW(pwszPath)
+
+                        if dwAttributes != INVALID_FILE_ATTRIBUTES
+                            && dwAttributes & FILE_ATTRIBUTE_READONLY != 0
+                        {
+                            // TOCTOU is possible here between GetFileAttributesW and SetFileAttributesW.
+                            // Only relevant though in the atypical case when SetFileInformationByHandle
+                            // returns false, where the thread is already on an error path.
+                            // Hence, skip expensive mitigation and defer to caller.
+                            if SetFileAttributesW(pwszPath, dwAttributes & ~FILE_ATTRIBUTE_READONLY) {
+                                renameOk = SetFileInformationByHandle(hFile, FileRenameInfoEx, pInfo, dwSize) // Retry
+
+                                if !renameOk {
+                                    dwError = GetLastError()
+                                }
+                            } else {
+                                dwError = GetLastError()
+                            }
+                        }
+                    }
+
+                    _ = CloseHandle(hFile)
+                    hFile = INVALID_HANDLE_VALUE
+
+                    if renameOk {
+                        return
+                    }
+
                     guard dwError == ERROR_NOT_SAME_DEVICE
                         || dwError == ERROR_NOT_SUPPORTED
                         || dwError == ERROR_FILE_SYSTEM_LIMITATION
                         || dwError == ERROR_INVALID_PARAMETER else {
                         throw CocoaError.errorWithFilePath(inPath, win32: dwError, reading: false)
                     }
-
-                    _ = CloseHandle(hFile)
-                    hFile = INVALID_HANDLE_VALUE
 
                     // The move is across volumes or on Volumes that don't support FILE_RENAME_FLAG_POSIX_SEMANTICS, like exFat.
                     guard MoveFileExW(pwszAuxiliaryPath, pwszPath, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING) else {

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -452,21 +452,14 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
                 if !renameOk {
                     var dwError = GetLastError()
 
-                    // FileRenameInfoEx with POSIX_SEMANTICS + REPLACE_IF_EXISTS
-                    // returns ERROR_ACCESS_DENIED (mapped from NTSTATUS STATUS_CANNOT_DELETE)
-                    // when the destination has FILE_ATTRIBUTE_READONLY.
-                    // Clear it on the destination (in line with POSIX semantics)
-                    // and retry once before falling through.
+                    // FileRenameInfoEx with POSIX_SEMANTICS + REPLACE_IF_EXISTS returns ERROR_ACCESS_DENIED (mapped from NTSTATUS STATUS_CANNOT_DELETE) when the destination has FILE_ATTRIBUTE_READONLY. Clear it on the destination (in line with POSIX semantics) and retry once before falling through.
                     if dwError == ERROR_ACCESS_DENIED {
                         let dwAttributes = GetFileAttributesW(pwszPath)
 
                         if dwAttributes != INVALID_FILE_ATTRIBUTES
                             && dwAttributes & FILE_ATTRIBUTE_READONLY != 0
                         {
-                            // TOCTOU is possible here between GetFileAttributesW and SetFileAttributesW.
-                            // Only relevant though in the atypical case when SetFileInformationByHandle
-                            // returns false, where the thread is already on an error path.
-                            // Hence, skip expensive mitigation and defer to caller.
+                            // TOCTOU is possible here between GetFileAttributesW and SetFileAttributesW. Only relevant though in the atypical case when SetFileInformationByHandle returns false, where the thread is already on an error path. Hence, skip expensive mitigation and defer to caller.
                             if SetFileAttributesW(pwszPath, dwAttributes & ~FILE_ATTRIBUTE_READONLY) {
                                 renameOk = SetFileInformationByHandle(hFile, FileRenameInfoEx, pInfo, dwSize) // Retry
 

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -18,10 +18,6 @@ import Testing
 @testable import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
-#if os(Windows)
-import WinSDK
-#endif
-
 private func generateTestData(count: Int = 16_777_216) -> Data {
     // Set a few bytes so we're sure to not be all zeros
     let buf = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: count)
@@ -216,29 +212,28 @@ private final class DataIOTests {
         #expect(readData == data)
     }
 
-#if os(Windows)
-    // Atomic writes on Windows use FileRenameInfoEx with POSIX_SEMANTICS.
-    // Even with REPLACE_IF_EXISTS the rename returns ERROR_ACCESS_DENIED when
-    // the destination has FILE_ATTRIBUTE_READONLY. Verify the attribute-clear
-    // retry path lets the write succeed.
+    // Atomic writes must succeed when the destination is read-only, and the resulting file must not retain the read-only state.
+    // On POSIX this is the behavior of rename(2). On Windows, SetFileInformationByHandle with FileRenameInfoEx returns ERROR_ACCESS_DENIED for a FILE_ATTRIBUTE_READONLY destination even with FILE_RENAME_FLAG_POSIX_SEMANTICS | FILE_RENAME_FLAG_REPLACE_IF_EXISTS. So the read-only attribute is cleared and the rename is retried.
     @Test
     func atomicWriteReplacesReadOnlyDestination() throws {
         let initial = Data("initial".utf8)
         let next = Data("next".utf8)
+        let later = Data("later".utf8)
 
         try initial.write(to: url)
-
-        let setOK: Bool = try url.path.withNTPathRepresentation { pwszPath in
-            SetFileAttributesW(pwszPath, DWORD(WinSDK.FILE_ATTRIBUTE_READONLY))
-        }
-        #expect(setOK)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o400], // Read-only for owner
+            ofItemAtPath: url.path
+        )
 
         try next.write(to: url, options: [.atomic])
 
         let read = try Data(contentsOf: url)
         #expect(read == next)
+
+        // The path now resolves to the new temp file (the rename operation detached the old destination). Confirm it's writable by performing a subsequent non-atomic write.
+        try later.write(to: url)
     }
-#endif
 }
 
 extension LargeDataTests {

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -18,6 +18,10 @@ import Testing
 @testable import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
+#if os(Windows)
+import WinSDK
+#endif
+
 private func generateTestData(count: Int = 16_777_216) -> Data {
     // Set a few bytes so we're sure to not be all zeros
     let buf = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: count)
@@ -211,6 +215,30 @@ private final class DataIOTests {
         let readData = try Data(contentsOf: url, options: [])
         #expect(readData == data)
     }
+
+#if os(Windows)
+    // Atomic writes on Windows use FileRenameInfoEx with POSIX_SEMANTICS.
+    // Even with REPLACE_IF_EXISTS the rename returns ERROR_ACCESS_DENIED when
+    // the destination has FILE_ATTRIBUTE_READONLY. Verify the attribute-clear
+    // retry path lets the write succeed.
+    @Test
+    func atomicWriteReplacesReadOnlyDestination() throws {
+        let initial = Data("initial".utf8)
+        let next = Data("next".utf8)
+
+        try initial.write(to: url)
+
+        let setOK: Bool = try url.path.withNTPathRepresentation { pwszPath in
+            SetFileAttributesW(pwszPath, DWORD(WinSDK.FILE_ATTRIBUTE_READONLY))
+        }
+        #expect(setOK)
+
+        try next.write(to: url, options: [.atomic])
+
+        let read = try Data(contentsOf: url)
+        #expect(read == next)
+    }
+#endif
 }
 
 extension LargeDataTests {


### PR DESCRIPTION
### Motivation:

`SetFileInformationByHandle` with `FileRenameInfoEx` and `FILE_RENAME_FLAG_POSIX_SEMANTICS | FILE_RENAME_FLAG_REPLACE_IF_EXISTS` can fail with `ERROR_ACCESS_DENIED` (mapped from NTSTATUS `STATUS_CANNOT_DELETE`) when the destination has `FILE_ATTRIBUTE_READONLY`. POSIX `rename(2)` is not affected if the destination file itself is read-only. This is the final piece for #1485.

### Modifications:

- When the rename fails with `ERROR_ACCESS_DENIED` and the destination has `FILE_ATTRIBUTE_READONLY` set, clear that attribute and retry the rename once before falling through to the existing `MoveFileExW` fallback.

### Result:

Atomic writes on Windows now replace a read-only destination, aligning with POSIX semantics.

### Testing:

Added a cross-platform test to verify the modification and its consistency.