### PR TITLE
Hebrew calendar fast paths + shared calendar helpers

### DIFF
--- a/Sources/FoundationEssentials/Calendar/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Calendar/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 target_sources(FoundationEssentials PRIVATE
     Calendar.swift
+    CalendarConstants.swift
+    CalendarUtility.swift
     Calendar_Autoupdating.swift
     Calendar_Cache.swift
     Calendar_Enumerate.swift

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1299,12 +1299,13 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - parameter direction: Which direction in time to search. The default value is `.forward`, which means later in time.
     /// - parameter block: A closure that is called with search results.
     @available(iOS 8.0, *)
+    /// Proxy to the calendar implementation's fast-path `nextDate`.
+    internal func _calendarNextDate(after date: Date, matching components: DateComponents, direction: SearchDirection) -> Date? {
+        _calendar.nextDate(after: date, matching: components, direction: direction)
+    }
+
     public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: (_ result: Date?, _ exactMatch: Bool, _ stop: inout Bool) -> Void) {
-        // Fast-path: if the calendar implementation has a direct answer for the
-        // first match AND default policies are in effect, drive the loop with
-        // repeated nextDate(after:matching:) calls instead of the generic
-        // enumerate framework. The fast path opts out (returns nil) for any
-        // pattern it can't handle, so this is safe.
+        // Fast-path: drive the loop with direct nextDate calls when default policies are in effect.
         if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
            let _ = _calendar.nextDate(after: start, matching: components, direction: direction) {
             var current = start

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1302,19 +1302,17 @@ public struct Calendar : Hashable, Equatable, Sendable {
         _calendar.nextDate(after: date, matching: components, direction: direction)
     }
 
-    /// Whether the calendar implementation supports the `nextDate` fast path.
-    internal var _supportsNextDateFastPath: Bool {
-        _calendar.supportsNextDateFastPath
+    /// Whether the calendar implementation supports the `nextDate` fast path for the given pattern.
+    internal func _supportsNextDateFastPath(for components: DateComponents) -> Bool {
+        _calendar.supportsNextDateFastPath(for: components)
     }
 
     @available(iOS 8.0, *)
     public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: (_ result: Date?, _ exactMatch: Bool, _ stop: inout Bool) -> Void) {
         // Fast-path: drive the loop with direct nextDate calls when default policies are in effect.
-        if matchingPolicy == .nextTime && repeatedTimePolicy == .first, _supportsNextDateFastPath,
-           let firstMatch = _calendar.nextDate(after: start, matching: components, direction: direction) {
+        if matchingPolicy == .nextTime && repeatedTimePolicy == .first, _supportsNextDateFastPath(for: components) {
+            var current = start
             var stop = false
-            block(firstMatch, true, &stop)
-            var current = firstMatch
             while !stop {
                 guard let next = _calendar.nextDate(after: current, matching: components, direction: direction) else {
                     block(nil, false, &stop)

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1312,9 +1312,11 @@ public struct Calendar : Hashable, Equatable, Sendable {
     public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: (_ result: Date?, _ exactMatch: Bool, _ stop: inout Bool) -> Void) {
         // Fast-path: drive the loop with direct nextDate calls when default policies are in effect.
         if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
-           _supportsNextDateFastPath {
-            var current = start
+           _supportsNextDateFastPath,
+           let firstMatch = _calendar.nextDate(after: start, matching: components, direction: direction) {
             var stop = false
+            block(firstMatch, true, &stop)
+            var current = firstMatch
             while !stop {
                 guard let next = _calendar.nextDate(after: current, matching: components, direction: direction) else {
                     block(nil, false, &stop)

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1285,7 +1285,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
         _calendar.nextDate(after: date, matching: components, direction: direction)
     }
 
-    internal func _supportsNextDateFastPath(for components: DateComponents) -> Bool {
+    internal func _supportsNextDateFastPath(for components: ComponentSet) -> Bool {
         _calendar.supportsNextDateFastPath(for: components)
     }
 
@@ -1309,7 +1309,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     @available(iOS 8.0, *)
     public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: (_ result: Date?, _ exactMatch: Bool, _ stop: inout Bool) -> Void) {
         // Fast-path: drive the loop with direct nextDate calls when default policies are in effect.
-        if matchingPolicy == .nextTime && repeatedTimePolicy == .first, _supportsNextDateFastPath(for: components) {
+        if matchingPolicy == .nextTime && repeatedTimePolicy == .first, _supportsNextDateFastPath(for: components._populatedComponentSet) {
             var current = start
             var stop = false
             while !stop {

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1298,8 +1298,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - parameter repeatedTimePolicy: Determines the behavior of the search algorithm when the input produces a time that occurs twice on a particular day.
     /// - parameter direction: Which direction in time to search. The default value is `.forward`, which means later in time.
     /// - parameter block: A closure that is called with search results.
-    @available(iOS 8.0, *)
-    /// Proxy to the calendar implementation's fast-path `nextDate`.
     internal func _calendarNextDate(after date: Date, matching components: DateComponents, direction: SearchDirection) -> Date? {
         _calendar.nextDate(after: date, matching: components, direction: direction)
     }
@@ -1309,10 +1307,10 @@ public struct Calendar : Hashable, Equatable, Sendable {
         _calendar.supportsNextDateFastPath
     }
 
+    @available(iOS 8.0, *)
     public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: (_ result: Date?, _ exactMatch: Bool, _ stop: inout Bool) -> Void) {
         // Fast-path: drive the loop with direct nextDate calls when default policies are in effect.
-        if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
-           _supportsNextDateFastPath,
+        if matchingPolicy == .nextTime && repeatedTimePolicy == .first, _supportsNextDateFastPath,
            let firstMatch = _calendar.nextDate(after: start, matching: components, direction: direction) {
             var stop = false
             block(firstMatch, true, &stop)

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1281,6 +1281,14 @@ public struct Calendar : Hashable, Equatable, Sendable {
         }
     }
 
+    internal func _calendarNextDate(after date: Date, matching components: DateComponents, direction: SearchDirection) -> Date? {
+        _calendar.nextDate(after: date, matching: components, direction: direction)
+    }
+
+    internal func _supportsNextDateFastPath(for components: DateComponents) -> Bool {
+        _calendar.supportsNextDateFastPath(for: components)
+    }
+
     /// Computes the dates which match (or most closely match) a given set of components, and calls the closure once for each of them, until the enumeration is stopped.
     ///
     /// There will be at least one intervening date which does not match all the components (or the given date itself must not match) between the given date and any result.
@@ -1298,15 +1306,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - parameter repeatedTimePolicy: Determines the behavior of the search algorithm when the input produces a time that occurs twice on a particular day.
     /// - parameter direction: Which direction in time to search. The default value is `.forward`, which means later in time.
     /// - parameter block: A closure that is called with search results.
-    internal func _calendarNextDate(after date: Date, matching components: DateComponents, direction: SearchDirection) -> Date? {
-        _calendar.nextDate(after: date, matching: components, direction: direction)
-    }
-
-    /// Whether the calendar implementation supports the `nextDate` fast path for the given pattern.
-    internal func _supportsNextDateFastPath(for components: DateComponents) -> Bool {
-        _calendar.supportsNextDateFastPath(for: components)
-    }
-
     @available(iOS 8.0, *)
     public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: (_ result: Date?, _ exactMatch: Bool, _ stop: inout Bool) -> Void) {
         // Fast-path: drive the loop with direct nextDate calls when default policies are in effect.

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1304,10 +1304,15 @@ public struct Calendar : Hashable, Equatable, Sendable {
         _calendar.nextDate(after: date, matching: components, direction: direction)
     }
 
+    /// Whether the calendar implementation supports the `nextDate` fast path.
+    internal var _supportsNextDateFastPath: Bool {
+        _calendar.supportsNextDateFastPath
+    }
+
     public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: (_ result: Date?, _ exactMatch: Bool, _ stop: inout Bool) -> Void) {
         // Fast-path: drive the loop with direct nextDate calls when default policies are in effect.
         if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
-           let _ = _calendar.nextDate(after: start, matching: components, direction: direction) {
+           _supportsNextDateFastPath {
             var current = start
             var stop = false
             while !stop {

--- a/Sources/FoundationEssentials/Calendar/CalendarConstants.swift
+++ b/Sources/FoundationEssentials/Calendar/CalendarConstants.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Time-unit constants shared across calendar implementations.
+internal enum _CalendarConstants {
+    static let kSecondsInWeek = 604_800
+    static let kSecondsInDay = 86400
+    static let kSecondsInHour = 3600
+    static let kSecondsInMinute = 60
+
+    /// Sentinel used by unbounded-range loops in date arithmetic.
+    static let inf_ti: TimeInterval = 4398046511104.0
+}

--- a/Sources/FoundationEssentials/Calendar/CalendarConstants.swift
+++ b/Sources/FoundationEssentials/Calendar/CalendarConstants.swift
@@ -10,13 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Time-unit constants shared across calendar implementations.
-internal enum _CalendarConstants {
-    static let kSecondsInWeek = 604_800
-    static let kSecondsInDay = 86400
-    static let kSecondsInHour = 3600
-    static let kSecondsInMinute = 60
+extension Calendar {
+    /// Time unit constants shared across calendar implementations.
+    static let _kSecondsInWeek = 604_800
+    static let _kSecondsInDay = 86400
+    static let _kSecondsInHour = 3600
+    static let _kSecondsInMinute = 60
 
-    /// Sentinel used by unbounded-range loops in date arithmetic.
-    static let inf_ti: TimeInterval = 4398046511104.0
+    /// Sentinel used by unbounded range loops in date arithmetic.
+    static let _inf_ti: TimeInterval = 4398046511104.0
 }

--- a/Sources/FoundationEssentials/Calendar/CalendarConstants.swift
+++ b/Sources/FoundationEssentials/Calendar/CalendarConstants.swift
@@ -12,11 +12,11 @@
 
 extension Calendar {
     /// Time unit constants shared across calendar implementations.
-    static let _kSecondsInWeek = 604_800
-    static let _kSecondsInDay = 86400
-    static let _kSecondsInHour = 3600
-    static let _kSecondsInMinute = 60
+    static let _secondsInWeek = 604_800
+    static let _secondsInDay = 86400
+    static let _secondsInHour = 3600
+    static let _secondsInMinute = 60
 
-    /// Sentinel used by unbounded range loops in date arithmetic.
-    static let _inf_ti: TimeInterval = 4398046511104.0
+    /// Upper bound for date interval durations in unbounded range loops.
+    static let _maxDateIntervalDuration: TimeInterval = 4398046511104.0
 }

--- a/Sources/FoundationEssentials/Calendar/CalendarUtility.swift
+++ b/Sources/FoundationEssentials/Calendar/CalendarUtility.swift
@@ -71,8 +71,7 @@ internal enum _CalendarUtility {
     // MARK: - isDateInWeekend
 
     /// Whether `weekday` + `timeInDay` falls within `weekendRange`.
-    static func isDateInWeekend(weekday: Int, timeInDay: TimeInterval,
-                                 weekendRange: WeekendRange) -> Bool {
+    static func isDateInWeekend(weekday: Int, timeInDay: TimeInterval, weekendRange: WeekendRange) -> Bool {
         if weekendRange.start == weekendRange.end && weekday != weekendRange.start {
             return false
         } else if weekendRange.start < weekendRange.end && (weekday < weekendRange.start || weekday > weekendRange.end) {

--- a/Sources/FoundationEssentials/Calendar/CalendarUtility.swift
+++ b/Sources/FoundationEssentials/Calendar/CalendarUtility.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Static helpers shared by `_CalendarProtocol` conformers.
+internal enum _CalendarUtility {
+
+    // MARK: - firstWeekday
+
+    /// Validates a `firstWeekday` value (must be 1...7).
+    static func validatedFirstWeekday(_ value: Int) -> Int {
+        precondition(value >= 1 && value <= 7, "Weekday should be in the range of 1...7")
+        return value
+    }
+
+    /// Resolves `firstWeekday`: stored value → locale preference → 1 (Sunday).
+    static func resolveFirstWeekday(stored: Int?, locale: Locale?) -> Int {
+        if let stored {
+            return stored
+        } else if let locale {
+            return locale.firstDayOfWeek.icuIndex
+        } else {
+            return 1
+        }
+    }
+
+    // MARK: - minimumDaysInFirstWeek
+
+    /// Clamps `minimumDaysInFirstWeek` to 1...7.
+    static func clampedMinimumDaysInFirstWeek(_ value: Int) -> Int {
+        if value < 1 { return 1 }
+        if value > 7 { return 7 }
+        return value
+    }
+
+    /// Resolves `minimumDaysInFirstWeek`: stored value → locale preference → 1.
+    static func resolveMinimumDaysInFirstWeek(stored: Int?, locale: Locale?) -> Int {
+        if let stored {
+            return stored
+        } else if let locale {
+            return locale.minimumDaysInFirstWeek
+        } else {
+            return 1
+        }
+    }
+
+    // MARK: - copy()
+
+    /// Resolves `copy(...)` arguments: override if supplied, else current value.
+    static func resolvedCopyArgs(
+        currentTimeZone: TimeZone, changingTimeZone: TimeZone?,
+        currentLocale: Locale?, changingLocale: Locale?,
+        currentFirstWeekday: Int?, changingFirstWeekday: Int?,
+        currentMinimumDaysInFirstWeek: Int?, changingMinimumDaysInFirstWeek: Int?
+    ) -> (timeZone: TimeZone, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?) {
+        let newTimeZone = changingTimeZone ?? currentTimeZone
+        let newLocale = changingLocale ?? currentLocale
+        let newFirstWeekday: Int? = changingFirstWeekday ?? currentFirstWeekday
+        let newMinDays: Int? = changingMinimumDaysInFirstWeek ?? currentMinimumDaysInFirstWeek
+        return (newTimeZone, newLocale, newFirstWeekday, newMinDays)
+    }
+
+    // MARK: - isDateInWeekend
+
+    /// Whether `weekday` + `timeInDay` falls within `weekendRange`.
+    static func isDateInWeekend(weekday: Int, timeInDay: TimeInterval,
+                                 weekendRange: WeekendRange) -> Bool {
+        if weekendRange.start == weekendRange.end && weekday != weekendRange.start {
+            return false
+        } else if weekendRange.start < weekendRange.end && (weekday < weekendRange.start || weekday > weekendRange.end) {
+            return false
+        } else if weekendRange.start > weekendRange.end && (weekday > weekendRange.end && weekday < weekendRange.start) {
+            return false
+        }
+
+        if weekday == weekendRange.start {
+            guard let onsetTime = weekendRange.onsetTime, onsetTime != 0 else {
+                return true
+            }
+            return timeInDay >= onsetTime
+        } else if weekday == weekendRange.end {
+            guard let ceaseTime = weekendRange.ceaseTime, ceaseTime < 86400 else {
+                return true
+            }
+            return timeInDay < ceaseTime
+        } else {
+            return true
+        }
+    }
+
+    /// Default weekend range (region 001): Sat–Sun, full day.
+    static let defaultWeekendRange = WeekendRange(onsetTime: 0, ceaseTime: 86400, start: 7, end: 1)
+}

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -331,8 +331,7 @@ extension Calendar {
                 let validates = matchingComponents._validate(for: calendar)
                 finished = !validates
 
-                self.usesFastPath = validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first
-                    && calendar._supportsNextDateFastPath(for: matchingComponents)
+                self.usesFastPath = validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first && calendar._supportsNextDateFastPath(for: matchingComponents)
             }
             
             mutating func next() -> Element? {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -332,8 +332,7 @@ extension Calendar {
                 finished = !validates
 
                 self.usesFastPath = validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first
-                    && calendar._supportsNextDateFastPath
-                    && calendar._calendarNextDate(after: start, matching: matchingComponents, direction: direction) != nil
+                    && calendar._supportsNextDateFastPath(for: matchingComponents)
             }
             
             mutating func next() -> Element? {
@@ -539,7 +538,7 @@ extension Calendar {
                                          previouslyReturnedMatchDate: Date?) throws -> SearchStepResult {
 
         // Fast-path: ask the calendar directly. Returns nil for unrecognized patterns.
-        if _supportsNextDateFastPath && matchingPolicy == .nextTime && repeatedTimePolicy == .first {
+        if _supportsNextDateFastPath(for: matchingComponents) && matchingPolicy == .nextTime && repeatedTimePolicy == .first {
             if let fast = _calendarNextDate(after: searchingDate, matching: matchingComponents, direction: direction) {
                 return SearchStepResult(result: (fast, true), newSearchDate: fast)
             }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -310,6 +310,9 @@ extension Calendar {
             // Calculated at init, checked on `next`
             var finished: Bool
             
+            // Fast-path: skip `_enumerateDatesStep` when the calendar can answer directly.
+            let usesFastPath: Bool
+
             internal init(_ calendar: Calendar, start: Date, range: Range<Date>?, matching matchingComponents: DateComponents, matchingPolicy: Calendar.MatchingPolicy, repeatedTimePolicy: Calendar.RepeatedTimePolicy, direction: Calendar.SearchDirection) {
                 self.calendar = calendar
                 
@@ -325,12 +328,35 @@ extension Calendar {
                 searchingDate = start
                 
                 // If this fails we'll short circuit the next `next`
-                finished = !matchingComponents._validate(for: calendar)
+                let validates = matchingComponents._validate(for: calendar)
+                finished = !validates
+
+                // Probe: commit to the fast loop if the calendar recognizes this pattern.
+                if validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first,
+                   calendar._calendarNextDate(after: start, matching: matchingComponents, direction: direction) != nil {
+                    self.usesFastPath = true
+                } else {
+                    self.usesFastPath = false
+                }
             }
             
             mutating func next() -> Element? {
                 guard !finished else { return nil }
                 
+                if usesFastPath {
+                    guard let next = calendar._calendarNextDate(after: searchingDate, matching: matchingComponents, direction: direction) else {
+                        finished = true
+                        return nil
+                    }
+                    if let range, !range.contains(next) {
+                        finished = true
+                        return nil
+                    }
+                    searchingDate = next
+                    previouslyReturnedMatchDate = next
+                    return next
+                }
+
                 repeat {
                     iterations += 1
                     do {
@@ -515,6 +541,13 @@ extension Calendar {
                                          direction: SearchDirection,
                                          inSearchingDate searchingDate: Date,
                                          previouslyReturnedMatchDate: Date?) throws -> SearchStepResult {
+
+        // Fast-path: ask the calendar directly. Returns nil for unrecognized patterns.
+        if matchingPolicy == .nextTime && repeatedTimePolicy == .first {
+            if let fast = _calendarNextDate(after: searchingDate, matching: matchingComponents, direction: direction) {
+                return SearchStepResult(result: (fast, true), newSearchDate: fast)
+            }
+        }
 
         // Step A: Call helper method that does the searching
 
@@ -1630,34 +1663,46 @@ extension Calendar {
         var result = startDate
         var dateMonth = component(.month, from: result)
         if month != dateMonth {
-            repeat {
-                let lastResult = result
-                
-                guard let foundRange = dateInterval(of: .month, for: result) else {
-                    throw CalendarEnumerationError.dateOutOfRange(.month, result)
+            // Fast-path: advance to target month directly.
+            if !isLeapMonthDesired || !strictMatching {
+                var minimal = DateComponents()
+                minimal.month = month
+                minimal.isLeapMonth = components.isLeapMonth
+                if let fast = _calendarNextDate(after: result, matching: minimal, direction: direction) {
+                    result = fast
+                    dateMonth = month
                 }
-                var duration = foundRange.duration
+            }
+            if month != dateMonth {
+                repeat {
+                    let lastResult = result
 
-                if direction == .backward {
-                    let numMonth = component(.month, from: foundRange.start)
-                    if numMonth == 3 && (self.identifier == .gregorian || self.identifier == .buddhist || self.identifier == .japanese || self.identifier == .iso8601 || self.identifier == .republicOfChina) {
-                        // Take it back 3 days so we land in february.  That is, March has 31 days, and Feb can have 28 or 29, so to ensure we get to either Feb 1 or 2, we need to take it back 3 days.
-                        duration -= 86400 * 3
-                    } else {
-                        // Take it back a day
-                        duration -= 86400
+                    guard let foundRange = dateInterval(of: .month, for: result) else {
+                        throw CalendarEnumerationError.dateOutOfRange(.month, result)
+                    }
+                    var duration = foundRange.duration
+
+                    if direction == .backward {
+                        let numMonth = component(.month, from: foundRange.start)
+                        if numMonth == 3 && (self.identifier == .gregorian || self.identifier == .buddhist || self.identifier == .japanese || self.identifier == .iso8601 || self.identifier == .republicOfChina) {
+                            // Take it back 3 days so we land in february.  That is, March has 31 days, and Feb can have 28 or 29, so to ensure we get to either Feb 1 or 2, we need to take it back 3 days.
+                            duration -= 86400 * 3
+                        } else {
+                            // Take it back a day
+                            duration -= 86400
+                        }
+
+                        // So we can go backwards in time
+                        duration *= -1
                     }
 
-                    // So we can go backwards in time
-                    duration *= -1
-                }
+                    let searchDate = foundRange.start + duration
+                    dateMonth = component(.month, from: searchDate)
+                    result = searchDate
 
-                let searchDate = foundRange.start + duration
-                dateMonth = component(.month, from: searchDate)
-                result = searchDate
-                
-                try verifyAdvancingResult(result, previous: lastResult, direction: direction)
-            } while month != dateMonth
+                    try verifyAdvancingResult(result, previous: lastResult, direction: direction)
+                } while month != dateMonth
+            }
         }
 
         // This is relevant for the Chinese, Vietnamese, Korean, and Hindu lunisolar calendars.  In those calendars, the leap month has the same month number as the preceding month.
@@ -1716,6 +1761,15 @@ extension Calendar {
         guard weekOfMonth != dateWeekOfMonth else {
             // Already matches
             return nil
+        }
+
+        // Fast-path: enrich with current month and ask the calendar directly.
+        if components.month == nil, components.weekday != nil {
+            var enriched = components
+            enriched.month = component(.month, from: startingAt)
+            if let fast = _calendarNextDate(after: startingAt, matching: enriched, direction: direction) {
+                return fast
+            }
         }
 
         // After this point, result is at least startDate
@@ -1805,6 +1859,11 @@ extension Calendar {
         guard weekdayOrdinal != dateWeekdayOrdinal else {
             // Nothing to do
             return nil
+        }
+
+        // Fast-path: ask the calendar directly.
+        if let fast = _calendarNextDate(after: startingAt, matching: components, direction: direction) {
+            return fast
         }
 
         // After this point, result is at least startDate
@@ -1911,6 +1970,13 @@ extension Calendar {
         guard weekday != dateWeekday else {
             // Already matches
             return nil
+        }
+
+        // Fast-path: use minimal {weekday}-only components.
+        var minimal = DateComponents()
+        minimal.weekday = weekday
+        if let fast = _calendarNextDate(after: startingAt, matching: minimal, direction: direction) {
+            return fast
         }
 
         // After this point, result is at least startDate

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -331,7 +331,7 @@ extension Calendar {
                 let validates = matchingComponents._validate(for: calendar)
                 finished = !validates
 
-                self.usesFastPath = validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first && calendar._supportsNextDateFastPath(for: matchingComponents)
+                self.usesFastPath = validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first && calendar._supportsNextDateFastPath(for: matchingComponents._populatedComponentSet)
             }
             
             mutating func next() -> Element? {
@@ -536,11 +536,12 @@ extension Calendar {
                                          inSearchingDate searchingDate: Date,
                                          previouslyReturnedMatchDate: Date?) throws -> SearchStepResult {
 
-        // Fast-path: ask the calendar directly. Returns nil for unrecognized patterns.
-        if _supportsNextDateFastPath(for: matchingComponents) && matchingPolicy == .nextTime && repeatedTimePolicy == .first {
+        // Fast-path: ask the calendar directly.
+        if _supportsNextDateFastPath(for: matchingComponents._populatedComponentSet) && matchingPolicy == .nextTime && repeatedTimePolicy == .first {
             if let fast = _calendarNextDate(after: searchingDate, matching: matchingComponents, direction: direction) {
                 return SearchStepResult(result: (fast, true), newSearchDate: fast)
             }
+            return SearchStepResult(result: nil, newSearchDate: searchingDate)
         }
 
         // Step A: Call helper method that does the searching
@@ -1659,12 +1660,14 @@ extension Calendar {
         if month != dateMonth {
             // Fast-path: advance to target month directly.
             if !isLeapMonthDesired || !strictMatching {
-                var minimal = DateComponents()
-                minimal.month = month
-                minimal.isLeapMonth = components.isLeapMonth
-                if let fast = _calendarNextDate(after: result, matching: minimal, direction: direction) {
-                    result = fast
-                    dateMonth = month
+                if _supportsNextDateFastPath(for: [.month]) {
+                    var minimal = DateComponents()
+                    minimal.month = month
+                    minimal.isLeapMonth = components.isLeapMonth
+                    if let fast = _calendarNextDate(after: result, matching: minimal, direction: direction) {
+                        result = fast
+                        dateMonth = month
+                    }
                 }
             }
             if month != dateMonth {
@@ -1761,8 +1764,8 @@ extension Calendar {
         if components.month == nil, components.weekday != nil {
             var enriched = components
             enriched.month = component(.month, from: startingAt)
-            if let fast = _calendarNextDate(after: startingAt, matching: enriched, direction: direction) {
-                return fast
+            if _supportsNextDateFastPath(for: enriched._populatedComponentSet) {
+                return _calendarNextDate(after: startingAt, matching: enriched, direction: direction)
             }
         }
 
@@ -1856,8 +1859,8 @@ extension Calendar {
         }
 
         // Fast-path: ask the calendar directly.
-        if let fast = _calendarNextDate(after: startingAt, matching: components, direction: direction) {
-            return fast
+        if _supportsNextDateFastPath(for: components._populatedComponentSet) {
+            return _calendarNextDate(after: startingAt, matching: components, direction: direction)
         }
 
         // After this point, result is at least startDate
@@ -1967,10 +1970,10 @@ extension Calendar {
         }
 
         // Fast-path: use minimal {weekday}-only components.
-        var minimal = DateComponents()
-        minimal.weekday = weekday
-        if let fast = _calendarNextDate(after: startingAt, matching: minimal, direction: direction) {
-            return fast
+        if _supportsNextDateFastPath(for: [.weekday]) {
+            var minimal = DateComponents()
+            minimal.weekday = weekday
+            return _calendarNextDate(after: startingAt, matching: minimal, direction: direction)
         }
 
         // After this point, result is at least startDate

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -331,7 +331,9 @@ extension Calendar {
                 let validates = matchingComponents._validate(for: calendar)
                 finished = !validates
 
-                self.usesFastPath = validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first && calendar._supportsNextDateFastPath
+                self.usesFastPath = validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first
+                    && calendar._supportsNextDateFastPath
+                    && calendar._calendarNextDate(after: start, matching: matchingComponents, direction: direction) != nil
             }
             
             mutating func next() -> Element? {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -331,13 +331,7 @@ extension Calendar {
                 let validates = matchingComponents._validate(for: calendar)
                 finished = !validates
 
-                // Probe: commit to the fast loop if the calendar recognizes this pattern.
-                if validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first,
-                   calendar._calendarNextDate(after: start, matching: matchingComponents, direction: direction) != nil {
-                    self.usesFastPath = true
-                } else {
-                    self.usesFastPath = false
-                }
+                self.usesFastPath = validates && matchingPolicy == .nextTime && repeatedTimePolicy == .first && calendar._supportsNextDateFastPath
             }
             
             mutating func next() -> Element? {
@@ -543,7 +537,7 @@ extension Calendar {
                                          previouslyReturnedMatchDate: Date?) throws -> SearchStepResult {
 
         // Fast-path: ask the calendar directly. Returns nil for unrecognized patterns.
-        if matchingPolicy == .nextTime && repeatedTimePolicy == .first {
+        if _supportsNextDateFastPath && matchingPolicy == .nextTime && repeatedTimePolicy == .first {
             if let fast = _calendarNextDate(after: searchingDate, matching: matchingComponents, direction: direction) {
                 return SearchStepResult(result: (fast, true), newSearchDate: fast)
             }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -12,6 +12,16 @@
 
 #if canImport(os)
 internal import os
+#elseif canImport(Bionic)
+@preconcurrency import Bionic
+#elseif canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(CRT)
+import CRT
+#elseif os(WASI)
+@preconcurrency import WASILibc
 #endif
 
 internal import Synchronization
@@ -30,13 +40,6 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         Logger(subsystem: "com.apple.foundation", category: "hebrew_calendar")
     }()
 #endif
-
-    let kSecondsInWeek = 604_800
-    let kSecondsInDay = 86400
-    let kSecondsInHour = 3600
-    let kSecondsInMinute = 60
-
-    let inf_ti: TimeInterval = 4398046511104.0
 
     init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
         // .hebrew is the only identifier this class handles. `gregorianStartDate`
@@ -69,77 +72,27 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     var _firstWeekday: Int?
     var firstWeekday: Int {
-        set {
-            precondition(newValue >= 1 && newValue <= 7, "Weekday should be in the range of 1...7")
-            _firstWeekday = newValue
-        }
-        get {
-            if let _firstWeekday {
-                return _firstWeekday
-            } else if let locale {
-                return locale.firstDayOfWeek.icuIndex
-            } else {
-                return 1
-            }
-        }
+        set { _firstWeekday = _CalendarUtility.validatedFirstWeekday(newValue) }
+        get { _CalendarUtility.resolveFirstWeekday(stored: _firstWeekday, locale: locale) }
     }
 
     var _minimumDaysInFirstWeek: Int?
     var minimumDaysInFirstWeek: Int {
-        set {
-            if newValue < 1 {
-                _minimumDaysInFirstWeek = 1
-            } else if newValue > 7 {
-                _minimumDaysInFirstWeek = 7
-            } else {
-                _minimumDaysInFirstWeek = newValue
-            }
-        }
-        get {
-            if let _minimumDaysInFirstWeek {
-                return _minimumDaysInFirstWeek
-            } else if let locale {
-                return locale.minimumDaysInFirstWeek
-            } else {
-                return 1
-            }
-        }
+        set { _minimumDaysInFirstWeek = _CalendarUtility.clampedMinimumDaysInFirstWeek(newValue) }
+        get { _CalendarUtility.resolveMinimumDaysInFirstWeek(stored: _minimumDaysInFirstWeek, locale: locale) }
     }
 
     func copy(changingLocale: Locale?, changingTimeZone: TimeZone?, changingFirstWeekday: Int?, changingMinimumDaysInFirstWeek: Int?) -> _CalendarProtocol {
-        let newTimeZone = changingTimeZone ?? self.timeZone
-        let newLocale = changingLocale ?? self.locale
-
-        let newFirstWeekday: Int?
-        if let changingFirstWeekday {
-            newFirstWeekday = changingFirstWeekday
-        } else if let _firstWeekday {
-            newFirstWeekday = _firstWeekday
-        } else {
-            newFirstWeekday = nil
-        }
-
-        let newMinDays: Int?
-        if let changingMinimumDaysInFirstWeek {
-            newMinDays = changingMinimumDaysInFirstWeek
-        } else if let _minimumDaysInFirstWeek {
-            newMinDays = _minimumDaysInFirstWeek
-        } else {
-            newMinDays = nil
-        }
-
-        return _CalendarHebrew(identifier: identifier, timeZone: newTimeZone, locale: newLocale, firstWeekday: newFirstWeekday, minimumDaysInFirstWeek: newMinDays, gregorianStartDate: nil)
+        let args = _CalendarUtility.resolvedCopyArgs(
+            currentTimeZone: timeZone, changingTimeZone: changingTimeZone,
+            currentLocale: locale, changingLocale: changingLocale,
+            currentFirstWeekday: _firstWeekday, changingFirstWeekday: changingFirstWeekday,
+            currentMinimumDaysInFirstWeek: _minimumDaysInFirstWeek, changingMinimumDaysInFirstWeek: changingMinimumDaysInFirstWeek
+        )
+        return _CalendarHebrew(identifier: identifier, timeZone: args.timeZone, locale: args.locale, firstWeekday: args.firstWeekday, minimumDaysInFirstWeek: args.minimumDaysInFirstWeek, gregorianStartDate: nil)
     }
 
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(identifier)
-        hasher.combine(timeZone)
-        hasher.combine(firstWeekday)
-        hasher.combine(minimumDaysInFirstWeek)
-        hasher.combine(localeIdentifier)
-        hasher.combine(preferredFirstWeekday)
-        hasher.combine(preferredMinimumDaysInFirstweek)
-    }
+    // hash(into:) uses the `_CalendarProtocol` default impl.
 
     // MARK: - Range
 
@@ -415,10 +368,10 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         case .era:
             // Hebrew has a single AM era spanning from epoch to effectively forever.
             // Matches ICU's reported start (Hebrew epoch, -181,778,083,200 s before
-            // Date reference = year 1 AM, Tishrei 1, midnight UTC) and duration (inf_ti).
+            // Date reference = year 1 AM, Tishrei 1, midnight UTC) and duration (_CalendarConstants.inf_ti).
             return DateInterval(
                 start: Date(timeIntervalSinceReferenceDate: -181_778_083_200.0),
-                duration: inf_ti
+                duration: _CalendarConstants.inf_ti
             )
         case .year:
             // Tishri 1 of this year → Tishri 1 of next year.
@@ -556,47 +509,16 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     // MARK: - Weekend queries
 
-    // TODO: Factor out into shared utility; identical to _CalendarGregorian.isDateInWeekend.
     func isDateInWeekend(_ date: Date) -> Bool {
-        let weekendRange: WeekendRange
-        if let localeWeekendRange = locale?.weekendRange {
-            weekendRange = localeWeekendRange
-        } else {
-            // Weekend range for 001 region (world default).
-            weekendRange = WeekendRange(onsetTime: 0, ceaseTime: 86400, start: 7, end: 1)
-        }
-
-        let comps = dateComponents([.weekday], from: date, in: self.timeZone)
+        let weekendRange = locale?.weekendRange ?? _CalendarUtility.defaultWeekendRange
+        let comps = dateComponents([.weekday, .hour, .minute, .second], from: date, in: self.timeZone)
         guard let dayOfWeek = comps.weekday else { return false }
-
-        if weekendRange.start == weekendRange.end && dayOfWeek != weekendRange.start {
-            return false
-        } else if weekendRange.start < weekendRange.end && (dayOfWeek < weekendRange.start || dayOfWeek > weekendRange.end) {
-            return false
-        } else if weekendRange.start > weekendRange.end && (dayOfWeek > weekendRange.end && dayOfWeek < weekendRange.start) {
-            return false
-        }
-
-        // Day matches; now check time-in-day if this day is the weekend start or end.
-        let tz = self.timeZone
-        let (tzOffset, dstOffset) = tz.rawAndDaylightSavingTimeOffset(for: date, repeatedTimePolicy: .former, skippedTimePolicy: .former)
-        let localSeconds = date.timeIntervalSinceReferenceDate + Double(tzOffset) + dstOffset
-        let daysSinceRef = (localSeconds / 86400).rounded(.down)
-        let timeInDay = localSeconds - daysSinceRef * 86400
-
-        if dayOfWeek == weekendRange.start {
-            guard let onsetTime = weekendRange.onsetTime, onsetTime != 0 else {
-                return true
-            }
-            return timeInDay >= onsetTime
-        } else if dayOfWeek == weekendRange.end {
-            guard let ceaseTime = weekendRange.ceaseTime, ceaseTime < 86400 else {
-                return true
-            }
-            return timeInDay < ceaseTime
-        } else {
-            return true
-        }
+        let timeInDay = TimeInterval(
+            (comps.hour ?? 0) * _CalendarConstants.kSecondsInHour
+            + (comps.minute ?? 0) * 60
+            + (comps.second ?? 0)
+        )
+        return _CalendarUtility.isDateInWeekend(weekday: dayOfWeek, timeInDay: timeInDay, weekendRange: weekendRange)
     }
 
     // MARK: - Date ↔ DateComponents

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -94,7 +94,29 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     // hash(into:) uses the `_CalendarProtocol` default impl.
 
-    var supportsNextDateFastPath: Bool { true }
+    func supportsNextDateFastPath(for components: DateComponents) -> Bool {
+        if components.era != nil || components.year != nil || components.weekOfYear != nil || components.yearForWeekOfYear != nil || components.dayOfYear != nil {
+            return false
+        }
+
+        let hasMonth = components.month != nil
+        let hasDay = components.day != nil
+        let hasWeekday = components.weekday != nil
+        let hasWdOrd = components.weekdayOrdinal != nil
+        let hasWeekOfMonth = components.weekOfMonth != nil
+
+        if hasWeekOfMonth && !(hasMonth && hasWeekday && !hasDay && !hasWdOrd) { return false }
+        if hasWdOrd && !(hasWeekday && !hasDay && !hasWeekOfMonth) { return false }
+        if hasWeekday && hasDay { return false }
+        if hasWeekday && hasMonth && !hasWdOrd && !hasWeekOfMonth { return false }
+
+        let timeOnly = !hasMonth && !hasDay && !hasWeekday
+        if timeOnly {
+            guard components.hour != nil, components.minute != nil, components.second != nil else { return false }
+        }
+
+        return true
+    }
 
     // MARK: - Range
 
@@ -952,33 +974,14 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     package func nextDate(after date: Date, matching components: DateComponents,
                           direction: Calendar.SearchDirection) -> Date? {
-        // Reject anything that requires the generic enumerate framework.
-        // Time-of-day fields (hour/minute/second/nanosecond) ARE allowed and preserved.
-        if components.era != nil || components.year != nil ||
-           components.weekOfYear != nil ||
-           components.yearForWeekOfYear != nil ||
-           components.dayOfYear != nil {
-            return nil
-        }
+        guard supportsNextDateFastPath(for: components) else { return nil }
 
         let hasMonth = components.month != nil
         let hasDay = components.day != nil
         let hasWeekday = components.weekday != nil
         let hasWdOrd = components.weekdayOrdinal != nil
         let hasWeekOfMonth = components.weekOfMonth != nil
-
-        // Only {month, weekday, weekOfMonth} is allowed for weekOfMonth patterns.
-        if hasWeekOfMonth && !(hasMonth && hasWeekday && !hasDay && !hasWdOrd) { return nil }
-        // weekdayOrdinal requires weekday, without day or weekOfMonth.
-        if hasWdOrd && !(hasWeekday && !hasDay && !hasWeekOfMonth) { return nil }
-        // {weekday, day} and {weekday, month} (without wdOrd/wOM) aren't fast-pathed.
-        if hasWeekday && hasDay { return nil }
-        if hasWeekday && hasMonth && !hasWdOrd && !hasWeekOfMonth { return nil }
-        // Time-only: requires hour/minute/second all set.
         let timeOnly = !hasMonth && !hasDay && !hasWeekday
-        if timeOnly {
-            guard components.hour != nil, components.minute != nil, components.second != nil else { return nil }
-        }
 
         let tz = self.timeZone
         let totalOffset = tz.secondsFromGMT(for: date)

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -400,10 +400,10 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         case .era:
             // Hebrew has a single AM era spanning from epoch to effectively forever.
             // Matches ICU's reported start (Hebrew epoch, -181,778,083,200 s before
-            // Date reference = year 1 AM, Tishrei 1, midnight UTC) and duration (Calendar._inf_ti).
+            // Date reference = year 1 AM, Tishrei 1, midnight UTC) and duration (Calendar._maxDateIntervalDuration).
             return DateInterval(
                 start: Date(timeIntervalSinceReferenceDate: -181_778_083_200.0),
-                duration: Calendar._inf_ti
+                duration: Calendar._maxDateIntervalDuration
             )
         case .year:
             // Tishri 1 of this year → Tishri 1 of next year.
@@ -546,8 +546,8 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         let comps = dateComponents([.weekday, .hour, .minute, .second], from: date, in: self.timeZone)
         guard let dayOfWeek = comps.weekday else { return false }
         let timeInDay = TimeInterval(
-            (comps.hour ?? 0) * Calendar._kSecondsInHour
-            + (comps.minute ?? 0) * 60
+            (comps.hour ?? 0) * Calendar._secondsInHour
+            + (comps.minute ?? 0) * Calendar._secondsInMinute
             + (comps.second ?? 0)
         )
         return _CalendarUtility.isDateInWeekend(weekday: dayOfWeek, timeInDay: timeInDay, weekendRange: weekendRange)
@@ -1001,14 +1001,14 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         let forward = direction == .forward
 
         if timeOnly {
-            return nextTimeOfDayMatch(rd: rd, currentSecsInDay: currentSecsInDay,
+            return nextTimeOfDayMatch(rataDie: rd, currentSecsInDay: currentSecsInDay,
                                       targetSecsInDay: secsInDay,
                                       forward: forward, tz: tz)
         }
 
         if hasWeekOfMonth {
             return nextMonthWeekdayWeekOfMonthMatch(
-                rd: rd, currentSecsInDay: currentSecsInDay, currentYear: year,
+                rataDie: rd, currentSecsInDay: currentSecsInDay, currentYear: year,
                 targetMonth: components.month!,
                 targetWeekday: components.weekday!,
                 targetWeekOfMonth: components.weekOfMonth!,
@@ -1018,14 +1018,14 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         if hasWdOrd {
             if hasMonth {
                 return nextMonthWeekdayOrdinalMatch(
-                    rd: rd, currentSecsInDay: currentSecsInDay, currentYear: year,
+                    rataDie: rd, currentSecsInDay: currentSecsInDay, currentYear: year,
                     targetMonth: components.month!,
                     targetWeekday: components.weekday!,
                     targetWdOrd: components.weekdayOrdinal!,
                     targetSecsInDay: secsInDay, forward: forward, tz: tz)
             } else {
                 return nextWeekdayOrdinalMatch(
-                    rd: rd, currentSecsInDay: currentSecsInDay,
+                    rataDie: rd, currentSecsInDay: currentSecsInDay,
                     currentYear: year, currentCivilMonth: civilMonth, currentDay: day,
                     targetWeekday: components.weekday!,
                     targetWdOrd: components.weekdayOrdinal!,
@@ -1034,12 +1034,12 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         }
 
         if hasWeekday {
-            return nextWeekdayMatch(rd: rd, currentSecsInDay: currentSecsInDay,
+            return nextWeekdayMatch(rataDie: rd, currentSecsInDay: currentSecsInDay,
                                     targetWeekday: components.weekday!,
                                     targetSecsInDay: secsInDay, forward: forward, tz: tz)
         }
 
-        return nextMonthDayMatch(rd: rd, currentSecsInDay: currentSecsInDay,
+        return nextMonthDayMatch(rataDie: rd, currentSecsInDay: currentSecsInDay,
                                  currentYear: year, currentCivilMonth: civilMonth, currentDay: day,
                                  targetMonth: components.month, targetDay: components.day,
                                  targetSecsInDay: secsInDay, forward: forward, tz: tz)
@@ -1048,7 +1048,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
     /// Fast path for `{month?, day?, h?, m?, s?, ns?}` — annual recurrence at month/day.
     /// Either month or day (or both) must be set; missing month iterates months in the
     /// year, missing day defaults to 1.
-    private func nextMonthDayMatch(rd: Int64, currentSecsInDay: Double,
+    private func nextMonthDayMatch(rataDie rd: Int64, currentSecsInDay: Double,
                                    currentYear: Int32, currentCivilMonth: UInt8, currentDay: UInt8,
                                    targetMonth: Int?, targetDay: Int?,
                                    targetSecsInDay: Double, forward: Bool,
@@ -1146,7 +1146,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
     }
 
     /// Fast path for `{h, mi, s, ns?}` — next date with the requested time-of-day.
-    private func nextTimeOfDayMatch(rd: Int64, currentSecsInDay: Double,
+    private func nextTimeOfDayMatch(rataDie rd: Int64, currentSecsInDay: Double,
                                     targetSecsInDay: Double,
                                     forward: Bool, tz: TimeZone) -> Date? {
         let targetRd: Int64
@@ -1161,7 +1161,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     /// Fast path for `{weekday, h?, m?, s?, ns?}` — find the next/prev RD whose
     /// weekday matches (Sun=1..Sat=7, ICU convention). Pure modular RD arithmetic.
-    private func nextWeekdayMatch(rd: Int64, currentSecsInDay: Double,
+    private func nextWeekdayMatch(rataDie rd: Int64, currentSecsInDay: Double,
                                   targetWeekday: Int,
                                   targetSecsInDay: Double, forward: Bool,
                                   tz: TimeZone) -> Date? {
@@ -1193,7 +1193,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     /// Fast path for `{month, weekday, weekdayOrdinal}` — "Nth weekday of month".
     private func nextMonthWeekdayOrdinalMatch(
-        rd: Int64, currentSecsInDay: Double, currentYear: Int32,
+        rataDie rd: Int64, currentSecsInDay: Double, currentYear: Int32,
         targetMonth: Int, targetWeekday: Int, targetWdOrd: Int,
         targetSecsInDay: Double, forward: Bool, tz: TimeZone
     ) -> Date? {
@@ -1247,7 +1247,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     /// Fast path for `{weekday, weekdayOrdinal}` (no month) — Nth weekday in the current month.
     private func nextWeekdayOrdinalMatch(
-        rd: Int64, currentSecsInDay: Double,
+        rataDie rd: Int64, currentSecsInDay: Double,
         currentYear: Int32, currentCivilMonth: UInt8, currentDay: UInt8,
         targetWeekday: Int, targetWdOrd: Int,
         targetSecsInDay: Double, forward: Bool, tz: TimeZone
@@ -1300,7 +1300,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     /// Fast path for `{month, weekday, weekOfMonth}` — "weekday in Nth week of month".
     private func nextMonthWeekdayWeekOfMonthMatch(
-        rd: Int64, currentSecsInDay: Double, currentYear: Int32,
+        rataDie rd: Int64, currentSecsInDay: Double, currentYear: Int32,
         targetMonth: Int, targetWeekday: Int, targetWeekOfMonth: Int,
         targetSecsInDay: Double, forward: Bool, tz: TimeZone
     ) -> Date? {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -92,18 +92,26 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         return _CalendarHebrew(identifier: identifier, timeZone: args.timeZone, locale: args.locale, firstWeekday: args.firstWeekday, minimumDaysInFirstWeek: args.minimumDaysInFirstWeek, gregorianStartDate: nil)
     }
 
-    // hash(into:) uses the `_CalendarProtocol` default impl.
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+        hasher.combine(timeZone)
+        hasher.combine(firstWeekday)
+        hasher.combine(minimumDaysInFirstWeek)
+        hasher.combine(localeIdentifier)
+        hasher.combine(preferredFirstWeekday)
+        hasher.combine(preferredMinimumDaysInFirstweek)
+    }
 
-    func supportsNextDateFastPath(for components: DateComponents) -> Bool {
-        if components.era != nil || components.year != nil || components.weekOfYear != nil || components.yearForWeekOfYear != nil || components.dayOfYear != nil {
+    func supportsNextDateFastPath(for components: Calendar.ComponentSet) -> Bool {
+        if components.contains(.era) || components.contains(.year) || components.contains(.weekOfYear) || components.contains(.yearForWeekOfYear) || components.contains(.dayOfYear) {
             return false
         }
 
-        let hasMonth = components.month != nil
-        let hasDay = components.day != nil
-        let hasWeekday = components.weekday != nil
-        let hasWdOrd = components.weekdayOrdinal != nil
-        let hasWeekOfMonth = components.weekOfMonth != nil
+        let hasMonth = components.contains(.month)
+        let hasDay = components.contains(.day)
+        let hasWeekday = components.contains(.weekday)
+        let hasWdOrd = components.contains(.weekdayOrdinal)
+        let hasWeekOfMonth = components.contains(.weekOfMonth)
 
         if hasWeekOfMonth && !(hasMonth && hasWeekday && !hasDay && !hasWdOrd) { return false }
         if hasWdOrd && !(hasWeekday && !hasDay && !hasWeekOfMonth) { return false }
@@ -112,7 +120,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
         let timeOnly = !hasMonth && !hasDay && !hasWeekday
         if timeOnly {
-            guard components.hour != nil, components.minute != nil, components.second != nil else { return false }
+            guard components.contains(.hour), components.contains(.minute), components.contains(.second) else { return false }
         }
 
         return true
@@ -974,7 +982,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     package func nextDate(after date: Date, matching components: DateComponents,
                           direction: Calendar.SearchDirection) -> Date? {
-        guard supportsNextDateFastPath(for: components) else { return nil }
+        guard supportsNextDateFastPath(for: components._populatedComponentSet) else { return nil }
 
         let hasMonth = components.month != nil
         let hasDay = components.day != nil

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -94,6 +94,8 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
     // hash(into:) uses the `_CalendarProtocol` default impl.
 
+    var supportsNextDateFastPath: Bool { true }
+
     // MARK: - Range
 
     // Year bounds: match ICU's Hebrew reporting of ±5M (covers full Int32 year range
@@ -368,10 +370,10 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         case .era:
             // Hebrew has a single AM era spanning from epoch to effectively forever.
             // Matches ICU's reported start (Hebrew epoch, -181,778,083,200 s before
-            // Date reference = year 1 AM, Tishrei 1, midnight UTC) and duration (_CalendarConstants.inf_ti).
+            // Date reference = year 1 AM, Tishrei 1, midnight UTC) and duration (Calendar._inf_ti).
             return DateInterval(
                 start: Date(timeIntervalSinceReferenceDate: -181_778_083_200.0),
-                duration: _CalendarConstants.inf_ti
+                duration: Calendar._inf_ti
             )
         case .year:
             // Tishri 1 of this year → Tishri 1 of next year.
@@ -514,7 +516,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         let comps = dateComponents([.weekday, .hour, .minute, .second], from: date, in: self.timeZone)
         guard let dayOfWeek = comps.weekday else { return false }
         let timeInDay = TimeInterval(
-            (comps.hour ?? 0) * _CalendarConstants.kSecondsInHour
+            (comps.hour ?? 0) * Calendar._kSecondsInHour
             + (comps.minute ?? 0) * 60
             + (comps.second ?? 0)
         )

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -12,16 +12,6 @@
 
 #if canImport(os)
 internal import os
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(CRT)
-import CRT
-#elseif os(WASI)
-@preconcurrency import WASILibc
 #endif
 
 internal import Synchronization
@@ -1041,7 +1031,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         // Reject anything that requires the generic enumerate framework.
         // Time-of-day fields (hour/minute/second/nanosecond) ARE allowed and preserved.
         if components.era != nil || components.year != nil ||
-           components.weekOfMonth != nil || components.weekOfYear != nil ||
+           components.weekOfYear != nil ||
            components.yearForWeekOfYear != nil ||
            components.dayOfYear != nil {
             return nil
@@ -1051,15 +1041,20 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         let hasDay = components.day != nil
         let hasWeekday = components.weekday != nil
         let hasWdOrd = components.weekdayOrdinal != nil
+        let hasWeekOfMonth = components.weekOfMonth != nil
 
-        // weekdayOrdinal is only fast-pathed for {month, weekday, weekdayOrdinal}
-        // (e.g. "4th Thursday of November" / "last Friday of Adar"). Any other shape
-        // falls through to the generic enumerate framework.
-        if hasWdOrd && !(hasMonth && hasWeekday && !hasDay) { return nil }
-        // {weekday, day} and {weekday, month} (without wdOrd) aren't fast-pathed.
+        // Only {month, weekday, weekOfMonth} is allowed for weekOfMonth patterns.
+        if hasWeekOfMonth && !(hasMonth && hasWeekday && !hasDay && !hasWdOrd) { return nil }
+        // weekdayOrdinal requires weekday, without day or weekOfMonth.
+        if hasWdOrd && !(hasWeekday && !hasDay && !hasWeekOfMonth) { return nil }
+        // {weekday, day} and {weekday, month} (without wdOrd/wOM) aren't fast-pathed.
         if hasWeekday && hasDay { return nil }
-        if hasWeekday && hasMonth && !hasWdOrd { return nil }
-        if !hasMonth && !hasDay && !hasWeekday { return nil }
+        if hasWeekday && hasMonth && !hasWdOrd && !hasWeekOfMonth { return nil }
+        // Time-only: requires hour/minute/second all set.
+        let timeOnly = !hasMonth && !hasDay && !hasWeekday
+        if timeOnly {
+            guard components.hour != nil, components.minute != nil, components.second != nil else { return nil }
+        }
 
         let tz = self.timeZone
         let totalOffset = tz.secondsFromGMT(for: date)
@@ -1070,13 +1065,37 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         let secsInDay = Self.secondsInDay(from: components)
         let forward = direction == .forward
 
-        if hasWdOrd {
-            return nextMonthWeekdayOrdinalMatch(
+        if timeOnly {
+            return nextTimeOfDayMatch(rd: rd, currentSecsInDay: currentSecsInDay,
+                                      targetSecsInDay: secsInDay,
+                                      forward: forward, tz: tz)
+        }
+
+        if hasWeekOfMonth {
+            return nextMonthWeekdayWeekOfMonthMatch(
                 rd: rd, currentSecsInDay: currentSecsInDay, currentYear: year,
                 targetMonth: components.month!,
                 targetWeekday: components.weekday!,
-                targetWdOrd: components.weekdayOrdinal!,
+                targetWeekOfMonth: components.weekOfMonth!,
                 targetSecsInDay: secsInDay, forward: forward, tz: tz)
+        }
+
+        if hasWdOrd {
+            if hasMonth {
+                return nextMonthWeekdayOrdinalMatch(
+                    rd: rd, currentSecsInDay: currentSecsInDay, currentYear: year,
+                    targetMonth: components.month!,
+                    targetWeekday: components.weekday!,
+                    targetWdOrd: components.weekdayOrdinal!,
+                    targetSecsInDay: secsInDay, forward: forward, tz: tz)
+            } else {
+                return nextWeekdayOrdinalMatch(
+                    rd: rd, currentSecsInDay: currentSecsInDay,
+                    currentYear: year, currentCivilMonth: civilMonth, currentDay: day,
+                    targetWeekday: components.weekday!,
+                    targetWdOrd: components.weekdayOrdinal!,
+                    targetSecsInDay: secsInDay, forward: forward, tz: tz)
+            }
         }
 
         if hasWeekday {
@@ -1191,6 +1210,20 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         return nil
     }
 
+    /// Fast path for `{h, mi, s, ns?}` — next date with the requested time-of-day.
+    private func nextTimeOfDayMatch(rd: Int64, currentSecsInDay: Double,
+                                    targetSecsInDay: Double,
+                                    forward: Bool, tz: TimeZone) -> Date? {
+        let targetRd: Int64
+        if forward {
+            targetRd = (targetSecsInDay > currentSecsInDay) ? rd : rd + 1
+        } else {
+            targetRd = (targetSecsInDay < currentSecsInDay) ? rd : rd - 1
+        }
+        return utcDate(fromRataDie: targetRd, secondsInDay: targetSecsInDay, in: tz,
+                      repeatedTimePolicy: .former, skippedTimePolicy: .former)
+    }
+
     /// Fast path for `{weekday, h?, m?, s?, ns?}` — find the next/prev RD whose
     /// weekday matches (Sun=1..Sat=7, ICU convention). Pure modular RD arithmetic.
     private func nextWeekdayMatch(rd: Int64, currentSecsInDay: Double,
@@ -1259,6 +1292,110 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         var y = currentYear
         for _ in 0..<6 {
             if let (bib, d) = dayForOrdinal(in: y) {
+                let cRd = HebrewArithmetic.fixedFromHebrew(year: y, month: bib, day: d)
+                if forward {
+                    if cRd > rd || (cRd == rd && targetSecsInDay > currentSecsInDay) {
+                        return utcDate(fromRataDie: cRd, secondsInDay: targetSecsInDay, in: tz,
+                                       repeatedTimePolicy: .former, skippedTimePolicy: .former)
+                    }
+                } else {
+                    if cRd < rd || (cRd == rd && targetSecsInDay < currentSecsInDay) {
+                        return utcDate(fromRataDie: cRd, secondsInDay: targetSecsInDay, in: tz,
+                                       repeatedTimePolicy: .former, skippedTimePolicy: .former)
+                    }
+                }
+            }
+            y += forward ? 1 : -1
+        }
+        return nil
+    }
+
+    /// Fast path for `{weekday, weekdayOrdinal}` (no month) — Nth weekday in the current month.
+    private func nextWeekdayOrdinalMatch(
+        rd: Int64, currentSecsInDay: Double,
+        currentYear: Int32, currentCivilMonth: UInt8, currentDay: UInt8,
+        targetWeekday: Int, targetWdOrd: Int,
+        targetSecsInDay: Double, forward: Bool, tz: TimeZone
+    ) -> Date? {
+        guard targetWeekday >= 1, targetWeekday <= 7 else { return nil }
+        guard targetWdOrd >= 1 else { return nil }
+
+        // Day-of-month for (weekday, ordinal) in a given month, or nil if out of range.
+        func dayForOrdinal(year y: Int32, civilMonth cm: UInt8) -> (bib: UInt8, day: UInt8)? {
+            if cm == 6 && !HebrewArithmetic.isLeapYear(y) { return nil }
+            guard let bib = HebrewArithmetic.civilToBiblical(year: y, civilMonth: cm) else { return nil }
+            let firstRd = HebrewArithmetic.fixedFromHebrew(year: y, month: bib, day: 1)
+            var firstWd = firstRd % 7
+            if firstWd < 0 { firstWd += 7 }
+            let firstWeekday = Int(firstWd) + 1                              // 1..7
+            let firstOcc = 1 + ((targetWeekday - firstWeekday + 7) % 7)      // 1..7
+            let dim = Int(HebrewArithmetic.lastDayOfMonth(y, month: bib))
+            let day = firstOcc + (targetWdOrd - 1) * 7
+            guard day >= 1, day <= dim else { return nil }
+            return (bib, UInt8(day))
+        }
+
+        // Walk months until we find the target ordinal in range.
+        var y = currentYear
+        var cm = currentCivilMonth
+        for _ in 0..<14 {
+            if let (bib, d) = dayForOrdinal(year: y, civilMonth: cm) {
+                let cRd = HebrewArithmetic.fixedFromHebrew(year: y, month: bib, day: d)
+                if forward {
+                    if cRd > rd || (cRd == rd && targetSecsInDay > currentSecsInDay) {
+                        return utcDate(fromRataDie: cRd, secondsInDay: targetSecsInDay, in: tz,
+                                       repeatedTimePolicy: .former, skippedTimePolicy: .former)
+                    }
+                } else {
+                    if cRd < rd || (cRd == rd && targetSecsInDay < currentSecsInDay) {
+                        return utcDate(fromRataDie: cRd, secondsInDay: targetSecsInDay, in: tz,
+                                       repeatedTimePolicy: .former, skippedTimePolicy: .former)
+                    }
+                }
+            }
+            // Advance / retreat civil month.
+            if forward {
+                (y, cm) = Self.nextCivilMonthForward(year: y, civilMonth: cm)
+            } else {
+                (y, cm) = Self.prevCivilMonthBackward(year: y, civilMonth: cm)
+            }
+        }
+        return nil
+    }
+
+    /// Fast path for `{month, weekday, weekOfMonth}` — "weekday in Nth week of month".
+    private func nextMonthWeekdayWeekOfMonthMatch(
+        rd: Int64, currentSecsInDay: Double, currentYear: Int32,
+        targetMonth: Int, targetWeekday: Int, targetWeekOfMonth: Int,
+        targetSecsInDay: Double, forward: Bool, tz: TimeZone
+    ) -> Date? {
+        guard targetMonth >= 1, targetMonth <= 13 else { return nil }
+        guard targetWeekday >= 1, targetWeekday <= 7 else { return nil }
+        guard targetWeekOfMonth >= 1 else { return nil }
+        let cm = UInt8(targetMonth)
+        let firstWd = self.firstWeekday
+        let minDays = self.minimumDaysInFirstWeek
+        let dayOffsetInWeek = ((targetWeekday - firstWd) % 7 + 7) % 7   // 0..6
+
+        // Day-of-month for (weekOfMonth, weekday) in a given year, or nil if out of range.
+        func dayForWeekOfMonth(in y: Int32) -> (bib: UInt8, day: UInt8)? {
+            if cm == 6 && !HebrewArithmetic.isLeapYear(y) { return nil }
+            guard let bib = HebrewArithmetic.civilToBiblical(year: y, civilMonth: cm) else { return nil }
+            let firstDayRd = HebrewArithmetic.fixedFromHebrew(year: y, month: bib, day: 1)
+            var firstDayWd = firstDayRd % 7
+            if firstDayWd < 0 { firstDayWd += 7 }
+            let firstDayWeekday = Int(firstDayWd) + 1                             // 1..7
+            let periodStart = ((firstDayWeekday - firstWd) % 7 + 7) % 7           // 0..6 (offset of day 1 within its week)
+            let correction = (7 - periodStart) >= minDays ? 1 : 0
+            let day = 7 * (targetWeekOfMonth - correction) + dayOffsetInWeek - periodStart + 1
+            let dim = Int(HebrewArithmetic.lastDayOfMonth(y, month: bib))
+            guard day >= 1, day <= dim else { return nil }
+            return (bib, UInt8(day))
+        }
+
+        var y = currentYear
+        for _ in 0..<6 {
+            if let (bib, d) = dayForWeekOfMonth(in: y) {
                 let cRd = HebrewArithmetic.fixedFromHebrew(year: y, month: bib, day: d)
                 if forward {
                     if cRd > rd || (cRd == rd && targetSecsInDay > currentSecsInDay) {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
@@ -54,7 +54,7 @@ package protocol _CalendarProtocol: AnyObject, Sendable, CustomDebugStringConver
     func nextDate(after date: Date, matching components: DateComponents, direction: Calendar.SearchDirection) -> Date?
 
     /// Whether this calendar can fast path the given pattern. Default returns false; calendar implementations override for patterns they handle.
-    func supportsNextDateFastPath(for components: DateComponents) -> Bool
+    func supportsNextDateFastPath(for components: Calendar.ComponentSet) -> Bool
 
 #if FOUNDATION_FRAMEWORK
     func bridgeToNSCalendar() -> NSCalendar
@@ -66,7 +66,7 @@ extension _CalendarProtocol {
         nil
     }
 
-    package func supportsNextDateFastPath(for components: DateComponents) -> Bool { false }
+    package func supportsNextDateFastPath(for components: Calendar.ComponentSet) -> Bool { false }
 
     package var preferredFirstWeekday: Int? { nil }
     package var preferredMinimumDaysInFirstweek: Int? { nil }
@@ -80,17 +80,6 @@ extension _CalendarProtocol {
     package var localeIdentifier: String {
         // We use this to provide a consistent answer for hashing and equality -- null is equal to an empty string
         locale?.identifier ?? ""
-    }
-
-    /// Default `hash(into:)` for the standard calendar identity tuple. Calendars with non-standard hashing (e.g. `_CalendarAutoupdating`, `_CalendarICU`, `_CalendarBridged`) override this.
-    package func hash(into hasher: inout Hasher) {
-        hasher.combine(identifier)
-        hasher.combine(timeZone)
-        hasher.combine(firstWeekday)
-        hasher.combine(minimumDaysInFirstWeek)
-        hasher.combine(localeIdentifier)
-        hasher.combine(preferredFirstWeekday)
-        hasher.combine(preferredMinimumDaysInFirstweek)
     }
 }
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
@@ -50,9 +50,8 @@ package protocol _CalendarProtocol: AnyObject, Sendable, CustomDebugStringConver
     func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date?
     func dateComponents(_ components: Calendar.ComponentSet, from start: Date, to end: Date) -> DateComponents
 
-    /// Optional fast path for `Calendar.nextDate(after:matching:)`. Default
-    /// returns nil, falling through to the generic enumerate framework. Calendar
-    /// implementations may override for patterns they can answer in O(1).
+    /// Optional fast path for `Calendar.nextDate(after:matching:)`.
+    /// Returns nil to fall through to the generic enumerate framework.
     func nextDate(after date: Date, matching components: DateComponents, direction: Calendar.SearchDirection) -> Date?
 
 #if FOUNDATION_FRAMEWORK
@@ -77,6 +76,23 @@ extension _CalendarProtocol {
     package var localeIdentifier: String {
         // We use this to provide a consistent answer for hashing and equality -- null is equal to an empty string
         locale?.identifier ?? ""
+    }
+
+    /// Default `hash(into:)` for calendars whose identity is the standard
+    /// `(identifier, timeZone, firstWeekday, minimumDaysInFirstWeek,
+    /// localeIdentifier, preferredFirstWeekday, preferredMinimumDaysInFirstweek)`
+    /// tuple. Calendars with non-standard hashing semantics
+    /// (e.g. `_CalendarAutoupdating`'s "all-equal" sentinel, `_CalendarICU`'s
+    /// locked-accessor variant, `_CalendarBridged`'s underlying-`NSCalendar`
+    /// hash) override this.
+    package func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+        hasher.combine(timeZone)
+        hasher.combine(firstWeekday)
+        hasher.combine(minimumDaysInFirstWeek)
+        hasher.combine(localeIdentifier)
+        hasher.combine(preferredFirstWeekday)
+        hasher.combine(preferredMinimumDaysInFirstweek)
     }
 }
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
@@ -50,9 +50,11 @@ package protocol _CalendarProtocol: AnyObject, Sendable, CustomDebugStringConver
     func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date?
     func dateComponents(_ components: Calendar.ComponentSet, from start: Date, to end: Date) -> DateComponents
 
-    /// Optional fast path for `Calendar.nextDate(after:matching:)`.
-    /// Returns nil to fall through to the generic enumerate framework.
+    /// Optional fast path for `Calendar.nextDate(after:matching:)`. Returns nil to fall through to the generic enumerate framework.
     func nextDate(after date: Date, matching components: DateComponents, direction: Calendar.SearchDirection) -> Date?
+
+    /// Whether this calendar implements `nextDate(after:matching:direction:)`.
+    var supportsNextDateFastPath: Bool { get }
 
 #if FOUNDATION_FRAMEWORK
     func bridgeToNSCalendar() -> NSCalendar
@@ -61,8 +63,10 @@ package protocol _CalendarProtocol: AnyObject, Sendable, CustomDebugStringConver
 
 extension _CalendarProtocol {
     package func nextDate(after date: Date, matching components: DateComponents, direction: Calendar.SearchDirection) -> Date? {
-        nil   // default — fall through to Calendar's enumerate-based implementation
+        nil
     }
+
+    package var supportsNextDateFastPath: Bool { false }
 
     package var preferredFirstWeekday: Int? { nil }
     package var preferredMinimumDaysInFirstweek: Int? { nil }
@@ -78,13 +82,7 @@ extension _CalendarProtocol {
         locale?.identifier ?? ""
     }
 
-    /// Default `hash(into:)` for calendars whose identity is the standard
-    /// `(identifier, timeZone, firstWeekday, minimumDaysInFirstWeek,
-    /// localeIdentifier, preferredFirstWeekday, preferredMinimumDaysInFirstweek)`
-    /// tuple. Calendars with non-standard hashing semantics
-    /// (e.g. `_CalendarAutoupdating`'s "all-equal" sentinel, `_CalendarICU`'s
-    /// locked-accessor variant, `_CalendarBridged`'s underlying-`NSCalendar`
-    /// hash) override this.
+    /// Default `hash(into:)` for the standard calendar identity tuple. Calendars with non-standard hashing (e.g. `_CalendarAutoupdating`, `_CalendarICU`, `_CalendarBridged`) override this.
     package func hash(into hasher: inout Hasher) {
         hasher.combine(identifier)
         hasher.combine(timeZone)

--- a/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
@@ -50,11 +50,11 @@ package protocol _CalendarProtocol: AnyObject, Sendable, CustomDebugStringConver
     func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date?
     func dateComponents(_ components: Calendar.ComponentSet, from start: Date, to end: Date) -> DateComponents
 
-    /// Optional fast path for `Calendar.nextDate(after:matching:)`. Returns nil to fall through to the generic enumerate framework.
+    /// Optional fast path for `Calendar.nextDate(after:matching:)`. Nil means no more matches (not "unsupported pattern" — use `supportsNextDateFastPath(for:)` to check that).
     func nextDate(after date: Date, matching components: DateComponents, direction: Calendar.SearchDirection) -> Date?
 
-    /// Whether this calendar implements `nextDate(after:matching:direction:)`.
-    var supportsNextDateFastPath: Bool { get }
+    /// Whether this calendar can fast path the given pattern. Default returns false; calendar implementations override for patterns they handle.
+    func supportsNextDateFastPath(for components: DateComponents) -> Bool
 
 #if FOUNDATION_FRAMEWORK
     func bridgeToNSCalendar() -> NSCalendar
@@ -66,7 +66,7 @@ extension _CalendarProtocol {
         nil
     }
 
-    package var supportsNextDateFastPath: Bool { false }
+    package func supportsNextDateFastPath(for components: DateComponents) -> Bool { false }
 
     package var preferredFirstWeekday: Int? { nil }
     package var preferredMinimumDaysInFirstweek: Int? { nil }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -1062,16 +1062,18 @@ extension Calendar {
                                       repeatedTimePolicy: RepeatedTimePolicy) throws -> [(Date, DateComponents)]? {
 
         // Fast-path short-circuits. Only fires when the calendar opts in.
-        if _supportsNextDateFastPath && matchingPolicy == .nextTime && repeatedTimePolicy == .first {
+        if matchingPolicy == .nextTime && repeatedTimePolicy == .first {
 
             // (1) Single-combination: one value per field.
             if let dc = _singleCombinationDateComponents(combinationComponents),
+               _supportsNextDateFastPath(for: dc),
                let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) {
                 return [(fast, dc)]
             }
 
             // (2) Multi-combination (positive ordinals): cartesian product.
-            if let allDCs = _expandedDateComponents(combinationComponents) {
+            if let allDCs = _expandedDateComponents(combinationComponents),
+               allDCs.allSatisfy({ _supportsNextDateFastPath(for: $0) }) {
                 var results: [(Date, DateComponents)] = []
                 results.reserveCapacity(allDCs.count)
                 var allFastPathed = true
@@ -1090,7 +1092,8 @@ extension Calendar {
 
             // (3) Multi-combination with negative ordinal translation.
             if _unadjustedDatesHasNegativeOrdinal(combinationComponents),
-               let allDCs = _expandedDateComponents(combinationComponents, anchor: startDate) {
+               let allDCs = _expandedDateComponents(combinationComponents, anchor: startDate),
+               allDCs.allSatisfy({ _supportsNextDateFastPath(for: $0) }) {
                 var results: [(Date, DateComponents)] = []
                 results.reserveCapacity(allDCs.count)
                 var allFastPathed = true

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -663,6 +663,218 @@ extension Calendar {
         var minutes: [Int]? = nil
         var seconds: [Int]? = nil
     }
+
+    /// Whether the combinations contain any `.nth(N, day)` with `N < 0`.
+    fileprivate func _unadjustedDatesHasNegativeOrdinal(_ c: _DateComponentCombinations) -> Bool {
+        guard let weekdays = c.weekdays else { return false }
+        for w in weekdays {
+            if case .nth(let n, _) = w, n < 0 { return true }
+        }
+        return false
+    }
+
+    /// Expand `_DateComponentCombinations` into a flat array of single-valued
+    /// `DateComponents`. Negative ordinals are translated to `{month, weekday,
+    /// weekOfMonth}` using `anchor`'s month structure. Returns nil if the
+    /// pattern can't be expanded (too many combinations, `.every()` weekday, etc).
+    fileprivate func _expandedDateComponents(
+        _ c: _DateComponentCombinations,
+        anchor: Date? = nil,
+        maxCombinations: Int = 64
+    ) -> [DateComponents]? {
+        var hasNegativeOrdinal = false
+        if let weekdays = c.weekdays {
+            for w in weekdays {
+                switch w {
+                case .every:
+                    return nil
+                case .nth(let n, _):
+                    if n == 0 { return nil }
+                    if n < 0 {
+                        guard anchor != nil else { return nil }
+                        hasNegativeOrdinal = true
+                    }
+                }
+            }
+        }
+
+        let monthsCount = c.months?.count ?? 1
+        let weekdaysCount = c.weekdays?.count ?? 1
+        let daysOfMonthCount = c.daysOfMonth?.count ?? 1
+        let daysOfYearCount = c.daysOfYear?.count ?? 1
+        let weeksOfYearCount = c.weeksOfYear?.count ?? 1
+        let hoursCount = c.hours?.count ?? 1
+        let minutesCount = c.minutes?.count ?? 1
+        let secondsCount = c.seconds?.count ?? 1
+
+        let total = monthsCount * weekdaysCount * daysOfMonthCount
+                  * daysOfYearCount * weeksOfYearCount
+                  * hoursCount * minutesCount * secondsCount
+        if total <= 0 { return nil }
+        if total > maxCombinations { return nil }
+        if total <= 1 { return nil }
+
+        // Precompute target month structure for negative-ordinal translation.
+        struct MonthInfo {
+            let month: Int
+            let isLeapMonth: Bool
+            let day1Weekday: Int   // 1..7 (Sunday=1)
+            let daysInMonth: Int
+            let firstWeekday: Int  // calendar's
+            let minDays: Int       // calendar's
+        }
+        var monthInfo: MonthInfo? = nil
+        if hasNegativeOrdinal, let anchor = anchor {
+            let targetMonth: Int
+            let targetIsLeap: Bool
+            let targetYear: Int
+            if let ms = c.months, ms.count == 1 {
+                targetMonth = ms[0].index
+                targetIsLeap = ms[0].isLeap
+                targetYear = self.component(.year, from: anchor)
+            } else if c.months == nil || c.months!.isEmpty {
+                targetMonth = self.component(.month, from: anchor)
+                targetIsLeap = false
+                targetYear = self.component(.year, from: anchor)
+            } else {
+                return nil
+            }
+
+            var monthStartComps = DateComponents()
+            monthStartComps.year = targetYear
+            monthStartComps.month = targetMonth
+            monthStartComps.day = 1
+            if targetIsLeap { monthStartComps.isLeapMonth = true }
+
+            guard let monthStart = self.date(from: monthStartComps),
+                  let dayRange = self.range(of: .day, in: .month, for: monthStart) else {
+                return nil
+            }
+            let daysInMonth = dayRange.upperBound - 1
+            let day1Weekday = self.component(.weekday, from: monthStart)
+
+            monthInfo = MonthInfo(
+                month: targetMonth,
+                isLeapMonth: targetIsLeap,
+                day1Weekday: day1Weekday,
+                daysInMonth: daysInMonth,
+                firstWeekday: self.firstWeekday,
+                minDays: self.minimumDaysInFirstWeek
+            )
+        }
+
+        // Translate a `.nth(N, day)` entry to DC fields. Returns false if out of range.
+        func translateWeekday(_ entry: RecurrenceRule.Weekday, into dc: inout DateComponents) -> Bool {
+            guard case .nth(let n, let dayOfWeek) = entry else { return false }
+            let wdIdx = dayOfWeek.icuIndex
+            if n > 0 {
+                dc.weekdayOrdinal = n
+                dc.weekday = wdIdx
+                return true
+            }
+            // Negative ordinal → {month, weekday, weekOfMonth}.
+            guard let info = monthInfo else { return false }
+            let firstOcc = 1 + ((wdIdx - info.day1Weekday + 7) % 7)   // 1..7
+            let totalOcc = (info.daysInMonth - firstOcc) / 7 + 1
+            let kthFromLast = -n
+            let dayOfMonth = firstOcc + (totalOcc - kthFromLast) * 7
+            guard dayOfMonth >= 1, dayOfMonth <= info.daysInMonth else { return false }
+            let periodStart = ((info.day1Weekday - info.firstWeekday) % 7 + 7) % 7
+            let correction = (7 - periodStart) >= info.minDays ? 1 : 0
+            let weekOfMonth = (dayOfMonth + periodStart - 1) / 7 + correction
+            dc.month = info.month
+            dc.isLeapMonth = info.isLeapMonth
+            dc.weekday = wdIdx
+            dc.weekOfMonth = weekOfMonth
+            return true
+        }
+
+        func make(monthIdx: Int, weekdayIdx: Int,
+                  daysOfMonthIdx: Int, daysOfYearIdx: Int, weeksOfYearIdx: Int,
+                  hoursIdx: Int, minutesIdx: Int, secondsIdx: Int) -> DateComponents? {
+            var dc = DateComponents()
+            if let ms = c.months {
+                dc.month = ms[monthIdx].index
+                dc.isLeapMonth = ms[monthIdx].isLeap
+            }
+            if let woy = c.weeksOfYear { dc.weekOfYear = woy[weeksOfYearIdx] }
+            if let doy = c.daysOfYear { dc.dayOfYear = doy[daysOfYearIdx] }
+            if let dom = c.daysOfMonth { dc.day = dom[daysOfMonthIdx] }
+            if let wds = c.weekdays {
+                guard translateWeekday(wds[weekdayIdx], into: &dc) else { return nil }
+            }
+            if let hs = c.hours { dc.hour = hs[hoursIdx] }
+            if let mins = c.minutes { dc.minute = mins[minutesIdx] }
+            if let secs = c.seconds { dc.second = secs[secondsIdx] }
+            return dc
+        }
+
+        var result: [DateComponents] = []
+        result.reserveCapacity(total)
+        for mIdx in 0..<monthsCount {
+            for wIdx in 0..<weekdaysCount {
+                for domIdx in 0..<daysOfMonthCount {
+                    for doyIdx in 0..<daysOfYearCount {
+                        for woyIdx in 0..<weeksOfYearCount {
+                            for hIdx in 0..<hoursCount {
+                                for miIdx in 0..<minutesCount {
+                                    for sIdx in 0..<secondsCount {
+                                        guard let dc = make(
+                                            monthIdx: mIdx, weekdayIdx: wIdx,
+                                            daysOfMonthIdx: domIdx,
+                                            daysOfYearIdx: doyIdx,
+                                            weeksOfYearIdx: woyIdx,
+                                            hoursIdx: hIdx, minutesIdx: miIdx,
+                                            secondsIdx: sIdx) else { return nil }
+                                        result.append(dc)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    /// Single-valued `DateComponents` from combinations, or nil if expansion is needed.
+    fileprivate func _singleCombinationDateComponents(
+        _ c: _DateComponentCombinations
+    ) -> DateComponents? {
+        if let count = c.weeksOfYear?.count, count > 1 { return nil }
+        if let count = c.daysOfYear?.count, count > 1 { return nil }
+        if let count = c.months?.count, count > 1 { return nil }
+        if let count = c.daysOfMonth?.count, count > 1 { return nil }
+        if let count = c.weekdays?.count, count > 1 { return nil }
+        if let count = c.hours?.count, count > 1 { return nil }
+        if let count = c.minutes?.count, count > 1 { return nil }
+        if let count = c.seconds?.count, count > 1 { return nil }
+
+        var dc = DateComponents()
+        if let m = c.months?.first {
+            dc.month = m.index
+            dc.isLeapMonth = m.isLeap
+        }
+        if let woy = c.weeksOfYear?.first { dc.weekOfYear = woy }
+        if let doy = c.daysOfYear?.first { dc.dayOfYear = doy }
+        if let dom = c.daysOfMonth?.first { dc.day = dom }
+        if let weekday = c.weekdays?.first {
+            switch weekday {
+            case .every:
+                return nil
+            case .nth(let n, let day):
+                guard n >= 1 else { return nil }   // negative ordinals not in our fast path
+                dc.weekdayOrdinal = n
+                dc.weekday = day.icuIndex
+            }
+        }
+        if let h = c.hours?.first { dc.hour = h }
+        if let mi = c.minutes?.first { dc.minute = mi }
+        if let s = c.seconds?.first { dc.second = s }
+
+        return dc
+    }
     
 
     /// Find date components which can be used to filter or enumerate each given
@@ -827,6 +1039,59 @@ extension Calendar {
                                       matching combinationComponents: _DateComponentCombinations,
                                       matchingPolicy: MatchingPolicy,
                                       repeatedTimePolicy: RepeatedTimePolicy) throws -> [(Date, DateComponents)]? {
+
+        // Fast-path short-circuits. The protocol default for _calendarNextDate is nil,
+        // so non-Hebrew calendars fall through to the existing path unchanged.
+
+        // (1) Single-combination: one value per field → single _calendarNextDate call.
+        if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
+           let dc = _singleCombinationDateComponents(combinationComponents),
+           let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) {
+            return [(fast, dc)]
+        }
+
+        // (2) Multi-combination (positive ordinals): cartesian product → probe each.
+        if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
+           let allDCs = _expandedDateComponents(combinationComponents) {
+            var results: [(Date, DateComponents)] = []
+            results.reserveCapacity(allDCs.count)
+            var allFastPathed = true
+            for dc in allDCs {
+                guard let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) else {
+                    allFastPathed = false
+                    break
+                }
+                results.append((fast, dc))
+            }
+            if allFastPathed && !results.isEmpty {
+                results.sort { $0.0 < $1.0 }
+                return results
+            }
+        }
+
+        // (3) Multi-combination with negative-ordinal translation.
+        if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
+           _unadjustedDatesHasNegativeOrdinal(combinationComponents) {
+            var sentinel = DateComponents()
+            sentinel.weekday = 1
+            if _calendarNextDate(after: startDate, matching: sentinel, direction: .forward) != nil,
+               let allDCs = _expandedDateComponents(combinationComponents, anchor: startDate) {
+                var results: [(Date, DateComponents)] = []
+                results.reserveCapacity(allDCs.count)
+                var allFastPathed = true
+                for dc in allDCs {
+                    guard let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) else {
+                        allFastPathed = false
+                        break
+                    }
+                    results.append((fast, dc))
+                }
+                if allFastPathed && !results.isEmpty {
+                    results.sort { $0.0 < $1.0 }
+                    return results
+                }
+            }
+        }
 
         let isStrictMatching = matchingPolicy == .strict
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -698,12 +698,41 @@ extension Calendar {
             if overflow || product > maxCombinations { return nil }
             total = product
         }
-        if total <= 1 { return nil }
+        if total < 1 { return nil }
 
-        var monthInfo: _NegativeOrdinalMonthInfo? = nil
+        var negOrdMonth = 0
+        var negOrdIsLeap = false
+        var negOrdDay1Weekday = 0
+        var negOrdDaysInMonth = 0
+        var negOrdFirstWeekday = 0
+        var negOrdMinDays = 0
         if hasNegativeOrdinal, let anchor = anchor {
-            guard let info = _NegativeOrdinalMonthInfo(calendar: self, combinations: c, anchor: anchor) else { return nil }
-            monthInfo = info
+            let targetMonth: Int
+            let targetIsLeap: Bool
+            let targetYear: Int
+            if let ms = c.months, ms.count == 1 {
+                targetMonth = ms[0].index
+                targetIsLeap = ms[0].isLeap
+                targetYear = self.component(.year, from: anchor)
+            } else if c.months == nil || c.months!.isEmpty {
+                targetMonth = self.component(.month, from: anchor)
+                targetIsLeap = false
+                targetYear = self.component(.year, from: anchor)
+            } else {
+                return nil
+            }
+            var monthStartComps = DateComponents()
+            monthStartComps.year = targetYear
+            monthStartComps.month = targetMonth
+            monthStartComps.day = 1
+            if targetIsLeap { monthStartComps.isLeapMonth = true }
+            guard let monthStart = self.date(from: monthStartComps), let dayRange = self.range(of: .day, in: .month, for: monthStart) else { return nil }
+            negOrdMonth = targetMonth
+            negOrdIsLeap = targetIsLeap
+            negOrdDay1Weekday = self.component(.weekday, from: monthStart)
+            negOrdDaysInMonth = dayRange.upperBound - 1
+            negOrdFirstWeekday = self.firstWeekday
+            negOrdMinDays = self.minimumDaysInFirstWeek
         }
 
         var base = DateComponents()
@@ -718,14 +747,14 @@ extension Calendar {
         var seeds: [DateComponents]
         if let wds = c.weekdays {
             if wds.count == 1 {
-                guard Self._translateWeekday(wds[0], into: &base, monthInfo: monthInfo) else { return nil }
+                guard Self._translateWeekday(wds[0], into: &base, hasNegativeOrdinal: hasNegativeOrdinal, month: negOrdMonth, isLeapMonth: negOrdIsLeap, day1Weekday: negOrdDay1Weekday, daysInMonth: negOrdDaysInMonth, firstWeekday: negOrdFirstWeekday, minDays: negOrdMinDays) else { return nil }
                 seeds = [base]
             } else {
                 seeds = []
                 seeds.reserveCapacity(wds.count)
                 for wd in wds {
                     var wdBase = base
-                    guard Self._translateWeekday(wd, into: &wdBase, monthInfo: monthInfo) else { return nil }
+                    guard Self._translateWeekday(wd, into: &wdBase, hasNegativeOrdinal: hasNegativeOrdinal, month: negOrdMonth, isLeapMonth: negOrdIsLeap, day1Weekday: negOrdDay1Weekday, daysInMonth: negOrdDaysInMonth, firstWeekday: negOrdFirstWeekday, minDays: negOrdMinDays) else { return nil }
                     seeds.append(wdBase)
                 }
             }
@@ -745,52 +774,8 @@ extension Calendar {
         return seeds
     }
 
-    private struct _NegativeOrdinalMonthInfo {
-        let month: Int
-        let isLeapMonth: Bool
-        let day1Weekday: Int
-        let daysInMonth: Int
-        let firstWeekday: Int
-        let minDays: Int
-
-        init?(calendar: Calendar, combinations c: _DateComponentCombinations, anchor: Date) {
-            let targetMonth: Int
-            let targetIsLeap: Bool
-            let targetYear: Int
-            if let ms = c.months, ms.count == 1 {
-                targetMonth = ms[0].index
-                targetIsLeap = ms[0].isLeap
-                targetYear = calendar.component(.year, from: anchor)
-            } else if c.months == nil || c.months!.isEmpty {
-                targetMonth = calendar.component(.month, from: anchor)
-                targetIsLeap = false
-                targetYear = calendar.component(.year, from: anchor)
-            } else {
-                return nil
-            }
-
-            var monthStartComps = DateComponents()
-            monthStartComps.year = targetYear
-            monthStartComps.month = targetMonth
-            monthStartComps.day = 1
-            if targetIsLeap { monthStartComps.isLeapMonth = true }
-
-            guard let monthStart = calendar.date(from: monthStartComps),
-                  let dayRange = calendar.range(of: .day, in: .month, for: monthStart) else {
-                return nil
-            }
-
-            self.month = targetMonth
-            self.isLeapMonth = targetIsLeap
-            self.day1Weekday = calendar.component(.weekday, from: monthStart)
-            self.daysInMonth = dayRange.upperBound - 1
-            self.firstWeekday = calendar.firstWeekday
-            self.minDays = calendar.minimumDaysInFirstWeek
-        }
-    }
-
     /// Translate a `.nth(N, day)` weekday entry into DateComponents fields. Returns false if out of range.
-    private static func _translateWeekday(_ entry: RecurrenceRule.Weekday, into dc: inout DateComponents, monthInfo: _NegativeOrdinalMonthInfo?) -> Bool {
+    private static func _translateWeekday(_ entry: RecurrenceRule.Weekday, into dc: inout DateComponents, hasNegativeOrdinal: Bool, month: Int, isLeapMonth: Bool, day1Weekday: Int, daysInMonth: Int, firstWeekday: Int, minDays: Int) -> Bool {
         guard case .nth(let n, let dayOfWeek) = entry else { return false }
         let wdIdx = dayOfWeek.icuIndex
         if n > 0 {
@@ -798,17 +783,17 @@ extension Calendar {
             dc.weekday = wdIdx
             return true
         }
-        guard let info = monthInfo else { return false }
-        let firstOcc = 1 + ((wdIdx - info.day1Weekday + 7) % 7)
-        let totalOcc = (info.daysInMonth - firstOcc) / 7 + 1
+        guard hasNegativeOrdinal else { return false }
+        let firstOcc = 1 + ((wdIdx - day1Weekday + 7) % 7)
+        let totalOcc = (daysInMonth - firstOcc) / 7 + 1
         let kthFromLast = -n
         let dayOfMonth = firstOcc + (totalOcc - kthFromLast) * 7
-        guard dayOfMonth >= 1, dayOfMonth <= info.daysInMonth else { return false }
-        let periodStart = ((info.day1Weekday - info.firstWeekday) % 7 + 7) % 7
-        let correction = (7 - periodStart) >= info.minDays ? 1 : 0
+        guard dayOfMonth >= 1, dayOfMonth <= daysInMonth else { return false }
+        let periodStart = ((day1Weekday - firstWeekday) % 7 + 7) % 7
+        let correction = (7 - periodStart) >= minDays ? 1 : 0
         let weekOfMonth = (dayOfMonth + periodStart - 1) / 7 + correction
-        dc.month = info.month
-        dc.isLeapMonth = info.isLeapMonth
+        dc.month = month
+        dc.isLeapMonth = isLeapMonth
         dc.weekday = wdIdx
         dc.weekOfMonth = weekOfMonth
         return true
@@ -816,7 +801,7 @@ extension Calendar {
 
     /// Probe all expanded DateComponents via the fast path. Returns sorted results or nil if any DC isn't fast-pathable.
     private func _probeAllFastPath(_ allDCs: [DateComponents], after startDate: Date) -> [(Date, DateComponents)]? {
-        guard allDCs.allSatisfy({ _supportsNextDateFastPath(for: $0) }) else { return nil }
+        guard allDCs.allSatisfy({ _supportsNextDateFastPath(for: $0._populatedComponentSet) }) else { return nil }
         var results: [(Date, DateComponents)] = []
         results.reserveCapacity(allDCs.count)
         for dc in allDCs {
@@ -827,44 +812,6 @@ extension Calendar {
         return results
     }
 
-    /// Single-valued `DateComponents` from combinations, or nil if expansion is needed.
-    fileprivate func _singleCombinationDateComponents(
-        _ c: _DateComponentCombinations
-    ) -> DateComponents? {
-        if let count = c.weeksOfYear?.count, count > 1 { return nil }
-        if let count = c.daysOfYear?.count, count > 1 { return nil }
-        if let count = c.months?.count, count > 1 { return nil }
-        if let count = c.daysOfMonth?.count, count > 1 { return nil }
-        if let count = c.weekdays?.count, count > 1 { return nil }
-        if let count = c.hours?.count, count > 1 { return nil }
-        if let count = c.minutes?.count, count > 1 { return nil }
-        if let count = c.seconds?.count, count > 1 { return nil }
-
-        var dc = DateComponents()
-        if let m = c.months?.first {
-            dc.month = m.index
-            dc.isLeapMonth = m.isLeap
-        }
-        if let woy = c.weeksOfYear?.first { dc.weekOfYear = woy }
-        if let doy = c.daysOfYear?.first { dc.dayOfYear = doy }
-        if let dom = c.daysOfMonth?.first { dc.day = dom }
-        if let weekday = c.weekdays?.first {
-            switch weekday {
-            case .every:
-                return nil
-            case .nth(let n, let day):
-                guard n >= 1 else { return nil }   // negative ordinals not in our fast path
-                dc.weekdayOrdinal = n
-                dc.weekday = day.icuIndex
-            }
-        }
-        if let h = c.hours?.first { dc.hour = h }
-        if let mi = c.minutes?.first { dc.minute = mi }
-        if let s = c.seconds?.first { dc.second = s }
-
-        return dc
-    }
-    
 
     /// Find date components which can be used to filter or enumerate each given
     /// weekday in a range
@@ -1029,17 +976,8 @@ extension Calendar {
                                       matchingPolicy: MatchingPolicy,
                                       repeatedTimePolicy: RepeatedTimePolicy) throws -> [(Date, DateComponents)]? {
 
-        // Fast-path short-circuits. Only fires when the calendar opts in.
+        // Fast-path: _probeAllFastPath checks supportsNextDateFastPath per pattern.
         if matchingPolicy == .nextTime && repeatedTimePolicy == .first {
-
-            // (1) Single-combination: one value per field.
-            if let dc = _singleCombinationDateComponents(combinationComponents),
-               _supportsNextDateFastPath(for: dc),
-               let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) {
-                return [(fast, dc)]
-            }
-
-            // (2) Multi-combination: cartesian product (handles both positive and negative ordinals).
             if let allDCs = _fastPathDateComponents(combinationComponents, anchor: startDate),
                let results = _probeAllFastPath(allDCs, after: startDate) {
                 return results

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -664,21 +664,8 @@ extension Calendar {
         var seconds: [Int]? = nil
     }
 
-    /// Whether the combinations contain any `.nth(N, day)` with `N < 0`.
-    fileprivate func _unadjustedDatesHasNegativeOrdinal(_ c: _DateComponentCombinations) -> Bool {
-        guard let weekdays = c.weekdays else { return false }
-        for w in weekdays {
-            if case .nth(let n, _) = w, n < 0 { return true }
-        }
-        return false
-    }
-
-    /// Expand `_DateComponentCombinations` into a flat array of single-valued `DateComponents`. Negative ordinals are translated to `{month, weekday, weekOfMonth}` using `anchor`'s month structure. Returns nil if the pattern can't be expanded.
-    fileprivate func _expandedDateComponents(
-        _ c: _DateComponentCombinations,
-        anchor: Date? = nil,
-        maxCombinations: Int = 64
-    ) -> [DateComponents]? {
+    /// Expand `_DateComponentCombinations` into a flat array of single-valued `DateComponents` for the fast path. Negative ordinals are translated to `{month, weekday, weekOfMonth}` using `anchor`'s month structure. Returns nil if the pattern can't be expanded.
+    fileprivate func _fastPathDateComponents(_ c: _DateComponentCombinations, anchor: Date? = nil, maxCombinations: Int = 64) -> [DateComponents]? {
         var hasNegativeOrdinal = false
         if let weekdays = c.weekdays {
             for w in weekdays {
@@ -704,35 +691,80 @@ extension Calendar {
         let minutesCount = c.minutes?.count ?? 1
         let secondsCount = c.seconds?.count ?? 1
 
-        let total = monthsCount * weekdaysCount * daysOfMonthCount
-                  * daysOfYearCount * weeksOfYearCount
-                  * hoursCount * minutesCount * secondsCount
-        if total <= 0 { return nil }
-        if total > maxCombinations { return nil }
+        let counts = [monthsCount, weekdaysCount, daysOfMonthCount, daysOfYearCount, weeksOfYearCount, hoursCount, minutesCount, secondsCount]
+        var total = 1
+        for count in counts {
+            let (product, overflow) = total.multipliedReportingOverflow(by: count)
+            if overflow || product > maxCombinations { return nil }
+            total = product
+        }
         if total <= 1 { return nil }
 
-        // Precompute target month structure for negative-ordinal translation.
-        struct MonthInfo {
-            let month: Int
-            let isLeapMonth: Bool
-            let day1Weekday: Int   // 1..7 (Sunday=1)
-            let daysInMonth: Int
-            let firstWeekday: Int  // calendar's
-            let minDays: Int       // calendar's
-        }
-        var monthInfo: MonthInfo? = nil
+        var monthInfo: _NegativeOrdinalMonthInfo? = nil
         if hasNegativeOrdinal, let anchor = anchor {
+            guard let info = _NegativeOrdinalMonthInfo(calendar: self, combinations: c, anchor: anchor) else { return nil }
+            monthInfo = info
+        }
+
+        var base = DateComponents()
+        if let ms = c.months, ms.count == 1 { base.month = ms[0].index; base.isLeapMonth = ms[0].isLeap }
+        if let woy = c.weeksOfYear, woy.count == 1 { base.weekOfYear = woy[0] }
+        if let doy = c.daysOfYear, doy.count == 1 { base.dayOfYear = doy[0] }
+        if let dom = c.daysOfMonth, dom.count == 1 { base.day = dom[0] }
+        if let hs = c.hours, hs.count == 1 { base.hour = hs[0] }
+        if let mins = c.minutes, mins.count == 1 { base.minute = mins[0] }
+        if let secs = c.seconds, secs.count == 1 { base.second = secs[0] }
+
+        var seeds: [DateComponents]
+        if let wds = c.weekdays {
+            if wds.count == 1 {
+                guard Self._translateWeekday(wds[0], into: &base, monthInfo: monthInfo) else { return nil }
+                seeds = [base]
+            } else {
+                seeds = []
+                seeds.reserveCapacity(wds.count)
+                for wd in wds {
+                    var wdBase = base
+                    guard Self._translateWeekday(wd, into: &wdBase, monthInfo: monthInfo) else { return nil }
+                    seeds.append(wdBase)
+                }
+            }
+        } else {
+            seeds = [base]
+        }
+
+        // Expand multi valued axes by cloning and setting each value directly.
+        if let ms = c.months, ms.count > 1 { seeds = seeds.flatMap { seed in ms.map { m in var dc = seed; dc.month = m.index; dc.isLeapMonth = m.isLeap; return dc } } }
+        if let woy = c.weeksOfYear, woy.count > 1 { seeds = seeds.flatMap { seed in woy.map { v in var dc = seed; dc.weekOfYear = v; return dc } } }
+        if let doy = c.daysOfYear, doy.count > 1 { seeds = seeds.flatMap { seed in doy.map { v in var dc = seed; dc.dayOfYear = v; return dc } } }
+        if let dom = c.daysOfMonth, dom.count > 1 { seeds = seeds.flatMap { seed in dom.map { v in var dc = seed; dc.day = v; return dc } } }
+        if let hs = c.hours, hs.count > 1 { seeds = seeds.flatMap { seed in hs.map { v in var dc = seed; dc.hour = v; return dc } } }
+        if let mins = c.minutes, mins.count > 1 { seeds = seeds.flatMap { seed in mins.map { v in var dc = seed; dc.minute = v; return dc } } }
+        if let secs = c.seconds, secs.count > 1 { seeds = seeds.flatMap { seed in secs.map { v in var dc = seed; dc.second = v; return dc } } }
+
+        return seeds
+    }
+
+    private struct _NegativeOrdinalMonthInfo {
+        let month: Int
+        let isLeapMonth: Bool
+        let day1Weekday: Int
+        let daysInMonth: Int
+        let firstWeekday: Int
+        let minDays: Int
+
+        init?(calendar: Calendar, combinations c: _DateComponentCombinations, anchor: Date) {
             let targetMonth: Int
             let targetIsLeap: Bool
             let targetYear: Int
             if let ms = c.months, ms.count == 1 {
                 targetMonth = ms[0].index
                 targetIsLeap = ms[0].isLeap
-                targetYear = self.component(.year, from: anchor)
+                targetYear = calendar.component(.year, from: anchor)
             } else if c.months == nil || c.months!.isEmpty {
-                targetMonth = self.component(.month, from: anchor)
+                targetMonth = calendar.component(.month, from: anchor)
                 targetIsLeap = false
-                targetYear = self.component(.year, from: anchor)
+                targetYear = calendar.component(.year, from: anchor)
             } else {
                 return nil
             }
@@ -743,120 +775,56 @@ extension Calendar {
             monthStartComps.day = 1
             if targetIsLeap { monthStartComps.isLeapMonth = true }
 
-            guard let monthStart = self.date(from: monthStartComps),
-                  let dayRange = self.range(of: .day, in: .month, for: monthStart) else {
+            guard let monthStart = calendar.date(from: monthStartComps),
+                  let dayRange = calendar.range(of: .day, in: .month, for: monthStart) else {
                 return nil
             }
-            let daysInMonth = dayRange.upperBound - 1
-            let day1Weekday = self.component(.weekday, from: monthStart)
 
-            monthInfo = MonthInfo(
-                month: targetMonth,
-                isLeapMonth: targetIsLeap,
-                day1Weekday: day1Weekday,
-                daysInMonth: daysInMonth,
-                firstWeekday: self.firstWeekday,
-                minDays: self.minimumDaysInFirstWeek
-            )
+            self.month = targetMonth
+            self.isLeapMonth = targetIsLeap
+            self.day1Weekday = calendar.component(.weekday, from: monthStart)
+            self.daysInMonth = dayRange.upperBound - 1
+            self.firstWeekday = calendar.firstWeekday
+            self.minDays = calendar.minimumDaysInFirstWeek
         }
+    }
 
-        // Translate a `.nth(N, day)` entry to DC fields. Returns false if out of range.
-        func translateWeekday(_ entry: RecurrenceRule.Weekday, into dc: inout DateComponents) -> Bool {
-            guard case .nth(let n, let dayOfWeek) = entry else { return false }
-            let wdIdx = dayOfWeek.icuIndex
-            if n > 0 {
-                dc.weekdayOrdinal = n
-                dc.weekday = wdIdx
-                return true
-            }
-            // Negative ordinal → {month, weekday, weekOfMonth}.
-            guard let info = monthInfo else { return false }
-            let firstOcc = 1 + ((wdIdx - info.day1Weekday + 7) % 7)   // 1..7
-            let totalOcc = (info.daysInMonth - firstOcc) / 7 + 1
-            let kthFromLast = -n
-            let dayOfMonth = firstOcc + (totalOcc - kthFromLast) * 7
-            guard dayOfMonth >= 1, dayOfMonth <= info.daysInMonth else { return false }
-            let periodStart = ((info.day1Weekday - info.firstWeekday) % 7 + 7) % 7
-            let correction = (7 - periodStart) >= info.minDays ? 1 : 0
-            let weekOfMonth = (dayOfMonth + periodStart - 1) / 7 + correction
-            dc.month = info.month
-            dc.isLeapMonth = info.isLeapMonth
+    /// Translate a `.nth(N, day)` weekday entry into DateComponents fields. Returns false if out of range.
+    private static func _translateWeekday(_ entry: RecurrenceRule.Weekday, into dc: inout DateComponents, monthInfo: _NegativeOrdinalMonthInfo?) -> Bool {
+        guard case .nth(let n, let dayOfWeek) = entry else { return false }
+        let wdIdx = dayOfWeek.icuIndex
+        if n > 0 {
+            dc.weekdayOrdinal = n
             dc.weekday = wdIdx
-            dc.weekOfMonth = weekOfMonth
             return true
         }
+        guard let info = monthInfo else { return false }
+        let firstOcc = 1 + ((wdIdx - info.day1Weekday + 7) % 7)
+        let totalOcc = (info.daysInMonth - firstOcc) / 7 + 1
+        let kthFromLast = -n
+        let dayOfMonth = firstOcc + (totalOcc - kthFromLast) * 7
+        guard dayOfMonth >= 1, dayOfMonth <= info.daysInMonth else { return false }
+        let periodStart = ((info.day1Weekday - info.firstWeekday) % 7 + 7) % 7
+        let correction = (7 - periodStart) >= info.minDays ? 1 : 0
+        let weekOfMonth = (dayOfMonth + periodStart - 1) / 7 + correction
+        dc.month = info.month
+        dc.isLeapMonth = info.isLeapMonth
+        dc.weekday = wdIdx
+        dc.weekOfMonth = weekOfMonth
+        return true
+    }
 
-        // Build a base DateComponents with single valued axes, then vary only the multi valued ones.
-        var base = DateComponents()
-        var axes: [(WritableKeyPath<DateComponents, Int?>, [Int])] = []
-
-        if let ms = c.months {
-            if ms.count == 1 {
-                base.month = ms[0].index
-                base.isLeapMonth = ms[0].isLeap
-            } else {
-                axes.append((\.month, ms.map(\.index)))
-            }
+    /// Probe all expanded DateComponents via the fast path. Returns sorted results or nil if any DC isn't fast-pathable.
+    private func _probeAllFastPath(_ allDCs: [DateComponents], after startDate: Date) -> [(Date, DateComponents)]? {
+        guard allDCs.allSatisfy({ _supportsNextDateFastPath(for: $0) }) else { return nil }
+        var results: [(Date, DateComponents)] = []
+        results.reserveCapacity(allDCs.count)
+        for dc in allDCs {
+            guard let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) else { return nil }
+            results.append((fast, dc))
         }
-        if let woy = c.weeksOfYear {
-            if woy.count == 1 { base.weekOfYear = woy[0] }
-            else { axes.append((\.weekOfYear, woy)) }
-        }
-        if let doy = c.daysOfYear {
-            if doy.count == 1 { base.dayOfYear = doy[0] }
-            else { axes.append((\.dayOfYear, doy)) }
-        }
-        if let dom = c.daysOfMonth {
-            if dom.count == 1 { base.day = dom[0] }
-            else { axes.append((\.day, dom)) }
-        }
-        if let hs = c.hours {
-            if hs.count == 1 { base.hour = hs[0] }
-            else { axes.append((\.hour, hs)) }
-        }
-        if let mins = c.minutes {
-            if mins.count == 1 { base.minute = mins[0] }
-            else { axes.append((\.minute, mins)) }
-        }
-        if let secs = c.seconds {
-            if secs.count == 1 { base.second = secs[0] }
-            else { axes.append((\.second, secs)) }
-        }
-
-        // Handle weekdays: translate each entry into the base or build a seed list.
-        var seeds: [DateComponents]
-        if let wds = c.weekdays {
-            if wds.count == 1 {
-                guard translateWeekday(wds[0], into: &base) else { return nil }
-                seeds = [base]
-            } else {
-                seeds = []
-                seeds.reserveCapacity(wds.count)
-                for wd in wds {
-                    var wdBase = base
-                    guard translateWeekday(wd, into: &wdBase) else { return nil }
-                    seeds.append(wdBase)
-                }
-            }
-        } else {
-            seeds = [base]
-        }
-
-        // Expand each multi valued axis by cloning and patching.
-        for (keyPath, values) in axes {
-            var expanded: [DateComponents] = []
-            expanded.reserveCapacity(seeds.count * values.count)
-            for seed in seeds {
-                for v in values {
-                    var dc = seed
-                    dc[keyPath: keyPath] = v
-                    expanded.append(dc)
-                }
-            }
-            seeds = expanded
-        }
-
-        return seeds
+        results.sort { $0.0 < $1.0 }
+        return results
     }
 
     /// Single-valued `DateComponents` from combinations, or nil if expansion is needed.
@@ -1071,43 +1039,10 @@ extension Calendar {
                 return [(fast, dc)]
             }
 
-            // (2) Multi-combination (positive ordinals): cartesian product.
-            if let allDCs = _expandedDateComponents(combinationComponents),
-               allDCs.allSatisfy({ _supportsNextDateFastPath(for: $0) }) {
-                var results: [(Date, DateComponents)] = []
-                results.reserveCapacity(allDCs.count)
-                var allFastPathed = true
-                for dc in allDCs {
-                    guard let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) else {
-                        allFastPathed = false
-                        break
-                    }
-                    results.append((fast, dc))
-                }
-                if allFastPathed && !results.isEmpty {
-                    results.sort { $0.0 < $1.0 }
-                    return results
-                }
-            }
-
-            // (3) Multi-combination with negative ordinal translation.
-            if _unadjustedDatesHasNegativeOrdinal(combinationComponents),
-               let allDCs = _expandedDateComponents(combinationComponents, anchor: startDate),
-               allDCs.allSatisfy({ _supportsNextDateFastPath(for: $0) }) {
-                var results: [(Date, DateComponents)] = []
-                results.reserveCapacity(allDCs.count)
-                var allFastPathed = true
-                for dc in allDCs {
-                    guard let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) else {
-                        allFastPathed = false
-                        break
-                    }
-                    results.append((fast, dc))
-                }
-                if allFastPathed && !results.isEmpty {
-                    results.sort { $0.0 < $1.0 }
-                    return results
-                }
+            // (2) Multi-combination: cartesian product (handles both positive and negative ordinals).
+            if let allDCs = _fastPathDateComponents(combinationComponents, anchor: startDate),
+               let results = _probeAllFastPath(allDCs, after: startDate) {
+                return results
             }
         }
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -673,10 +673,7 @@ extension Calendar {
         return false
     }
 
-    /// Expand `_DateComponentCombinations` into a flat array of single-valued
-    /// `DateComponents`. Negative ordinals are translated to `{month, weekday,
-    /// weekOfMonth}` using `anchor`'s month structure. Returns nil if the
-    /// pattern can't be expanded (too many combinations, `.every()` weekday, etc).
+    /// Expand `_DateComponentCombinations` into a flat array of single-valued `DateComponents`. Negative ordinals are translated to `{month, weekday, weekOfMonth}` using `anchor`'s month structure. Returns nil if the pattern can't be expanded.
     fileprivate func _expandedDateComponents(
         _ c: _DateComponentCombinations,
         anchor: Date? = nil,
@@ -789,53 +786,77 @@ extension Calendar {
             return true
         }
 
-        func make(monthIdx: Int, weekdayIdx: Int,
-                  daysOfMonthIdx: Int, daysOfYearIdx: Int, weeksOfYearIdx: Int,
-                  hoursIdx: Int, minutesIdx: Int, secondsIdx: Int) -> DateComponents? {
-            var dc = DateComponents()
-            if let ms = c.months {
-                dc.month = ms[monthIdx].index
-                dc.isLeapMonth = ms[monthIdx].isLeap
+        // Build a base DateComponents with single valued axes, then vary only the multi valued ones.
+        var base = DateComponents()
+        var axes: [(WritableKeyPath<DateComponents, Int?>, [Int])] = []
+
+        if let ms = c.months {
+            if ms.count == 1 {
+                base.month = ms[0].index
+                base.isLeapMonth = ms[0].isLeap
+            } else {
+                axes.append((\.month, ms.map(\.index)))
             }
-            if let woy = c.weeksOfYear { dc.weekOfYear = woy[weeksOfYearIdx] }
-            if let doy = c.daysOfYear { dc.dayOfYear = doy[daysOfYearIdx] }
-            if let dom = c.daysOfMonth { dc.day = dom[daysOfMonthIdx] }
-            if let wds = c.weekdays {
-                guard translateWeekday(wds[weekdayIdx], into: &dc) else { return nil }
-            }
-            if let hs = c.hours { dc.hour = hs[hoursIdx] }
-            if let mins = c.minutes { dc.minute = mins[minutesIdx] }
-            if let secs = c.seconds { dc.second = secs[secondsIdx] }
-            return dc
+        }
+        if let woy = c.weeksOfYear {
+            if woy.count == 1 { base.weekOfYear = woy[0] }
+            else { axes.append((\.weekOfYear, woy)) }
+        }
+        if let doy = c.daysOfYear {
+            if doy.count == 1 { base.dayOfYear = doy[0] }
+            else { axes.append((\.dayOfYear, doy)) }
+        }
+        if let dom = c.daysOfMonth {
+            if dom.count == 1 { base.day = dom[0] }
+            else { axes.append((\.day, dom)) }
+        }
+        if let hs = c.hours {
+            if hs.count == 1 { base.hour = hs[0] }
+            else { axes.append((\.hour, hs)) }
+        }
+        if let mins = c.minutes {
+            if mins.count == 1 { base.minute = mins[0] }
+            else { axes.append((\.minute, mins)) }
+        }
+        if let secs = c.seconds {
+            if secs.count == 1 { base.second = secs[0] }
+            else { axes.append((\.second, secs)) }
         }
 
-        var result: [DateComponents] = []
-        result.reserveCapacity(total)
-        for mIdx in 0..<monthsCount {
-            for wIdx in 0..<weekdaysCount {
-                for domIdx in 0..<daysOfMonthCount {
-                    for doyIdx in 0..<daysOfYearCount {
-                        for woyIdx in 0..<weeksOfYearCount {
-                            for hIdx in 0..<hoursCount {
-                                for miIdx in 0..<minutesCount {
-                                    for sIdx in 0..<secondsCount {
-                                        guard let dc = make(
-                                            monthIdx: mIdx, weekdayIdx: wIdx,
-                                            daysOfMonthIdx: domIdx,
-                                            daysOfYearIdx: doyIdx,
-                                            weeksOfYearIdx: woyIdx,
-                                            hoursIdx: hIdx, minutesIdx: miIdx,
-                                            secondsIdx: sIdx) else { return nil }
-                                        result.append(dc)
-                                    }
-                                }
-                            }
-                        }
-                    }
+        // Handle weekdays: translate each entry into the base or build a seed list.
+        var seeds: [DateComponents]
+        if let wds = c.weekdays {
+            if wds.count == 1 {
+                guard translateWeekday(wds[0], into: &base) else { return nil }
+                seeds = [base]
+            } else {
+                seeds = []
+                seeds.reserveCapacity(wds.count)
+                for wd in wds {
+                    var wdBase = base
+                    guard translateWeekday(wd, into: &wdBase) else { return nil }
+                    seeds.append(wdBase)
                 }
             }
+        } else {
+            seeds = [base]
         }
-        return result
+
+        // Expand each multi valued axis by cloning and patching.
+        for (keyPath, values) in axes {
+            var expanded: [DateComponents] = []
+            expanded.reserveCapacity(seeds.count * values.count)
+            for seed in seeds {
+                for v in values {
+                    var dc = seed
+                    dc[keyPath: keyPath] = v
+                    expanded.append(dc)
+                }
+            }
+            seeds = expanded
+        }
+
+        return seeds
     }
 
     /// Single-valued `DateComponents` from combinations, or nil if expansion is needed.
@@ -1040,41 +1061,35 @@ extension Calendar {
                                       matchingPolicy: MatchingPolicy,
                                       repeatedTimePolicy: RepeatedTimePolicy) throws -> [(Date, DateComponents)]? {
 
-        // Fast-path short-circuits. The protocol default for _calendarNextDate is nil,
-        // so non-Hebrew calendars fall through to the existing path unchanged.
+        // Fast-path short-circuits. Only fires when the calendar opts in.
+        if _supportsNextDateFastPath && matchingPolicy == .nextTime && repeatedTimePolicy == .first {
 
-        // (1) Single-combination: one value per field → single _calendarNextDate call.
-        if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
-           let dc = _singleCombinationDateComponents(combinationComponents),
-           let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) {
-            return [(fast, dc)]
-        }
+            // (1) Single-combination: one value per field.
+            if let dc = _singleCombinationDateComponents(combinationComponents),
+               let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) {
+                return [(fast, dc)]
+            }
 
-        // (2) Multi-combination (positive ordinals): cartesian product → probe each.
-        if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
-           let allDCs = _expandedDateComponents(combinationComponents) {
-            var results: [(Date, DateComponents)] = []
-            results.reserveCapacity(allDCs.count)
-            var allFastPathed = true
-            for dc in allDCs {
-                guard let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) else {
-                    allFastPathed = false
-                    break
+            // (2) Multi-combination (positive ordinals): cartesian product.
+            if let allDCs = _expandedDateComponents(combinationComponents) {
+                var results: [(Date, DateComponents)] = []
+                results.reserveCapacity(allDCs.count)
+                var allFastPathed = true
+                for dc in allDCs {
+                    guard let fast = _calendarNextDate(after: startDate, matching: dc, direction: .forward) else {
+                        allFastPathed = false
+                        break
+                    }
+                    results.append((fast, dc))
                 }
-                results.append((fast, dc))
+                if allFastPathed && !results.isEmpty {
+                    results.sort { $0.0 < $1.0 }
+                    return results
+                }
             }
-            if allFastPathed && !results.isEmpty {
-                results.sort { $0.0 < $1.0 }
-                return results
-            }
-        }
 
-        // (3) Multi-combination with negative-ordinal translation.
-        if matchingPolicy == .nextTime && repeatedTimePolicy == .first,
-           _unadjustedDatesHasNegativeOrdinal(combinationComponents) {
-            var sentinel = DateComponents()
-            sentinel.weekday = 1
-            if _calendarNextDate(after: startDate, matching: sentinel, direction: .forward) != nil,
+            // (3) Multi-combination with negative ordinal translation.
+            if _unadjustedDatesHasNegativeOrdinal(combinationComponents),
                let allDCs = _expandedDateComponents(combinationComponents, anchor: startDate) {
                 var results: [(Date, DateComponents)] = []
                 results.reserveCapacity(allDCs.count)

--- a/Sources/FoundationEssentials/Calendar/DateComponents.swift
+++ b/Sources/FoundationEssentials/Calendar/DateComponents.swift
@@ -532,6 +532,27 @@ public struct DateComponents : Hashable, Equatable, Sendable {
     }
 }
 
+extension DateComponents {
+    internal var _populatedComponentSet: Calendar.ComponentSet {
+        var result = Calendar.ComponentSet()
+        if era != nil { result.insert(.era) }
+        if year != nil { result.insert(.year) }
+        if month != nil { result.insert(.month) }
+        if day != nil { result.insert(.day) }
+        if hour != nil { result.insert(.hour) }
+        if minute != nil { result.insert(.minute) }
+        if second != nil { result.insert(.second) }
+        if weekday != nil { result.insert(.weekday) }
+        if weekdayOrdinal != nil { result.insert(.weekdayOrdinal) }
+        if weekOfMonth != nil { result.insert(.weekOfMonth) }
+        if weekOfYear != nil { result.insert(.weekOfYear) }
+        if yearForWeekOfYear != nil { result.insert(.yearForWeekOfYear) }
+        if nanosecond != nil { result.insert(.nanosecond) }
+        if dayOfYear != nil { result.insert(.dayOfYear) }
+        return result
+    }
+}
+
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension DateComponents : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
 

--- a/Tests/FoundationInternationalizationTests/HebrewRecurrenceRuleParityProbe.swift
+++ b/Tests/FoundationInternationalizationTests/HebrewRecurrenceRuleParityProbe.swift
@@ -1,0 +1,418 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationInternationalization
+@testable import FoundationEssentials
+#endif
+
+/// RecurrenceRule parity probe: compares date sequences from `recurrences(of:)`
+/// between the ICU backed Hebrew calendar and `_CalendarHebrew`. Verifies that
+/// the fast path short circuits in `_unadjustedDates` / `_dates` produce
+/// identical results to the generic enumerate framework.
+@Suite("Hebrew RecurrenceRule Parity Probe")
+private struct HebrewRecurrenceRuleParityProbe {
+
+    // MARK: - Setup
+
+    private static func makePair(timeZone: TimeZone = .gmt) -> (icu: Calendar, ours: Calendar) {
+        var icu = Calendar(identifier: .hebrew)
+        icu.timeZone = timeZone
+        let oursInner = _CalendarHebrew(
+            identifier: .hebrew, timeZone: timeZone, locale: nil,
+            firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil
+        )
+        return (icu, Calendar(inner: oursInner))
+    }
+
+    /// Anchor dates spanning leap/common years, year boundaries, and Adar I transitions.
+    private static func probeStarts(in timeZone: TimeZone = .gmt) -> [(label: String, date: Date)] {
+        var g = Calendar(identifier: .gregorian)
+        g.timeZone = timeZone
+        func d(_ y: Int, _ m: Int, _ day: Int, hour: Int = 12) -> Date {
+            var dc = DateComponents()
+            dc.year = y; dc.month = m; dc.day = day; dc.hour = hour; dc.timeZone = timeZone
+            return g.date(from: dc)!
+        }
+        return [
+            ("2016-09-23 14:35 (benchmark anchor)",   d(2016, 9, 23, hour: 14)),
+            ("2016-02-10 (Adar I, leap)",             d(2016, 2, 10)),
+            ("2016-03-11 (Adar II, leap)",            d(2016, 3, 11)),
+            ("2017-12-15 (mid common year)",          d(2017, 12, 15)),
+            ("2025-09-23 (Tishri 1 common)",          d(2025, 9, 23)),
+            ("2015-09-14 (Tishri 1 leap)",            d(2015, 9, 14)),
+            ("2025-03-01 (Adar common)",              d(2025, 3, 1)),
+            ("2016-12-25 (Hanukkah common)",          d(2016, 12, 25)),
+        ]
+    }
+
+    private final class Divergences {
+        var list: [String] = []
+        var compared: Int = 0
+        var rulesRun: Int = 0
+
+        func compare(_ rule: String, _ start: String, _ icu: [Date], _ ours: [Date]) {
+            rulesRun += 1
+            let n = max(icu.count, ours.count)
+            for i in 0..<n {
+                compared += 1
+                let a = i < icu.count ? icu[i] : nil
+                let b = i < ours.count ? ours[i] : nil
+                if a != b {
+                    if list.count < 25 {
+                        list.append("[\(rule)] start=\(start) idx=\(i): ICU=\(describe(a)) ours=\(describe(b))")
+                    } else if list.count == 25 {
+                        list.append("... (more divergences truncated)")
+                    }
+                }
+            }
+        }
+
+        private func describe(_ d: Date?) -> String {
+            d.map { "\($0)" } ?? "nil"
+        }
+    }
+
+    /// Drive a single `RecurrenceRule` shape across all probe starts and
+    /// compare the date streams between ICU Hebrew and native Hebrew.
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    private static func runProbe(name: String,
+                                 configure: (Calendar) -> Calendar.RecurrenceRule,
+                                 starts: [(String, Date)],
+                                 limit: Int,
+                                 div: Divergences,
+                                 icuCal: Calendar,
+                                 oursCal: Calendar) {
+        let icuRule = configure(icuCal)
+        let ourRule = configure(oursCal)
+        for (lbl, start) in starts {
+            let icuDates = Array(icuRule.recurrences(of: start).prefix(limit))
+            let ourDates = Array(ourRule.recurrences(of: start).prefix(limit))
+            div.compare(name, lbl, icuDates, ourDates)
+        }
+    }
+
+    private static func report(_ name: String, _ div: Divergences) {
+        print("[\(name)] rules=\(div.rulesRun) compared=\(div.compared) divergences=\(div.list.count)")
+        for d in div.list.prefix(10) { print("  \(d)") }
+    }
+
+    // MARK: - Tests
+
+    /// Single combination yearly (Thanksgiving style).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func yearly_singleMonth_nthWeekday() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Self.probeStarts()
+        let div = Divergences()
+        // Civil months: 1=Tishri, 3=Kislev, 7=Adar/AdarII, 11=Tammuz.
+        for m in [1, 3, 7, 11] {
+            for wd in [Locale.Weekday.sunday, .thursday, .saturday] {
+                for n in [1, 2, 4] {
+                    Self.runProbe(
+                        name: "yearly m=\(m) wd=\(wd) n=\(n)",
+                        configure: { cal in
+                            var r = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(5))
+                            r.months = [.init(m)]
+                            r.weekdays = [.nth(n, wd)]
+                            r.matchingPolicy = .nextTime
+                            return r
+                        },
+                        starts: starts, limit: 5, div: div,
+                        icuCal: icuCal, oursCal: oursCal
+                    )
+                }
+            }
+        }
+        Self.report("yearly_singleMonth_nthWeekday", div)
+        #expect(div.list.isEmpty, "RecurrenceRule diverges between ICU and our Hebrew on \(div.list.count) date(s)")
+    }
+
+    /// Single combination monthly.
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func monthly_nthWeekday() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(4))
+        let div = Divergences()
+        for wd in [Locale.Weekday.monday, .wednesday, .friday] {
+            for n in [1, 2, 4] {
+                Self.runProbe(
+                    name: "monthly wd=\(wd) n=\(n)",
+                    configure: { cal in
+                        var r = Calendar.RecurrenceRule(calendar: cal, frequency: .monthly, end: .afterOccurrences(5))
+                        r.weekdays = [.nth(n, wd)]
+                        r.matchingPolicy = .nextTime
+                        return r
+                    },
+                    starts: starts, limit: 5, div: div,
+                    icuCal: icuCal, oursCal: oursCal
+                )
+            }
+        }
+        Self.report("monthly_nthWeekday", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Multi combination: hours expansion (ThanksgivingMeals shape).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func yearly_multipleHours() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Self.probeStarts()
+        let div = Divergences()
+        Self.runProbe(
+            name: "yearly m=11 wd=5 n=4 h=[14,18]",
+            configure: { cal in
+                var r = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(8))
+                r.months = [11]
+                r.weekdays = [.nth(4, .thursday)]
+                r.hours = [14, 18]
+                r.matchingPolicy = .nextTime
+                return r
+            },
+            starts: starts, limit: 8, div: div,
+            icuCal: icuCal, oursCal: oursCal
+        )
+        Self.report("yearly_multipleHours", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Multi weekday with positive AND negative ordinals (BikeParties shape).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func monthly_multipleNthWeekdays() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(4))
+        let div = Divergences()
+        Self.runProbe(
+            name: "monthly [.nth(1, fri), .nth(-1, fri)]",
+            configure: { cal in
+                var r = Calendar.RecurrenceRule(calendar: cal, frequency: .monthly, end: .afterOccurrences(10))
+                r.weekdays = [.nth(1, .friday), .nth(-1, .friday)]
+                r.matchingPolicy = .nextTime
+                return r
+            },
+            starts: starts, limit: 10, div: div,
+            icuCal: icuCal, oursCal: oursCal
+        )
+        Self.report("monthly_multipleNthWeekdays", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Daily recurrence with multiple times (DailyWithTimes shape).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func daily_withTimes() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(2))
+        let div = Divergences()
+        Self.runProbe(
+            name: "daily wd=[mon,tue,wed] h=[9,10] mi=[0,30]",
+            configure: { cal in
+                var r = Calendar.RecurrenceRule(calendar: cal, frequency: .daily, end: .afterOccurrences(20))
+                r.weekdays = [.every(.monday), .every(.tuesday), .every(.wednesday)]
+                r.hours = [9, 10]
+                r.minutes = [0, 30]
+                r.matchingPolicy = .nextTime
+                return r
+            },
+            starts: starts, limit: 20, div: div,
+            icuCal: icuCal, oursCal: oursCal
+        )
+        Self.report("daily_withTimes", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Negative ordinals (last X of month).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func negativeOrdinals() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(4))
+        let div = Divergences()
+        for wd in [Locale.Weekday.sunday, .friday] {
+            for n in [-1, -2] {
+                Self.runProbe(
+                    name: "monthly wd=\(wd) n=\(n)",
+                    configure: { cal in
+                        var r = Calendar.RecurrenceRule(calendar: cal, frequency: .monthly, end: .afterOccurrences(5))
+                        r.weekdays = [.nth(n, wd)]
+                        r.matchingPolicy = .nextTime
+                        return r
+                    },
+                    starts: starts, limit: 5, div: div,
+                    icuCal: icuCal, oursCal: oursCal
+                )
+            }
+        }
+        Self.report("negativeOrdinals", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Multiple months (quarterly style).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func multipleMonths() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(4))
+        let div = Divergences()
+        Self.runProbe(
+            name: "yearly months=[1,4,7,10] wd=.nth(1,sun)",
+            configure: { cal in
+                var r = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(8))
+                r.months = [.init(1), .init(4), .init(7), .init(10)]
+                r.weekdays = [.nth(1, .sunday)]
+                r.matchingPolicy = .nextTime
+                return r
+            },
+            starts: starts, limit: 8, div: div,
+            icuCal: icuCal, oursCal: oursCal
+        )
+        Self.report("multipleMonths", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Adar I (civil month 6, leap year only).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func adarI_leapOnly() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(4))
+        let div = Divergences()
+        Self.runProbe(
+            name: "yearly m=6 (Adar I) .nth(1,mon)",
+            configure: { cal in
+                var r = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(5))
+                r.months = [.init(6)]   // Adar I — only exists in leap years
+                r.weekdays = [.nth(1, .monday)]
+                r.matchingPolicy = .nextTime
+                return r
+            },
+            starts: starts, limit: 5, div: div,
+            icuCal: icuCal, oursCal: oursCal
+        )
+        Self.report("adarI_leapOnly", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Single combination yearly with explicit time of day.
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func timeOfDay() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(4))
+        let div = Divergences()
+        for hour in [6, 14, 22] {
+            Self.runProbe(
+                name: "yearly m=11 wd=5 n=4 h=\(hour)",
+                configure: { cal in
+                    var r = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(5))
+                    r.months = [11]
+                    r.weekdays = [.nth(4, .thursday)]
+                    r.hours = [hour]
+                    r.matchingPolicy = .nextTime
+                    return r
+                },
+                starts: starts, limit: 5, div: div,
+                icuCal: icuCal, oursCal: oursCal
+            )
+        }
+        Self.report("timeOfDay", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Default `matchingPolicy` (not `.nextTime`). Fast path only fires
+    /// for `.nextTime`, so this exercises the generic path.
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func defaultMatchingPolicy() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(3))
+        let div = Divergences()
+        Self.runProbe(
+            name: "default-policy yearly m=11 wd=.nth(4,thu)",
+            configure: { cal in
+                var r = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, end: .afterOccurrences(5))
+                r.months = [11]
+                r.weekdays = [.nth(4, .thursday)]
+                // matchingPolicy left at default (.nextTimePreservingSmallerComponents)
+                return r
+            },
+            starts: starts, limit: 5, div: div,
+            icuCal: icuCal, oursCal: oursCal
+        )
+        Self.report("defaultMatchingPolicy", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// `interval > 1`.
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func intervalGreaterThanOne() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(3))
+        let div = Divergences()
+        Self.runProbe(
+            name: "yearly interval=2 m=11 wd=.nth(4,thu)",
+            configure: { cal in
+                var r = Calendar.RecurrenceRule(calendar: cal, frequency: .yearly, interval: 2, end: .afterOccurrences(5))
+                r.months = [11]
+                r.weekdays = [.nth(4, .thursday)]
+                r.matchingPolicy = .nextTime
+                return r
+            },
+            starts: starts, limit: 5, div: div,
+            icuCal: icuCal, oursCal: oursCal
+        )
+        Self.report("intervalGreaterThanOne", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// Day of month patterns (no weekday).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func dayOfMonth() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(3))
+        let div = Divergences()
+        for day in [1, 15, 25] {
+            Self.runProbe(
+                name: "monthly day=\(day)",
+                configure: { cal in
+                    var r = Calendar.RecurrenceRule(calendar: cal, frequency: .monthly, end: .afterOccurrences(8))
+                    r.daysOfTheMonth = [day]
+                    r.matchingPolicy = .nextTime
+                    return r
+                },
+                starts: starts, limit: 8, div: div,
+                icuCal: icuCal, oursCal: oursCal
+            )
+        }
+        Self.report("dayOfMonth", div)
+        #expect(div.list.isEmpty)
+    }
+
+    /// `.every(weekday)` pattern (no ordinal).
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func everyWeekday() {
+        let (icuCal, oursCal) = Self.makePair()
+        let starts = Array(Self.probeStarts().prefix(3))
+        let div = Divergences()
+        Self.runProbe(
+            name: "weekly .every(.thursday)",
+            configure: { cal in
+                var r = Calendar.RecurrenceRule(calendar: cal, frequency: .weekly, end: .afterOccurrences(10))
+                r.weekdays = [.every(.thursday)]
+                r.matchingPolicy = .nextTime
+                return r
+            },
+            starts: starts, limit: 10, div: div,
+            icuCal: icuCal, oursCal: oursCal
+        )
+        Self.report("everyWeekday", div)
+        #expect(div.list.isEmpty)
+    }
+}


### PR DESCRIPTION
## Hebrew calendar fast paths + shared calendar helpers

Follow up to PR #1953 (Hebrew calendar port, merged as #2017).

### Summary

**Commit 1**: Add Hebrew calendar fast paths + shared protocol method

Adds `_CalendarProtocol.nextDate(after:matching:direction:)` as an optional fast path hook (default returns nil, existing paths unchanged for all other calendars). `_CalendarHebrew` implements it for:
- `{month, day}` (annual recurrence, e.g. Hanukkah)
- `{month, weekday, weekdayOrdinal}` (Nth weekday of month)
- `{month, weekday, weekOfMonth}` (weekday in Nth week of month)
- Time only `{hour, minute, second}`

`Calendar_Enumerate.swift` probes the fast path at init; `Calendar_Recurrence.swift` adds single combination, multi combination cartesian, and negative ordinal translation short circuits for `RecurrenceRule`.

**Commit 2**: Extract shared calendar helpers into `_CalendarConstants` + `_CalendarUtility`

Addresses PR #1953 review feedback (comments #6 + #7). Introduces shared static helpers for time unit constants, `hash(into:)`, `firstWeekday`, `minimumDaysInFirstWeek`, `copy()`, and `isDateInWeekend`. Hebrew adopts them; Gregorian adoption deferred to a follow up PR.

### Performance

Measured on arm64 (M3 Max), release build, `swift-benchmark`. Zero heap allocations in all cases.

| Benchmark | ICU (C++) | Native Swift | Speedup |
|---|---|---|---|
| `nextThousandHanukkahs` (enumerate {month,day}) | 55 μs | 167 ns | **325×** |
| `dateComponents` {year,month,day} (10K dates) | 3 ns/date | 1 ns/date | **2–3×** |
| `roundTripDateComponents` (10K dates) | 6 ns/date | 2 ns/date | **2–3×** |
| Calendar instantiation + `date(byAdding:)` | 514 ns | 122 ns | **4.2×** |
| Copy on write mutation | 1,736 ns | 31 ns | **54×** |

The 325× enumeration speedup comes from O(1) direct computation fast paths for common date matching patterns, bypassing the generic iterate and test framework entirely.

### Testing

- `HebrewRecurrenceRuleParityProbe.swift`: 13 tests, 392 rule shapes × 2,088 date comparisons, 0 divergences vs Foundation's ICU backed Hebrew calendar.
- All existing tests pass (1100 tests, 59 suites).

### Cross calendar safety

- Non implementing calendars are unchanged: the protocol default returns nil, leaving all existing paths intact.
- The `RecurrenceRule` short circuits probe with a sentinel `_calendarNextDate` call first; non Hebrew calendars bail before any expensive work.
