### PR TITLE
SortComparator: materialise comparator `Sequence` before reusing it for sort (#874)

### DIFF
--- a/Sources/FoundationEssentials/SortComparator.swift
+++ b/Sources/FoundationEssentials/SortComparator.swift
@@ -258,6 +258,12 @@ extension Sequence {
         S.Element == Comparator,
         Element == Comparator.Compared
     {
+        // Materialize the comparator sequence into an array: `compare(_:_:)` is
+        // invoked once per pair of elements, and `Sequence` does not promise
+        // non-destructive multi-pass iteration. A single-use sequence (e.g. one
+        // backed by `AnyIterator`) would otherwise be exhausted after the first
+        // comparison and silently produce an unsorted result.
+        let comparators = Array(comparators)
         return self.sorted {
             comparators.compare($0, $1) == .orderedAscending
         }

--- a/Tests/FoundationEssentialsTests/SortComparatorTests.swift
+++ b/Tests/FoundationEssentialsTests/SortComparatorTests.swift
@@ -41,6 +41,22 @@ private struct SortComparatorTests {
         #expect(intDesc.compare(100, 100) == .orderedSame)
     }
     
+    @Test func sortedWithSingleUseSequenceOfComparators() {
+        struct OrderTracker: SortComparator, Equatable {
+            var order: SortOrder = .forward
+            func compare(_ lhs: Int, _ rhs: Int) -> ComparisonResult {
+                if lhs < rhs { return order == .forward ? .orderedAscending : .orderedDescending }
+                if lhs > rhs { return order == .forward ? .orderedDescending : .orderedAscending }
+                return .orderedSame
+            }
+        }
+        let comparator = OrderTracker()
+        let input = [5, 2, 9, 1, 3]
+        var iterator = AnyIterator([comparator].makeIterator())
+        let singleUse = AnySequence { iterator }
+        #expect(input.sorted(using: singleUse) == [1, 2, 3, 5, 9])
+    }
+
     @Test func anySortComparatorEquality() {
         let a: ComparableComparator<Int> = ComparableComparator<Int>()
         let b: ComparableComparator<Int> = ComparableComparator<Int>(order: .reverse)


### PR DESCRIPTION
`SortComparator` shouldn't assume it can iterate its `Sequence` of `SortComparator`s multiple times.

### Motivation:

The public `Sequence.sorted(using: S)` overload that takes a `Sequence` of `SortComparator`s forwards each pair of elements through `comparators.compare(_:_:)`, which itself iterates the entire sequence.  That works for `Array` (or any multi-pass collection) but `Sequence` does not promise non-destructive iteration: a single-use sequence (e.g. `AnySequence` wrapping an `AnyIterator`) is exhausted after the first comparison, so every subsequent call to `compare` walks an empty iterator and returns `.orderedSame` — silently leaving the bulk of the input unsorted.

I don't know how common it is to do this - I imagine the concrete type used is just an `Array` 99% of the time, which happens to work just fine - but this is easy to fix and the kind of bug that's quite hard to find if you stumble into it unwittingly, as a user of this API.

### Modifications:

This patch fixes that by snapshotting the comparator sequence into an `Array` before sorting so it can be replayed safely.

### Result:

Sorting works as the caller intended, irrespective of what type of `Sequence` they use.

### Testing:

New unit test added.