### PR TITLE
Prepare Data(capacity:_:) and Data(rawCapacity:_:) for renaming

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -278,6 +278,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///         space for the specified number of bytes.
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
+    @_spi(_) // TODO: Remove pending API surface amendment
     public init<E: Error>(
         rawCapacity capacity: Int,
         initializingWith initializer: (_ span: inout OutputRawSpan) throws(E) -> Void
@@ -304,9 +305,9 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///     - Parameters:
     ///       - span: An `OutputSpan` covering uninitialized memory with
     ///         space for the specified number of elements.
+    // TODO: Make public pending API surface amendment
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-    @_alwaysEmitIntoClient
-    public init<E: Error>(
+    internal init<E: Error>(
         capacity: Int,
         initializingWith initializer: (_ span: inout OutputSpan<UInt8>) throws(E) -> Void
     ) throws(E) {


### PR DESCRIPTION
Marks `Data`'s relatively new initializers as non-public while its naming is under review

### Motivation:

I'm preparing a pitch for new APIs across the `Data` type that align with new APIs proposed for `UniqueArray` and `RigidArray`. I'd like to reconsider the naming of these initializers to make them consistent with new naming proposed for other to-be-added APIs. Since we haven't shipped them yet, we can avoid a deprecate-and-replace by hiding the new APIs for now until the naming is confirmed 

### Modifications:

Marks the two initializers as `internal` or `@_spi` as needed to hide them without breaking clients.

### Result:

These APIs are not widely accessible until the naming is finalized

### Testing:

Existing unit tests still pass
