### PR TITLE
Fix two-digit era year parsing

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -1051,7 +1051,7 @@ extension Date.FormatStyle : ParseStrategy {
     /// - Parameter value: The string to parse.
     /// - Returns: An instance of `Date` parsed from the input string.
     public func parse(_ value: String) throws -> Date {
-        guard let fm = ICUDateFormatter.cachedFormatter(for: self) else {
+        guard let fm = ICUDateFormatter.cachedFormatter(forParsing: self) else {
             throw CocoaError(CocoaError.formatting, userInfo: [ NSDebugDescriptionErrorKey: "Error creating icu date formatter" ])
         }
 

--- a/Sources/FoundationInternationalization/Formatting/Date/DateParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateParseStrategy.swift
@@ -59,7 +59,8 @@ extension Date {
         }
 
         private var formatter: ICUDateFormatter? {
-            let dateFormatInfo = ICUDateFormatter.DateFormatInfo(localeIdentifier: locale?.identifier, timeZoneIdentifier: timeZone.identifier, calendarIdentifier: calendar.identifier, firstWeekday: calendar.firstWeekday, minimumDaysInFirstWeek: calendar.minimumDaysInFirstWeek, capitalizationContext: .unknown, pattern: format, parseLenient: isLenient, parseTwoDigitStartDate: twoDigitStartDate)
+            let parsePattern = ICUDateFormatter.DateFormatInfo.parsePattern(for: format, calendarIdentifier: calendar.identifier)
+            let dateFormatInfo = ICUDateFormatter.DateFormatInfo(localeIdentifier: locale?.identifier, timeZoneIdentifier: timeZone.identifier, calendarIdentifier: calendar.identifier, firstWeekday: calendar.firstWeekday, minimumDaysInFirstWeek: calendar.minimumDaysInFirstWeek, capitalizationContext: .unknown, pattern: parsePattern, parseLenient: isLenient, parseTwoDigitStartDate: twoDigitStartDate)
             return ICUDateFormatter.cachedFormatter(for: dateFormatInfo)
         }
 

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -282,6 +282,10 @@ final class ICUDateFormatter : @unchecked Sendable {
         cachedFormatter(for: .init(format))
     }
 
+    static func cachedFormatter(forParsing format: Date.FormatStyle) -> ICUDateFormatter? {
+        cachedFormatter(for: .init(format, forParsing: true))
+    }
+
     static func cachedFormatter(for format: Date.VerbatimFormatStyle) -> ICUDateFormatter? {
         cachedFormatter(for: .init(format))
     }
@@ -293,7 +297,7 @@ final class ICUDateFormatter : @unchecked Sendable {
 }
 
 extension ICUDateFormatter.DateFormatInfo {
-    init(_ format: Date.FormatStyle) {
+    init(_ format: Date.FormatStyle, forParsing: Bool = false) {
         let calendarIdentifier = format.calendar.identifier
         let datePatternOverride: String?
 #if FOUNDATION_FRAMEWORK
@@ -323,6 +327,13 @@ extension ICUDateFormatter.DateFormatInfo {
             }
         }
 
+        let dateFormatPattern: String
+        if forParsing {
+            dateFormatPattern = Self.parsePattern(for: pattern, calendarIdentifier: calendarIdentifier)
+        } else {
+            dateFormatPattern = pattern
+        }
+
         let firstWeekday: Int
         if let forceFirstWeekday = format.locale.forceFirstWeekday(calendarIdentifier) {
             firstWeekday = forceFirstWeekday.icuIndex
@@ -330,7 +341,7 @@ extension ICUDateFormatter.DateFormatInfo {
             firstWeekday = format.calendar.firstWeekday
         }
 
-        self.init(localeIdentifier: format.locale.identifier, timeZoneIdentifier: format.timeZone.identifier, calendarIdentifier: calendarIdentifier, firstWeekday: firstWeekday, minimumDaysInFirstWeek: format.calendar.minimumDaysInFirstWeek, capitalizationContext: format.capitalizationContext, pattern: pattern, parseLenient: format.parseLenient)
+        self.init(localeIdentifier: format.locale.identifier, timeZoneIdentifier: format.timeZone.identifier, calendarIdentifier: calendarIdentifier, firstWeekday: firstWeekday, minimumDaysInFirstWeek: format.calendar.minimumDaysInFirstWeek, capitalizationContext: format.capitalizationContext, pattern: dateFormatPattern, parseLenient: format.parseLenient)
     }
 
     init(_ format: Date.VerbatimFormatStyle) {
@@ -342,6 +353,77 @@ extension ICUDateFormatter.DateFormatInfo {
         // Currently this always uses `.unknown` for capitalization. We should
         // consider allowing customization with rdar://71815286
         self.init(localeIdentifier: calendar.locale?.identifier, timeZoneIdentifier: calendar.timeZone.identifier, calendarIdentifier: calendar.identifier, firstWeekday: calendar.firstWeekday, minimumDaysInFirstWeek: calendar.minimumDaysInFirstWeek, capitalizationContext: .unknown, pattern: "")
+    }
+
+    static func parsePattern(for pattern: String, calendarIdentifier: Calendar.Identifier) -> String {
+        guard calendarIdentifier == .japanese || calendarIdentifier == .republicOfChina else {
+            return pattern
+        }
+        guard containsUnquotedField("G", in: pattern) else {
+            return pattern
+        }
+
+        // Era years are already scoped by the parsed era. Use a wider year
+        // field for parsing to avoid applying ICU's two-digit year window to
+        // Japanese and ROC year-of-era values.
+        return replacingUnquotedFieldRuns(in: pattern, matching: "y") { count in
+            String(repeating: "y", count: max(count, 4))
+        }
+    }
+
+    private static func containsUnquotedField(_ field: Character, in pattern: String) -> Bool {
+        var found = false
+        forEachUnquotedFieldRun(in: pattern) { runField, _ in
+            if runField == field {
+                found = true
+            }
+        }
+        return found
+    }
+
+    private static func replacingUnquotedFieldRuns(in pattern: String, matching field: Character, with replacement: (Int) -> String) -> String {
+        var result = ""
+        forEachUnquotedFieldRun(in: pattern) { runField, runLength in
+            if runField == field {
+                result += replacement(runLength)
+            } else {
+                result += String(repeating: String(runField), count: runLength)
+            }
+        } quotedRun: { quotedText in
+            result += quotedText
+        }
+        return result
+    }
+
+    private static func forEachUnquotedFieldRun(in pattern: String, _ body: (Character, Int) -> Void, quotedRun: ((String) -> Void)? = nil) {
+        var index = pattern.startIndex
+        var isInQuote = false
+
+        while index < pattern.endIndex {
+            let character = pattern[index]
+            if character == "'" {
+                let next = pattern.index(after: index)
+                if next < pattern.endIndex && pattern[next] == "'" {
+                    quotedRun?("''")
+                    index = pattern.index(after: next)
+                } else {
+                    quotedRun?("'")
+                    isInQuote.toggle()
+                    index = next
+                }
+            } else if isInQuote {
+                quotedRun?(String(character))
+                index = pattern.index(after: index)
+            } else {
+                let runStart = index
+                var runLength = 0
+                repeat {
+                    runLength += 1
+                    index = pattern.index(after: index)
+                } while index < pattern.endIndex && pattern[index] == character
+                body(pattern[runStart], runLength)
+            }
+        }
     }
 }
 

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -363,11 +363,14 @@ extension ICUDateFormatter.DateFormatInfo {
             return pattern
         }
 
-        // Era years are already scoped by the parsed era. Use a wider year
-        // field for parsing to avoid applying ICU's two-digit year window to
-        // Japanese and ROC year-of-era values.
+        // ICU applies its two-digit year window only to year fields narrower
+        // than 3. Era years are already scoped by the parsed era, so widen
+        // only those affected fields for parsing.
         return replacingUnquotedFieldRuns(in: pattern, matching: "y") { count in
-            String(repeating: "y", count: max(count, 4))
+            guard count < 3 else {
+                return String(repeating: "y", count: count)
+            }
+            return "yyyy"
         }
     }
 

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -359,72 +359,56 @@ extension ICUDateFormatter.DateFormatInfo {
         guard calendarIdentifier == .japanese || calendarIdentifier == .republicOfChina else {
             return pattern
         }
-        guard containsUnquotedField("G", in: pattern) else {
-            return pattern
-        }
 
-        // ICU applies its two-digit year window only to year fields narrower
-        // than 3. Era years are already scoped by the parsed era, so widen
-        // only those affected fields for parsing.
-        return replacingUnquotedFieldRuns(in: pattern, matching: "y") { count in
-            guard count < 3 else {
-                return String(repeating: "y", count: count)
-            }
-            return "yyyy"
-        }
-    }
-
-    private static func containsUnquotedField(_ field: Character, in pattern: String) -> Bool {
-        var found = false
-        forEachUnquotedFieldRun(in: pattern) { runField, _ in
-            if runField == field {
-                found = true
-            }
-        }
-        return found
-    }
-
-    private static func replacingUnquotedFieldRuns(in pattern: String, matching field: Character, with replacement: (Int) -> String) -> String {
+        // ICU applies its two-digit year window only to year fields narrower than 3. Era years are already scoped by the parsed era, so widen only those affected fields for parsing.
+        var containsEra = false
         var result = ""
+        result.reserveCapacity(pattern.utf8.count)
         forEachUnquotedFieldRun(in: pattern) { runField, runLength in
-            if runField == field {
-                result += replacement(runLength)
-            } else {
-                result += String(repeating: String(runField), count: runLength)
+            if runField == "G" {
+                containsEra = true
             }
-        } quotedRun: { quotedText in
-            result += quotedText
+            if runField == "y" && runLength < 3 {
+                result += "yyyy"
+            } else {
+                for _ in 0 ..< runLength {
+                    result.unicodeScalars.append(runField)
+                }
+            }
+        } quotedScalar: { scalar in
+            result.unicodeScalars.append(scalar)
         }
-        return result
+        return containsEra ? result : pattern
     }
 
-    private static func forEachUnquotedFieldRun(in pattern: String, _ body: (Character, Int) -> Void, quotedRun: ((String) -> Void)? = nil) {
-        var index = pattern.startIndex
+    private static func forEachUnquotedFieldRun(in pattern: String, _ body: (Unicode.Scalar, Int) -> Void, quotedScalar: ((Unicode.Scalar) -> Void)? = nil) {
+        // ICU pattern fields and quoting are defined in terms of Unicode scalars.
+        let scalars = pattern.unicodeScalars
+        var index = scalars.startIndex
         var isInQuote = false
 
-        while index < pattern.endIndex {
-            let character = pattern[index]
-            if character == "'" {
-                let next = pattern.index(after: index)
-                if next < pattern.endIndex && pattern[next] == "'" {
-                    quotedRun?("''")
-                    index = pattern.index(after: next)
+        while index < scalars.endIndex {
+            let scalar = scalars[index]
+            if scalar == "'" {
+                quotedScalar?(scalar)
+                let next = scalars.index(after: index)
+                if next < scalars.endIndex && scalars[next] == "'" {
+                    quotedScalar?(scalars[next])
+                    index = scalars.index(after: next)
                 } else {
-                    quotedRun?("'")
                     isInQuote.toggle()
                     index = next
                 }
             } else if isInQuote {
-                quotedRun?(String(character))
-                index = pattern.index(after: index)
+                quotedScalar?(scalar)
+                index = scalars.index(after: index)
             } else {
-                let runStart = index
                 var runLength = 0
                 repeat {
                     runLength += 1
-                    index = pattern.index(after: index)
-                } while index < pattern.endIndex && pattern[index] == character
-                body(pattern[runStart], runLength)
+                    index = scalars.index(after: index)
+                } while index < scalars.endIndex && scalars[index] == scalar
+                body(scalar, runLength)
             }
         }
     }

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -360,7 +360,8 @@ extension ICUDateFormatter.DateFormatInfo {
             return pattern
         }
 
-        // ICU applies its two-digit year window only to year fields narrower than 3. Era years are already scoped by the parsed era, so widen only those affected fields for parsing.
+        // ICU applies its two-digit year window only to year fields narrower than 3.
+        // Era years are already scoped by the parsed era, so widen only those affected fields for parsing.
         var containsEra = false
         var result = ""
         result.reserveCapacity(pattern.utf8.count)

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -187,6 +187,25 @@ private struct DateFormatStyleTests {
         #expect(parsed.formatted(style) == format)
     }
 
+    @Test func eraYearParsePatternOnlyWidensAffectedYearFields() {
+        func parsePattern(_ pattern: String, calendarIdentifier: Calendar.Identifier = .japanese) -> String {
+            ICUDateFormatter.DateFormatInfo.parsePattern(for: pattern, calendarIdentifier: calendarIdentifier)
+        }
+
+        #expect(parsePattern("y年M月d日") == "y年M月d日")
+        #expect(parsePattern("Gy年M月d日") == "Gyyyy年M月d日")
+        #expect(parsePattern("Gyy年M月d日") == "Gyyyy年M月d日")
+        #expect(parsePattern("Gyyy年M月d日") == "Gyyy年M月d日")
+        #expect(parsePattern("Gyyyy年M月d日") == "Gyyyy年M月d日")
+        #expect(parsePattern("G 'y' y年M月d日") == "G 'y' yyyy年M月d日")
+        #expect(parsePattern("'G' y年M月d日") == "'G' y年M月d日")
+        #expect(parsePattern("G '' y年M月d日") == "G '' yyyy年M月d日")
+        #expect(parsePattern("G 'it''s y' y年M月d日") == "G 'it''s y' yyyy年M月d日")
+
+        #expect(parsePattern("Gy年M月d日", calendarIdentifier: .republicOfChina) == "Gyyyy年M月d日")
+        #expect(parsePattern("Gy年M月d日", calendarIdentifier: .gregorian) == "Gy年M月d日")
+    }
+
     @Test func leadingDotSyntax() async {
         let date = Date.now
         let locale = Locale(identifier: "es_ES")

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -903,6 +903,48 @@ private struct DateVerbatimFormatStyleTests {
         try verify("\(year: .defaultDigits)_\(month: .defaultDigits)_\(day: .defaultDigits) at \(hour: .defaultDigits(clock: .twentyFourHour, hourCycle: .zeroBased))", expectedString: "2021_1_23 at 14", expectedDate: Date(timeIntervalSinceReferenceDate: 633103200.0))
     }
 
+    @Test func parseableEraYearsDoNotUseTwoDigitYearWindow() throws {
+        let timeZone = TimeZone.gmt
+        var gregorianCalendar = Calendar(identifier: .gregorian)
+        gregorianCalendar.timeZone = timeZone
+
+        func date(_ year: Int, _ month: Int, _ day: Int) throws -> Date {
+            try #require(gregorianCalendar.date(from: DateComponents(timeZone: timeZone, year: year, month: month, day: day)))
+        }
+
+        let japaneseLocale = Locale(identifier: "ja_JP@calendar=japanese")
+        var japaneseCalendar = Calendar(identifier: .japanese)
+        japaneseCalendar.locale = japaneseLocale
+        japaneseCalendar.timeZone = timeZone
+
+        let japaneseFormat: Date.FormatString = "\(era: .wide)\(year: .defaultDigits)年\(month: .defaultDigits)月\(day: .defaultDigits)日"
+        let japaneseStrategy = Date.ParseStrategy(format: japaneseFormat, locale: japaneseLocale, timeZone: timeZone, calendar: japaneseCalendar, isLenient: false)
+        #expect(try japaneseStrategy.parse("平成09年1月1日") == date(1997, 1, 1))
+        #expect(try japaneseStrategy.parse("平成10年1月1日") == date(1998, 1, 1))
+        #expect(try japaneseStrategy.parse("令和01年5月1日") == date(2019, 5, 1))
+
+        let japaneseVerbatim = Date.VerbatimFormatStyle(format: japaneseFormat, locale: japaneseLocale, timeZone: timeZone, calendar: japaneseCalendar)
+        #expect(try japaneseVerbatim.parseStrategy.parse("平成10年1月1日") == date(1998, 1, 1))
+
+        let japaneseStyle = Date.FormatStyle(locale: japaneseLocale, calendar: japaneseCalendar, timeZone: timeZone)
+            .era(.wide)
+            .year(.defaultDigits)
+            .month(.defaultDigits)
+            .day(.defaultDigits)
+        #expect(try japaneseStyle.parse("平成10/01/01") == date(1998, 1, 1))
+
+        let rocLocale = Locale(identifier: "zh_TW@calendar=roc")
+        var rocCalendar = Calendar(identifier: .republicOfChina)
+        rocCalendar.locale = rocLocale
+        rocCalendar.timeZone = timeZone
+
+        let rocFormat: Date.FormatString = "\(era: .wide)\(year: .defaultDigits)年\(month: .defaultDigits)月\(day: .defaultDigits)日"
+        let rocStrategy = Date.ParseStrategy(format: rocFormat, locale: rocLocale, timeZone: timeZone, calendar: rocCalendar, isLenient: false)
+        #expect(try rocStrategy.parse("民國01年1月1日") == date(1912, 1, 1))
+        #expect(try rocStrategy.parse("民國58年1月1日") == date(1969, 1, 1))
+        #expect(try rocStrategy.parse("民國59年1月1日") == date(1970, 1, 1))
+    }
+
     // Test parsing strings containing `abbreviated` names
     @Test func nonLenientParsingAbbreviatedNames() throws {
 

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -201,6 +201,11 @@ private struct DateFormatStyleTests {
         #expect(parsePattern("'G' y年M月d日") == "'G' y年M月d日")
         #expect(parsePattern("G '' y年M月d日") == "G '' yyyy年M月d日")
         #expect(parsePattern("G 'it''s y' y年M月d日") == "G 'it''s y' yyyy年M月d日")
+        #expect(parsePattern("G\u{301}y年M月d日") == "G\u{301}yyyy年M月d日")
+
+        let patternWithQuotedScalars = parsePattern("G 'e\u{301} y' y年M月d日")
+        let expectedPatternWithQuotedScalars = "G 'e\u{301} y' yyyy年M月d日"
+        #expect(patternWithQuotedScalars.unicodeScalars.elementsEqual(expectedPatternWithQuotedScalars.unicodeScalars))
 
         #expect(parsePattern("Gy年M月d日", calendarIdentifier: .republicOfChina) == "Gyyyy年M月d日")
         #expect(parsePattern("Gy年M月d日", calendarIdentifier: .gregorian) == "Gy年M月d日")


### PR DESCRIPTION
Fix two-digit era year parsing for Japanese and ROC calendars.
Fixes https://github.com/swiftlang/swift-foundation/issues/2061

### Motivation:

`ICUDateFormatter` sets a two-digit-year start date for parsing. ICU then treats exactly two parsed year digits with a narrow `y` pattern as a two-digit year window, even when the value is already scoped by an explicit era such as `平成` or `民國`.

This causes Japanese and ROC era-year inputs such as `平成10年` and `民國01年` to parse into the wrong century.

### Modifications:

- Use a parse-only date pattern for `Date.FormatStyle` parsing while preserving the formatting pattern.
- Apply the same parse-only pattern adjustment to `Date.ParseStrategy` fixed-format parsing.
- For Japanese and ROC calendars with an explicit unquoted era field, widen only affected unquoted `y`/`yy` year-of-era fields to `yyyy` for parsing.
- Leave `yyy`/`yyyy`, patterns without an era field, quoted pattern text, and escaped apostrophes unchanged.
- Add coverage for `Date.ParseStrategy`, `VerbatimFormatStyle`, `Date.FormatStyle.parse`, ROC edge cases, and focused parse-pattern rewriting behavior.

### Result:

Japanese and ROC era-year parsing no longer applies ICU's two-digit-year window to explicit year-of-era values. Formatting output remains unchanged because the wider year field is used only for parsing.

### Testing:

- `swift test --filter FoundationInternationalizationTests.DateFormatStyleTests/eraYearParsePatternOnlyWidensAffectedYearFields`
- `swift test --filter FoundationInternationalizationTests.DateVerbatimFormatStyleTests/parseableEraYearsDoNotUseTwoDigitYearWindow`
- `swift test --filter FoundationInternationalizationTests.DateFormatStyleTests`
- `swift test --filter FoundationInternationalizationTests.DateVerbatimFormatStyleTests`
