### PR TITLE
Return CFString from certain Swift CFURL methods to avoid bridging

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_C+Encoding.swift
+++ b/Sources/FoundationEssentials/URL/URL_C+Encoding.swift
@@ -109,13 +109,13 @@ extension NSURL {
         return URLEncoder.percentEncode(string: path, encoding: encoding, component: component, skipAlreadyEncoded: false)
     }
 
-    static func __copySwiftEncodedFSRPath(_ path: String) -> String? {
+    static func __copySwiftEncodedFSRPath(_ path: String) -> Unmanaged<CFString>? {
         guard !path.isEmpty else {
-            return path
+            return _createCFStringFromASCIIString(path)
         }
         // Convert path to its decomposed file system representation then encode
         let maxFSRSize = 3 * path.utf8.count
-        return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: maxFSRSize) { pathBuffer -> String? in
+        return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: maxFSRSize) { pathBuffer in
             guard var pathLength = path._decomposed(.hfsPlus, into: pathBuffer) else {
                 return nil
             }
@@ -124,15 +124,14 @@ extension NSURL {
             while pathLength > rootLength && pathBuffer[pathLength - 1] == UInt8(ascii: "/") {
                 pathLength -= 1
             }
-            return withUnsafeTemporaryAllocation(of: UInt8.self, capacity: 3 * pathLength) { encodedBuffer in
-                let encodedLength = URLEncoder.percentEncodeUnchecked(
+            return _createCFStringFromASCIIBuffer(capacity: 3 * pathLength) { encodedBuffer in
+                URLEncoder.percentEncodeUnchecked(
                     input: UnsafeBufferPointer(rebasing: pathBuffer[..<pathLength]),
                     output: encodedBuffer,
                     // Encode ";" for compatibility
                     component: .pathNoSemicolon,
                     skipAlreadyEncoded: false
                 )
-                return String(decoding: encodedBuffer[..<encodedLength], as: UTF8.self)
             }
         }
     }

--- a/Sources/FoundationEssentials/URL/URL_C+File.swift
+++ b/Sources/FoundationEssentials/URL/URL_C+File.swift
@@ -35,15 +35,13 @@ extension NSURL {
             assert(false, "Unexpected path style: \(pathStyle)")
             return false
         }
-        guard let urlString else {
+        guard let urlString, let cfString = _createCFStringFromASCIIString(urlString) else {
             return false
         }
 
         assert(flags.isDisjoint(with: .nonFileImplFlags))
         impl.pointee._header._flags = flags
-        impl.pointee._header._string = Unmanaged<CFString>.passRetained(
-            urlString as CFString
-        )
+        impl.pointee._header._string = cfString
         return true
     }
 
@@ -55,15 +53,14 @@ extension NSURL {
 
         var flags = __CFURLFlags.fileImplFlags
         let buffer = UnsafeBufferPointer(start: fsr, count: length)
-        guard let urlString = parseFileSystemRepresentation(buffer: buffer, flags: &flags, isDirectory: isDirectory) else {
+        guard let urlString = parseFileSystemRepresentation(buffer: buffer, flags: &flags, isDirectory: isDirectory),
+              let cfString = _createCFStringFromASCIIString(urlString) else {
             return false
         }
 
         assert(flags.isDisjoint(with: .nonFileImplFlags))
         impl.pointee._header._flags = flags
-        impl.pointee._header._string = Unmanaged<CFString>.passRetained(
-            urlString as CFString
-        )
+        impl.pointee._header._string = cfString
         return true
     }
 

--- a/Sources/FoundationEssentials/URL/URL_C+Spans.swift
+++ b/Sources/FoundationEssentials/URL/URL_C+Spans.swift
@@ -160,4 +160,23 @@ internal func _createCFStringFromCharacterBuffer(
     }
 }
 
+internal func _createCFStringFromASCIIString(_ string: String) -> Unmanaged<CFString>? {
+    let ascii = CFStringBuiltInEncodings.ASCII.rawValue
+    guard !string.isEmpty else {
+        guard let empty = CFStringCreateWithCString(kCFAllocatorDefault, "", ascii) else {
+            return nil
+        }
+        return Unmanaged.passRetained(empty)
+    }
+    var mut = string
+    return mut.withUTF8 { utf8 in
+        guard let result = CFStringCreateWithBytes(
+            kCFAllocatorDefault, utf8.baseAddress!, utf8.count, ascii, false
+        ) else {
+            return nil
+        }
+        return Unmanaged.passRetained(result)
+    }
+}
+
 #endif // FOUNDATION_FRAMEWORK


### PR DESCRIPTION
Return/use `CFString` directly from the Swift implementation of some `CFURL` functions that can be called before Foundation/`NSString` bridging classes are initialized.

### Motivation:

`String` to `NSString` bridging and `NSString` ObjC dispatch require the respective classes to be initialized in Foundation. If certain `CFURL` functions (implemented in Swift) return `String` and are called from CoreFoundation before this initialization occurs, it fails to find the concrete bridging class.

### Modifications:

Return a true `CFString` from `__copySwiftEncodedFSRPath`, and store a true `CFString` in `CFURL`s initialized from a file path/representation.

### Result:

N/A for swift-foundation. These CF APIs work as expected regardless of Foundation initialization status.

### Testing:

Test suites for `NSURL` and `CFURL`.
