### PR TITLE
URL v2 file path performance and bug fixes

### DIFF
--- a/Sources/FoundationEssentials/String/Span+Path.swift
+++ b/Sources/FoundationEssentials/String/Span+Path.swift
@@ -228,4 +228,43 @@ extension Span<UInt8> {
             memcmp(buffer.baseAddress.unsafelyUnwrapped, prefix.utf8Start, prefixLength) == 0
         }
     }
+
+    /// Returns a `String` by compressing consecutive forward slashes.
+    func slashCompressedString() -> String {
+        String(unsafeUninitializedCapacity: count) { buffer in
+            _compressSlashes(into: buffer)
+        }
+    }
+
+    /// - Precondition: `buffer.count >= self.count`
+    private func _compressSlashes(into buffer: UnsafeMutableBufferPointer<UInt8>) -> Int {
+        precondition(buffer.count >= count)
+        var writeIndex = 0, prev = UInt8(0), i = 0
+        while i < count {
+            let v = self[i]
+            buffer[writeIndex] = v
+            // Branchless skip of duplicate slashes
+            writeIndex &+= (v == ._slash && prev == ._slash) ? 0 : 1
+            prev = v
+            i &+= 1
+        }
+        return writeIndex
+    }
+}
+
+extension UnsafeBufferPointer<UInt8> {
+    func count(trailingNullsRemoved: Bool) -> Int {
+        var length = self.count
+        if trailingNullsRemoved {
+            while length > 0 && self[length - 1] == 0 {
+                length -= 1
+            }
+        }
+        return length
+    }
+
+    @_lifetime(borrow self)
+    func span(trailingNullsRemoved: Bool) -> Span<UInt8> {
+        self.span.extracting(first: count(trailingNullsRemoved: trailingNullsRemoved))
+    }
 }

--- a/Sources/FoundationEssentials/URL/URL_C+File.swift
+++ b/Sources/FoundationEssentials/URL/URL_C+File.swift
@@ -122,7 +122,7 @@ private func parseFileSystemRepresentation(
             isDirectory: isDirectory
         )
         let path = pathBuffer.span.extracting(first: finalLength)
-        return URL.parseFinalFileSystemRepresentation(path: path, flags: &flags, encodeSemicolons: true)
+        return URL.parseFinalFileSystemRepresentation(path: path, flags: &flags, compatibility: .cfURL)
     }
 }
 
@@ -159,7 +159,7 @@ private func parsePOSIX(_ path: CFString, flags: inout _URLFlags, isDirectory: B
             isDirectory: isDirectory
         )
         let path = pathBuffer.span.extracting(first: finalLength)
-        return URL.parseFinalFileSystemRepresentation(path: path, flags: &flags, encodeSemicolons: true)
+        return URL.parseFinalFileSystemRepresentation(path: path, flags: &flags, compatibility: .cfURL)
     }
 }
 
@@ -187,7 +187,7 @@ private func parseHFS(_ path: String, flags: inout _URLFlags, isDirectory: Bool)
     guard !path.isEmpty else {
         return ""
     }
-    return URL.parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, encodeSemicolons: true)
+    return URL.parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, compatibility: .cfURL)
 }
 
 // Note this does not percent-encode the path

--- a/Sources/FoundationEssentials/URL/URL_File.swift
+++ b/Sources/FoundationEssentials/URL/URL_File.swift
@@ -30,6 +30,11 @@ private extension UnsafeMutableBufferPointer<UInt8> {
 
 extension URL {
 
+    enum _FilePathCompatibility {
+        case swiftURL
+        case cfURL
+    }
+
     /// Updates `pathBuffer` for directory trailing-slash handling, returning the
     /// new path length. May append a trailing slash for directories or trim trailing
     /// slashes for non-directories.
@@ -77,7 +82,7 @@ extension URL {
     static func parseFinalFileSystemRepresentation(
         path: borrowing Span<UInt8>,
         flags: inout _URLFlags,
-        encodeSemicolons: Bool
+        compatibility: _FilePathCompatibility
     ) -> String {
         guard path.count > 0 else {
             return ""
@@ -101,40 +106,61 @@ extension URL {
             maxEncodedSize += filePrefix.utf8CodeUnitCount
         }
         return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: maxEncodedSize) { encodedBuffer in
-            var pathStart = 0
+            var encodeFrom = 0
+            var writeIndex = 0
             if isAbsolute {
-                pathStart = encodedBuffer.initialize(fromContentsOf: filePrefix)
+                writeIndex = encodedBuffer.initialize(fromContentsOf: filePrefix)
+            } else if compatibility == .swiftURL {
+                // Encode ":" in the first segment of the relative path
+                var firstSegmentEnd = 0
+                while firstSegmentEnd < path.count && path[firstSegmentEnd] != UInt8(ascii: "/") {
+                    firstSegmentEnd += 1
+                }
+                writeIndex = path.withUnsafeBufferPointer { pathBuffer in
+                    URLEncoder.percentEncodeUnchecked(
+                        input: .init(rebasing: pathBuffer[..<firstSegmentEnd]),
+                        output: encodedBuffer,
+                        component: .pathFirstSegment,
+                        skipAlreadyEncoded: false
+                    )
+                }
+                encodeFrom = firstSegmentEnd
             }
-            let bytesWritten = path.withUnsafeBufferPointer { pathBuffer in
+            writeIndex += path.withUnsafeBufferPointer { pathBuffer in
                 URLEncoder.percentEncodeUnchecked(
-                    input: pathBuffer,
-                    output: .init(rebasing: encodedBuffer[pathStart...]),
-                    // Encode ";" for CF/NSURL (encodeSemicolons: true)
-                    component: encodeSemicolons ? .pathNoSemicolon : .path,
+                    input: .init(rebasing: pathBuffer[encodeFrom...]),
+                    output: .init(rebasing: encodedBuffer[writeIndex...]),
+                    // Encode ";" for CF/NSURL
+                    component: compatibility == .cfURL ? .pathNoSemicolon : .path,
                     skipAlreadyEncoded: false
                 )
             }
-            if bytesWritten != path.count {
-                // The path was percent-encoded
+            // Percent-encoding only ever adds bytes, so a longer encoded path
+            // means something was encoded (and the path now contains a "%").
+            let pathStart = isAbsolute ? filePrefix.utf8CodeUnitCount : 0
+            if writeIndex - pathStart != path.count {
                 flags.insert(.hasEncodedPath)
             }
-            return String(decoding: encodedBuffer[..<(pathStart + bytesWritten)], as: UTF8.self)
+            return String(decoding: encodedBuffer[..<writeIndex], as: UTF8.self)
         }
     }
 
-    static func parseUTF8Path(_ path: String, flags: inout _URLFlags, isDirectory: Bool, encodeSemicolons: Bool) -> String {
+    static func parseUTF8Path(_ path: String, flags: inout _URLFlags, isDirectory: Bool, compatibility: _FilePathCompatibility) -> String {
         var path = path
         return path.withUTF8 { pathBuffer in
+            // Swift URL strips trailing nulls. CFURL (HFS path style) doesn't.
+            let length = pathBuffer.count(trailingNullsRemoved: compatibility == .swiftURL)
+
             // Allocate an extra byte in case we need to append a directory slash.
-            return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: pathBuffer.count + 1) {
+            return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: length + 1) {
                 let pathLength = finalPathLength(
                     updating: $0,
-                    currentLength: $0.initialize(fromContentsOf: pathBuffer),
+                    currentLength: $0.initialize(fromContentsOf: pathBuffer[..<length]),
                     flags: &flags,
                     isDirectory: isDirectory
                 )
                 let path = $0.span.extracting(first: pathLength)
-                return parseFinalFileSystemRepresentation(path: path, flags: &flags, encodeSemicolons: encodeSemicolons)
+                return parseFinalFileSystemRepresentation(path: path, flags: &flags, compatibility: compatibility)
             }
         }
     }
@@ -145,7 +171,7 @@ extension URL {
         #if FOUNDATION_FRAMEWORK
         #if !os(watchOS)
         if path.utf8Span.isKnownASCII {
-            return parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, encodeSemicolons: false)
+            return parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, compatibility: .swiftURL)
         }
         #endif
         // Convert path to its decomposed file system representation
@@ -164,7 +190,7 @@ extension URL {
                     isDirectory: isDirectory
                 )
                 let path = pathBuffer.span.extracting(first: finalLength)
-                return parseFinalFileSystemRepresentation(path: path, flags: &flags, encodeSemicolons: false)
+                return parseFinalFileSystemRepresentation(path: path, flags: &flags, compatibility: .swiftURL)
             }
 
             // Decomposition failed or there was an embedded null byte.
@@ -177,10 +203,10 @@ extension URL {
             // to a "file not found" error, this is more practical and debuggable
             // than returning an empty URL or crashing with fatalError().
 
-            return parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, encodeSemicolons: false)
+            return parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, compatibility: .swiftURL)
         }
         #else
-        return parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, encodeSemicolons: false)
+        return parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, compatibility: .swiftURL)
         #endif
     }
 
@@ -191,6 +217,6 @@ extension URL {
         guard !path.isEmpty else {
             return ""
         }
-        return parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, encodeSemicolons: false)
+        return parseUTF8Path(path, flags: &flags, isDirectory: isDirectory, compatibility: .swiftURL)
     }
 }

--- a/Sources/FoundationEssentials/URL/URL_Impl.swift
+++ b/Sources/FoundationEssentials/URL/URL_Impl.swift
@@ -26,8 +26,9 @@ import WinSDK
 
 #if FOUNDATION_FRAMEWORK
 internal import _ForSwiftFoundation
-#if canImport(Synchronization)
 internal import Synchronization
+#if canImport(os)
+internal import os
 #endif
 #endif
 
