### PR TITLE
Fix typos in doc comments

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -242,14 +242,14 @@ extension AttributedStringProtocol { // Equatable, Hashable
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedStringProtocol {
-    /// Returns the position of the character immediately after another charcter indicated by an index.
+    /// Returns the position of the character immediately after another character indicated by an index.
     ///
     /// - Parameter i: The index of a character in the attributed string.
     /// - Returns: The position of the character immediately after the character at index `i`.
     public func index(afterCharacter i: AttributedString.Index) -> AttributedString.Index {
         self.characters.index(after: i)
     }
-    /// Returns the position of the character immediately before another charcter indicated by an index.
+    /// Returns the position of the character immediately before another character indicated by an index.
     ///
     /// - Parameter i: The index of a character in the attributed string.
     /// - Returns: The position of the character immediately before the character at index `i`.

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -699,7 +699,7 @@ extension Calendar {
         // necessarily occur in the first week of the month.
         
         /// The component where we set the week number, if we are targeting only
-        /// a particular occurence of a weekday
+        /// a particular occurrence of a weekday
         let weekComponent: Calendar.Component = if parent == .month {
             .weekOfMonth
         } else {

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -19,10 +19,10 @@ import FoundationEssentials
 public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {    
     /// The set of supported safely serializable comparisons.
     enum AllowedComparison: Hashable, Codable, Sendable {
-        /// Compare `String` by retrieving from key path, using using the given standard string comparator.
+        /// Compare `String` by retrieving from key path, using the given standard string comparator.
         case comparableString(String.StandardComparator, KeyPath<Compared, String> & Sendable)
         
-        /// Compare `String?` by retrieving from key path, using using the given standard string comparator.
+        /// Compare `String?` by retrieving from key path, using the given standard string comparator.
         case comparableOptionalString(String.StandardComparator, KeyPath<Compared, String?> & Sendable)
         
         /// Compares using `Swift.Comparable` implementation.


### PR DESCRIPTION
Documentation-only fixes in doc comments:

- SortDescriptor: remove duplicated 'using' in two comparator docs.
- Calendar_Recurrence: fix 'occurence' -> 'occurrence'.
- AttributedStringProtocol: fix 'charcter' -> 'character' in two index docs.

No source or behavior changes.