### PR TITLE
Add FoundationPreview 6.5 version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ list(APPEND _SwiftFoundation_versions
     "6.2"
     "6.3"
     "6.4"
+    "6.5"
     )
 
 # Each availability name to define

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import CompilerPluginSupport
 let availabilityTags: [_Availability] = [
     _Availability("FoundationPreview"), // Default FoundationPreview availability
 ]
-let versionNumbers = ["6.0.2", "6.1", "6.2", "6.3", "6.4"]
+let versionNumbers = ["6.0.2", "6.1", "6.2", "6.3", "6.4", "6.5"]
 
 // Availability Macro Utilities
 


### PR DESCRIPTION
Adds a `FoundationPreview 6.5` version

### Motivation:

This allows APIs to declare availability if they will land in the 6.5 release (or whatever comes after 6.4 if the version number happens to change)

### Modifications:

Adds `FoundationPreview 6.5` to the SwiftPM and CMake builds

### Result:

APIs can be marked as available in `FoundationPreview 6.5`

### Testing:

CI validates that the project still builds
