### PR TITLE
URL: don't append a trailing '?' when the queryItems list is empty (#1548)

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1713,6 +1713,9 @@ extension URL {
     /// - Parameter queryItems: A list of `URLQueryItem` to append to the receiver.
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public func appending(queryItems: [URLQueryItem]) -> URL {
+        // Appending nothing should not alter the URL — in particular, must not
+        // synthesize a trailing "?" when the receiver had no query.
+        guard !queryItems.isEmpty else { return self }
         guard var c = URLComponents(url: self, resolvingAgainstBaseURL: true) else { return self }
         var newItems = c.queryItems ?? []
         newItems.append(contentsOf: queryItems)

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -2055,6 +2055,20 @@ private struct URLTests {
         #expect(url.pathComponents == ["/", "a"])
     }
 
+    @Test func appendingEmptyQueryItemsLeavesURLUnchanged() throws {
+        // Appending an empty list of query items to a URL that has no existing query string should not introduce a stray "?" trailer.
+        let plain = try #require(URL(string: "https://www.example.com/path"))
+        #expect(plain.appending(queryItems: []).absoluteString == "https://www.example.com/path")
+
+        // If there are existing query items, an empty append must preserve them.
+        let withQuery = try #require(URL(string: "https://www.example.com/path?a=1"))
+        #expect(withQuery.appending(queryItems: []).absoluteString == "https://www.example.com/path?a=1")
+
+        // And of course the regular case must still work.
+        let appended = plain.appending(queryItems: [.init(name: "k", value: "v")])
+        #expect(appended.absoluteString == "https://www.example.com/path?k=v")
+    }
+
     @Test func lastPathComponent() throws {
         var url = URL(filePath: "/")
         #expect(url.lastPathComponent == "/")


### PR DESCRIPTION
### Motivation:

`URL.appending(queryItems:)` blindly assigned `c.queryItems = newItems` even when `newItems` was empty. `URLComponents` distinguishes between `queryItems == nil` (no query, no '?') and `queryItems == []` (empty query, trailing '?'), so appending an empty array to a URL that had no query introduced a stray '?':

```swift
URL(string: "https://www.example.com/path")!
    .appending(queryItems: [])
// -> "https://www.example.com/path?"
````

### Modifications:

This patch makes it short-circuit on an empty input list and return the receiver unchanged.

### Result:

Appending an empty list won't change the URL.

### Testing:

Added a new unit test which checks that the errant '?' is no longer appended, but also that the '?' remains if already there, and that appending a non-empty set of items still works (technically redundant with other tests - IMO makes sense locally since it encompasses the full set of '?'-related cases, but I can remove that if you prefer).