### PR TITLE
Fixed buffer overrun in error message generation

### DIFF
--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -336,7 +336,11 @@ private func parseU16Scalar(_ pInfo: inout _ParseInfo) -> UInt16? {
     }
     // We have to have encountered at least one hex digit for the `\U` directive to be valid.
     if num == 0, numDigits == 4 {
-        pInfo.err = OpenStepPlistError("Unexpected character `\(String(describing: Unicode.Scalar(pInfo.currChar)))` while parsing unicode character escape sequence on line \(lineNumberStrings(pInfo))")
+        if !pInfo.isAtEnd {
+            pInfo.err = OpenStepPlistError("Unexpected character `\(String(describing: Unicode.Scalar(pInfo.currChar)))` while parsing unicode character escape sequence on line \(lineNumberStrings(pInfo))")
+        } else {
+            pInfo.err = OpenStepPlistError("Unexpected end of file while parsing unicode character escape sequence on line \(lineNumberStrings(pInfo))")
+        }
         return nil
     }
     return num

--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -936,6 +936,7 @@ private struct PropertyListEncoderTests {
 
     @Test func oldStylePlist_getSlashedChars_unicode_invalid() {
         let examples = [
+            #"'\U"#, // EOF following directive
             #"'\U'"#,
             #"'\Ux'"#,
             #"'\Uxx'"#,


### PR DESCRIPTION
In the previous fix, I coalesced two scenarios in the error generation—getting a non-hex character right after \U, and getting EOF. In the attempt to helpfully print out the character in the former, I introduced a buffer overrun in the latter.