### PR TITLE
(rdar://173406489) Plist parsing should reject \U sequences without any valid hex digits (#4168)

### DIFF
--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -239,7 +239,11 @@ private func parseQuotedPlistString(_ pInfo: inout _ParseInfo, quote: UInt16) ->
                 return nil
             }
             
-            guard let scalar = UnicodeScalar(getSlashedChar(&pInfo)) else {
+            guard let slashedChar = getSlashedChar(&pInfo) else {
+                // Error set by getSlashedChar.
+                return nil
+            }
+            guard let scalar = UnicodeScalar(slashedChar) else {
                 pInfo.err = OpenStepPlistError("Invalid character on line \(lineNumberStrings(pInfo))")
                 return nil
             }
@@ -310,7 +314,7 @@ private func parseOctal(startingWith ch: UInt16, _ pInfo: inout _ParseInfo) -> U
     return .init(nextStep: num)
 }
 
-private func parseU16Scalar(_ pInfo: inout _ParseInfo) -> UInt16 {
+private func parseU16Scalar(_ pInfo: inout _ParseInfo) -> UInt16? {
     var num : UInt16 = 0
     var numDigits = 4
     while !pInfo.isAtEnd && numDigits > 0 {
@@ -325,13 +329,20 @@ private func parseU16Scalar(_ pInfo: inout _ParseInfo) -> UInt16 {
             } else {
                 num += (ch2 &- UInt16(ascii: "a") &+ 10)
             }
+            numDigits -= 1
+        } else {
+            break
         }
-        numDigits -= 1
+    }
+    // We have to have encountered at least one hex digit for the `\U` directive to be valid.
+    if num == 0, numDigits == 4 {
+        pInfo.err = OpenStepPlistError("Unexpected character `\(String(describing: Unicode.Scalar(pInfo.currChar)))` while parsing unicode character escape sequence on line \(lineNumberStrings(pInfo))")
+        return nil
     }
     return num
 }
 
-private func getSlashedChar(_ pInfo: inout _ParseInfo) -> UInt16 {
+private func getSlashedChar(_ pInfo: inout _ParseInfo) -> UInt16? {
     let ch = pInfo.currChar
     pInfo.advance()
     switch ch {

--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -918,7 +918,38 @@ private struct PropertyListEncoderTests {
         let strings = try PropertyListDecoder().decode([String].self, from: data)
         #expect(strings == literals)
     }
-    
+
+    // \U syntax stops counting characters after a non-hex digit.
+    @Test func oldStylePlist_getSlashedChars_variableSizeWithFollowingCharacters() throws {
+        let data = #"('\U1z', '\U12z', '\U123z', '\U1234')"#.data(using: .utf8)!
+
+        let expectedResults = [
+            "\u{1}z",
+            "\u{12}z",
+            "\u{123}z",
+            "\u{1234}",
+        ]
+
+        let strings = try PropertyListDecoder().decode([String].self, from: data)
+        #expect(strings == expectedResults)
+    }
+
+    @Test func oldStylePlist_getSlashedChars_unicode_invalid() {
+        let examples = [
+            #"'\U'"#,
+            #"'\Ux'"#,
+            #"'\Uxx'"#,
+            #"'\Uxxx'"#,
+            #"'\Uxxxx'"#,
+        ]
+        for example in examples {
+            let data = example.data(using: .utf8)!
+            #expect(throws: (any Error).self) {
+                try PropertyListDecoder().decode(String.self, from: data)
+            }
+        }
+    }
+
     @Test func oldStylePlist_dictionary() {
         let data = """
 { "test key" = value;


### PR DESCRIPTION
The OpenStep plist format supports a variable 1-4 hex characters following a \U escape. The current implementation basically tries this algorithm four times:

* Read current character
* If it's valid hex, accumulate it and advance to the next character
Then:

* Return the accumulated value as the character.

The issue is that \U followed by ZERO valid hex characters is treated as a NUL character instead of an error.