### PR TITLE
Fixup URLFormatStyle.swift and URLParseStrategy.swift in cmakelists

### DIFF
--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -19,9 +19,7 @@ add_library(FoundationInternationalization
     RangeExpression.swift
     TimeInterval+Utils.swift
     URL+UnicodeLookalikeTable.swift
-    Formatting/URLFormatStyle.swift
-    URLParser+ICU.swift
-    Formatting/URLParseStrategy.swift)
+    URLParser+ICU.swift)
 
 add_subdirectory(Calendar)
 add_subdirectory(Formatting)

--- a/Sources/FoundationInternationalization/Formatting/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/Formatting/CMakeLists.txt
@@ -46,4 +46,6 @@ target_sources(FoundationInternationalization PRIVATE
     Duration+UnitsFormatStyle.swift
     ICUListFormatter.swift
     ListFormatStyle.swift
-    Measurement+FormatStyle+Stub.swift)
+    Measurement+FormatStyle+Stub.swift
+    URLFormatStyle.swift
+    URLParseStrategy.swift)


### PR DESCRIPTION
Following the pattern of other files in `FoundationInternationalization/Formatting/`, move the include of the two files into the CMakeLists inside the `Formatting` folder.
