### PR TITLE
Fix a few warnings

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -204,7 +204,7 @@ private func createTemporaryFile(at destinationPath: String, inPath: borrowing s
             }
 #else
             @diagnose(DeprecatedDeclaration, as: ignored)
-            func _mktemp(_ templateFileSystemRep: UnsafeMutablePointer<CChar>?) -> UnsafeMutablePointer<CChar>? {
+            func _mktemp(_ templateFileSystemRep: UnsafeMutablePointer<CChar>!) -> UnsafeMutablePointer<CChar>! {
                 mktemp(templateFileSystemRep)
             }
             

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -203,7 +203,12 @@ private func createTemporaryFile(at destinationPath: String, inPath: borrowing s
                 openFileDescriptorProtected(path: $0, flags: _O_BINARY | _O_CREAT | _O_EXCL | _O_RDWR, options: options)
             }
 #else
-            guard mktemp(templateFileSystemRep) != nil else {
+            @diagnose(DeprecatedDeclaration, as: ignored)
+            func _mktemp(_ templateFileSystemRep: UnsafeMutablePointer<CChar>?) -> UnsafeMutablePointer<CChar>? {
+                mktemp(templateFileSystemRep)
+            }
+            
+            guard _mktemp(templateFileSystemRep) != nil else {
                 throw CocoaError.errorWithFilePath(inPath, errno: errno, reading: false, variant: variant)
             }
             let fd = openFileDescriptorProtected(path: templateFileSystemRep, flags: O_CREAT | O_EXCL | O_RDWR, options: options)

--- a/Sources/FoundationEssentials/NotificationCenter/NotificationCenterMessage.swift
+++ b/Sources/FoundationEssentials/NotificationCenter/NotificationCenterMessage.swift
@@ -136,6 +136,11 @@ extension NotificationCenter {
 
 extension NotificationCenter {
     internal var asyncObserverQueue: _NotificationCenterActorQueueManager {
+#if FOUNDATION_FRAMEWORK
         self._getActorQueueManager() as! _NotificationCenterActorQueueManager
+#else
+        // No need to cast on this platform, the type comes from the Swift API
+        self._getActorQueueManager()
+#endif
     }
 }


### PR DESCRIPTION
Fix 2 warnings in Foundation.

### Motivation:

We previously had no way to silence the `mktemp` deprecation warning in Data+Writing.swift. Now we do!

Fixed another platform-specific warning in NotificationCenter too.

### Modifications:

Moved the deprecated function into a helper so we scope the warning silencing to a small surface area.

### Result:

Two less warnings.

### Testing:

Unit tests are sufficient.