### PR TITLE
Read POSIX locale environment on non-Darwin

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -291,9 +291,22 @@ struct LocaleCache : Sendable, ~Copyable {
     }
 #else
     private static let fallbackLocaleIdentifier = "en_001"
+    private static let maximumPOSIXLocaleIdentifierUTF8Count = 156 // Source: ICU's ULOC_FULLNAME_CAPACITY - 1.
+    private static let allowedPOSIXLocaleIdentifierScalars = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.@".unicodeScalars)
 
+    // Source: ICU's POSIX default-locale lookup uses LC_MESSAGES, indirectly
+    // following POSIX setlocale(3)'s category order: LC_ALL, the category
+    // variable, then LANG. POSIX locale names commonly use
+    // language[_territory][.codeset][@modifier]; Foundation's locale identifier
+    // for this fallback only needs the base language/territory/variant portion.
     private static func _localeIdentifier(fromPOSIXLocaleIdentifier identifier: String) -> String? {
         guard !identifier.isEmpty && identifier != "C" && identifier != "POSIX" else {
+            return nil
+        }
+        guard identifier.utf8.count <= Self.maximumPOSIXLocaleIdentifierUTF8Count else {
+            return nil
+        }
+        guard identifier.unicodeScalars.allSatisfy(Self.allowedPOSIXLocaleIdentifierScalars.contains) else {
             return nil
         }
 

--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -290,19 +290,57 @@ struct LocaleCache : Sendable, ~Copyable {
         return preferredLocaleID
     }
 #else
+    private static let fallbackLocaleIdentifier = "en_001"
+
+    private static func _localeIdentifier(fromPOSIXLocaleIdentifier identifier: String) -> String? {
+        guard !identifier.isEmpty && identifier != "C" && identifier != "POSIX" else {
+            return nil
+        }
+
+        let endIndex = identifier.firstIndex { character in
+            character == "." || character == "@"
+        } ?? identifier.endIndex
+        let baseIdentifier = String(identifier[..<endIndex])
+        guard !baseIdentifier.isEmpty && baseIdentifier != "C" && baseIdentifier != "POSIX" else {
+            return nil
+        }
+
+        return baseIdentifier.replacing("-", with: "_")
+    }
+
+    private static func _preferredLanguageIdentifier(fromLocaleIdentifier identifier: String) -> String {
+        let languageIdentifier = String(identifier.split(separator: "@", maxSplits: 1)[0]).replacing("_", with: "-")
+        return Locale.canonicalLanguageIdentifier(from: languageIdentifier)
+    }
+
+    private static func _localeIdentifierFromEnvironment() -> String? {
+        #if !NO_PROCESS && (os(Linux) || os(Android) || os(FreeBSD) || os(OpenBSD) || canImport(Musl))
+        for environmentVariable in ["LC_ALL", "LC_MESSAGES", "LANG"] {
+            guard let value = Platform.getEnvSecure(environmentVariable), !value.isEmpty else {
+                continue
+            }
+            return _localeIdentifier(fromPOSIXLocaleIdentifier: value)
+        }
+        #endif
+
+        return nil
+    }
+
     func preferences() -> (LocalePreferences, Bool) {
         var prefs = LocalePreferences()
-        prefs.locale = "en_001"
-        prefs.languages = ["en-001"]
+        let localeIdentifier = Self._localeIdentifierFromEnvironment() ?? Self.fallbackLocaleIdentifier
+        prefs.locale = localeIdentifier
+        prefs.languages = [Self._preferredLanguageIdentifier(fromLocaleIdentifier: localeIdentifier)]
         return (prefs, true)
     }
 
     func preferredLanguages(forCurrentUser: Bool) -> [String] {
-        [Locale.canonicalLanguageIdentifier(from: "en-001")]
+        let localeIdentifier = Self._localeIdentifierFromEnvironment() ?? Self.fallbackLocaleIdentifier
+        return [Self._preferredLanguageIdentifier(fromLocaleIdentifier: localeIdentifier)]
     }
 
     func preferredLocale() -> String? {
-        "en_001"
+        Self._localeIdentifierFromEnvironment() ?? Self.fallbackLocaleIdentifier
     }
 #endif
 

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -106,6 +106,7 @@ private struct LocaleTests {
         await usingCurrentInternationalizationPreferences {
             withLocaleEnvironment(lcAll: nil, lcMessages: nil, lang: "en_US.UTF-8") {
                 LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "en_US")
                 #expect(Locale.current.identifier == "en_US")
                 #expect(Locale.current.region?.identifier == "US")
                 #expect(Locale.preferredLanguages == ["en-US"])
@@ -113,6 +114,7 @@ private struct LocaleTests {
 
             withLocaleEnvironment(lcAll: nil, lcMessages: "zh_CN.UTF-8", lang: "en_US.UTF-8") {
                 LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "zh_CN")
                 #expect(Locale.current.identifier == "zh_CN")
                 #expect(Locale.current.region?.identifier == "CN")
                 #expect(Locale.preferredLanguages == ["zh-CN"])
@@ -120,6 +122,7 @@ private struct LocaleTests {
 
             withLocaleEnvironment(lcAll: "de_DE.UTF-8", lcMessages: "zh_CN.UTF-8", lang: "en_US.UTF-8") {
                 LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "de_DE")
                 #expect(Locale.current.identifier == "de_DE")
                 #expect(Locale.current.region?.identifier == "DE")
                 #expect(Locale.preferredLanguages == ["de-DE"])
@@ -127,6 +130,7 @@ private struct LocaleTests {
 
             withLocaleEnvironment(lcAll: "C", lcMessages: "zh_CN.UTF-8", lang: "en_US.UTF-8") {
                 LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "en_001")
                 #expect(Locale.current.identifier == "en_001")
                 #expect(Locale.current.region?.identifier == "001")
                 #expect(Locale.preferredLanguages == ["en-001"])
@@ -134,9 +138,42 @@ private struct LocaleTests {
 
             withLocaleEnvironment(lcAll: nil, lcMessages: nil, lang: "pt-BR.UTF-8") {
                 LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "pt_BR")
                 #expect(Locale.current.identifier == "pt_BR")
                 #expect(Locale.current.region?.identifier == "BR")
                 #expect(Locale.preferredLanguages == ["pt-BR"])
+            }
+
+            withLocaleEnvironment(lcAll: nil, lcMessages: nil, lang: "fr_FR.utf8@euro") {
+                LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "fr_FR")
+                #expect(Locale.current.identifier == "fr_FR")
+                #expect(Locale.current.region?.identifier == "FR")
+                #expect(Locale.preferredLanguages == ["fr-FR"])
+            }
+
+            withLocaleEnvironment(lcAll: nil, lcMessages: nil, lang: "en_US/UTF-8") {
+                LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "en_001")
+                #expect(Locale.current.identifier == "en_001")
+                #expect(Locale.current.region?.identifier == "001")
+                #expect(Locale.preferredLanguages == ["en-001"])
+            }
+
+            withLocaleEnvironment(lcAll: nil, lcMessages: nil, lang: "en_US_é") {
+                LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "en_001")
+                #expect(Locale.current.identifier == "en_001")
+                #expect(Locale.current.region?.identifier == "001")
+                #expect(Locale.preferredLanguages == ["en-001"])
+            }
+
+            withLocaleEnvironment(lcAll: nil, lcMessages: nil, lang: String(repeating: "a", count: 157)) {
+                LocaleCache.cache.reset()
+                #expect(LocaleCache.cache.preferredLocale() == "en_001")
+                #expect(Locale.current.identifier == "en_001")
+                #expect(Locale.current.region?.identifier == "001")
+                #expect(Locale.preferredLanguages == ["en-001"])
             }
         }
     }

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -12,12 +12,65 @@
 
 import Testing
 
+#if canImport(Android)
+@preconcurrency import Android
+#elseif canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#endif
+
 #if FOUNDATION_FRAMEWORK
 @testable import Foundation
 #elseif canImport(FoundationInternationalization)
 @testable import FoundationEssentials
 @testable import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
+
+#if !FOUNDATION_FRAMEWORK && (os(Linux) || os(Android) || canImport(Musl))
+private func environmentValue(_ name: String) -> String? {
+    name.withCString { namePtr in
+        guard let value = getenv(namePtr) else {
+            return nil
+        }
+        return String(cString: value)
+    }
+}
+
+private func setEnvironmentValue(_ name: String, _ value: String?) {
+    name.withCString { namePtr in
+        if let value {
+            value.withCString { valuePtr in
+                _ = setenv(namePtr, valuePtr, 1)
+            }
+        } else {
+            _ = unsetenv(namePtr)
+        }
+    }
+}
+
+private func withLocaleEnvironment(lcAll: String?, lcMessages: String?, lang: String?, body: () -> Void) {
+    let updates: [(String, String?)] = [
+        ("LC_ALL", lcAll),
+        ("LC_MESSAGES", lcMessages),
+        ("LANG", lang),
+    ]
+    let oldValues = updates.map { (name, _) in
+        (name, environmentValue(name))
+    }
+
+    for (name, value) in updates {
+        setEnvironmentValue(name, value)
+    }
+    defer {
+        for (name, value) in oldValues {
+            setEnvironmentValue(name, value)
+        }
+    }
+
+    body()
+}
+#endif
 
 @Suite("Locale")
 private struct LocaleTests {
@@ -47,6 +100,47 @@ private struct LocaleTests {
         // Need to find a good test case for collator identifier
         // #expect("something" == locale.localizedString(forCollatorIdentifier: "en"))
     }
+
+#if !FOUNDATION_FRAMEWORK && (os(Linux) || os(Android) || canImport(Musl))
+    @Test func currentLocaleUsesPOSIXLocaleEnvironment() async {
+        await usingCurrentInternationalizationPreferences {
+            withLocaleEnvironment(lcAll: nil, lcMessages: nil, lang: "en_US.UTF-8") {
+                LocaleCache.cache.reset()
+                #expect(Locale.current.identifier == "en_US")
+                #expect(Locale.current.region?.identifier == "US")
+                #expect(Locale.preferredLanguages == ["en-US"])
+            }
+
+            withLocaleEnvironment(lcAll: nil, lcMessages: "zh_CN.UTF-8", lang: "en_US.UTF-8") {
+                LocaleCache.cache.reset()
+                #expect(Locale.current.identifier == "zh_CN")
+                #expect(Locale.current.region?.identifier == "CN")
+                #expect(Locale.preferredLanguages == ["zh-CN"])
+            }
+
+            withLocaleEnvironment(lcAll: "de_DE.UTF-8", lcMessages: "zh_CN.UTF-8", lang: "en_US.UTF-8") {
+                LocaleCache.cache.reset()
+                #expect(Locale.current.identifier == "de_DE")
+                #expect(Locale.current.region?.identifier == "DE")
+                #expect(Locale.preferredLanguages == ["de-DE"])
+            }
+
+            withLocaleEnvironment(lcAll: "C", lcMessages: "zh_CN.UTF-8", lang: "en_US.UTF-8") {
+                LocaleCache.cache.reset()
+                #expect(Locale.current.identifier == "en_001")
+                #expect(Locale.current.region?.identifier == "001")
+                #expect(Locale.preferredLanguages == ["en-001"])
+            }
+
+            withLocaleEnvironment(lcAll: nil, lcMessages: nil, lang: "pt-BR.UTF-8") {
+                LocaleCache.cache.reset()
+                #expect(Locale.current.identifier == "pt_BR")
+                #expect(Locale.current.region?.identifier == "BR")
+                #expect(Locale.preferredLanguages == ["pt-BR"])
+            }
+        }
+    }
+#endif
 
     @available(macOS, deprecated: 13)
     @available(iOS, deprecated: 16)


### PR DESCRIPTION
## Summary

Read the POSIX locale environment in the non-Darwin `LocaleCache` fallback path before falling back to `en_001`.

The current non-Darwin implementation always reports `en_001`, which makes APIs such as `Locale.current.region?.identifier` return `001` even when the process was launched with a concrete locale such as `en_US.UTF-8` or `zh_CN.UTF-8`.

## Changes

- Check `LC_ALL`, `LC_MESSAGES`, then `LANG` on Linux/Android/BSD/musl builds.
- Normalize POSIX locale values by removing encoding/modifier suffixes and converting hyphen separators to underscores for locale identifiers.
- Preserve the existing `en_001` fallback when the environment is unset or explicitly `C`/`POSIX`.
- Add coverage for `LANG`, `LC_MESSAGES`, `LC_ALL`, `LC_ALL=C`, and hyphenated locale values.

## Links

- Forum Discussion: https://forums.swift.org/t/foundation-locale-current-is-incorrect/77231
- Related PR: https://github.com/swiftlang/swift-foundation/pull/1308