### PR TITLE
Add imports for Foundation Darwin Extras

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -23,6 +23,8 @@ import CRT
 import WinSDK
 #elseif os(WASI)
 import WASILibc
+#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+internal import _FoundationDarwinExtras
 #elseif canImport(stdlib_h)
 import stdlib_h
 #endif

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -46,6 +46,10 @@
 @usableFromInline let memset = WASILibc.memset
 @usableFromInline let memcpy = WASILibc.memcpy
 @usableFromInline let memcmp = WASILibc.memcmp
+#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+@usableFromInline let memset = _FoundationDarwinExtras.memset
+@usableFromInline let memcpy = _FoundationDarwinExtras.memcpy
+@usableFromInline let memcmp = _FoundationDarwinExtras.memcmp
 #endif
 
 #if !NO_CSHIMS
@@ -81,6 +85,8 @@ internal func malloc_good_size(_ size: Int) -> Int {
 import ucrt
 #elseif canImport(WASILibc)
 @preconcurrency import WASILibc
+#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+internal import _FoundationDarwinExtras.POSIX.sys.mman
 #elseif canImport(string_h)
 import string_h
 #endif

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -22,6 +22,8 @@ import ucrt
 @preconcurrency import WASILibc
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
+#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+internal import _FoundationDarwinExtras
 #elseif canImport(stdlib_h)
 import stdlib_h
 #endif
@@ -42,7 +44,7 @@ internal final class __DataStorage : @unchecked Sendable {
     #endif
 
     static func allocate(_ size: Int, _ clear: Bool) -> UnsafeMutableRawPointer? {
-#if canImport(Darwin) && _pointerBitWidth(_64) && !NO_TYPED_MALLOC
+#if (canImport(Darwin) || HAS_FOUNDATION_DARWIN_EXTRAS) && _pointerBitWidth(_64) && !NO_TYPED_MALLOC
         var typeDesc = malloc_type_descriptor_v0_t()
         typeDesc.summary.layout_semantics.contains_generic_data = true
         if clear {
@@ -60,7 +62,7 @@ internal final class __DataStorage : @unchecked Sendable {
     }
     
     static func reallocate(_ ptr: UnsafeMutableRawPointer, _ newSize: Int) -> UnsafeMutableRawPointer? {
-#if canImport(Darwin) && _pointerBitWidth(_64) && !NO_TYPED_MALLOC
+#if (canImport(Darwin) || HAS_FOUNDATION_DARWIN_EXTRAS)  && _pointerBitWidth(_64) && !NO_TYPED_MALLOC
         var typeDesc = malloc_type_descriptor_v0_t()
         typeDesc.summary.layout_semantics.contains_generic_data = true
         return malloc_type_realloc(ptr, newSize, typeDesc.type_id);

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -47,6 +47,12 @@ import C.strings
 import C
 #endif
 fileprivate let _pageSize: Int = Int(getpagesize())
+#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+internal import _FoundationDarwinExtras
+internal import _FoundationDarwinExtras._string_runtime.xlocale
+import stdlib_h
+
+fileprivate let _pageSize: Int = Int(getpagesize())
 #elseif canImport(stdlib_h)
 import stdlib_h
 #endif // canImport(Darwin)
@@ -386,7 +392,7 @@ extension Platform {
 }
 
 extension Platform {
-    #if canImport(Darwin)
+    #if canImport(Darwin) || HAS_FOUNDATION_DARWIN_EXTRAS
     private static var cLocale: locale_t? { /* LC_C_LOCALE */ nil }
     #elseif os(Windows)
     private static var cLocale: _locale_t = {


### PR DESCRIPTION
Adds imports for `_FoundationDarwinExtras` where appropriate

### Motivation:

On some Darwin platforms, Foundation needs to import an extra module to have access to necessary declarations

### Modifications:

Adds imports of the extra module where appropriate

### Result:

Foundation builds on all Darwin platforms. No impact to other platforms.

### Testing:

CI builds on Darwin platforms pass