@@ -45,11 +46,7 @@ final class _URL: Sendable {
     #if FOUNDATION_FRAMEWORK
     // Note: We use a lock instead of a lazy var to ensure that we always
     // bridge to the same NSURL even if the URL was copied across threads.
-    #if canImport(Synchronization)
     private let _nsurlLock = Mutex<NSURL?>(nil)
-    #else
-    private let _nsurlLock = LockedState<NSURL?>(initialState: nil)
-    #endif
     private var _nsurl: NSURL {
         return _nsurlLock.withLock {
             if let nsurl = $0 { return nsurl }
@@ -60,7 +57,6 @@ final class _URL: Sendable {
     }
     #endif
 
-    @inline(__always)
     private init(_info: _URLInfo, _baseURL: URL._Impl?) {
         // We shouldn't be passing a base URL if we have a scheme
         assert(_baseURL == nil || !_info.hasScheme)
@@ -73,7 +69,6 @@ final class _URL: Sendable {
 extension _URL: _URLProtocol {}
 #endif
 
-@inline(__always)
 private func hasTrailingSeparator(_ path: String) -> Bool {
     #if os(Windows)
     path.utf8.last == ._backslash || path.utf8.last == ._slash
@@ -83,17 +78,14 @@ private func hasTrailingSeparator(_ path: String) -> Bool {
 }
 
 extension _URL {
-    @inline(__always)
     private var url: URL {
         URL(self)
     }
 
-    @inline(__always)
     private var flags: _URLFlags {
         _info.flags
     }
 
-    @inline(__always)
     private func replacing(info: _URLInfo) -> _URL {
         _URL(_info: info, _baseURL: _baseURL)
     }
@@ -108,12 +100,10 @@ extension _URL {
         }
     }
 
-    @inline(__always)
     private convenience init(url: _URL) {
         self.init(_info: url._info, _baseURL: url._baseURL)
     }
 
-    @inline(__always)
     private convenience init?(_ string: String, relativeTo base: URL? = nil, encodingInvalidCharacters: Bool = true) {
         guard let parseInfo = _URLInfo.parse(
             string: string,
@@ -178,6 +168,48 @@ extension _URL {
     }
 
     private convenience init(filePath path: String, pathStyle: URL.PathStyle, directoryHint: URL.DirectoryHint = .inferFromPath, relativeTo base: URL? = nil) {
+        #if FOUNDATION_FRAMEWORK
+        var path = path
+        // Linked-on-or-after check for apps which incorrectly pass a full URL
+        // string with a scheme. In the old implementation, this could work
+        // rarely if the app immediately called .appendingPathComponent(_:),
+        // which used to accidentally interpret a relative path starting with
+        // "scheme:" as an absolute "scheme:" URL string.
+        if URL.compatibility1 {
+            // Best-effort fixes for lowercase "http(s)" and "file" schemes
+            enum SchemeMisuse { case http, file(String), none }
+            let misuse: SchemeMisuse = path.withUTF8 { utf8 in
+                let span = utf8.span
+                if span.starts(with: "http:") || span.starts(with: "https:") {
+                    return .http
+                }
+                if span.starts(with: "file:") {
+                    return .file(span.extracting(droppingFirst: 5).slashCompressedString())
+                }
+                return .none
+            }
+            switch misuse {
+            case .http:
+                #if canImport(os)
+                URL.logger.error("API MISUSE: URL(filePath:) called with an HTTP URL string. Using URL(string:) instead.")
+                #endif
+                // Drop any base URL since we have an HTTP scheme
+                if let url = _URL(string: path) {
+                    self.init(url: url)
+                    return
+                }
+                // Fall through to file path handling
+            case .file(let compressed):
+                #if canImport(os)
+                URL.logger.error("API MISUSE: URL(filePath:) called with a \"file:\" scheme. Input must only contain a path. Dropping \"file:\" scheme.")
+                #endif
+                path = compressed
+            case .none:
+                break
+            }
+        }
+        #endif // FOUNDATION_FRAMEWORK
+
         var directoryHint = directoryHint
         if directoryHint == .checkFileSystem {
             #if NO_FILESYSTEM
@@ -191,8 +223,7 @@ extension _URL {
             #endif
         }
 
-        @inline(__always)
-        func hasTrailingSeparator(_ path: String) -> Bool {
+        func hasTrailingSeparator() -> Bool {
             path.utf8.last == ._slash || (pathStyle == .windows && path.utf8.last == ._backslash)
         }
 
@@ -200,7 +231,7 @@ extension _URL {
         case .isDirectory: true
         case .notDirectory: false
         case .checkFileSystem: nil
-        case .inferFromPath: hasTrailingSeparator(path)
+        case .inferFromPath: hasTrailingSeparator()
         }
 
         var (info, base) = _URLInfo.parse(
@@ -222,16 +253,14 @@ extension _URL {
         // Now we must check the file system
         let url = _URL(info: info, relativeTo: base)
         let resourceIsDirectory = url.checkResourceIsDirectory()
-        if resourceIsDirectory == false || (resourceIsDirectory == nil && !hasTrailingSeparator(path)) {
+        if resourceIsDirectory == false || (resourceIsDirectory == nil && !hasTrailingSeparator()) {
             self.init(url: url)
             return
         }
 
-        // Append a directory slash
-        info.string += "/"
-        info.flags.insert(.hasDirectoryPath)
-        info.pathRange = info.pathRange.startIndex..<(info.pathRange.endIndex + 1)
-        self.init(info: info, relativeTo: base)
+        // Checked the file system and path points to a directory, or
+        // it's non-existent and we're honoring the trailing slash.
+        self.init(url: url.appendingTrailingSlash())
         #endif
     }
 
@@ -336,12 +365,10 @@ extension _URL {
     }
 
     // True for an absolute file URL created via a file path initializer
-    @inline(__always)
     private var isCanonicalFileURL: Bool {
         flags.intersection([.implTypeMask, .hasScheme]) == [_URLFlags(type: .file), .hasScheme]
     }
 
-    @inline(__always)
     internal var hasAuthority: Bool {
         flags.contains(.hasHost)
     }
@@ -444,17 +471,10 @@ extension _URL {
 
     // MARK: - Path Info
 
-    @inline(__always)
     private var pathIsEmpty: Bool {
         _info.pathRange.isEmpty
     }
 
-    @inline(__always)
-    private var pathIsRelative: Bool {
-        _info.path.utf8.first != ._slash
-    }
-
-    @inline(__always)
     private var hasEncodedPath: Bool {
         flags.contains(.hasEncodedPath)
     }
@@ -569,7 +589,6 @@ extension _URL {
 
     // MARK: - File Paths
 
-    @inline(__always)
     private static func fileSystemPath(
         for urlPath: borrowing Span<UInt8>,
         isKnownUnencoded: Bool = false,
@@ -790,37 +809,59 @@ extension _URL {
 
     // MARK: - Helpers for Path Manipulation
 
-    @inline(__always)
+    private func replacing(
+        path: borrowing Span<UInt8>,
+        encodingState: _URLInfo.PathEncodingState
+    ) -> URL {
+        let info = _info.replacingPath(unsafeUninitializedCapacity: path.count) {
+            ($0.initialize(fromSpan: path), encodingState)
+        }
+        return replacing(info: info).url
+    }
+
     private func replacing(
         path: StaticString,
-        isDirectory: Bool,
-        encodingState: _URLInfo.PathEncodingState = .unknown
+        encodingState: _URLInfo.PathEncodingState
     ) -> URL {
-        let span = Span(_unsafeStart: path.utf8Start, count: path.utf8CodeUnitCount)
-        return replacing(path: span, isDirectory: isDirectory, encodingState: encodingState)
-    }
-
-    @inline(__always)
-    private func replacing(
-        path: borrowing Span<UInt8>,
-        encodingState: _URLInfo.PathEncodingState = .unknown
-    ) -> URL {
-        let info = _info.replacing(path: path, encodingState: encodingState)
+        let info = _info.replacingPath(unsafeUninitializedCapacity: path.utf8CodeUnitCount) { buffer in
+            path.withUTF8Buffer { (buffer.initialize(fromContentsOf: $0), encodingState) }
+        }
         return replacing(info: info).url
     }
 
-    @inline(__always)
-    private func replacing(
-        path: borrowing Span<UInt8>,
-        isDirectory: Bool,
-        encodingState: _URLInfo.PathEncodingState = .unknown
-    ) -> URL {
-        let info = _info.replacing(
-            path: path,
-            isDirectory: isDirectory,
-            encodingState: encodingState
-        )
-        return replacing(info: info).url
+    // Prepends "./" to a relative path whose first segment would
+    // otherwise be mistaken for a scheme (RFC 3986 Section 4.2).
+    // Returns the final path length.
+    private func prependDotSlashIfNeeded(
+        _ buffer: UnsafeMutableBufferPointer<UInt8>,
+        pathLength: Int
+    ) -> Int {
+        // Callers must reserve 2 spare bytes
+        assert(pathLength + 2 <= buffer.count)
+        guard flags.isDisjoint(with: [.hasScheme, .hasHost]) else {
+            return pathLength
+        }
+        let hasColonInFirstSegment = {
+            for i in 0..<pathLength {
+                let byte = buffer[i]
+                if byte == ._slash {
+                    return false
+                } else if byte == ._colon {
+                    return true
+                }
+            }
+            return false
+        }()
+        guard hasColonInFirstSegment else {
+            return pathLength
+        }
+        // Shift path by 2 and prepend "./"
+        for i in (0..<pathLength).reversed() {
+            buffer[i + 2] = buffer[i]
+        }
+        buffer[0] = ._dot
+        buffer[1] = ._slash
+        return pathLength + 2
     }
 
     private static func withEncodedURLPath<R>(
@@ -829,7 +870,6 @@ extension _URL {
         isFileURL: Bool,
         block: (borrowing Span<UInt8>) -> R
     ) -> R {
-        @inline(__always)
         func withPercentEncoded(_ input: UnsafeBufferPointer<UInt8>) -> R {
             return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: 3 * input.count) {
                 let length = URLEncoder.percentEncodeUnchecked(
@@ -899,11 +939,6 @@ extension _URL {
     }
 
     private func appending<S: StringProtocol>(path toAppend: S, directoryHint: URL.DirectoryHint, encodingSlashes: Bool) -> URL? {
-        // Appending "" to "http://example.com" returns "http://example.com/"
-        guard !toAppend.isEmpty || flags.contains(.hasOldPath) else {
-            return nil
-        }
-
         var directoryHint = directoryHint
         if directoryHint == .checkFileSystem {
             #if NO_FILESYSTEM
@@ -915,170 +950,215 @@ extension _URL {
             #endif
         }
 
-        var s = String(toAppend)
-        return s.withUTF8 {
-            let spanToAppend = $0.span
+        // When encodeSlashes is true, "component/" becomes "component%2F".
+        // Since "/" is part of the encoded component, it shouldn't also serve
+        // as a directory-ness hint, so treat .inferFromPath as .notDirectory.
+        // This matters especially because .inferFromPath is the default, which
+        // would otherwise make base.appending(component: "folder/") confusing.
+        if encodingSlashes && directoryHint == .inferFromPath {
+            directoryHint = .notDirectory
+        }
+
+        var stringToAppend = _specialize(toAppend, for: String.self) ?? String(toAppend)
+        return stringToAppend.withUTF8 {
+            let spanToAppend = $0.span(trailingNullsRemoved: isFileURL)
+
+            func hasTrailingSeparator() -> Bool {
+                #if os(Windows)
+                spanToAppend.last == ._backslash || spanToAppend.last == ._slash
+                #else
+                spanToAppend.last == ._slash
+                #endif
+            }
 
             let isDirectory: Bool? = switch directoryHint {
             case .isDirectory: true
             case .notDirectory: false
             case .checkFileSystem: nil
-            case .inferFromPath:
-                #if os(Windows)
-                spanToAppend.count > 0 && (
-                    spanToAppend[spanToAppend.count - 1] == ._backslash ||
-                    spanToAppend[spanToAppend.count - 1] == ._slash
-                )
-                #else
-                spanToAppend.count > 0 && spanToAppend[spanToAppend.count - 1] == ._slash
-                #endif
+            case .inferFromPath: hasTrailingSeparator()
             }
 
-            if !encodingSlashes && strictValidate(path: spanToAppend) {
+            let url = if !encodingSlashes && strictValidate(path: spanToAppend) {
                 // If we're not encoding slashes and the appended component is
                 // valid, the resulting path keeps the current encoding state.
-                return appending(
+                appending(
                     span: spanToAppend,
-                    isDirectory: isDirectory,
-                    encodingState: hasEncodedPath ? .encoded : .notEncoded
+                    encodingState: hasEncodedPath ? .encoded : .notEncoded,
+                    // Strip trailing slashes before checking the file system
+                    isDirectory: isDirectory ?? false
                 )
-            }
-
-            return Self.withEncodedURLPath(for: spanToAppend, encodingSlashes: encodingSlashes, isFileURL: isFileURL) {
+            } else {
                 // If encodingSlashes is false, we know validation failed above,
                 // so we must have encoded the appended path; however, Windows
                 // paths may have backslashes that fail strictValidate but are
                 // now converted to "/", leaving a possibly un-encoded path.
-                #if os(Windows)
-                let state = _URLInfo.PathEncodingState.unknown
-                #else
-                let state: _URLInfo.PathEncodingState = encodingSlashes ? .unknown : .encoded
-                #endif
-                return appending(
-                    span: $0,
-                    isDirectory: isDirectory,
-                    encodingState: state
-                )
+                Self.withEncodedURLPath(for: spanToAppend, encodingSlashes: encodingSlashes, isFileURL: isFileURL) {
+                    #if os(Windows)
+                    let state: _URLInfo.PathEncodingState = .unknown
+                    #else
+                    let state: _URLInfo.PathEncodingState = encodingSlashes ? .unknown : .encoded
+                    #endif
+                    return appending(
+                        span: $0,
+                        encodingState: state,
+                        isDirectory: isDirectory ?? false
+                    )
+                }
             }
+
+            guard let url else {
+                return nil
+            }
+
+            #if NO_FILESYSTEM
+            return url.url
+            #else
+            if isDirectory != nil {
+                return url.url
+            }
+
+            let resourceIsDirectory = url.checkResourceIsDirectory()
+            if resourceIsDirectory == false || (resourceIsDirectory == nil && !hasTrailingSeparator()) {
+                return url.url
+            }
+
+            // Checked the file system and path points to a directory, or
+            // it's non-existent and we're honoring the trailing slash.
+            return url.appendingTrailingSlash().url
+            #endif
         }
     }
 
-    private func appending(span: borrowing Span<UInt8>, isDirectory: Bool?, encodingState: _URLInfo.PathEncodingState) -> URL {
-        return withPathSpan { path in
-            // Max size occurs for "" with directory: "." + "/" + span + "/"
-            let maxLength = 1 + path.count + 1 + span.count + 1
-            return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: maxLength) { buffer in
-                @inline(__always)
-                func isSeparator(_ byte: UInt8) -> Bool {
-                    #if os(Windows)
-                    byte == ._backslash || byte == ._slash
-                    #else
-                    byte == ._slash
-                    #endif
-                }
+    private func appendingTrailingSlash() -> _URL {
+        replacing(info: _info.appendingTrailingSlash())
+    }
 
-                var pathLength: Int = {
-                    var writeIndex = 0
-
-                    if !path.isEmpty {
-                        writeIndex = buffer.initialize(fromSpan: path)
-                        guard !span.isEmpty else {
-                            return writeIndex
-                        }
-                        let twoSlashes = (path.last == ._slash && isSeparator(span[0]))
-                        let noSlash = (path.last != ._slash && !isSeparator(span[0]))
-                        if noSlash {
-                            buffer[writeIndex] = ._slash
-                            writeIndex += 1
-                        }
-                        // Compiler complains if we try to ternary this
-                        if twoSlashes {
-                            writeIndex = buffer[writeIndex...].initialize(
-                                fromSpan: span.extracting(droppingFirst: 1)
-                            )
-                        } else {
-                            writeIndex = buffer[writeIndex...].initialize(
-                                fromSpan: span
-                            )
-                        }
-                    } else if hasAuthority {
-                        // Current path is empty and we have an authority
-                        if span.isEmpty || !isSeparator(span[0]) {
-                            // Prepend a slash to separate the relative path from
-                            // the authority component, e.g. "http://example.com"
-                            buffer[writeIndex] = ._slash
-                            writeIndex += 1
-                        }
-                        writeIndex = buffer[writeIndex...].initialize(fromSpan: span)
-                    } else if span.isEmpty {
-                        // Current path and path to append are both empty
-                        return 0
-                    } else if isSeparator(span[0]) || !_info.hasScheme {
-                        // Treat our current empty path as "."
-                        buffer[writeIndex] = ._dot
-                        writeIndex += 1
-                        if !isSeparator(span[0]) {
-                            buffer[writeIndex] = ._slash
-                            writeIndex += 1
-                        }
-                        writeIndex = buffer[writeIndex...].initialize(fromSpan: span)
-                    } else {
-                        // Scheme only, append directly to the empty path, e.g.
-                        // URL("scheme:").appending("path") == "scheme:path"
-                        writeIndex = buffer.initialize(fromSpan: span)
-                    }
-
-                    #if os(Windows)
-                    // Only replace backslashes in the appended portion
-                    for i in path.count..<writeIndex where buffer[i] == ._backslash {
-                        buffer[i] = ._slash
-                    }
-                    #endif
-
-                    return writeIndex
-                }()
-
-                if isDirectory != true {
-                    // Note: if isDirectory is nil, we still want to strip
-                    // trailing slashes before checking the file system.
-                    let rootLength = isFileURL ? rootLength(pathBuffer: .init(buffer), length: pathLength) : 1
-                    while pathLength > rootLength && buffer[pathLength - 1] == ._slash {
-                        pathLength -= 1
-                    }
-                } else if pathLength > 0 && buffer[pathLength - 1] != ._slash {
-                    buffer[pathLength] = ._slash
-                    pathLength += 1
-                }
-
-                let newInfo = _info.replacing(
-                    path: buffer.span.extracting(first: pathLength),
-                    encodingState: encodingState
+    private func appending(
+        span: borrowing Span<UInt8>,
+        encodingState: _URLInfo.PathEncodingState,
+        isDirectory: Bool
+    ) -> _URL? {
+        if pathIsEmpty && !hasAuthority {
+            // E.g. "scheme:" or "scheme:?query" or "?query"
+            if _info.hasScheme {
+                return appendingToSchemeOnly(
+                    span: span,
+                    encodingState: encodingState,
+                    isDirectory: isDirectory
                 )
-                let url = replacing(info: newInfo)
-                #if NO_FILESYSTEM
-                return url.url
-                #else
-                if isDirectory != nil {
-                    return url.url
-                }
+            }
 
-                let resourceIsDirectory = url.checkResourceIsDirectory()
-                if resourceIsDirectory == false || (resourceIsDirectory == nil && (span.isEmpty || !isSeparator(span.last!))) {
-                    return url.url
-                }
+            if span.isEmpty && !isDirectory {
+                return nil // Return the URL unchanged
+            }
 
-                // Checked the file system and path points to a directory, or
-                // it's non-existent and we're honoring the trailing slash.
-                buffer[pathLength] = ._slash
-                pathLength += 1
-                return replacing(
-                    path: buffer.span.extracting(first: pathLength),
-                    isDirectory: true,
-                    encodingState: encodingState
+            // E.g. "?query" or "#fragment". A few cases of ambiguity to avoid:
+            // - Appending "//path" shouldn't interpret "//" as the authority
+            // - Appending "/path" shouldn't change a relative path to absolute
+            // - Appending "foo:bar" shouldn't interpret "foo" as the scheme
+            // To achieve this, we always treat the current empty path as "."
+            return ("." as StaticString).withUTF8Buffer { dotBuffer in
+                appending(
+                    currentPath: dotBuffer.span,
+                    toAppend: span,
+                    encodingState: encodingState,
+                    isDirectory: isDirectory
                 )
-                #endif
             }
         }
+        return withPathSpan { path in
+            appending(
+                currentPath: path,
+                toAppend: span,
+                encodingState: encodingState,
+                isDirectory: isDirectory
+            )
+        }
+    }
+
+    private func appendingToSchemeOnly(
+        span: borrowing Span<UInt8>,
+        encodingState: _URLInfo.PathEncodingState,
+        isDirectory: Bool
+    ) -> _URL? {
+        // E.g. "scheme:" or "scheme:?query", append directly such that
+        // URL(string: "mailto:").appending(path: "user@example.com")
+        // returns "mailto:user@example.com"
+        assert(_info.hasScheme)
+        assert(!hasAuthority)
+        assert(pathIsEmpty)
+        guard !span.isEmpty else {
+            // Empty path + empty component: return the URL unchanged,
+            // or with "/" path for consistency with isDirectory: true.
+            return isDirectory ? appendingTrailingSlash() : nil
+        }
+
+        let info = _info.replacingPath(unsafeUninitializedCapacity: span.count + 1) { buffer in
+            var offset = 0
+            // Compress leading slashes so "//" isn't mistaken as an authority
+            if span[0] == ._slash {
+                while offset + 1 < span.count, span[offset + 1] == ._slash {
+                    offset += 1
+                }
+            }
+            var writeIndex = buffer.initialize(fromSpan: span.extracting(offset...))
+            if !isDirectory {
+                while writeIndex > 1, buffer[writeIndex - 1] == ._slash {
+                    writeIndex -= 1
+                }
+            } else if buffer[writeIndex - 1] != ._slash {
+                buffer[writeIndex] = ._slash
+                writeIndex += 1
+            }
+            return (writeIndex, encodingState)
+        }
+        return replacing(info: info)
+    }
+
+    private func appending(
+        currentPath path: borrowing Span<UInt8>,
+        toAppend: borrowing Span<UInt8>,
+        encodingState: _URLInfo.PathEncodingState,
+        isDirectory: Bool
+    ) -> _URL {
+        // Backslashes should be encoded, or converted to "/" on Windows
+        assert(!toAppend.contains(._backslash))
+
+        let maxLength = path.count + toAppend.count + 2
+        let info = _info.replacingPath(unsafeUninitializedCapacity: maxLength) { buffer in
+            var writeIndex = buffer.initialize(fromSpan: path)
+            var offset = 0
+            if path.last != ._slash && toAppend.first != ._slash {
+                // Insert a slash if one doesn't already exist
+                buffer[writeIndex] = ._slash
+                writeIndex += 1
+            } else if path.last == ._slash && toAppend.first == ._slash {
+                // Skip a slash if both parties already have one
+                offset += 1
+                if path.count == 1 && !hasAuthority {
+                    // path is "/". Strip leading slashes from toAppend
+                    // so that "//" isn't mistaken as an authority.
+                    while offset < toAppend.count, toAppend[offset] == ._slash {
+                        offset += 1
+                    }
+                }
+            }
+            writeIndex = buffer[writeIndex...].initialize(
+                fromSpan: toAppend.extracting(offset...)
+            )
+            if !isDirectory {
+                // Strip component's trailing slashes
+                while writeIndex > path.count + 1, buffer[writeIndex - 1] == ._slash {
+                    writeIndex -= 1
+                }
+            } else if writeIndex == 0 || buffer[writeIndex - 1] != ._slash {
+                // Append a trailing slash if one doesn't already exist
+                buffer[writeIndex] = ._slash
+                writeIndex += 1
+            }
+            return (writeIndex, encodingState)
+        }
+        return replacing(info: info)
     }
 
     #if !NO_FILESYSTEM
@@ -1124,14 +1204,13 @@ extension _URL {
             assert(path.count > 0 && path[path.count - 1] == ._slash)
             return replacing(
                 path: path,
-                isDirectory: true,
                 encodingState: hasEncodedPath ? .unknown : .notEncoded
             )
         }
 
         @inline(__always)
         func result(path: StaticString) -> URL? {
-            return replacing(path: path, isDirectory: true, encodingState: .notEncoded)
+            return replacing(path: path, encodingState: .notEncoded)
         }
 
         guard !pathIsEmpty else {
@@ -1143,7 +1222,7 @@ extension _URL {
             return result(path: "../")
         }
 
-        return withPathSpan { path in
+        return withPathSpan { path -> URL? in
             // First check common cases of last component length, then
             // fall back to checking "." and ".." edge cases where we
             // need to replace or append another ".." component.
@@ -1156,7 +1235,7 @@ extension _URL {
                     // Note we cannot have a host with a relative path.
                     if _info.hasScheme {
                         // Don't append "." or ".." to a lone "scheme:"
-                        return replacing(path: "", isDirectory: false, encodingState: .notEncoded)
+                        return result(path: "")
                     }
                     // Replace a single component like "path" with "./"
                     return result(path: "./")
@@ -1196,7 +1275,7 @@ extension _URL {
                component[0] == ._dot,
                component[1] == ._dot {
                 // ".." - append another "/../"
-                return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: componentRange.endIndex + 4) { buffer in
+                let info = _info.replacingPath(unsafeUninitializedCapacity: componentRange.endIndex + 4) { buffer in
                     let writeIndex = buffer.initialize(
                         fromSpan: path.extracting(..<componentRange.endIndex)
                     )
@@ -1205,28 +1284,30 @@ extension _URL {
                     buffer[writeIndex + 2] = ._dot
                     buffer[writeIndex + 3] = ._slash
                     assert(writeIndex + 4 == buffer.count)
-                    return result(path: buffer.span)
+                    return (writeIndex + 4, hasEncodedPath ? .unknown : .notEncoded)
                 }
+                return replacing(info: info).url
             }
 
             if component.count == 1, component[0] == ._dot {
                 // "." - replace with "../" by appending "./"
-                return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: componentRange.endIndex + 2) { buffer in
+                let info = _info.replacingPath(unsafeUninitializedCapacity: componentRange.endIndex + 2) { buffer in
                     let writeIndex = buffer.initialize(
                         fromSpan: path.extracting(..<componentRange.endIndex)
                     )
                     buffer[writeIndex + 0] = ._dot
                     buffer[writeIndex + 1] = ._slash
                     assert(writeIndex + 2 == buffer.count)
-                    return result(path: buffer.span)
+                    return (writeIndex + 2, hasEncodedPath ? .unknown : .notEncoded)
                 }
+                return replacing(info: info).url
             }
 
             // Non-dot component of length 1 or 2
             if componentRange.startIndex == 0 {
                 if _info.hasScheme {
                     // Don't append "." or ".." to a lone "scheme:"
-                    return replacing(path: "", isDirectory: false, encodingState: .notEncoded)
+                    return result(path: "")
                 }
                 // Replace a single component like "path" with "./"
                 return result(path: "./")
@@ -1249,16 +1330,17 @@ extension _URL {
 
             var s = pathExtension
             return s.withUTF8 {
-                let pathExtension = $0.span
+                let pathExtension = $0.span(trailingNullsRemoved: isFileURL)
                 guard pathExtension.isValidPathExtension else {
                     return nil
                 }
                 let isDirectory = (path.last == ._slash)
 
-                @inline(__always)
                 func append(_ ext: borrowing Span<UInt8>, encodingState: _URLInfo.PathEncodingState) -> URL {
-                    // Append ".\(pathExtension)" with a potential trailing slash
-                    return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: componentRange.endIndex + ext.count + 2) { buffer in
+                    // Append ".\(pathExtension)" with a potential trailing
+                    // slash and extra room to prepend "./" if needed.
+                    let maxLength = componentRange.endIndex + ext.count + 4
+                    let info = _info.replacingPath(unsafeUninitializedCapacity: maxLength) { buffer in
                         var writeIndex = buffer.initialize(
                             fromSpan: path.extracting(first: componentRange.endIndex)
                         )
@@ -1271,12 +1353,10 @@ extension _URL {
                             buffer[writeIndex] = ._slash
                             writeIndex += 1
                         }
-                        return replacing(
-                            path: buffer.span.extracting(first: writeIndex),
-                            isDirectory: isDirectory,
-                            encodingState: encodingState
-                        )
+                        let finalLength = prependDotSlashIfNeeded(buffer, pathLength: writeIndex)
+                        return (finalLength, encodingState)
                     }
+                    return replacing(info: info).url
                 }
 
                 // Fast path for the common case that doesn't require encoding
@@ -1300,7 +1380,7 @@ extension _URL {
                 return nil
             }
             let isDirectory = (path.last == ._slash)
-            return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: dotIndex + 1) { buffer in
+            let info = _info.replacingPath(unsafeUninitializedCapacity: dotIndex + 1) { buffer in
                 var writeIndex = buffer.initialize(
                     fromSpan: path.extracting(first: dotIndex)
                 )
@@ -1308,12 +1388,9 @@ extension _URL {
                     buffer[writeIndex] = ._slash
                     writeIndex += 1
                 }
-                return replacing(
-                    path: buffer.span.extracting(first: writeIndex),
-                    isDirectory: isDirectory,
-                    encodingState: hasEncodedPath ? .unknown : .notEncoded
-                )
+                return (writeIndex, hasEncodedPath ? .unknown : .notEncoded)
             }
+            return replacing(info: info).url
         }
     }
 
@@ -1321,7 +1398,7 @@ extension _URL {
         guard flags.contains(.isDecomposable) else {
             return nil
         }
-        return withPathSpan { path in
+        return withPathSpan { path -> URL? in
             #if FOUNDATION_FRAMEWORK
             // Compatibility path for apps that loop on:
             // while !url.path.isEmpty {
@@ -1332,25 +1409,55 @@ extension _URL {
             // URL("/").deletingLastPathComponent == URL("/../")
             // URL("/../").standardized == URL("")
             if URL.compatibility1, path.count == 4, path.starts(with: "/../") {
-                return replacing(path: "", isDirectory: false, encodingState: .notEncoded)
+                return replacing(path: "", encodingState: .notEncoded)
             }
             #endif
             guard !path.isEmpty else {
                 if flags.contains([.hasScheme, .hasHost]) && !flags.contains(.hasOldNetLocation) {
                     // Standardize "scheme://" to "scheme:///"
-                    return replacing(path: "/", isDirectory: true, encodingState: .notEncoded)
+                    return replacing(path: "/", encodingState: .notEncoded)
                 }
                 return nil
             }
-            return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: path.count) { buffer in
-                _ = buffer.initialize(fromSpan: path)
-                let pathLength = resolveDotSegmentsInPlace(buffer: buffer, useRFC1808: true)
-                let span = buffer.span.extracting(first: pathLength)
-                return replacing(
-                    path: span,
-                    encodingState: hasEncodedPath ? .unknown : .notEncoded
-                )
+            var info = _info
+            if flags.contains(.hasScheme) && !flags.contains(.hasHost) && path[0] == ._slash {
+                // Standardize e.g. "file:/path" -> "file:///path"
+                let newString = _info.withSpan { stringSpan in
+                    // Note: the new string must be path-preserving, since the
+                    // resolution code below uses the original path span.
+                    String(unsafeUninitializedCapacity: stringSpan.count + 2) { buffer in
+                        var writeIndex = buffer.initialize(
+                            fromSpan: stringSpan.extracting(info.schemeRange)
+                        )
+                        buffer[writeIndex + 0] = ._colon
+                        buffer[writeIndex + 1] = ._slash
+                        buffer[writeIndex + 2] = ._slash
+                        writeIndex = buffer[(writeIndex + 3)...].initialize(
+                            fromSpan: stringSpan.extracting((info.schemeRange.endIndex + 1)...)
+                        )
+                        assert(writeIndex == buffer.count)
+                        return writeIndex
+                    }
+                }
+                info = _URLInfo.parse(string: newString, encodingInvalidCharacters: true) ?? info
             }
+            // The potential re-parse above must preserve the path bytes
+            assert(path.count == info.pathRange.count)
+            // + 2 reserves room to prepend "./" if needed
+            let newInfo = info.replacingPath(unsafeUninitializedCapacity: path.count + 2) { buffer in
+                _ = buffer.initialize(fromSpan: path)
+                let resolvedLength = resolveDotSegmentsInPlace(
+                    buffer: buffer[..<path.count],
+                    useRFC1808: true
+                )
+                // resolvedLength == path.count iff no resolution occurred
+                guard resolvedLength != path.count else {
+                    return (resolvedLength, hasEncodedPath ? .unknown : .notEncoded)
+                }
+                let finalLength = prependDotSlashIfNeeded(buffer, pathLength: resolvedLength)
+                return (finalLength, hasEncodedPath ? .unknown : .notEncoded)
+            }
+            return replacing(info: newInfo).url
         }
     }
 

--- a/Sources/FoundationEssentials/URL/URL_Info.swift
+++ b/Sources/FoundationEssentials/URL/URL_Info.swift
@@ -74,6 +74,12 @@ extension _URLFlags {
     static var didEncodeFragment:   Self { .shouldEncodeFragment }
 }
 
+private extension _URLFlags {
+    mutating func set(_ flags: _URLFlags, _ value: Bool) {
+        if value { insert(flags) } else { remove(flags) }
+    }
+}
+
 internal struct _URLInfo: _URLParseable, _URLHeader {
     static var maxStringLength: Int { Int.max }
     var string: String
@@ -114,7 +120,6 @@ internal struct _URLInfo: _URLParseable, _URLHeader {
         return s.withUTF8 { block($0.span) }
     }
 
-    @inline(__always)
     private func substring(_ range: Range<Int>) -> Substring {
         let start = string.utf8.index(string.startIndex, offsetBy: range.startIndex)
         let end = string.utf8.index(string.startIndex, offsetBy: range.endIndex)
@@ -214,7 +219,6 @@ extension _URLInfo {
         )
     }
 
-    @inline(__always)
     private static func resolveBaseURL(_ base: URL?, updating flags: inout _URLFlags) -> URL? {
         if flags.contains(.hasScheme) {
             // Absolute file path, drop the base URL
@@ -282,7 +286,7 @@ extension _URLInfo {
                 isDirectory: isDirectory
             )
             let path = buffer.span.extracting(first: finalLength)
-            return URL.parseFinalFileSystemRepresentation(path: path, flags: &flags, encodeSemicolons: false)
+            return URL.parseFinalFileSystemRepresentation(path: path, flags: &flags, compatibility: .swiftURL)
         }
 
         let base = resolveBaseURL(base, updating: &flags)
@@ -306,101 +310,130 @@ extension _URLInfo {
         case unknown
     }
 
-    func replacing(
-        path: borrowing Span<UInt8>,
-        encodingState: PathEncodingState = .unknown
+    func replacingPath(
+        unsafeUninitializedCapacity capacity: Int,
+        initializingWith initializer: (
+            _ buffer: UnsafeMutableBufferPointer<UInt8>
+        ) -> (initializedCount: Int, encodingState: PathEncodingState)
     ) -> _URLInfo {
-        let isDirectory = path.withUnsafeBufferPointer {
-            URL.hasDirectoryPath($0, pathEnd: $0.count, pathLength: $0.count)
-        }
-        return replacing(path: path, isDirectory: isDirectory, encodingState: encodingState)
-    }
+        withSpan { stringSpan in
+            // Values the String closure reports back to us
+            var pathLength = 0
+            var hasAbsolutePath = false
+            var hasDirectoryPath = false
+            var hasEncodedPath = false
 
-    func replacing(
-        path newPath: borrowing Span<UInt8>,
-        isDirectory: Bool,
-        encodingState: PathEncodingState
-    ) -> _URLInfo {
-        let pathDelta = newPath.count - pathRange.count
-        let newString = withSpan { stringSpan in
-            let newLength = stringSpan.count + pathDelta
-            return String(unsafeUninitializedCapacity: newLength) { buffer in
+            let newCapacity = stringSpan.count - pathRange.count + capacity
+            let newString = String(unsafeUninitializedCapacity: newCapacity) { buffer in
                 var writeIndex = buffer.initialize(
                     fromSpan: stringSpan.extracting(..<pathRange.startIndex)
                 )
-                writeIndex = buffer[writeIndex...].initialize(
-                    fromSpan: newPath
+                let pathAllocation = UnsafeMutableBufferPointer(
+                    rebasing: buffer[writeIndex..<(writeIndex + capacity)]
                 )
-                writeIndex = buffer[writeIndex...].initialize(
+                let (initializedCount, encodingState) = initializer(pathAllocation)
+                pathLength = initializedCount
+                writeIndex += pathLength
+
+                let path = UnsafeBufferPointer(rebasing: pathAllocation[..<pathLength])
+                hasAbsolutePath = (path.first == ._slash)
+                hasDirectoryPath = path.hasDirectoryPath
+                hasEncodedPath = switch encodingState {
+                case .notEncoded: false
+                case .encoded: true
+                case .unknown: path.contains(UInt8(ascii: "%"))
+                }
+                assert(hasEncodedPath == path.contains(UInt8(ascii: "%")))
+
+                return buffer[writeIndex...].initialize(
                     fromSpan: stringSpan.extracting(pathRange.endIndex...)
                 )
-                return writeIndex
+            }
+
+            var flags = flags
+            if hasAbsolutePath {
+                flags.insert([.hasOldPath, .isDecomposable])
+            } else if pathLength == 0 {
+                flags.set(.hasOldPath, flags.contains(.hasOldNetLocation))
+            } else {
+                flags.set(.hasOldPath, flags.contains(.isDecomposable))
+            }
+            flags.set(.hasDirectoryPath, hasDirectoryPath)
+            flags.set(.hasEncodedPath, hasEncodedPath)
+            // Remove all .didEncode flags since we're treating this
+            // as a new, validly percent-encoded (UTF8) URL string.
+            flags.remove([
+                .hasNonUTF8Encoding,
+                .didEncodeUser, .didEncodePassword, .didEncodeHost,
+                .didEncodePath, .didEncodeQuery, .didEncodeFragment
+            ])
+
+            let pathDelta = pathLength - pathRange.count
+
+            var result = self
+            result.string = newString
+            result.flags = flags
+            result.pathRange = pathRange.extended(by: pathDelta)
+
+            // Shift the query and fragment ranges to account for the new path
+            if flags.contains(.hasQuery) {
+                result.queryRange = queryRange.shifted(by: pathDelta)
+            }
+            if flags.contains(.hasFragment) {
+                result.fragmentRange = fragmentRange.shifted(by: pathDelta)
+            }
+
+            // We should have the exact same ranges and flags if we re-parse
+            assert(result.isEquivalent(to: _URLInfo.parse(string: newString, encodingInvalidCharacters: false)))
+            return result
+        }
+    }
+
+    private func isEquivalent(to other: _URLInfo?) -> Bool {
+        guard let other else { return false }
+        // Don't include the Impl type flags or flags that might depend
+        // on the base URL such as .isFileURL and .isFileReferenceURL.
+        let flagsToIgnore: _URLFlags = [.implTypeMask, .isFileURL, .isFileReferenceURL]
+        return string == other.string
+        && flags.subtracting(flagsToIgnore) == other.flags.subtracting(flagsToIgnore)
+        && schemeRange == other.schemeRange
+        && hostRange == other.hostRange
+        && portRange == other.portRange
+        && pathRange == other.pathRange
+        && queryRange == other.queryRange
+        && fragmentRange == other.fragmentRange
+        && userRange == other.userRange
+        && passwordRange == other.passwordRange
+    }
+
+    func appendingTrailingSlash() -> _URLInfo {
+        withSpan { stringSpan in
+            let path = stringSpan.extracting(pathRange)
+            guard path.last != UInt8(ascii: "/") else {
+                return self
+            }
+            return replacingPath(unsafeUninitializedCapacity: path.count + 1) { buffer in
+                let pathLength = buffer.initialize(fromSpan: path)
+                buffer[pathLength] = UInt8(ascii: "/")
+                return (pathLength + 1, flags.contains(.hasEncodedPath) ? .encoded : .notEncoded)
             }
         }
-
-        // Update flags for the new path
-        var flags = flags
-        if (!newPath.isEmpty && flags.contains(.isDecomposable)) ||
-            (newPath.isEmpty && flags.contains(.hasOldNetLocation)) {
-            flags.insert(.hasOldPath)
-        } else {
-            flags.remove(.hasOldPath)
-        }
-
-        assert(isDirectory == newPath.withUnsafeBufferPointer {
-            URL.hasDirectoryPath($0, pathEnd: $0.count, pathLength: $0.count)
-        })
-        if isDirectory {
-            flags.insert(.hasDirectoryPath)
-        } else {
-            flags.remove(.hasDirectoryPath)
-        }
-
-        let hasEncodedPath: Bool
-        switch encodingState {
-        case .notEncoded:
-            assert(!newPath.contains(UInt8(ascii: "%")))
-            hasEncodedPath = false
-        case .encoded:
-            assert(newPath.contains(UInt8(ascii: "%")))
-            hasEncodedPath = true
-        case .unknown:
-            hasEncodedPath = newPath.contains(UInt8(ascii: "%"))
-        }
-
-        if hasEncodedPath {
-            flags.insert(.hasEncodedPath)
-        } else {
-            flags.remove(.hasEncodedPath)
-        }
-
-        // Remove all .didEncode flags since we're treating this
-        // as a new, validly percent-encoded (UTF8) URL string.
-        flags.remove([
-            .hasNonUTF8Encoding,
-            .didEncodeUser, .didEncodePassword, .didEncodeHost,
-            .didEncodePath, .didEncodeQuery, .didEncodeFragment
-        ])
-
-        var result = self
-        result.string = newString
-        result.flags = flags
-        result.pathRange = pathRange.startIndex..<(pathRange.startIndex + newPath.count)
-
-        // Shift the query and fragment ranges to account for the new path
-        if flags.contains(.hasQuery) {
-            result.queryRange = queryRange.shifted(by: pathDelta)
-        }
-        if flags.contains(.hasFragment) {
-            result.fragmentRange = fragmentRange.shifted(by: pathDelta)
-        }
-        return result
     }
 }
 
 private extension Range<Int> {
+    func extended(by delta: Int) -> Range<Int> {
+        lowerBound..<(upperBound + delta)
+    }
+
     func shifted(by delta: Int) -> Range<Int> {
-        return (lowerBound + delta)..<(upperBound + delta)
+        (lowerBound + delta)..<(upperBound + delta)
+    }
+}
+
+private extension UnsafeBufferPointer<UInt8> {
+    var hasDirectoryPath: Bool {
+        URL.hasDirectoryPath(self, pathEnd: count, pathLength: count)
     }
 }
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -561,6 +561,45 @@ private struct URLTests {
         try FileManager.default.removeItem(at: URL(filePath: "\(tempDirectory.path)/tmp-dir"))
     }
 
+    @Test func fileURLWithPathDirectoryHintConversion() throws {
+        let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
+
+        // URL(fileURLWithPath:isDirectory:relativeTo:) must forward
+        // `isDirectory` to URL(filePath:directoryHint:relativeTo:).
+        let dir = URL(fileURLWithPath: "sub", isDirectory: true, relativeTo: base)
+        #expect(dir.hasDirectoryPath)
+        #expect(dir == URL(filePath: "sub", directoryHint: .isDirectory, relativeTo: base))
+
+        let notDir = URL(fileURLWithPath: "sub", isDirectory: false, relativeTo: base)
+        #expect(!notDir.hasDirectoryPath)
+        #expect(notDir == URL(filePath: "sub", directoryHint: .notDirectory, relativeTo: base))
+
+        let absDir = URL(fileURLWithPath: "/abs/path", isDirectory: true)
+        #expect(absDir.hasDirectoryPath)
+        #expect(absDir.absoluteString == "file:///abs/path/")
+
+        let absNotDir = URL(fileURLWithPath: "/abs/path", isDirectory: false)
+        #expect(!absNotDir.hasDirectoryPath)
+        #expect(absNotDir.absoluteString == "file:///abs/path")
+
+        // An empty path is converted to "." before calling URL(filePath:).
+        let emptyDir = URL(fileURLWithPath: "", isDirectory: true, relativeTo: base)
+        #expect(emptyDir == URL(filePath: ".", directoryHint: .isDirectory, relativeTo: base))
+
+        // URL(fileURLWithPath:relativeTo:) infers directory-ness:
+        // a trailing slash maps to .isDirectory, otherwise .checkFileSystem.
+        let inferredDir = URL(fileURLWithPath: "sub/", relativeTo: base)
+        #expect(inferredDir.hasDirectoryPath)
+        #expect(inferredDir == URL(filePath: "sub/", directoryHint: .isDirectory, relativeTo: base))
+
+        // Without a trailing slash it maps to .checkFileSystem
+        let checked = URL(fileURLWithPath: "sub", relativeTo: base)
+        #expect(checked == URL(filePath: "sub", directoryHint: .checkFileSystem, relativeTo: base))
+
+        let emptyChecked = URL(fileURLWithPath: "", relativeTo: base)
+        #expect(emptyChecked == URL(filePath: ".", directoryHint: .checkFileSystem, relativeTo: base))
+    }
+
     @Test func filePathAPIsWithSemicolon() throws {
         // The NSURL and CFURL file path APIs encode ";" in file paths
         // for compatibility. URL and other modern parsers do not.
@@ -575,6 +614,57 @@ private struct URLTests {
         url.appendPathExtension("some;ext")
         #expect(url.path == "/path;to/file/hello;world.some;ext")
         #expect(url.relativeString == "file:///path;to/file/hello;world.some;ext")
+    }
+
+    @Test func filePathAPIMisuse() throws {
+        // Note: this exercises the new (non-compatibility) path
+        var url = URL(filePath: "file:///some/path")
+        #expect(url.relativePath == "file:///some/path")
+        #expect(url.relativePath(percentEncoded: true) == "file%3A///some/path")
+        #expect(url.relativeString == "file%3A///some/path")
+
+        url.append(path: "hello")
+        #expect(url.relativePath == "file:///some/path/hello")
+        #expect(url.relativePath(percentEncoded: true) == "file%3A///some/path/hello")
+        #expect(url.relativeString == "file%3A///some/path/hello")
+
+        url = URL(filePath: "http://example.com")
+        #expect(url.relativePath == "http://example.com")
+        #expect(url.relativePath(percentEncoded: true) == "http%3A//example.com")
+        #expect(url.relativeString == "http%3A//example.com")
+    }
+
+    @Test func filePathFirstSegmentColon() throws {
+        // Any ":" in the first segment of a relative path is encoded
+        // so the path can't be re-parsed as "scheme:..."
+        var url = URL(filePath: "foo:bar")
+        #expect(url.relativeString == "foo%3Abar")
+        #expect(url.relativePath == "foo:bar")
+        #expect(URL(string: url.relativeString)?.scheme == nil)
+
+        // The encoding survives standardization
+        #expect(url.standardized.relativeString == "foo%3Abar")
+
+        // Absolute paths are unambiguous, so ":" is left alone
+        url = URL(filePath: "/foo:bar")
+        #expect(url.relativeString == "file:///foo:bar")
+        #expect(url.path() == "/foo:bar")
+
+        // Only the first segment needs to be considered
+        url = URL(filePath: "foo/bar:baz")
+        #expect(url.relativeString == "foo/bar:baz")
+        #expect(URL(string: url.relativeString)?.scheme == nil)
+
+        // Every ":" in the first segment is encoded, even when the prefix
+        // could not be a valid scheme (e.g. starts with a digit or "%").
+        #expect(URL(filePath: "1:bar").relativeString == "1%3Abar")
+        #expect(URL(filePath: "%43:bar").relativeString == "%2543%3Abar")
+
+        // Multiple colons in the first segment are all encoded
+        url = URL(filePath: "a:b:c")
+        #expect(url.relativeString == "a%3Ab%3Ac")
+        #expect(url.relativePath == "a:b:c")
+        #expect(URL(string: url.relativeString)?.scheme == nil)
     }
 
     #if FOUNDATION_FRAMEWORK
@@ -734,6 +824,44 @@ private struct URLTests {
     }
     #endif
 
+    @Test func appendingPathWithNull() throws {
+        // FSR decomposition fails when there's an embedded null byte,
+        // so URL falls back to percent-encoding the input as-is.
+        let base = URL(filePath: "/base/")
+        var appended = base.appending(path: "bar\u{0}baz")
+        #expect(appended.path() == "/base/bar%00baz")
+
+        appended = base.appending(path: "\u{0}baz")
+        #expect(appended.path() == "/base/%00baz")
+
+        // Decomposition fails, so é remains in NFC form
+        appended = base.appending(path: "caf\u{E9}\u{0}bar")
+        #expect(appended.path() == "/base/caf%C3%A9%00bar")
+
+        // Trailing null bytes are stripped
+        appended = base.appending(path: "bar\u{0}")
+        #expect(appended.path() == "/base/bar")
+
+        appended = base.appending(path: "bar\u{0}\u{0}")
+        #expect(appended.path() == "/base/bar")
+
+        appended = base.appending(path: "\u{0}")
+        #expect(appended.path() == "/base/")
+
+        appended = base.appending(component: "bar\u{0}")
+        #expect(appended.path() == "/base/bar")
+
+        // File path initializer should also strip trailing null bytes
+        // for compatibility with previous NSURL/CFURL behavior
+        #expect(URL(filePath: "/base\u{0}").path() == "/base")
+        #expect(URL(filePath: "/base\u{0}\u{0}").path() == "/base")
+
+        // Non-file URLs keep nulls percent-encoded instead of stripping
+        let httpURL = URL(string: "https://example.com/base")!
+        #expect(httpURL.appending(path: "x\u{0}").path() == "/base/x%00")
+        #expect(httpURL.appending(component: "x\u{0}").path() == "/base/x%00")
+    }
+
     #if os(Windows)
     @Test func windowsDriveLetterPath() throws {
         var url = URL(filePath: #"C:\test\path"#, directoryHint: .notDirectory)
@@ -764,17 +892,9 @@ private struct URLTests {
 
         let base = URL(filePath: #"\d:\path\"#, directoryHint: .isDirectory)
         url = URL(filePath: #"%43:\fake\letter"#, directoryHint: .notDirectory, relativeTo: base)
-        if foundation_swift_url_v2_enabled() {
-            // More compatible with the old implementation recognizing that
-            // non-scheme characters like "%" cannot be interpreted as part
-            // of a scheme and must instead represent a relative path.
-            #expect(url.relativeString == "%2543:/fake/letter")
-            #expect(url.path() == "/d:/path/%2543:/fake/letter")
-        } else {
-            // ":" is encoded to "%3A" in the first path segment so it's not mistaken as the scheme separator
-            #expect(url.relativeString == "%2543%3A/fake/letter")
-            #expect(url.path() == "/d:/path/%2543%3A/fake/letter")
-        }
+        // ":" is encoded to "%3A" in the first path segment so it's not mistaken as the scheme separator
+        #expect(url.relativeString == "%2543%3A/fake/letter")
+        #expect(url.path() == "/d:/path/%2543%3A/fake/letter")
         #expect(url.path == "d:/path/%43:/fake/letter")
         #expect(url.fileSystemPath() == "d:/path/%43:/fake/letter")
 
@@ -829,6 +949,10 @@ private struct URLTests {
         #expect(
             base.appending(component: "AC/DC").absoluteString ==
             "https://www.example.com/AC%2FDC"
+        )
+        #expect(
+            base.appending(component: "AC/DC/").absoluteString ==
+            "https://www.example.com/AC%2FDC%2F"
         )
         var testAppendComponent = base
         testAppendComponent.append(component: "AC/DC")
@@ -946,6 +1070,1465 @@ private struct URLTests {
         )
         #expect(builder(tempDirectory).hasDirectoryPath)
         try FileManager.default.removeItem(at: builder(tempDirectory))
+    }
+
+    @Test func appendingComponent() throws {
+        var url = try #require(URL(string: "https://example.com/api"))
+        var result = url.appending(component: "AC/DC", directoryHint: .isDirectory)
+        #expect(result.absoluteString == "https://example.com/api/AC%2FDC/")
+
+        result = url.appending(component: "/leading")
+        #expect(result.absoluteString == "https://example.com/api/%2Fleading")
+
+        result = url.appending(component: "//double//")
+        #expect(result.absoluteString == "https://example.com/api/%2F%2Fdouble%2F%2F")
+
+        // A trailing slash is encoded, so it never implies a directory.
+        result = url.appending(component: "x/")
+        #expect(result.absoluteString == "https://example.com/api/x%2F")
+
+        // For a non-file URL, .checkFileSystem degrades to .inferFromPath.
+        // Since the trailing "/" is percent-encoded, it shouldn't be treated
+        // as a directory hint, so .checkFileSystem matches .inferFromPath
+        // (no trailing slash) rather than honoring the slash.
+        let checkFileSystem = url.appending(component: "x/", directoryHint: .checkFileSystem)
+        let inferFromPath = url.appending(component: "x/", directoryHint: .inferFromPath)
+        #expect(checkFileSystem.absoluteString == "https://example.com/api/x%2F")
+        #expect(checkFileSystem.absoluteString == inferFromPath.absoluteString)
+
+        // The explicit .isDirectory hint still appends a trailing slash.
+        result = url.appending(component: "x/", directoryHint: .isDirectory)
+        #expect(result.absoluteString == "https://example.com/api/x%2F/")
+
+        result = url.appending(component: "100%")
+        #expect(result.absoluteString == "https://example.com/api/100%25")
+
+        result = url.appending(component: "", directoryHint: .isDirectory)
+        #expect(result.absoluteString == "https://example.com/api/")
+
+        // Dot components are encoded literally for non-file URLs (not treated as dot segments)
+        result = url.appending(component: "..")
+        #expect(result.absoluteString == "https://example.com/api/..")
+
+        result = url.appending(component: ".")
+        #expect(result.absoluteString == "https://example.com/api/.")
+
+        // Empty component with notDirectory hint preserves trailing slash
+        url = try #require(URL(string: "https://example.com/api/"))
+        result = url.appending(component: "", directoryHint: .notDirectory)
+        #expect(result.absoluteString == "https://example.com/api/")
+
+        url = try #require(URL(string: "https://example.com"))
+        result = url.appending(component: "café")
+        #expect(result.absoluteString == "https://example.com/caf%C3%A9")
+    }
+
+    @Test(.enabled(if: foundation_swift_url_v2_enabled()))
+    func appendingPathComponentFileCases() throws {
+        func check(
+            _ base: URL,
+            _ component: String,
+            notDirectory expectedNotDir: String,
+            isDirectory expectedIsDir: String,
+            inferFromPath expectedInferred: String,
+            sourceLocation: SourceLocation = #_sourceLocation
+        ) {
+            func sourceOffset(_ offset: Int) -> SourceLocation {
+                var l = sourceLocation
+                l.line += offset
+                return l
+            }
+            var result = base.appending(path: component, directoryHint: .notDirectory)
+            #expect(result.absoluteString == expectedNotDir, Comment(rawValue: result.absoluteString), sourceLocation: sourceOffset(1))
+            #expect(result.host == base.host, Comment(rawValue: result.host ?? "nil"), sourceLocation: sourceOffset(1))
+            result = base.appending(path: component, directoryHint: .isDirectory)
+            #expect(result.absoluteString == expectedIsDir, Comment(rawValue: result.absoluteString), sourceLocation: sourceOffset(2))
+            #expect(result.host == base.host, Comment(rawValue: result.host ?? "nil"), sourceLocation: sourceOffset(2))
+            result = base.appending(path: component, directoryHint: .inferFromPath)
+            #expect(result.absoluteString == expectedInferred, Comment(rawValue: result.absoluteString), sourceLocation: sourceOffset(3))
+            #expect(result.host == base.host, Comment(rawValue: result.host ?? "nil"), sourceLocation: sourceOffset(3))
+        }
+
+        // Base file URL with no trailing slash
+        var base = URL(filePath: "/file/path", directoryHint: .notDirectory)
+
+        check(base, "",
+              notDirectory:     "file:///file/path/",
+              isDirectory:      "file:///file/path/",
+              inferFromPath:    "file:///file/path/")
+        check(base, "/",
+              notDirectory:     "file:///file/path/",
+              isDirectory:      "file:///file/path/",
+              inferFromPath:    "file:///file/path/")
+        check(base, "//",
+              notDirectory:     "file:///file/path/",
+              isDirectory:      "file:///file/path//",
+              inferFromPath:    "file:///file/path//")
+        check(base, ".",
+              notDirectory:     "file:///file/path/.",
+              isDirectory:      "file:///file/path/./",
+              inferFromPath:    "file:///file/path/.")
+        check(base, "..",
+              notDirectory:     "file:///file/path/..",
+              isDirectory:      "file:///file/path/../",
+              inferFromPath:    "file:///file/path/..")
+        check(base, "/.",
+              notDirectory:     "file:///file/path/.",
+              isDirectory:      "file:///file/path/./",
+              inferFromPath:    "file:///file/path/.")
+        check(base, "/..",
+              notDirectory:     "file:///file/path/..",
+              isDirectory:      "file:///file/path/../",
+              inferFromPath:    "file:///file/path/..")
+        check(base, "./",
+              notDirectory:     "file:///file/path/.",
+              isDirectory:      "file:///file/path/./",
+              inferFromPath:    "file:///file/path/./")
+        check(base, "../",
+              notDirectory:     "file:///file/path/..",
+              isDirectory:      "file:///file/path/../",
+              inferFromPath:    "file:///file/path/../")
+        check(base, "a",
+              notDirectory:     "file:///file/path/a",
+              isDirectory:      "file:///file/path/a/",
+              inferFromPath:    "file:///file/path/a")
+        check(base, "/a",
+              notDirectory:     "file:///file/path/a",
+              isDirectory:      "file:///file/path/a/",
+              inferFromPath:    "file:///file/path/a")
+        check(base, "a/",
+              notDirectory:     "file:///file/path/a",
+              isDirectory:      "file:///file/path/a/",
+              inferFromPath:    "file:///file/path/a/")
+        check(base, "a//",
+              notDirectory:     "file:///file/path/a",
+              isDirectory:      "file:///file/path/a//",
+              inferFromPath:    "file:///file/path/a//")
+        check(base, "//a",
+              notDirectory:     "file:///file/path//a",
+              isDirectory:      "file:///file/path//a/",
+              inferFromPath:    "file:///file/path//a")
+        #if FOUNDATION_FRAMEWORK
+        check(base, "é",
+              notDirectory:     "file:///file/path/e%CC%81",
+              isDirectory:      "file:///file/path/e%CC%81/",
+              inferFromPath:    "file:///file/path/e%CC%81")
+        #endif
+
+        // Base file URL with trailing slash
+        base = URL(filePath: "/file/path/", directoryHint: .isDirectory)
+
+        check(base, "",
+              notDirectory:     "file:///file/path/",
+              isDirectory:      "file:///file/path/",
+              inferFromPath:    "file:///file/path/")
+        check(base, "/",
+              notDirectory:     "file:///file/path/",
+              isDirectory:      "file:///file/path/",
+              inferFromPath:    "file:///file/path/")
+        check(base, "//",
+              notDirectory:     "file:///file/path//",
+              isDirectory:      "file:///file/path//",
+              inferFromPath:    "file:///file/path//")
+        check(base, ".",
+              notDirectory:     "file:///file/path/.",
+              isDirectory:      "file:///file/path/./",
+              inferFromPath:    "file:///file/path/.")
+        check(base, "..",
+              notDirectory:     "file:///file/path/..",
+              isDirectory:      "file:///file/path/../",
+              inferFromPath:    "file:///file/path/..")
+        check(base, "/.",
+              notDirectory:     "file:///file/path/.",
+              isDirectory:      "file:///file/path/./",
+              inferFromPath:    "file:///file/path/.")
+        check(base, "/..",
+              notDirectory:     "file:///file/path/..",
+              isDirectory:      "file:///file/path/../",
+              inferFromPath:    "file:///file/path/..")
+        check(base, "./",
+              notDirectory:     "file:///file/path/.",
+              isDirectory:      "file:///file/path/./",
+              inferFromPath:    "file:///file/path/./")
+        check(base, "../",
+              notDirectory:     "file:///file/path/..",
+              isDirectory:      "file:///file/path/../",
+              inferFromPath:    "file:///file/path/../")
+        check(base, "a",
+              notDirectory:     "file:///file/path/a",
+              isDirectory:      "file:///file/path/a/",
+              inferFromPath:    "file:///file/path/a")
+        check(base, "/a",
+              notDirectory:     "file:///file/path/a",
+              isDirectory:      "file:///file/path/a/",
+              inferFromPath:    "file:///file/path/a")
+        check(base, "a/",
+              notDirectory:     "file:///file/path/a",
+              isDirectory:      "file:///file/path/a/",
+              inferFromPath:    "file:///file/path/a/")
+        check(base, "a//",
+              notDirectory:     "file:///file/path/a",
+              isDirectory:      "file:///file/path/a//",
+              inferFromPath:    "file:///file/path/a//")
+        check(base, "//a",
+              notDirectory:     "file:///file/path//a",
+              isDirectory:      "file:///file/path//a/",
+              inferFromPath:    "file:///file/path//a")
+        #if FOUNDATION_FRAMEWORK
+        check(base, "é",
+              notDirectory:     "file:///file/path/e%CC%81",
+              isDirectory:      "file:///file/path/e%CC%81/",
+              inferFromPath:    "file:///file/path/e%CC%81")
+        #endif
+
+        // Base file URL with two trailing slashes
+        base = URL(filePath: "/file/path//", directoryHint: .isDirectory)
+
+        check(base, "",
+              notDirectory:     "file:///file/path//",
+              isDirectory:      "file:///file/path//",
+              inferFromPath:    "file:///file/path//")
+        check(base, "/",
+              notDirectory:     "file:///file/path//",
+              isDirectory:      "file:///file/path//",
+              inferFromPath:    "file:///file/path//")
+        check(base, "//",
+              notDirectory:     "file:///file/path///",
+              isDirectory:      "file:///file/path///",
+              inferFromPath:    "file:///file/path///")
+        check(base, ".",
+              notDirectory:     "file:///file/path//.",
+              isDirectory:      "file:///file/path//./",
+              inferFromPath:    "file:///file/path//.")
+        check(base, "..",
+              notDirectory:     "file:///file/path//..",
+              isDirectory:      "file:///file/path//../",
+              inferFromPath:    "file:///file/path//..")
+        check(base, "/.",
+              notDirectory:     "file:///file/path//.",
+              isDirectory:      "file:///file/path//./",
+              inferFromPath:    "file:///file/path//.")
+        check(base, "/..",
+              notDirectory:     "file:///file/path//..",
+              isDirectory:      "file:///file/path//../",
+              inferFromPath:    "file:///file/path//..")
+        check(base, "./",
+              notDirectory:     "file:///file/path//.",
+              isDirectory:      "file:///file/path//./",
+              inferFromPath:    "file:///file/path//./")
+        check(base, "../",
+              notDirectory:     "file:///file/path//..",
+              isDirectory:      "file:///file/path//../",
+              inferFromPath:    "file:///file/path//../")
+        check(base, "a",
+              notDirectory:     "file:///file/path//a",
+              isDirectory:      "file:///file/path//a/",
+              inferFromPath:    "file:///file/path//a")
+        check(base, "/a",
+              notDirectory:     "file:///file/path//a",
+              isDirectory:      "file:///file/path//a/",
+              inferFromPath:    "file:///file/path//a")
+        check(base, "a/",
+              notDirectory:     "file:///file/path//a",
+              isDirectory:      "file:///file/path//a/",
+              inferFromPath:    "file:///file/path//a/")
+        check(base, "a//",
+              notDirectory:     "file:///file/path//a",
+              isDirectory:      "file:///file/path//a//",
+              inferFromPath:    "file:///file/path//a//")
+        check(base, "//a",
+              notDirectory:     "file:///file/path///a",
+              isDirectory:      "file:///file/path///a/",
+              inferFromPath:    "file:///file/path///a")
+        #if FOUNDATION_FRAMEWORK
+        check(base, "é",
+              notDirectory:     "file:///file/path//e%CC%81",
+              isDirectory:      "file:///file/path//e%CC%81/",
+              inferFromPath:    "file:///file/path//e%CC%81")
+
+        // Base file URL whose existing path contains an encoded character
+        base = URL(filePath: "/file/páth/", directoryHint: .isDirectory)
+
+        check(base, "",
+              notDirectory:     "file:///file/pa%CC%81th/",
+              isDirectory:      "file:///file/pa%CC%81th/",
+              inferFromPath:    "file:///file/pa%CC%81th/")
+        check(base, "/",
+              notDirectory:     "file:///file/pa%CC%81th/",
+              isDirectory:      "file:///file/pa%CC%81th/",
+              inferFromPath:    "file:///file/pa%CC%81th/")
+        check(base, "//",
+              notDirectory:     "file:///file/pa%CC%81th//",
+              isDirectory:      "file:///file/pa%CC%81th//",
+              inferFromPath:    "file:///file/pa%CC%81th//")
+        check(base, ".",
+              notDirectory:     "file:///file/pa%CC%81th/.",
+              isDirectory:      "file:///file/pa%CC%81th/./",
+              inferFromPath:    "file:///file/pa%CC%81th/.")
+        check(base, "..",
+              notDirectory:     "file:///file/pa%CC%81th/..",
+              isDirectory:      "file:///file/pa%CC%81th/../",
+              inferFromPath:    "file:///file/pa%CC%81th/..")
+        check(base, "/.",
+              notDirectory:     "file:///file/pa%CC%81th/.",
+              isDirectory:      "file:///file/pa%CC%81th/./",
+              inferFromPath:    "file:///file/pa%CC%81th/.")
+        check(base, "/..",
+              notDirectory:     "file:///file/pa%CC%81th/..",
+              isDirectory:      "file:///file/pa%CC%81th/../",
+              inferFromPath:    "file:///file/pa%CC%81th/..")
+        check(base, "./",
+              notDirectory:     "file:///file/pa%CC%81th/.",
+              isDirectory:      "file:///file/pa%CC%81th/./",
+              inferFromPath:    "file:///file/pa%CC%81th/./")
+        check(base, "../",
+              notDirectory:     "file:///file/pa%CC%81th/..",
+              isDirectory:      "file:///file/pa%CC%81th/../",
+              inferFromPath:    "file:///file/pa%CC%81th/../")
+        check(base, "a",
+              notDirectory:     "file:///file/pa%CC%81th/a",
+              isDirectory:      "file:///file/pa%CC%81th/a/",
+              inferFromPath:    "file:///file/pa%CC%81th/a")
+        check(base, "/a",
+              notDirectory:     "file:///file/pa%CC%81th/a",
+              isDirectory:      "file:///file/pa%CC%81th/a/",
+              inferFromPath:    "file:///file/pa%CC%81th/a")
+        check(base, "a/",
+              notDirectory:     "file:///file/pa%CC%81th/a",
+              isDirectory:      "file:///file/pa%CC%81th/a/",
+              inferFromPath:    "file:///file/pa%CC%81th/a/")
+        check(base, "a//",
+              notDirectory:     "file:///file/pa%CC%81th/a",
+              isDirectory:      "file:///file/pa%CC%81th/a//",
+              inferFromPath:    "file:///file/pa%CC%81th/a//")
+        check(base, "//a",
+              notDirectory:     "file:///file/pa%CC%81th//a",
+              isDirectory:      "file:///file/pa%CC%81th//a/",
+              inferFromPath:    "file:///file/pa%CC%81th//a")
+        check(base, "é",
+              notDirectory:     "file:///file/pa%CC%81th/e%CC%81",
+              isDirectory:      "file:///file/pa%CC%81th/e%CC%81/",
+              inferFromPath:    "file:///file/pa%CC%81th/e%CC%81")
+        #endif
+
+        // Base file URL with empty host and path
+        base = try #require(URL(string: "file://"))
+
+        check(base, "",
+              notDirectory:     "file:///",
+              isDirectory:      "file:///",
+              inferFromPath:    "file:///")
+        check(base, "/",
+              notDirectory:     "file:///",
+              isDirectory:      "file:///",
+              inferFromPath:    "file:///")
+        check(base, "//",
+              notDirectory:     "file:///",
+              isDirectory:      "file:////",
+              inferFromPath:    "file:////")
+        check(base, ".",
+              notDirectory:     "file:///.",
+              isDirectory:      "file:///./",
+              inferFromPath:    "file:///.")
+        check(base, "..",
+              notDirectory:     "file:///..",
+              isDirectory:      "file:///../",
+              inferFromPath:    "file:///..")
+        check(base, "/.",
+              notDirectory:     "file:///.",
+              isDirectory:      "file:///./",
+              inferFromPath:    "file:///.")
+        check(base, "/..",
+              notDirectory:     "file:///..",
+              isDirectory:      "file:///../",
+              inferFromPath:    "file:///..")
+        check(base, "./",
+              notDirectory:     "file:///.",
+              isDirectory:      "file:///./",
+              inferFromPath:    "file:///./")
+        check(base, "../",
+              notDirectory:     "file:///..",
+              isDirectory:      "file:///../",
+              inferFromPath:    "file:///../")
+        check(base, "a",
+              notDirectory:     "file:///a",
+              isDirectory:      "file:///a/",
+              inferFromPath:    "file:///a")
+        check(base, "/a",
+              notDirectory:     "file:///a",
+              isDirectory:      "file:///a/",
+              inferFromPath:    "file:///a")
+        check(base, "a/",
+              notDirectory:     "file:///a",
+              isDirectory:      "file:///a/",
+              inferFromPath:    "file:///a/")
+        check(base, "a//",
+              notDirectory:     "file:///a",
+              isDirectory:      "file:///a//",
+              inferFromPath:    "file:///a//")
+        check(base, "//a",
+              notDirectory:     "file:////a",
+              isDirectory:      "file:////a/",
+              inferFromPath:    "file:////a")
+        #if FOUNDATION_FRAMEWORK
+        check(base, "é",
+              notDirectory:     "file:///e%CC%81",
+              isDirectory:      "file:///e%CC%81/",
+              inferFromPath:    "file:///e%CC%81")
+        #endif
+
+        // Base file URL with non-standard root path
+        // Make sure we don't append a host component
+        base = try #require(URL(string: "file:/"))
+
+        check(base, "",
+              notDirectory:     "file:/",
+              isDirectory:      "file:/",
+              inferFromPath:    "file:/")
+        check(base, "/",
+              notDirectory:     "file:/",
+              isDirectory:      "file:/",
+              inferFromPath:    "file:/")
+        check(base, "//",
+              notDirectory:     "file:/",
+              isDirectory:      "file:/",
+              inferFromPath:    "file:/")
+        check(base, ".",
+              notDirectory:     "file:/.",
+              isDirectory:      "file:/./",
+              inferFromPath:    "file:/.")
+        check(base, "..",
+              notDirectory:     "file:/..",
+              isDirectory:      "file:/../",
+              inferFromPath:    "file:/..")
+        check(base, "/.",
+              notDirectory:     "file:/.",
+              isDirectory:      "file:/./",
+              inferFromPath:    "file:/.")
+        check(base, "/..",
+              notDirectory:     "file:/..",
+              isDirectory:      "file:/../",
+              inferFromPath:    "file:/..")
+        check(base, "./",
+              notDirectory:     "file:/.",
+              isDirectory:      "file:/./",
+              inferFromPath:    "file:/./")
+        check(base, "../",
+              notDirectory:     "file:/..",
+              isDirectory:      "file:/../",
+              inferFromPath:    "file:/../")
+        check(base, "a",
+              notDirectory:     "file:/a",
+              isDirectory:      "file:/a/",
+              inferFromPath:    "file:/a")
+        check(base, "/a",
+              notDirectory:     "file:/a",
+              isDirectory:      "file:/a/",
+              inferFromPath:    "file:/a")
+        check(base, "a/",
+              notDirectory:     "file:/a",
+              isDirectory:      "file:/a/",
+              inferFromPath:    "file:/a/")
+        check(base, "a//",
+              notDirectory:     "file:/a",
+              isDirectory:      "file:/a//",
+              inferFromPath:    "file:/a//")
+        check(base, "//a",
+              notDirectory:     "file:/a",
+              isDirectory:      "file:/a/",
+              inferFromPath:    "file:/a")
+        #if FOUNDATION_FRAMEWORK
+        check(base, "é",
+              notDirectory:     "file:/e%CC%81",
+              isDirectory:      "file:/e%CC%81/",
+              inferFromPath:    "file:/e%CC%81")
+        #endif
+    }
+
+    @Test(.enabled(if: foundation_swift_url_v2_enabled()))
+    func appendingPathComponentNonFileCases() throws {
+        func check(
+            _ base: URL,
+            _ component: String,
+            notDirectory expectedNotDir: String,
+            isDirectory expectedIsDir: String,
+            inferFromPath expectedInferred: String,
+            sourceLocation: SourceLocation = #_sourceLocation
+        ) {
+            func sourceOffset(_ offset: Int) -> SourceLocation {
+                var l = sourceLocation
+                l.line += offset
+                return l
+            }
+            var result = base.appending(path: component, directoryHint: .notDirectory)
+            #expect(result.absoluteString == expectedNotDir, Comment(rawValue: result.absoluteString), sourceLocation: sourceOffset(1))
+            #expect(result.host == base.host, Comment(rawValue: result.host ?? "nil"), sourceLocation: sourceOffset(1))
+            result = base.appending(path: component, directoryHint: .isDirectory)
+            #expect(result.absoluteString == expectedIsDir, Comment(rawValue: result.absoluteString), sourceLocation: sourceOffset(2))
+            #expect(result.host == base.host, Comment(rawValue: result.host ?? "nil"), sourceLocation: sourceOffset(2))
+            result = base.appending(path: component, directoryHint: .inferFromPath)
+            #expect(result.absoluteString == expectedInferred, Comment(rawValue: result.absoluteString), sourceLocation: sourceOffset(3))
+            #expect(result.host == base.host, Comment(rawValue: result.host ?? "nil"), sourceLocation: sourceOffset(3))
+        }
+
+        // Single dot relative URL
+        var base = try #require(URL(string: "."))
+
+        check(base, "",
+              notDirectory:     "./",
+              isDirectory:      "./",
+              inferFromPath:    "./")
+        check(base, "/",
+              notDirectory:     "./",
+              isDirectory:      "./",
+              inferFromPath:    "./")
+        check(base, "//",
+              notDirectory:     "./",
+              isDirectory:      ".//",
+              inferFromPath:    ".//")
+        check(base, ".",
+              notDirectory:     "./.",
+              isDirectory:      "././",
+              inferFromPath:    "./.")
+        check(base, "..",
+              notDirectory:     "./..",
+              isDirectory:      "./../",
+              inferFromPath:    "./..")
+        check(base, "/.",
+              notDirectory:     "./.",
+              isDirectory:      "././",
+              inferFromPath:    "./.")
+        check(base, "/..",
+              notDirectory:     "./..",
+              isDirectory:      "./../",
+              inferFromPath:    "./..")
+        check(base, "./",
+              notDirectory:     "./.",
+              isDirectory:      "././",
+              inferFromPath:    "././")
+        check(base, "../",
+              notDirectory:     "./..",
+              isDirectory:      "./../",
+              inferFromPath:    "./../")
+        check(base, "a",
+              notDirectory:     "./a",
+              isDirectory:      "./a/",
+              inferFromPath:    "./a")
+        check(base, "/a",
+              notDirectory:     "./a",
+              isDirectory:      "./a/",
+              inferFromPath:    "./a")
+        check(base, "a/",
+              notDirectory:     "./a",
+              isDirectory:      "./a/",
+              inferFromPath:    "./a/")
+        check(base, "a//",
+              notDirectory:     "./a",
+              isDirectory:      "./a//",
+              inferFromPath:    "./a//")
+        check(base, "//a",
+              notDirectory:     ".//a",
+              isDirectory:      ".//a/",
+              inferFromPath:    ".//a")
+        check(base, "é",
+              notDirectory:     "./%C3%A9",
+              isDirectory:      "./%C3%A9/",
+              inferFromPath:    "./%C3%A9")
+
+        // Single dot relative URL with directory slash
+        base = try #require(URL(string: "./"))
+
+        check(base, "",
+              notDirectory:     "./",
+              isDirectory:      "./",
+              inferFromPath:    "./")
+        check(base, "/",
+              notDirectory:     "./",
+              isDirectory:      "./",
+              inferFromPath:    "./")
+        check(base, "//",
+              notDirectory:     ".//",
+              isDirectory:      ".//",
+              inferFromPath:    ".//")
+        check(base, ".",
+              notDirectory:     "./.",
+              isDirectory:      "././",
+              inferFromPath:    "./.")
+        check(base, "..",
+              notDirectory:     "./..",
+              isDirectory:      "./../",
+              inferFromPath:    "./..")
+        check(base, "/.",
+              notDirectory:     "./.",
+              isDirectory:      "././",
+              inferFromPath:    "./.")
+        check(base, "/..",
+              notDirectory:     "./..",
+              isDirectory:      "./../",
+              inferFromPath:    "./..")
+        check(base, "./",
+              notDirectory:     "./.",
+              isDirectory:      "././",
+              inferFromPath:    "././")
+        check(base, "../",
+              notDirectory:     "./..",
+              isDirectory:      "./../",
+              inferFromPath:    "./../")
+        check(base, "a",
+              notDirectory:     "./a",
+              isDirectory:      "./a/",
+              inferFromPath:    "./a")
+        check(base, "/a",
+              notDirectory:     "./a",
+              isDirectory:      "./a/",
+              inferFromPath:    "./a")
+        check(base, "a/",
+              notDirectory:     "./a",
+              isDirectory:      "./a/",
+              inferFromPath:    "./a/")
+        check(base, "a//",
+              notDirectory:     "./a",
+              isDirectory:      "./a//",
+              inferFromPath:    "./a//")
+        check(base, "//a",
+              notDirectory:     ".//a",
+              isDirectory:      ".//a/",
+              inferFromPath:    ".//a")
+        check(base, "é",
+              notDirectory:     "./%C3%A9",
+              isDirectory:      "./%C3%A9/",
+              inferFromPath:    "./%C3%A9")
+
+        // Non-decomposable with empty path
+        base = try #require(URL(string: "scheme:"))
+
+        check(base, "",
+              notDirectory:     "scheme:",
+              isDirectory:      "scheme:/",
+              inferFromPath:    "scheme:")
+        check(base, "/",
+              notDirectory:     "scheme:/",
+              isDirectory:      "scheme:/",
+              inferFromPath:    "scheme:/")
+        check(base, "//",
+              notDirectory:     "scheme:/",
+              isDirectory:      "scheme:/",
+              inferFromPath:    "scheme:/")
+        check(base, ".",
+              notDirectory:     "scheme:.",
+              isDirectory:      "scheme:./",
+              inferFromPath:    "scheme:.")
+        check(base, "..",
+              notDirectory:     "scheme:..",
+              isDirectory:      "scheme:../",
+              inferFromPath:    "scheme:..")
+        check(base, "/.",
+              notDirectory:     "scheme:/.",
+              isDirectory:      "scheme:/./",
+              inferFromPath:    "scheme:/.")
+        check(base, "/..",
+              notDirectory:     "scheme:/..",
+              isDirectory:      "scheme:/../",
+              inferFromPath:    "scheme:/..")
+        check(base, "./",
+              notDirectory:     "scheme:.",
+              isDirectory:      "scheme:./",
+              inferFromPath:    "scheme:./")
+        check(base, "../",
+              notDirectory:     "scheme:..",
+              isDirectory:      "scheme:../",
+              inferFromPath:    "scheme:../")
+        check(base, "a",
+              notDirectory:     "scheme:a",
+              isDirectory:      "scheme:a/",
+              inferFromPath:    "scheme:a")
+        check(base, "/a",
+              notDirectory:     "scheme:/a",
+              isDirectory:      "scheme:/a/",
+              inferFromPath:    "scheme:/a")
+        check(base, "a/",
+              notDirectory:     "scheme:a",
+              isDirectory:      "scheme:a/",
+              inferFromPath:    "scheme:a/")
+        check(base, "a//",
+              notDirectory:     "scheme:a",
+              isDirectory:      "scheme:a//",
+              inferFromPath:    "scheme:a//")
+        check(base, "//a",
+              notDirectory:     "scheme:/a",
+              isDirectory:      "scheme:/a/",
+              inferFromPath:    "scheme:/a")
+        check(base, "é",
+              notDirectory:     "scheme:%C3%A9",
+              isDirectory:      "scheme:%C3%A9/",
+              inferFromPath:    "scheme:%C3%A9")
+
+        // Non-decomposable with non-empty path
+        base = try #require(URL(string: "scheme:path"))
+
+        check(base, "",
+              notDirectory:     "scheme:path/",
+              isDirectory:      "scheme:path/",
+              inferFromPath:    "scheme:path/")
+        check(base, "/",
+              notDirectory:     "scheme:path/",
+              isDirectory:      "scheme:path/",
+              inferFromPath:    "scheme:path/")
+        check(base, "//",
+              notDirectory:     "scheme:path/",
+              isDirectory:      "scheme:path//",
+              inferFromPath:    "scheme:path//")
+        check(base, ".",
+              notDirectory:     "scheme:path/.",
+              isDirectory:      "scheme:path/./",
+              inferFromPath:    "scheme:path/.")
+        check(base, "..",
+              notDirectory:     "scheme:path/..",
+              isDirectory:      "scheme:path/../",
+              inferFromPath:    "scheme:path/..")
+        check(base, "/.",
+              notDirectory:     "scheme:path/.",
+              isDirectory:      "scheme:path/./",
+              inferFromPath:    "scheme:path/.")
+        check(base, "/..",
+              notDirectory:     "scheme:path/..",
+              isDirectory:      "scheme:path/../",
+              inferFromPath:    "scheme:path/..")
+        check(base, "./",
+              notDirectory:     "scheme:path/.",
+              isDirectory:      "scheme:path/./",
+              inferFromPath:    "scheme:path/./")
+        check(base, "../",
+              notDirectory:     "scheme:path/..",
+              isDirectory:      "scheme:path/../",
+              inferFromPath:    "scheme:path/../")
+        check(base, "a",
+              notDirectory:     "scheme:path/a",
+              isDirectory:      "scheme:path/a/",
+              inferFromPath:    "scheme:path/a")
+        check(base, "/a",
+              notDirectory:     "scheme:path/a",
+              isDirectory:      "scheme:path/a/",
+              inferFromPath:    "scheme:path/a")
+        check(base, "a/",
+              notDirectory:     "scheme:path/a",
+              isDirectory:      "scheme:path/a/",
+              inferFromPath:    "scheme:path/a/")
+        check(base, "a//",
+              notDirectory:     "scheme:path/a",
+              isDirectory:      "scheme:path/a//",
+              inferFromPath:    "scheme:path/a//")
+        check(base, "//a",
+              notDirectory:     "scheme:path//a",
+              isDirectory:      "scheme:path//a/",
+              inferFromPath:    "scheme:path//a")
+        check(base, "é",
+              notDirectory:     "scheme:path/%C3%A9",
+              isDirectory:      "scheme:path/%C3%A9/",
+              inferFromPath:    "scheme:path/%C3%A9")
+
+        // Non-decomposable with non-empty directory path
+        base = try #require(URL(string: "scheme:path/"))
+
+        check(base, "",
+              notDirectory:     "scheme:path/",
+              isDirectory:      "scheme:path/",
+              inferFromPath:    "scheme:path/")
+        check(base, "/",
+              notDirectory:     "scheme:path/",
+              isDirectory:      "scheme:path/",
+              inferFromPath:    "scheme:path/")
+        check(base, "//",
+              notDirectory:     "scheme:path//",
+              isDirectory:      "scheme:path//",
+              inferFromPath:    "scheme:path//")
+        check(base, ".",
+              notDirectory:     "scheme:path/.",
+              isDirectory:      "scheme:path/./",
+              inferFromPath:    "scheme:path/.")
+        check(base, "..",
+              notDirectory:     "scheme:path/..",
+              isDirectory:      "scheme:path/../",
+              inferFromPath:    "scheme:path/..")
+        check(base, "/.",
+              notDirectory:     "scheme:path/.",
+              isDirectory:      "scheme:path/./",
+              inferFromPath:    "scheme:path/.")
+        check(base, "/..",
+              notDirectory:     "scheme:path/..",
+              isDirectory:      "scheme:path/../",
+              inferFromPath:    "scheme:path/..")
+        check(base, "./",
+              notDirectory:     "scheme:path/.",
+              isDirectory:      "scheme:path/./",
+              inferFromPath:    "scheme:path/./")
+        check(base, "../",
+              notDirectory:     "scheme:path/..",
+              isDirectory:      "scheme:path/../",
+              inferFromPath:    "scheme:path/../")
+        check(base, "a",
+              notDirectory:     "scheme:path/a",
+              isDirectory:      "scheme:path/a/",
+              inferFromPath:    "scheme:path/a")
+        check(base, "/a",
+              notDirectory:     "scheme:path/a",
+              isDirectory:      "scheme:path/a/",
+              inferFromPath:    "scheme:path/a")
+        check(base, "a/",
+              notDirectory:     "scheme:path/a",
+              isDirectory:      "scheme:path/a/",
+              inferFromPath:    "scheme:path/a/")
+        check(base, "a//",
+              notDirectory:     "scheme:path/a",
+              isDirectory:      "scheme:path/a//",
+              inferFromPath:    "scheme:path/a//")
+        check(base, "//a",
+              notDirectory:     "scheme:path//a",
+              isDirectory:      "scheme:path//a/",
+              inferFromPath:    "scheme:path//a")
+        check(base, "é",
+              notDirectory:     "scheme:path/%C3%A9",
+              isDirectory:      "scheme:path/%C3%A9/",
+              inferFromPath:    "scheme:path/%C3%A9")
+
+        // Decomposable with host and empty path
+        base = try #require(URL(string: "http://example.com"))
+
+        check(base, "",
+              notDirectory:     "http://example.com/",
+              isDirectory:      "http://example.com/",
+              inferFromPath:    "http://example.com/")
+        check(base, "/",
+              notDirectory:     "http://example.com/",
+              isDirectory:      "http://example.com/",
+              inferFromPath:    "http://example.com/")
+        check(base, "//",
+              notDirectory:     "http://example.com/",
+              isDirectory:      "http://example.com//",
+              inferFromPath:    "http://example.com//")
+        check(base, ".",
+              notDirectory:     "http://example.com/.",
+              isDirectory:      "http://example.com/./",
+              inferFromPath:    "http://example.com/.")
+        check(base, "..",
+              notDirectory:     "http://example.com/..",
+              isDirectory:      "http://example.com/../",
+              inferFromPath:    "http://example.com/..")
+        check(base, "/.",
+              notDirectory:     "http://example.com/.",
+              isDirectory:      "http://example.com/./",
+              inferFromPath:    "http://example.com/.")
+        check(base, "/..",
+              notDirectory:     "http://example.com/..",
+              isDirectory:      "http://example.com/../",
+              inferFromPath:    "http://example.com/..")
+        check(base, "./",
+              notDirectory:     "http://example.com/.",
+              isDirectory:      "http://example.com/./",
+              inferFromPath:    "http://example.com/./")
+        check(base, "../",
+              notDirectory:     "http://example.com/..",
+              isDirectory:      "http://example.com/../",
+              inferFromPath:    "http://example.com/../")
+        check(base, "a",
+              notDirectory:     "http://example.com/a",
+              isDirectory:      "http://example.com/a/",
+              inferFromPath:    "http://example.com/a")
+        check(base, "/a",
+              notDirectory:     "http://example.com/a",
+              isDirectory:      "http://example.com/a/",
+              inferFromPath:    "http://example.com/a")
+        check(base, "a/",
+              notDirectory:     "http://example.com/a",
+              isDirectory:      "http://example.com/a/",
+              inferFromPath:    "http://example.com/a/")
+        check(base, "a//",
+              notDirectory:     "http://example.com/a",
+              isDirectory:      "http://example.com/a//",
+              inferFromPath:    "http://example.com/a//")
+        check(base, "//a",
+              notDirectory:     "http://example.com//a",
+              isDirectory:      "http://example.com//a/",
+              inferFromPath:    "http://example.com//a")
+        check(base, "é",
+              notDirectory:     "http://example.com/%C3%A9",
+              isDirectory:      "http://example.com/%C3%A9/",
+              inferFromPath:    "http://example.com/%C3%A9")
+
+        // Decomposable with host and root path
+        base = try #require(URL(string: "http://example.com/"))
+
+        check(base, "",
+              notDirectory:     "http://example.com/",
+              isDirectory:      "http://example.com/",
+              inferFromPath:    "http://example.com/")
+        check(base, "/",
+              notDirectory:     "http://example.com/",
+              isDirectory:      "http://example.com/",
+              inferFromPath:    "http://example.com/")
+        check(base, "//",
+              notDirectory:     "http://example.com//",
+              isDirectory:      "http://example.com//",
+              inferFromPath:    "http://example.com//")
+        check(base, ".",
+              notDirectory:     "http://example.com/.",
+              isDirectory:      "http://example.com/./",
+              inferFromPath:    "http://example.com/.")
+        check(base, "..",
+              notDirectory:     "http://example.com/..",
+              isDirectory:      "http://example.com/../",
+              inferFromPath:    "http://example.com/..")
+        check(base, "/.",
+              notDirectory:     "http://example.com/.",
+              isDirectory:      "http://example.com/./",
+              inferFromPath:    "http://example.com/.")
+        check(base, "/..",
+              notDirectory:     "http://example.com/..",
+              isDirectory:      "http://example.com/../",
+              inferFromPath:    "http://example.com/..")
+        check(base, "./",
+              notDirectory:     "http://example.com/.",
+              isDirectory:      "http://example.com/./",
+              inferFromPath:    "http://example.com/./")
+        check(base, "../",
+              notDirectory:     "http://example.com/..",
+              isDirectory:      "http://example.com/../",
+              inferFromPath:    "http://example.com/../")
+        check(base, "a",
+              notDirectory:     "http://example.com/a",
+              isDirectory:      "http://example.com/a/",
+              inferFromPath:    "http://example.com/a")
+        check(base, "/a",
+              notDirectory:     "http://example.com/a",
+              isDirectory:      "http://example.com/a/",
+              inferFromPath:    "http://example.com/a")
+        check(base, "a/",
+              notDirectory:     "http://example.com/a",
+              isDirectory:      "http://example.com/a/",
+              inferFromPath:    "http://example.com/a/")
+        check(base, "a//",
+              notDirectory:     "http://example.com/a",
+              isDirectory:      "http://example.com/a//",
+              inferFromPath:    "http://example.com/a//")
+        check(base, "//a",
+              notDirectory:     "http://example.com//a",
+              isDirectory:      "http://example.com//a/",
+              inferFromPath:    "http://example.com//a")
+        check(base, "é",
+              notDirectory:     "http://example.com/%C3%A9",
+              isDirectory:      "http://example.com/%C3%A9/",
+              inferFromPath:    "http://example.com/%C3%A9")
+
+        // Decomposable with host and non-empty path
+        base = try #require(URL(string: "http://example.com/path"))
+
+        check(base, "",
+              notDirectory:     "http://example.com/path/",
+              isDirectory:      "http://example.com/path/",
+              inferFromPath:    "http://example.com/path/")
+        check(base, "/",
+              notDirectory:     "http://example.com/path/",
+              isDirectory:      "http://example.com/path/",
+              inferFromPath:    "http://example.com/path/")
+        check(base, "//",
+              notDirectory:     "http://example.com/path/",
+              isDirectory:      "http://example.com/path//",
+              inferFromPath:    "http://example.com/path//")
+        check(base, ".",
+              notDirectory:     "http://example.com/path/.",
+              isDirectory:      "http://example.com/path/./",
+              inferFromPath:    "http://example.com/path/.")
+        check(base, "..",
+              notDirectory:     "http://example.com/path/..",
+              isDirectory:      "http://example.com/path/../",
+              inferFromPath:    "http://example.com/path/..")
+        check(base, "/.",
+              notDirectory:     "http://example.com/path/.",
+              isDirectory:      "http://example.com/path/./",
+              inferFromPath:    "http://example.com/path/.")
+        check(base, "/..",
+              notDirectory:     "http://example.com/path/..",
+              isDirectory:      "http://example.com/path/../",
+              inferFromPath:    "http://example.com/path/..")
+        check(base, "./",
+              notDirectory:     "http://example.com/path/.",
+              isDirectory:      "http://example.com/path/./",
+              inferFromPath:    "http://example.com/path/./")
+        check(base, "../",
+              notDirectory:     "http://example.com/path/..",
+              isDirectory:      "http://example.com/path/../",
+              inferFromPath:    "http://example.com/path/../")
+        check(base, "a",
+              notDirectory:     "http://example.com/path/a",
+              isDirectory:      "http://example.com/path/a/",
+              inferFromPath:    "http://example.com/path/a")
+        check(base, "/a",
+              notDirectory:     "http://example.com/path/a",
+              isDirectory:      "http://example.com/path/a/",
+              inferFromPath:    "http://example.com/path/a")
+        check(base, "a/",
+              notDirectory:     "http://example.com/path/a",
+              isDirectory:      "http://example.com/path/a/",
+              inferFromPath:    "http://example.com/path/a/")
+        check(base, "a//",
+              notDirectory:     "http://example.com/path/a",
+              isDirectory:      "http://example.com/path/a//",
+              inferFromPath:    "http://example.com/path/a//")
+        check(base, "//a",
+              notDirectory:     "http://example.com/path//a",
+              isDirectory:      "http://example.com/path//a/",
+              inferFromPath:    "http://example.com/path//a")
+        check(base, "é",
+              notDirectory:     "http://example.com/path/%C3%A9",
+              isDirectory:      "http://example.com/path/%C3%A9/",
+              inferFromPath:    "http://example.com/path/%C3%A9")
+
+        // Decomposable with host and non-empty directory path
+        base = try #require(URL(string: "http://example.com/path/"))
+
+        check(base, "",
+              notDirectory:     "http://example.com/path/",
+              isDirectory:      "http://example.com/path/",
+              inferFromPath:    "http://example.com/path/")
+        check(base, "/",
+              notDirectory:     "http://example.com/path/",
+              isDirectory:      "http://example.com/path/",
+              inferFromPath:    "http://example.com/path/")
+        check(base, "//",
+              notDirectory:     "http://example.com/path//",
+              isDirectory:      "http://example.com/path//",
+              inferFromPath:    "http://example.com/path//")
+        check(base, ".",
+              notDirectory:     "http://example.com/path/.",
+              isDirectory:      "http://example.com/path/./",
+              inferFromPath:    "http://example.com/path/.")
+        check(base, "..",
+              notDirectory:     "http://example.com/path/..",
+              isDirectory:      "http://example.com/path/../",
+              inferFromPath:    "http://example.com/path/..")
+        check(base, "/.",
+              notDirectory:     "http://example.com/path/.",
+              isDirectory:      "http://example.com/path/./",
+              inferFromPath:    "http://example.com/path/.")
+        check(base, "/..",
+              notDirectory:     "http://example.com/path/..",
+              isDirectory:      "http://example.com/path/../",
+              inferFromPath:    "http://example.com/path/..")
+        check(base, "./",
+              notDirectory:     "http://example.com/path/.",
+              isDirectory:      "http://example.com/path/./",
+              inferFromPath:    "http://example.com/path/./")
+        check(base, "../",
+              notDirectory:     "http://example.com/path/..",
+              isDirectory:      "http://example.com/path/../",
+              inferFromPath:    "http://example.com/path/../")
+        check(base, "a",
+              notDirectory:     "http://example.com/path/a",
+              isDirectory:      "http://example.com/path/a/",
+              inferFromPath:    "http://example.com/path/a")
+        check(base, "/a",
+              notDirectory:     "http://example.com/path/a",
+              isDirectory:      "http://example.com/path/a/",
+              inferFromPath:    "http://example.com/path/a")
+        check(base, "a/",
+              notDirectory:     "http://example.com/path/a",
+              isDirectory:      "http://example.com/path/a/",
+              inferFromPath:    "http://example.com/path/a/")
+        check(base, "a//",
+              notDirectory:     "http://example.com/path/a",
+              isDirectory:      "http://example.com/path/a//",
+              inferFromPath:    "http://example.com/path/a//")
+        check(base, "//a",
+              notDirectory:     "http://example.com/path//a",
+              isDirectory:      "http://example.com/path//a/",
+              inferFromPath:    "http://example.com/path//a")
+        check(base, "é",
+              notDirectory:     "http://example.com/path/%C3%A9",
+              isDirectory:      "http://example.com/path/%C3%A9/",
+              inferFromPath:    "http://example.com/path/%C3%A9")
+
+        // Decomposable with empty host
+        base = try #require(URL(string: "http://"))
+
+        check(base, "",
+              notDirectory:     "http:///",
+              isDirectory:      "http:///",
+              inferFromPath:    "http:///")
+        check(base, "/",
+              notDirectory:     "http:///",
+              isDirectory:      "http:///",
+              inferFromPath:    "http:///")
+        check(base, "//",
+              notDirectory:     "http:///",
+              isDirectory:      "http:////",
+              inferFromPath:    "http:////")
+        check(base, ".",
+              notDirectory:     "http:///.",
+              isDirectory:      "http:///./",
+              inferFromPath:    "http:///.")
+        check(base, "..",
+              notDirectory:     "http:///..",
+              isDirectory:      "http:///../",
+              inferFromPath:    "http:///..")
+        check(base, "/.",
+              notDirectory:     "http:///.",
+              isDirectory:      "http:///./",
+              inferFromPath:    "http:///.")
+        check(base, "/..",
+              notDirectory:     "http:///..",
+              isDirectory:      "http:///../",
+              inferFromPath:    "http:///..")
+        check(base, "./",
+              notDirectory:     "http:///.",
+              isDirectory:      "http:///./",
+              inferFromPath:    "http:///./")
+        check(base, "../",
+              notDirectory:     "http:///..",
+              isDirectory:      "http:///../",
+              inferFromPath:    "http:///../")
+        check(base, "a",
+              notDirectory:     "http:///a",
+              isDirectory:      "http:///a/",
+              inferFromPath:    "http:///a")
+        check(base, "/a",
+              notDirectory:     "http:///a",
+              isDirectory:      "http:///a/",
+              inferFromPath:    "http:///a")
+        check(base, "a/",
+              notDirectory:     "http:///a",
+              isDirectory:      "http:///a/",
+              inferFromPath:    "http:///a/")
+        check(base, "a//",
+              notDirectory:     "http:///a",
+              isDirectory:      "http:///a//",
+              inferFromPath:    "http:///a//")
+        check(base, "//a",
+              notDirectory:     "http:////a",
+              isDirectory:      "http:////a/",
+              inferFromPath:    "http:////a")
+        check(base, "é",
+              notDirectory:     "http:///%C3%A9",
+              isDirectory:      "http:///%C3%A9/",
+              inferFromPath:    "http:///%C3%A9")
+
+        // Decomposable with no host and root path
+        base = try #require(URL(string: "scheme:/"))
+
+        check(base, "",
+              notDirectory:     "scheme:/",
+              isDirectory:      "scheme:/",
+              inferFromPath:    "scheme:/")
+        check(base, "/",
+              notDirectory:     "scheme:/",
+              isDirectory:      "scheme:/",
+              inferFromPath:    "scheme:/")
+        check(base, "//",
+              notDirectory:     "scheme:/",
+              isDirectory:      "scheme:/",
+              inferFromPath:    "scheme:/")
+        check(base, ".",
+              notDirectory:     "scheme:/.",
+              isDirectory:      "scheme:/./",
+              inferFromPath:    "scheme:/.")
+        check(base, "..",
+              notDirectory:     "scheme:/..",
+              isDirectory:      "scheme:/../",
+              inferFromPath:    "scheme:/..")
+        check(base, "/.",
+              notDirectory:     "scheme:/.",
+              isDirectory:      "scheme:/./",
+              inferFromPath:    "scheme:/.")
+        check(base, "/..",
+              notDirectory:     "scheme:/..",
+              isDirectory:      "scheme:/../",
+              inferFromPath:    "scheme:/..")
+        check(base, "./",
+              notDirectory:     "scheme:/.",
+              isDirectory:      "scheme:/./",
+              inferFromPath:    "scheme:/./")
+        check(base, "../",
+              notDirectory:     "scheme:/..",
+              isDirectory:      "scheme:/../",
+              inferFromPath:    "scheme:/../")
+        check(base, "a",
+              notDirectory:     "scheme:/a",
+              isDirectory:      "scheme:/a/",
+              inferFromPath:    "scheme:/a")
+        check(base, "/a",
+              notDirectory:     "scheme:/a",
+              isDirectory:      "scheme:/a/",
+              inferFromPath:    "scheme:/a")
+        check(base, "a/",
+              notDirectory:     "scheme:/a",
+              isDirectory:      "scheme:/a/",
+              inferFromPath:    "scheme:/a/")
+        check(base, "a//",
+              notDirectory:     "scheme:/a",
+              isDirectory:      "scheme:/a//",
+              inferFromPath:    "scheme:/a//")
+        check(base, "//a",
+              notDirectory:     "scheme:/a",
+              isDirectory:      "scheme:/a/",
+              inferFromPath:    "scheme:/a")
+        check(base, "é",
+              notDirectory:     "scheme:/%C3%A9",
+              isDirectory:      "scheme:/%C3%A9/",
+              inferFromPath:    "scheme:/%C3%A9")
+
+        // Decomposable with empty relative path
+        base = try #require(URL(string: "?query"))
+
+        check(base, "",
+              notDirectory:     "?query",
+              isDirectory:      "./?query",
+              inferFromPath:    "?query")
+        check(base, "/",
+              notDirectory:     "./?query",
+              isDirectory:      "./?query",
+              inferFromPath:    "./?query")
+        check(base, "//",
+              notDirectory:     "./?query",
+              isDirectory:      ".//?query",
+              inferFromPath:    ".//?query")
+        check(base, ".",
+              notDirectory:     "./.?query",
+              isDirectory:      "././?query",
+              inferFromPath:    "./.?query")
+        check(base, "..",
+              notDirectory:     "./..?query",
+              isDirectory:      "./../?query",
+              inferFromPath:    "./..?query")
+        check(base, "/.",
+              notDirectory:     "./.?query",
+              isDirectory:      "././?query",
+              inferFromPath:    "./.?query")
+        check(base, "/..",
+              notDirectory:     "./..?query",
+              isDirectory:      "./../?query",
+              inferFromPath:    "./..?query")
+        check(base, "./",
+              notDirectory:     "./.?query",
+              isDirectory:      "././?query",
+              inferFromPath:    "././?query")
+        check(base, "../",
+              notDirectory:     "./..?query",
+              isDirectory:      "./../?query",
+              inferFromPath:    "./../?query")
+        check(base, "a",
+              notDirectory:     "./a?query",
+              isDirectory:      "./a/?query",
+              inferFromPath:    "./a?query")
+        check(base, "/a",
+              notDirectory:     "./a?query",
+              isDirectory:      "./a/?query",
+              inferFromPath:    "./a?query")
+        check(base, "a/",
+              notDirectory:     "./a?query",
+              isDirectory:      "./a/?query",
+              inferFromPath:    "./a/?query")
+        check(base, "a//",
+              notDirectory:     "./a?query",
+              isDirectory:      "./a//?query",
+              inferFromPath:    "./a//?query")
+        check(base, "//a",
+              notDirectory:     ".//a?query",
+              isDirectory:      ".//a/?query",
+              inferFromPath:    ".//a?query")
+        check(base, "é",
+              notDirectory:     "./%C3%A9?query",
+              isDirectory:      "./%C3%A9/?query",
+              inferFromPath:    "./%C3%A9?query")
+
+        // Decomposable with query and fragment
+        base = try #require(URL(string: "https://example.com?q=1#f"))
+        check(base, "",
+              notDirectory:     "https://example.com/?q=1#f",
+              isDirectory:      "https://example.com/?q=1#f",
+              inferFromPath:    "https://example.com/?q=1#f")
+        check(base, "more",
+              notDirectory:     "https://example.com/more?q=1#f",
+              isDirectory:      "https://example.com/more/?q=1#f",
+              inferFromPath:    "https://example.com/more?q=1#f")
+        check(base, "more/",
+              notDirectory:     "https://example.com/more?q=1#f",
+              isDirectory:      "https://example.com/more/?q=1#f",
+              inferFromPath:    "https://example.com/more/?q=1#f")
+
+        base = try #require(URL(string: "https://example.com/p?q=1#f"))
+        check(base, "",
+              notDirectory:     "https://example.com/p/?q=1#f",
+              isDirectory:      "https://example.com/p/?q=1#f",
+              inferFromPath:    "https://example.com/p/?q=1#f")
+        check(base, "more",
+              notDirectory:     "https://example.com/p/more?q=1#f",
+              isDirectory:      "https://example.com/p/more/?q=1#f",
+              inferFromPath:    "https://example.com/p/more?q=1#f")
+        check(base, "more/",
+              notDirectory:     "https://example.com/p/more?q=1#f",
+              isDirectory:      "https://example.com/p/more/?q=1#f",
+              inferFromPath:    "https://example.com/p/more/?q=1#f")
+
+        // Decomposable with more authority components
+        base = try #require(URL(string: "https://user:pass@example.com:8080/a"))
+        check(base, "b",
+              notDirectory:     "https://user:pass@example.com:8080/a/b",
+              isDirectory:      "https://user:pass@example.com:8080/a/b/",
+              inferFromPath:    "https://user:pass@example.com:8080/a/b")
+
+        // Percent-encoded path remains encoded
+        base = try #require(URL(string: "https://example.com/a%20b"))
+        check(base, "c",
+              notDirectory:     "https://example.com/a%20b/c",
+              isDirectory:      "https://example.com/a%20b/c/",
+              inferFromPath:    "https://example.com/a%20b/c")
+
+        // Components with special characters that should be percent-encoded
+        base = try #require(URL(string: "https://example.com/a"))
+        check(base, " spaced ",
+              notDirectory:     "https://example.com/a/%20spaced%20",
+              isDirectory:      "https://example.com/a/%20spaced%20/",
+              inferFromPath:    "https://example.com/a/%20spaced%20")
+        check(base, "?",
+              notDirectory:     "https://example.com/a/%3F",
+              isDirectory:      "https://example.com/a/%3F/",
+              inferFromPath:    "https://example.com/a/%3F")
+
+        // Already-percent-encoded sequences are re-encoded literally
+        check(base, "%2F",
+              notDirectory:     "https://example.com/a/%252F",
+              isDirectory:      "https://example.com/a/%252F/",
+              inferFromPath:    "https://example.com/a/%252F")
+        #if !os(Windows)
+        check(base, "back\\slash",
+              notDirectory:     "https://example.com/a/back%5Cslash",
+              isDirectory:      "https://example.com/a/back%5Cslash/",
+              inferFromPath:    "https://example.com/a/back%5Cslash")
+        #endif
+
+        base = try #require(URL(string: "mailto:"))
+        check(base, "user@example.com",
+              notDirectory:     "mailto:user@example.com",
+              isDirectory:      "mailto:user@example.com/",
+              inferFromPath:    "mailto:user@example.com")
+    }
+
+    @Test(.enabled(if: foundation_swift_url_v2_enabled()))
+    func appendingPathComponentCheckFilesystem() async throws {
+        // For file URLs, .checkFileSystem uses lstat() to decide directory-ness.
+        try await FilePlayground {
+            Directory("dir") {
+                "nestedFile"
+            }
+            File("file.txt")
+            SymbolicLink("symlinkToFile", destination: "file.txt")
+            SymbolicLink("symlinkToDir", destination: "dir")
+            SymbolicLink("danglingSymlink", destination: "doesNotExist")
+        }.test {
+            let base = URL(filePath: $0.currentDirectoryPath, directoryHint: .isDirectory)
+            let basePrefix = base.absoluteString
+
+            func checkFile(
+                _ component: String,
+                absoluteSuffix: String,
+                hasDirectoryPath: Bool,
+                sourceLocation: SourceLocation = #_sourceLocation
+            ) {
+                let expected = basePrefix + absoluteSuffix
+                var appended = base.appending(path: component, directoryHint: .checkFileSystem)
+                #expect(appended.absoluteString == expected, sourceLocation: sourceLocation)
+                #expect(appended.hasDirectoryPath == hasDirectoryPath, sourceLocation: sourceLocation)
+
+                // .appendingPathComponent(_:) defaults to .checkFileSystem
+                appended = base.appendingPathComponent(component)
+                #expect(appended.absoluteString == expected, sourceLocation: sourceLocation)
+                #expect(appended.hasDirectoryPath == hasDirectoryPath, sourceLocation: sourceLocation)
+            }
+
+            // Existing regular file -> not a directory.
+            checkFile("file.txt",
+                      absoluteSuffix: "file.txt",
+                      hasDirectoryPath: false)
+            checkFile("file.txt/",
+                      absoluteSuffix: "file.txt",
+                      hasDirectoryPath: false)
+
+            // Existing directory -> directory.
+            checkFile("dir",
+                      absoluteSuffix: "dir/",
+                      hasDirectoryPath: true)
+            checkFile("dir/",
+                      absoluteSuffix: "dir/",
+                      hasDirectoryPath: true)
+
+            // Existing nested file inside a directory -> not a directory.
+            checkFile("dir/nestedFile",
+                      absoluteSuffix: "dir/nestedFile",
+                      hasDirectoryPath: false)
+            checkFile("dir/nestedFile/",
+                      absoluteSuffix: "dir/nestedFile",
+                      hasDirectoryPath: false)
+
+            // Existing symlink to a regular file -> not a directory.
+            checkFile("symlinkToFile",
+                      absoluteSuffix: "symlinkToFile",
+                      hasDirectoryPath: false)
+            checkFile("symlinkToFile/",
+                      absoluteSuffix: "symlinkToFile",
+                      hasDirectoryPath: false)
+
+            // Existing symlink to a directory -> not a directory.
+            // URL uses lstat() which does not follow the trailing symlink.
+            checkFile("symlinkToDir",
+                      absoluteSuffix: "symlinkToDir",
+                      hasDirectoryPath: false)
+            checkFile("symlinkToDir/",
+                      absoluteSuffix: "symlinkToDir",
+                      hasDirectoryPath: false)
+
+            // Existing dangling symlink (target missing) -> not a directory.
+            // lstat() sees the symlink itself, so the trailing slash is dropped.
+            checkFile("danglingSymlink",
+                      absoluteSuffix: "danglingSymlink",
+                      hasDirectoryPath: false)
+            checkFile("danglingSymlink/",
+                      absoluteSuffix: "danglingSymlink",
+                      hasDirectoryPath: false)
+
+            // Non-existent path with no trailing slash -> not a directory.
+            checkFile("missing",
+                      absoluteSuffix: "missing",
+                      hasDirectoryPath: false)
+
+            // Non-existent path with trailing slash -> trailing slash honored.
+            checkFile("missing/",
+                      absoluteSuffix: "missing/",
+                      hasDirectoryPath: true)
+        }
+
+        // For non-file URLs, .checkFileSystem is treated as .inferFromPath.
+        let httpBase = try #require(URL(string: "https://example.com/base/"))
+
+        func checkHTTP(
+            _ component: String,
+            absoluteString: String,
+            hasDirectoryPath: Bool,
+            sourceLocation: SourceLocation = #_sourceLocation
+        ) {
+            var appended = httpBase.appending(path: component, directoryHint: .checkFileSystem)
+            #expect(appended.absoluteString == absoluteString, sourceLocation: sourceLocation)
+            #expect(appended.hasDirectoryPath == hasDirectoryPath, sourceLocation: sourceLocation)
+
+            appended = httpBase.appendingPathComponent(component)
+            #expect(appended.absoluteString == absoluteString, sourceLocation: sourceLocation)
+            #expect(appended.hasDirectoryPath == hasDirectoryPath, sourceLocation: sourceLocation)
+        }
+
+        checkHTTP("a/b",
+                  absoluteString: "https://example.com/base/a/b",
+                  hasDirectoryPath: false)
+        checkHTTP("a/b/",
+                  absoluteString: "https://example.com/base/a/b/",
+                  hasDirectoryPath: true)
     }
 
     @Test(arguments: [
@@ -1158,6 +2741,110 @@ private struct URLTests {
 
         schemeRelative.deleteLastPathComponent()
         #expect(schemeRelative.relativePath == "")
+
+        // Deleting from an empty path is a no-op and keeps any query and fragment.
+        url = try #require(URL(string: "scheme:"))
+        var result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "scheme:")
+
+        url = try #require(URL(string: "https://example.com?q=1#f"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "https://example.com?q=1#f")
+
+        // Scheme-only URLs with paths
+        url = try #require(URL(string: "scheme:relative/"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "scheme:")
+
+        url = try #require(URL(string: "scheme:a/b/c"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "scheme:a/b/")
+
+        // All-slashes paths stay at the root after delete
+        url = try #require(URL(string: "scheme:////"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "scheme:///")
+
+        // Single-character relative URL: delete leaves "./"
+        url = try #require(URL(string: "a"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "./")
+
+        // Trailing "." or ".." should not be deleted like a regular
+        // component. Replace "." with "..", or append ".." to an existing "..".
+        url = try #require(URL(string: ".."))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "../../")
+
+        url = try #require(URL(string: "."))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "../")
+
+        if foundation_swift_url_v2_enabled() {
+            // v1 implementation deletes the "." and ".." right out
+            url = try #require(URL(string: "https://example.com/a/."))
+            result = url.deletingLastPathComponent()
+            #expect(result.absoluteString == "https://example.com/a/../")
+
+            url = try #require(URL(string: "https://example.com/a/.."))
+            result = url.deletingLastPathComponent()
+            #expect(result.absoluteString == "https://example.com/a/../../")
+        }
+
+        // Trailing slashes are stripped before searching for the last component
+        url = try #require(URL(string: "https://example.com/a/b///"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "https://example.com/a/")
+
+        // Query and fragment are preserved across delete
+        url = try #require(URL(string: "https://example.com/a/b?q=1#f"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "https://example.com/a/?q=1#f")
+        #expect(result.query() == "q=1")
+        #expect(result.fragment() == "f")
+
+        // Empty relative path: delete prepends ".." and preserves query/fragment
+        url = try #require(URL(string: "?query#frag"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "../?query#frag")
+
+        // Percent-encoded paths preserve their encoding
+        url = try #require(URL(string: "https://example.com/a%20b/c"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "https://example.com/a%20b/")
+        #expect(result.path(percentEncoded: false) == "/a b/")
+
+        // %2E (encoded dot) is treated literally, not as a dot segment
+        url = try #require(URL(string: "https://example.com/x/%2E"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "https://example.com/x/")
+
+        // %2F (encoded slash) is preserved as part of the component, not a separator
+        url = try #require(URL(string: "https://example.com/a/b%2Fc"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "https://example.com/a/")
+
+        // Relative URL with base
+        let httpBase = try #require(URL(string: "https://example.com/base/dir/"))
+        let httpRel = try #require(URL(string: "sub/file", relativeTo: httpBase))
+        result = httpRel.deletingLastPathComponent()
+        #expect(result.relativeString == "sub/")
+        #expect(result.absoluteString == "https://example.com/base/dir/sub/")
+        #expect(result.path == "/base/dir/sub")
+
+        url = try #require(URL(string: "scheme:ab"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "scheme:")
+
+        url = try #require(URL(string: "a:b"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "a:")
+
+        url = try #require(URL(string: "scheme:a/b"))
+        result = url.deletingLastPathComponent()
+        #expect(result.absoluteString == "scheme:a/")
+        result = result.deletingLastPathComponent()
+        #expect(result.absoluteString == "scheme:")
     }
 
     @Test func deletingLastPathComponentWithBase() throws {
@@ -1370,7 +3057,13 @@ private struct URLTests {
 
         emptyHost.append(path: "")
         #expect(emptyHost.host() == nil)
-        #expect(emptyHost.path().isEmpty)
+        if foundation_swift_url_v2_enabled() {
+            // Treat "scheme://" the same as other URLs with an authority
+            // component and insert a "/" to separate authority from path.
+            #expect(emptyHost.path() == "/")
+        } else {
+            #expect(emptyHost.path().isEmpty)
+        }
 
         emptyHost.append(path: "foo")
         #expect(emptyHost.host()?.isEmpty ?? true)
@@ -1388,6 +3081,32 @@ private struct URLTests {
         // Old behavior appends to the string, but is missing the path
         checkBehavior(schemeOnly.path(), new: "foo", old: "")
         #expect(schemeOnly.absoluteString == "scheme:foo")
+    }
+
+    // A scheme-less relative reference with an empty path ("?q", "#frag") must
+    // keep the appended component as a relative path. A bare component that
+    // looks like a scheme ("foo:bar") would otherwise re-parse as one.
+    @Test func appendingToRelativeReferenceWithEmptyPath() throws {
+        func expectNoScheme(_ url: URL, _ string: String, sourceLocation: SourceLocation = #_sourceLocation) {
+            #expect(url.absoluteString == string, sourceLocation: sourceLocation)
+            #expect(url.scheme == nil, sourceLocation: sourceLocation)
+            // Re-parsing the result must not introduce a scheme
+            #expect(URL(string: url.absoluteString)?.scheme == nil, sourceLocation: sourceLocation)
+        }
+
+        var base = try #require(URL(string: "?q"))
+        expectNoScheme(base.appending(path: "foo:bar"), "./foo:bar?q")
+        #expect(base.appending(path: "foo").absoluteString == "./foo?q")
+
+        base = try #require(URL(string: "#frag"))
+        expectNoScheme(base.appending(path: "foo:bar"), "./foo:bar#frag")
+        expectNoScheme(base.appending(component: "foo:bar"), "./foo:bar#frag")
+        #expect(base.appending(path: "foo", directoryHint: .isDirectory).absoluteString == "./foo/#frag")
+
+        // ":" is allowed in a relative path if a scheme already exists
+        let schemeOnly = try #require(URL(string: "scheme:")).appending(path: "foo:bar")
+        #expect(schemeOnly.absoluteString == "scheme:foo:bar")
+        #expect(schemeOnly.scheme == "scheme")
     }
 
     @Test func emptySchemeCompatibility() throws {
@@ -1445,42 +3164,54 @@ private struct URLTests {
 
         #expect(url.user() == "%3Auser")
         #expect(url.user(percentEncoded: false) == ":user")
+        #expect(url.user == ":user")
 
         #expect(url.password() == "%3Apassword")
         #expect(url.password(percentEncoded: false) == ":password")
+        #expect(url.password == "%3Apassword")
 
         #expect(url.host() == "%3A.com")
         #expect(url.host(percentEncoded: false) == ":.com")
+        #expect(url.host == ":.com")
 
         #expect(url.path() == "/%3Apath")
         #expect(url.path(percentEncoded: false) == "/:path")
+        #expect(url.path == "/:path")
 
         #expect(url.query() == "%3Aquery=%3A")
         #expect(url.query(percentEncoded: false) == ":query=:")
+        #expect(url.query == "%3Aquery=%3A")
 
         #expect(url.fragment() == "%3Afragment")
         #expect(url.fragment(percentEncoded: false) == ":fragment")
+        #expect(url.fragment == "%3Afragment")
 
         // Lowercase input
         url = URL(string: "https://%3auser:%3apassword@%3a.com/%3apath?%3aquery=%3a#%3afragment")!
 
         #expect(url.user() == "%3auser")
         #expect(url.user(percentEncoded: false) == ":user")
+        #expect(url.user == ":user")
 
         #expect(url.password() == "%3apassword")
         #expect(url.password(percentEncoded: false) == ":password")
+        #expect(url.password == "%3apassword")
 
         #expect(url.host() == "%3a.com")
         #expect(url.host(percentEncoded: false) == ":.com")
+        #expect(url.host == ":.com")
 
         #expect(url.path() == "/%3apath")
         #expect(url.path(percentEncoded: false) == "/:path")
+        #expect(url.path == "/:path")
 
         #expect(url.query() == "%3aquery=%3a")
         #expect(url.query(percentEncoded: false) == ":query=:")
+        #expect(url.query == "%3aquery=%3a")
 
         #expect(url.fragment() == "%3afragment")
         #expect(url.fragment(percentEncoded: false) == ":fragment")
+        #expect(url.fragment == "%3afragment")
     }
 
     @Test func componentsUppercasePercentEncoding() throws {
@@ -1875,16 +3606,13 @@ private struct URLTests {
         #expect(comp.path == "/my\u{0}path")
     }
 
-    @Test func standardizedDotSegments() throws {
-        var standardized = try #require(URL(string: "../../../")).standardized
-        // URL should not remove leading dot segments until it's actually
-        // resolved against a base (longstanding CFURL behavior, too).
-        #expect(standardized.path() == "../../../")
-
+    @Test func standardizedAfterAppending() throws {
+        // After appending ".." to a relative URL with a base, standardizing
+        // resolves the dot segment against the resolved absolute path.
         let base = URL(filePath: "/base/directory/")
         let relative = URL(filePath: "dev", relativeTo: base)
         let combined = relative.appending(path: "../thing")
-        standardized = combined.standardized
+        let standardized = combined.standardized
         let expected = URL(filePath: "thing", relativeTo: base)
 
         #expect(standardized == expected)
@@ -1896,12 +3624,31 @@ private struct URLTests {
         #expect(standardized.absoluteURL.path() == "/base/directory/thing")
     }
 
-    @Test func standardizedEdgeCases() throws {
+    @Test func standardized() throws {
+        // No-op for empty or non-decomposable URLs
+        var url = try #require(URL(string: "https://example.com"))
+        #expect(url.standardized.absoluteString == "https://example.com")
+        #expect(url.standardized.path() == "")
+
+        url = try #require(URL(string: "scheme:"))
+        #expect(url.standardized.absoluteString == "scheme:")
+
+        url = try #require(URL(string: "scheme:relative/path"))
+        #expect(url.standardized.absoluteString == "scheme:relative/path")
+
+        url = try #require(URL(string: "."))
+        #expect(url.standardized.absoluteString == ".")
+
         // Empty path with empty authority standardizes to "/"
-        var url = try #require(URL(string: "https://"))
+        url = try #require(URL(string: "https://"))
         #expect(url.standardized.relativeString == "https:///")
         #expect(url.standardized.path() == "/")
 
+        // Non-decomposable URL returns self
+        url = try #require(URL(string: "mailto:user@example.com"))
+        #expect(url.standardized.absoluteString == "mailto:user@example.com")
+
+        // Dot segment resolution
         url = try #require(URL(string: "https://example.com/a/b/../c/./d"))
         #expect(url.standardized.path() == "/a/c/d")
 
@@ -1911,9 +3658,33 @@ private struct URLTests {
         url = try #require(URL(string: "https://example.com/a/b/.."))
         #expect(url.standardized.path() == "/a/")
 
+        // %2E is treated literally and is NOT a dot segment
+        url = try #require(URL(string: "https://example.com/a/%2E/b"))
+        #expect(url.standardized.absoluteString == "https://example.com/a/%2E/b")
+
+        // Multiple consecutive slashes are preserved (not collapsed)
+        url = try #require(URL(string: "https://example.com/a//b"))
+        #expect(url.standardized.absoluteString == "https://example.com/a//b")
+
+        // Percent-encoding is preserved through dot resolution
+        url = try #require(URL(string: "https://example.com/a%20b/./c"))
+        var result = url.standardized
+        #expect(result.absoluteString == "https://example.com/a%20b/c")
+        #expect(result.path(percentEncoded: false) == "/a b/c")
+
+        // Query and fragment are preserved through dot resolution
+        url = try #require(URL(string: "https://example.com/a/b/../c?q=1#frag"))
+        result = url.standardized
+        #expect(result.absoluteString == "https://example.com/a/c?q=1#frag")
+        #expect(result.query() == "q=1")
+        #expect(result.fragment() == "frag")
+
         // Preserve leading dot segments until resolution (RFC 1808)
         url = try #require(URL(string: "https://example.com/../../a"))
         #expect(url.standardized.path() == "/../../a")
+
+        url = try #require(URL(string: "../../../"))
+        #expect(url.standardized.path() == "../../../")
 
         url = try #require(URL(string: "../../a/b"))
         #expect(url.standardized.path() == "../../a/b")
@@ -1936,11 +3707,61 @@ private struct URLTests {
         #expect(url.relativeString == "..")
         #expect(url.hasDirectoryPath)
 
-        #if FOUNDATION_FRAMEWORK
-        // Non-decomposable URL returns self
-        url = try #require(URL(string: "mailto:user@example.com"))
-        #expect(url.standardized.absoluteString == "mailto:user@example.com")
-        #endif
+        // Relative URL with base resolves dot segments via the base
+        let httpBase = try #require(URL(string: "https://example.com/base/dir/"))
+        let httpRel = try #require(URL(string: "../sibling", relativeTo: httpBase))
+        result = httpRel.standardized
+        #expect(result.relativeString == "../sibling")
+        #expect(result.absoluteString == "https://example.com/base/sibling")
+
+        // Schemes with absolute path are given an empty authority "//"
+        url = try #require(URL(string: "file:/"))
+        #expect(url.standardized.absoluteString == "file:///")
+
+        url = try #require(URL(string: "file:/path"))
+        #expect(url.standardized.absoluteString == "file:///path")
+
+        // Canonicalization and dot resolution happen in one pass
+        url = try #require(URL(string: "file:/a/./b/../c"))
+        #expect(url.standardized.absoluteString == "file:///a/c")
+
+        url = try #require(URL(string: "custom:/path/./more"))
+        #expect(url.standardized.absoluteString == "custom:///path/more")
+
+        // Standardizing dot segments must not introduce an authority
+        url = try #require(URL(string: "foo/..///host"))
+        #expect(url.standardized.absoluteString == "host")
+        #expect(url.standardized.host() == nil)
+        #expect(URL(string: url.standardized.absoluteString)?.host() == nil)
+
+        url = try #require(URL(string: "scheme:/a/..///host"))
+        #expect(url.standardized.absoluteString == "scheme://///host")
+        #expect(url.standardized.host() == nil)
+        #expect(URL(string: url.standardized.absoluteString)?.host() == nil)
+
+        // Dot resolution can move a colon-bearing segment to the front of a
+        // scheme-less path. The result must not re-parse as having a scheme.
+        if foundation_swift_url_v2_enabled() {
+            url = try #require(URL(string: "./foo:bar"))
+            #expect(url.standardized.relativeString == "./foo:bar")
+            #expect(url.standardized.scheme == nil)
+            #expect(URL(string: url.standardized.absoluteString)?.scheme == nil)
+
+            url = try #require(URL(string: "a/../b:c"))
+            #expect(url.standardized.relativeString == "./b:c")
+            #expect(url.standardized.scheme == nil)
+            #expect(URL(string: url.standardized.absoluteString)?.scheme == nil)
+
+            url = try #require(URL(string: "a/../:b"))
+            #expect(url.standardized.relativeString == "./:b")
+            #expect(url.standardized.scheme == nil)
+            #expect(URL(string: url.standardized.absoluteString)?.scheme == nil)
+
+            url = try #require(URL(string: "a/../12:34"))
+            #expect(url.standardized.relativeString == "./12:34")
+            #expect(url.standardized.scheme == nil)
+            #expect(URL(string: url.standardized.absoluteString)?.scheme == nil)
+        }
     }
 
     @Test func pathComponents() throws {
@@ -2178,7 +3999,7 @@ private struct URLTests {
         #expect(url.lastPathComponent == "c")
     }
 
-    @Test func pathExtensionsContinued() throws {
+    @Test func pathExtensionProperty() throws {
         var url = URL(filePath: "/file")
         #expect(url.pathExtension == "")
 
@@ -2274,6 +4095,13 @@ private struct URLTests {
         extended = url.appendingPathExtension("txt")
         #expect(extended.path() == "/file.txt")
 
+        if foundation_swift_url_v2_enabled() {
+            extended = url.appendingPathExtension("txt\u{0}")
+            #expect(extended.path() == "/file.txt")
+            extended = url.appendingPathExtension("txt\u{0}\u{0}")
+            #expect(extended.path() == "/file.txt")
+        }
+
         // Preserves trailing slash for directories
         url = URL(filePath: "/dir/file", directoryHint: .isDirectory)
         extended = url.appendingPathExtension("txt")
@@ -2300,6 +4128,9 @@ private struct URLTests {
         #expect(extended.query() == "q=1")
         #expect(extended.fragment() == "frag")
 
+        extended = url.appendingPathExtension("txt\u{0}")
+        #expect(extended.path() == "/file.txt%00")
+
         // Relative path with base
         let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
         url = URL(filePath: "file", relativeTo: base)
@@ -2309,6 +4140,68 @@ private struct URLTests {
         url = try #require(URL(string: "scheme:file"))
         extended = url.appendingPathExtension("txt")
         #expect(extended.absoluteString == "scheme:file.txt")
+
+        // All-slashes path returns self
+        url = try #require(URL(string: "https://example.com//"))
+        extended = url.appendingPathExtension("ext")
+        if foundation_swift_url_v2_enabled() {
+            #expect(extended.absoluteString == "https://example.com//")
+        } else {
+            #expect(extended.absoluteString == "https://example.com/.ext/")
+        }
+
+        // Leading-dot extension just inserts the dot separator
+        url = URL(filePath: "/file")
+        extended = url.appendingPathExtension(".tar")
+        #expect(extended.absoluteString == "file:///file..tar")
+
+        // Multiple trailing slashes
+        url = try #require(URL(string: "https://example.com/dir//"))
+        extended = url.appendingPathExtension("ext")
+        #expect(extended.absoluteString == "https://example.com/dir.ext/")
+
+        url = try #require(URL(string: "https://example.com/a%20b"))
+        extended = url.appendingPathExtension("txt")
+        #expect(extended.absoluteString == "https://example.com/a%20b.txt")
+        #expect(extended.path(percentEncoded: false) == "/a b.txt")
+
+        url = try #require(URL(string: "scheme:dir/"))
+        extended = url.appendingPathExtension("ext")
+        #expect(extended.absoluteString == "scheme:dir.ext/")
+
+        let httpBase = try #require(URL(string: "https://example.com/base/"))
+        let httpRel = try #require(URL(string: "sub/file", relativeTo: httpBase))
+        extended = httpRel.appendingPathExtension("txt")
+        #expect(extended.relativeString == "sub/file.txt")
+        #expect(extended.absoluteString == "https://example.com/base/sub/file.txt")
+
+        // Last component is "." or ".."
+        url = try #require(URL(string: "https://example.com/a/."))
+        extended = url.appendingPathExtension("ext")
+        #expect(extended.absoluteString == "https://example.com/a/..ext")
+
+        url = try #require(URL(string: "https://example.com/a/.."))
+        extended = url.appendingPathExtension("ext")
+        #expect(extended.absoluteString == "https://example.com/a/...ext")
+
+        url = URL(filePath: "/file")
+        extended = url.appendingPathExtension("ßeta")
+        #expect(extended.absoluteString == "file:///file.%C3%9Feta")
+
+        // Extension with percent-encoded characters is re-encoded
+        url = URL(filePath: "/file")
+        extended = url.appendingPathExtension("a%20b")
+        #expect(extended.absoluteString == "file:///file.a%2520b")
+
+        // Appending an extension with ":" to a relative path must
+        // not cause the path to be interpreted as a scheme.
+        if foundation_swift_url_v2_enabled() {
+            url = try #require(URL(string: "fake"))
+            extended = url.appendingPathExtension("scheme:path")
+            #expect(extended.scheme == nil)
+            #expect(extended.path() == "./fake.scheme:path")
+            #expect(extended.absoluteString == "./fake.scheme:path")
+        }
     }
 
     @Test func deletingPathExtension() throws {
@@ -2390,6 +4283,42 @@ private struct URLTests {
         #expect(url.pathExtension == "framework") // From the absolute path
         #expect(url.deletingPathExtension() == url)
         #expect(url.deletingPathExtension().path() == "/path/dir.framework/")
+
+        // All-slashes path returns self (no component to strip)
+        url = try #require(URL(string: "https://example.com///"))
+        #expect(url.deletingPathExtension().absoluteString == "https://example.com///")
+
+        // Multi-dot single component: only the last extension is removed
+        url = URL(filePath: "/a/b.c.d.e")
+        #expect(url.deletingPathExtension().absoluteString == "file:///a/b.c.d")
+
+        // %2E is treated literally and is not recognized as the extension separator
+        url = try #require(URL(string: "https://example.com/file%2Etxt"))
+        #expect(url.deletingPathExtension().absoluteString == "https://example.com/file%2Etxt")
+
+        // Non-file URL: %2F decodes, so "name%2F.hidden" has no extension
+        url = try #require(URL(string: "https://example.com/name%2F.hidden"))
+        #expect(url.deletingPathExtension().absoluteString == "https://example.com/name%2F")
+
+        // File URL: %2F is preserved as part of the component, so "name%2F.txt" has extension "txt"
+        url = try #require(URL(string: "file:///dir/name%2F.txt"))
+        #expect(url.deletingPathExtension().absoluteString == "file:///dir/name%2F")
+
+        url = try #require(URL(string: "scheme:dir/file.txt"))
+        #expect(url.deletingPathExtension().absoluteString == "scheme:dir/file")
+
+        let httpBase = try #require(URL(string: "https://example.com/base/dir/"))
+        let httpRel = try #require(URL(string: "sub/file.txt", relativeTo: httpBase))
+        deleted = httpRel.deletingPathExtension()
+        #expect(deleted.relativeString == "sub/file")
+        #expect(deleted.absoluteString == "https://example.com/base/dir/sub/file")
+
+        // Last component is "." or ".." - treated as having no extension
+        url = try #require(URL(string: "https://example.com/."))
+        #expect(url.deletingPathExtension().absoluteString == "https://example.com/.")
+
+        url = try #require(URL(string: "https://example.com/.."))
+        #expect(url.deletingPathExtension().absoluteString == "https://example.com/..")
     }
 
     @Test func hasDirectoryPathDotSegments() throws {


### PR DESCRIPTION
Improve correctness, compatibility, and performance of file-path parsing and manipulation in the Swift 6.4 `URL` v2 implementation, with ~2,000 new lines of unit tests to lock down the behavior and achieve near-100% code coverage.

### Motivation:

The path-manipulation methods should not be able to introduce or change a `URL`'s scheme or host, and the stored string should always be unambiguous. Prior `CF`/`NS`/`URL` implementations have ambiguities here because they don't follow RFC 3986 Section 4.2 in many cases. This change closes those ambiguities, aligns behavior with the previous Swift `URL` (v1) for compatibility in some edge cases, and improves path manipulation performance with minor code size wins along the way.

### Modifications:

**Prevent path manipulation from introducing a new scheme or host**

- Following RFC 3986 Section 4.2, path manipulation methods now prepend `./` to a relative path that has no scheme or host and whose first segment contains `:`. For example, `URL("?query").appending(path: "fake:scheme")` becomes `./fake:scheme?query`, so it can't re-parse as having a scheme.
- A path with no host is no longer allowed to begin with `//` (the leading slashes are compressed), which would otherwise re-parse as having a host. Note that this does not affect the common case of canonical `file://` URLs with empty host, e.g. it does not affect `URL(filePath: #"\\server\share"#)` on Windows.
- A new debug `assert` in `_URLInfo.replacingPath` requires that the result is identical to re-parsing the whole string, a strong invariant for the wide range of test and fuzzer inputs to these APIs.

**Align with previous Swift `URL` (v1) in some edge cases**

- Appending `""` to e.g. `http://example.com/path` appends a trailing slash regardless of `isDirectory == false`. Some apps rely on this as a way to append a trailing slash.
- `URL(filePath:)` encodes _every_ `:` in the first segment of a relative path, even when preceding characters aren't scheme-legal.
- `URL(filePath:)`, `appending(path:)`, and `appendingPathExtension(_:)` strip trailing null bytes for file URLs.
- `URL(filePath:)` fixes and logs errors for API misuse when given a full URL string instead of a file path (gated on linked-on-or-after).
- `.standardized` expands `file:/path` to `file:///path` and `scheme://` to `scheme:///`.
- `.appending(component: "folder/", directoryHint: .inferFromPath)` no longer both encodes and appends a trailing slash (resolves #1931).

**Re-organized the appending code to highlight a clear set of rules:**

- `path/` + `/component` drops one slash to avoid a double slash.
- `path` + `component` inserts a single slash.
- `isDirectory: false` strips trailing slashes from the component, but not from the current path.
- `isDirectory: true` adds a trailing slash if one isn't already present.
- An empty relative path with no scheme or host is treated as `.`, so `.` + `fake:scheme` becomes `./fake:scheme` (unambiguous).
- Appending to a scheme-only URL appends directly (`mailto:` + `user@example.com` becomes `mailto:user@example.com`), compressing leading `//` so it isn't read as an authority.

**Performance / code size**

- `_URLInfo.replacingPath` writes the new path directly into the destination `String` buffer (one allocation) instead of building it in a temporary allocation and copying.
- Removed `@inline(__always)` annotations that were either already inlined or bloated code size without a perf benefit. In particular, the `_URLInfo.substring(_:)` helper (~179 lines of `String.utf8` index arithmetic) was pushing the simple component accessors over the inlining size threshold and preventing them from being inlined upward.
- Avoid a `String` copy when the appended `StringProtocol` is already a `String`, via `_specialize`.

### Result:

- Path-manipulation methods can no longer introduce or change a scheme or host, and always produce an unambiguous stored string that round-trips through the parser.
- Behavior matches the previous Swift `URL` (v1) in some edge cases.
- Appending edge cases now follow a clearer, more organized set of rules.
- `URL` path manipulation is 10-20% faster than the prior v2 implementation.

### Testing:

- ~2,000 new lines of unit tests lock down this behavior and reach near-100% coverage of `URL_Impl.swift`.
- Running these URL APIs with fuzzer inputs and the `assert` in `_URLInfo.replacingPath` enabled shows no ambiguities.
