### PR TITLE
[CharacterSet] Replace withUnsafePointer with C-helper method

### DIFF
--- a/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
@@ -60,7 +60,7 @@ internal struct BuiltInUnicodeScalarSet {
         case decomposable
     }
 
-    var charset: SetType
+    let charset: SetType
     init(type: SetType) {
         charset = type
     }
@@ -120,7 +120,7 @@ internal struct BuiltInUnicodeScalarSet {
             return nil
         }
     }
-    
+
     enum BitmapResult {
         case bitmapFilled // kCFUniCharBitmapFilled
         case bitmapEmpty // kCFUniCharBitmapEmpty
@@ -295,7 +295,7 @@ internal struct BuiltInUnicodeScalarSet {
     // Full version used internally; the `shouldInvert` flag indicates that the stored bitmap
     // is the LEGAL set (for illegal charset) and callers must invert membership results.
     @_lifetime(immortal)
-    private func _bitmapPtrForPlane(_ plane: Int) -> (span: Span<UInt8>, shouldInvert: Bool)? {
+    internal func _bitmapPtrForPlane(_ plane: Int) -> (span: Span<UInt8>, shouldInvert: Bool)? {
         switch charset {
         case .whitespace, .whitespaceAndNewline, .newline:
             return nil
@@ -307,12 +307,8 @@ internal struct BuiltInUnicodeScalarSet {
             guard tableIndex < __CFUniCharNumberOfBitmaps else {
                 return nil
             }
-
-            let data = withUnsafePointer(to: __CFUniCharBitmapDataArray) { ptr in
-                ptr.withMemoryRebound(to: __CFUniCharBitmapData.self, capacity: Int(__CFUniCharNumberOfBitmaps)) { bitmapDataPtr in
-                    bitmapDataPtr.advanced(by: tableIndex).pointee
-                }
-            }
+            
+            let data = getCFUniCharBitmapDataArray().advanced(by: tableIndex).pointee
 
             guard plane < data._numPlanes, let planePtr = data._planes[plane] else {
                 return nil
@@ -435,22 +431,17 @@ internal struct BuiltInUnicodeScalarSet {
             return 17
         default:
             precondition(_bitmapTableIndex != nil)
-            let data = withUnsafePointer(to: __CFUniCharBitmapDataArray) { ptr in
-                ptr.withMemoryRebound(to: __CFUniCharBitmapData.self, capacity: Int(__CFUniCharNumberOfBitmaps)) { bitmapDataPtr in
-                    bitmapDataPtr.advanced(by: _bitmapTableIndex!).pointee
-                }
-            }
-            
+            let data = getCFUniCharBitmapDataArray().advanced(by: _bitmapTableIndex!).pointee
             return Int(data._numPlanes)
         }
     }
     
     // MARK: Helper methods
-    private func isWhitespace(_ scalar: Unicode.Scalar) -> Bool {
+    internal func isWhitespace(_ scalar: Unicode.Scalar) -> Bool {
         return (scalar.value == 0x0020) || (scalar.value == 0x0009) || (scalar.value == 0x00A0) || (scalar.value == 0x1680) || (scalar.value >= 0x2000 && scalar.value <= 0x200B) || (scalar.value == 0x202F) || (scalar.value == 0x205F) || (scalar.value == 0x3000)
     }
     
-    private func isNewline(_ scalar: Unicode.Scalar) -> Bool {
+    internal func isNewline(_ scalar: Unicode.Scalar) -> Bool {
         return ((scalar.value >= 0x000A && scalar.value <= 0x000D) || (scalar.value == 0x0085) || (scalar.value == 0x2028) || (scalar.value == 0x2029))
     }
 

--- a/Sources/_FoundationCShims/include/CFUniCharBitmapDataAccess.h
+++ b/Sources/_FoundationCShims/include/CFUniCharBitmapDataAccess.h
@@ -1,0 +1,16 @@
+/*
+    CFUniCharBitmapDataAccess.h
+    Copyright (c) 2026, Apple Inc. and the Swift project authors. All rights reserved.
+
+    This header relies on CFUniCharBitmapData.inc.h and CFUniCharBitmapData.h
+    being included before it.
+*/
+
+#ifndef _cfunichar_bitmap_data_access_h
+#define _cfunichar_bitmap_data_access_h
+
+static inline __CFUniCharBitmapData const *getCFUniCharBitmapDataArray(void) {
+    return __CFUniCharBitmapDataArray;
+}
+
+#endif /* _cfunichar_bitmap_data_access_h */

--- a/Sources/_FoundationCShims/include/_FoundationCShims.h
+++ b/Sources/_FoundationCShims/include/_FoundationCShims.h
@@ -17,6 +17,7 @@
 #include "_CStdlib.h"
 #include "CFUniCharBitmapData.inc.h"
 #include "CFUniCharBitmapData.h"
+#include "CFUniCharBitmapDataAccess.h"
 #include "string_shims.h"
 #include "bplist_shims.h"
 #include "io_shims.h"

--- a/Tests/FoundationEssentialsTests/BuiltInUnicodeScalarSetTests.swift
+++ b/Tests/FoundationEssentialsTests/BuiltInUnicodeScalarSetTests.swift
@@ -21,11 +21,11 @@ import Testing
 @Suite("BuiltInUnicodeScalarSet")
 private struct BuiltInUnicodeScalarSetTests {
 
-    @Test func membership() {
-        func setContainsScalar(_ set: BuiltInUnicodeScalarSet, _ scalar: Unicode.Scalar, _ expect: Bool, sourceLocation: SourceLocation = #_sourceLocation) {
-            #expect(set.contains(scalar) == expect, sourceLocation: sourceLocation)
-        }
+    func setContainsScalar(_ set: BuiltInUnicodeScalarSet, _ scalar: Unicode.Scalar, _ expect: Bool, sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(set.contains(scalar) == expect, sourceLocation: sourceLocation)
+    }
 
+    @Test func membership() {
         setContainsScalar(.lowercaseLetters, "a", true)
         setContainsScalar(.lowercaseLetters, "ô", true)
         setContainsScalar(.lowercaseLetters, "\u{01FB}", true)
@@ -54,6 +54,111 @@ private struct BuiltInUnicodeScalarSetTests {
         setContainsScalar(.graphemeExtends, "\u{E0020}", true) // TAG SPACE
         setContainsScalar(.graphemeExtends, "A", false)
         setContainsScalar(.graphemeExtends, "~", false)
+    }
+
+    @Test func bmpMembership() {
+        setContainsScalar(.uppercaseLetters, "\u{FFFF}", false)
+        setContainsScalar(.lowercaseLetters, "\u{FFFF}", false)
+        setContainsScalar(BuiltInUnicodeScalarSet(type: .letter), "\u{FFFF}", false)
+        setContainsScalar(BuiltInUnicodeScalarSet(type: .alphanumeric), "\u{FFFF}", false)
+        setContainsScalar(BuiltInUnicodeScalarSet(type: .decimalDigit), "\u{FFFF}", false)
+    }
+
+    @Test func nonBMPMembership() {
+        setContainsScalar(BuiltInUnicodeScalarSet(type: .letter), "\u{10000}", true) // LINEAR B SYLLABLE B008 A
+        setContainsScalar(BuiltInUnicodeScalarSet(type: .alphanumeric), "\u{10000}", true) // LINEAR B SYLLABLE B008 A
+        setContainsScalar(.uppercaseLetters, "\u{10000}", false)
+        setContainsScalar(.lowercaseLetters, "\u{10000}", false)
+        setContainsScalar(BuiltInUnicodeScalarSet(type: .decimalDigit), "\u{10000}", false)
+    }
+
+    @Test func illegalSetMembership() {
+        let illegal = BuiltInUnicodeScalarSet(type: .illegal)
+        setContainsScalar(illegal, "A", false)
+        setContainsScalar(illegal, "0", false)
+        setContainsScalar(illegal, "a", false)
+        setContainsScalar(illegal, "\u{E0001}", false) // LANGUAGE TAG
+        setContainsScalar(illegal, "\u{E0020}", false) // TAG SPACE
+        setContainsScalar(illegal, "\u{E007F}", false) // CANCEL TAG
+        setContainsScalar(illegal, "\u{E0000}", true)
+    }
+
+    @Test func controlAndFormatterSetMembership() {
+        let controlAndFormatter = BuiltInUnicodeScalarSet(type: .controlAndFormatter)
+        setContainsScalar(controlAndFormatter, "\u{0001}", true) // START OF HEADING
+        setContainsScalar(controlAndFormatter, "\u{0007}", true) // BELL
+        setContainsScalar(controlAndFormatter, "\u{200B}", true) // ZERO WIDTH SPACE
+        setContainsScalar(controlAndFormatter, "a", false)
+        setContainsScalar(controlAndFormatter, "0", false)
+        setContainsScalar(controlAndFormatter, "\u{E0001}", true) // LANGUAGE TAG
+        setContainsScalar(controlAndFormatter, "\u{E0020}", true) // TAG SPACE
+        setContainsScalar(controlAndFormatter, "\u{E007F}", true) // CANCEL TAG
+        setContainsScalar(controlAndFormatter, "\u{E0000}", false)
+    }
+
+    @Test func whitespaceSetMembership() {
+        let whitespace = BuiltInUnicodeScalarSet(type: .whitespace)
+        setContainsScalar(whitespace, " ", true)
+        setContainsScalar(whitespace, "\u{0009}", true) // CHARACTER TABULATION
+        setContainsScalar(whitespace, "\u{00A0}", true) // NO-BREAK SPACE
+        setContainsScalar(whitespace, "\u{1680}", true) // OGHAM SPACE MARK
+        setContainsScalar(whitespace, "\u{2000}", true) // EN QUAD
+        setContainsScalar(whitespace, "\u{200B}", true) // ZERO WIDTH SPACE
+        setContainsScalar(whitespace, "\u{202F}", true) // NARROW NO-BREAK SPACE
+        setContainsScalar(whitespace, "\u{205F}", true) // MEDIUM MATHEMATICAL SPACE
+        setContainsScalar(whitespace, "\u{3000}", true) // IDEOGRAPHIC SPACE
+        setContainsScalar(whitespace, "\u{000A}", false) // LINE FEED
+        setContainsScalar(whitespace, "a", false)
+    }
+
+    @Test func newlineSetMembership() {
+        let newline = BuiltInUnicodeScalarSet(type: .newline)
+        setContainsScalar(newline, "\u{000A}", true) // LINE FEED
+        setContainsScalar(newline, "\u{000B}", true) // LINE TABULATION
+        setContainsScalar(newline, "\u{000C}", true) // FORM FEED
+        setContainsScalar(newline, "\u{000D}", true) // CARRIAGE RETURN
+        setContainsScalar(newline, "\u{0085}", true) // NEXT LINE
+        setContainsScalar(newline, "\u{2028}", true) // LINE SEPARATOR
+        setContainsScalar(newline, "\u{2029}", true) // PARAGRAPH SEPARATOR
+        setContainsScalar(newline, " ", false)
+        setContainsScalar(newline, "a", false)
+    }
+
+    @Test func whitespaceAndNewlineSetMembership() {
+        let whitespaceAndNewline = BuiltInUnicodeScalarSet(type: .whitespaceAndNewline)
+        setContainsScalar(whitespaceAndNewline, " ", true)
+        setContainsScalar(whitespaceAndNewline, "\u{000A}", true) // LINE FEED
+        setContainsScalar(whitespaceAndNewline, "\u{2028}", true) // LINE SEPARATOR
+        setContainsScalar(whitespaceAndNewline, "\u{3000}", true) // IDEOGRAPHIC SPACE
+        setContainsScalar(whitespaceAndNewline, "a", false)
+    }
+
+    @Test func unsupportedNonBMPPlaneMembership() {
+        setContainsScalar(.uppercaseLetters, "\u{D0000}", false)
+        setContainsScalar(.lowercaseLetters, "\u{D0000}", false)
+        setContainsScalar(BuiltInUnicodeScalarSet(type: .decimalDigit), "\u{D0000}", false)
+    }
+
+    @Test func illegalSetUnsupportedNonBMPNonSpecialPlaneMembership() {
+        let illegal = BuiltInUnicodeScalarSet(type: .illegal)
+        setContainsScalar(illegal, "\u{10000}", false) // LINEAR B SYLLABLE B008 A
+        setContainsScalar(illegal, "\u{1D7CF}", false) // MATHEMATICAL BOLD DIGIT ZERO
+        setContainsScalar(illegal, "\u{D0000}", false)
+    }
+
+    @Test func illegalSetUnsupportedPlane15And16Membership() {
+        let illegal = BuiltInUnicodeScalarSet(type: .illegal)
+        setContainsScalar(illegal, "\u{F0000}", false)
+        setContainsScalar(illegal, "\u{FFFFE}", false)
+        setContainsScalar(illegal, "\u{100000}", false)
+        setContainsScalar(illegal, "\u{10FFFD}", false)
+    }
+
+    @Test func controlAndFormatterSetUnsupportedNonBMPNonPlane14() {
+        let controlAndFormatter = BuiltInUnicodeScalarSet(type: .controlAndFormatter)
+        setContainsScalar(controlAndFormatter, "\u{10000}", false) // LINEAR B SYLLABLE B008 A
+        setContainsScalar(controlAndFormatter, "\u{1D7CF}", false) // MATHEMATICAL BOLD DIGIT ZERO
+        setContainsScalar(controlAndFormatter, "\u{D0000}", false)
     }
 
 }


### PR DESCRIPTION
This replaces the `withUnsafePointer` call with a C-helper method. 

### Motivation:

To avoid unsafety as much as possible. 

### Modifications:

Access `CFUniCharBitmapData` safely via a C-helper. 

### Result:

No behavioral change is expected. 

### Testing:

Added additional tests and existing tests should pass. 