### PR TITLE
Avoid crashing when removing empty subrange from empty Data

### DIFF
--- a/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
@@ -193,6 +193,8 @@ extension Data {
             precondition(startIndex <= subrange.lowerBound, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
             precondition(subrange.upperBound <= endIndex, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
 
+            if subrange.isEmpty && cnt == 0 { return }
+
             ensureUniqueReference()
             let upper = _slice.upperBound
             let nsRange = (

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -297,7 +297,9 @@ internal final class __DataStorage : @unchecked Sendable {
             if isExternallyOwned {
                 let newCapacity = malloc_good_size(_length)
                 let newBytes = __DataStorage.allocate(newCapacity, false)
-                __DataStorage.move(newBytes!, _bytes!, _length)
+                if let bytes = _bytes {
+                    __DataStorage.move(newBytes!, bytes, _length)
+                }
                 _freeBytes()
                 _bytes = newBytes
                 _capacity = newCapacity

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2992,7 +2992,13 @@ extension DataTests {
         }
         #expect(mutateMe == expected)
     }
-    
+
+    @Test func emptyDataRemoveSubrange() {
+        var empty = Data()
+        empty.removeSubrange(0 ..< 0)
+        #expect(empty.count == 0)
+    }
+
     @Test func rangeOfSlice() throws {
         let data = try #require("FooBar".data(using: .ascii))
         let slice = data[3...] // Bar


### PR DESCRIPTION
Fixes a crash introduced by the new Data ABI

### Motivation:

Removing the empty subrange `0 ..< 0` from an empty `Data` is a valid operation (although it has no effect). It should not crash and in an ideal world should also not trigger a copy.

### Modifications:

- Fixed a discrepancy in the handling of `nil` pointers in `__DataStorage` to ensure we only copy from non-null pointers
- Added an early-exit in `Data._Representation.replaceSubrange()` to avoid triggering CoW for empty replacements of an empty subrange

### Result:

Removing an empty subrange of `0 ..< 0` from an empty `Data` no longer crashes or triggers CoW

Resolves #2054 

### Testing:

Added an additional test that crashed prior to this change but passes now
