### PR TITLE
Recurse through Optional when allowlisting predicate key paths

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -15,6 +15,17 @@
 #if canImport(ReflectionInternal)
 internal import ReflectionInternal
 
+/// An internal marker used to look through `Optional` when recursively allowlisting key paths.
+///
+/// Conforming `Optional` to this protocol exposes its `Wrapped` metatype so that a key path whose value type is `Optional<Wrapped>` can be unwrapped to `Wrapped` before checking for `PredicateCodableKeyPathProviding` conformance.
+private protocol _PredicateOptionalProtocol {
+    static var _wrappedType: Any.Type { get }
+}
+
+extension Optional: _PredicateOptionalProtocol {
+    static var _wrappedType: Any.Type { Wrapped.self }
+}
+
 /// A type that provides the expected key paths found in an archived predicate.
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public protocol PredicateCodableKeyPathProviding {
@@ -261,19 +272,33 @@ public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConverti
     public mutating func allowKeyPathsForPropertiesProvided<T: PredicateCodableKeyPathProviding>(by type: T.Type, recursive: Bool = false) {
         for (identifier, keyPath) in type.predicateCodableKeyPaths {
             allowKeyPath(keyPath, identifier: identifier)
-            if recursive, let valueType = Swift.type(of: keyPath).valueType as? any PredicateCodableKeyPathProviding.Type {
+            if recursive, let valueType = _providingType(forValueOf: keyPath) {
                 allowKeyPathsForPropertiesProvided(by: valueType, recursive: true)
             }
         }
     }
-    
+
     public mutating func disallowKeyPathsForPropertiesProvided<T: PredicateCodableKeyPathProviding>(by type: T.Type, recursive: Bool = false) {
         for (_, keyPath) in type.predicateCodableKeyPaths {
             disallowKeyPath(keyPath)
-            if recursive, let valueType = Swift.type(of: keyPath).valueType as? any PredicateCodableKeyPathProviding.Type {
+            if recursive, let valueType = _providingType(forValueOf: keyPath) {
                 disallowKeyPathsForPropertiesProvided(by: valueType, recursive: true)
             }
         }
+    }
+
+    /// Returns the providing type to recurse into for a key path's value, looking through one layer of `Optional` when necessary.
+    ///
+    /// A key path whose value is declared as an optional property (such as `Address?`) reports a value type of `Optional<Address>`, which does not itself conform to `PredicateCodableKeyPathProviding`. Looking through the optional lets recursive allowlisting reach the wrapped type's key paths.
+    private func _providingType(forValueOf keyPath: AnyKeyPath) -> (any PredicateCodableKeyPathProviding.Type)? {
+        let valueType = Swift.type(of: keyPath).valueType
+        if let providing = valueType as? any PredicateCodableKeyPathProviding.Type {
+            return providing
+        }
+        if let optional = valueType as? any _PredicateOptionalProtocol.Type {
+            return optional._wrappedType as? any PredicateCodableKeyPathProviding.Type
+        }
+        return nil
     }
     
     public mutating func allow(_ other: Self) {

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -83,10 +83,20 @@ private struct PredicateCodableTests {
     struct Object2 : Equatable, PredicateCodableKeyPathProviding {
         var a: Int
         var b: String
-        
+
         static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object2> & Sendable] {
             ["Object2.a" : \.a]
         }
+    }
+
+    struct ObjectWithOptional : Equatable, PredicateCodableKeyPathProviding {
+        var child: Object2?
+
+        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.ObjectWithOptional> & Sendable] {
+            ["ObjectWithOptional.child" : \.child]
+        }
+
+        static let example = ObjectWithOptional(child: Object2(a: 1, b: "Foo"))
     }
     
     struct MinimalConfig : PredicateCodingConfigurationProviding {
@@ -122,6 +132,16 @@ private struct PredicateCodableTests {
         }()
     }
     
+    struct RecursiveOptionalProvidedKeyPathConfig : PredicateCodingConfigurationProviding {
+        static let config = {
+            var config = PredicateCodableConfiguration.standardConfiguration
+            config.allowType(ObjectWithOptional.self, identifier: "Foundation.PredicateCodableTests.ObjectWithOptional")
+            config.allowType(Object2.self, identifier: "Foundation.PredicateCodableTests.Object2")
+            config.allowKeyPathsForPropertiesProvided(by: ObjectWithOptional.self, recursive: true)
+            return config
+        }()
+    }
+
     struct EmptyConfig : PredicateCodingConfigurationProviding {
         static let config = PredicateCodableConfiguration()
     }
@@ -304,6 +324,15 @@ private struct PredicateCodableTests {
         #expect(try decoded.evaluate(.example) == predicate.evaluate(.example))
     }
     
+    @Test func recursiveProvidedPropertiesThroughOptional() throws {
+        let predicate = #Predicate<ObjectWithOptional> {
+            ($0.child?.a ?? 0) == 1
+        }
+
+        let decoded = try _encodeDecode(predicate, for: RecursiveOptionalProvidedKeyPathConfig.self)
+        #expect(try decoded.evaluate(.example) == predicate.evaluate(.example))
+    }
+
     @Test func defaultAllowlist() throws {
         var predicate = #Predicate<String> {
             $0.isEmpty


### PR DESCRIPTION
## Summary

`PredicateCodableConfiguration.allowKeyPathsForPropertiesProvided(by:recursive:)` skipped recursion for any property whose declared type is Optional, so an optional sub-object's key paths were never added to the allowlist. Encoding a predicate that traversed such a property then failed with a "keypath is not in the provided allowlist" error unless the wrapped type was allowlisted by hand. This addresses #1356.

## Root cause

The recursion guard cast the key path's value type directly to `PredicateCodableKeyPathProviding`:

```swift
if recursive, let valueType = Swift.type(of: keyPath).valueType as? any PredicateCodableKeyPathProviding.Type {
    allowKeyPathsForPropertiesProvided(by: valueType, recursive: true)
}
```

For a non-optional property like `let address: Address`, the value type is `Address`, the cast succeeds, and recursion proceeds. For an optional property like `let address: Address?`, the value type is `Optional<Address>`. `Optional<Address>` does not conform to `PredicateCodableKeyPathProviding` even when `Address` does, so the cast fails and the wrapped type's key paths are silently never allowed. That mismatch is exactly why the issue's example works after a manual `allowKeyPathsForPropertiesProvided(by: Address.self)` call but not with `recursive: true` alone.

## Fix

A small helper looks through a single layer of Optional before checking for conformance. If the value type already conforms it is used directly, preserving existing behavior. If it is an Optional, the wrapped type is checked for conformance and recursed into when it conforms. The same helper is used by the matching disallow path so the two stay symmetric. Looking through the optional means an optional providing property now recurses into its wrapped type the same way a non-optional property already did.

## Testing

Added `recursiveProvidedPropertiesThroughOptional` to `PredicateCodableTests`, which encodes and decodes a predicate that traverses an optional providing property under a recursive configuration and verifies the round-tripped predicate evaluates identically. The test fails before this change (encoding throws because the wrapped type's key path is not allowlisted) and passes after it.

The predicate archiving code is gated behind `FOUNDATION_FRAMEWORK`, so I confirmed the FoundationEssentials and FoundationEssentialsTests targets build cleanly, validated the Optional look-through logic in isolation, and ran the SwiftPM predicate test suite, which passes with no regressions.

Fixes #1356