### PR TITLE
Support var default values as replacement for @CodableDefault

### DIFF
--- a/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
+++ b/Sources/NewCodableMacros/SharedMacroInfrastructure.swift
@@ -373,14 +373,16 @@ func extractDetailedStoredProperties(
                 isOptional = false
                 typeName = type.trimmedDescription
             }
-
+          
+            let resolvedDefaultExpr = defaultExpr ?? binding.initializer?.value.trimmedDescription
+          
             properties.append(DetailedStoredProperty(
                 name: propertyName,
                 key: key,
                 aliases: aliases,
                 typeName: typeName,
                 isOptional: isOptional,
-                defaultExpr: defaultExpr,
+                defaultExpr: resolvedDefaultExpr,
                 encodingStrategy: encodingStrat,
                 decodingStrategy: decodingStrat
             ))

--- a/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
@@ -394,6 +394,91 @@ struct CommonCodableMacroTests {
             macros: codableTestMacros
         )
     }
+    
+    @Test func varDefaultValue() {
+        AssertMacroExpansion(
+            """
+            @CommonCodable
+            struct Config {
+                let name: String
+                var locale: String = "en"
+            }
+            """,
+            expandedSource: """
+            struct Config {
+                let name: String
+                var locale: String = "en"
+            }
+            
+            extension Config {
+                enum CommonCodingFields: StaticStringCodingField {
+                    case name
+                    case locale
+                    case unknown
+
+                    @_transparent
+                    var staticString: StaticString {
+                        switch self {
+                        case .name:
+                            "name"
+                        case .locale:
+                            "locale"
+                        case .unknown:
+                            fatalError()
+                        }
+                    }
+
+                    static func field(for key: UTF8Span) throws(CodingError.Decoding) -> CommonCodingFields {
+                        switch UTF8SpanComparator(key) {
+                        case "name":
+                            .name
+                        case "locale":
+                            .locale
+                        default:
+                            .unknown
+                        }
+                    }
+                }
+            }
+
+            extension Config: CommonEncodable {
+                func encode(to encoder: inout some CommonEncoder & ~Copyable & ~Escapable) throws(CodingError.Encoding) {
+                    try encoder.encodeStructFields(count: 2) { structEncoder throws(CodingError.Encoding) in
+                        try structEncoder.encode(field: CommonCodingFields.name, value: self.name)
+                        try structEncoder.encode(field: CommonCodingFields.locale, value: self.locale)
+                    }
+                }
+            }
+
+            extension Config: CommonDecodable {
+                static func decode(from decoder: inout some CommonDecoder & ~Escapable) throws(CodingError.Decoding) -> Config {
+                    try decoder.decodeStruct { structDecoder throws(CodingError.Decoding) in
+                        var name: String?
+                        var locale: String?
+                        var _codingField: CommonCodingFields?
+                        try structDecoder.decodeEachField { fieldDecoder throws(CodingError.Decoding) in
+                            _codingField = try fieldDecoder.decode(CommonCodingFields.self)
+                        } andValue: { valueDecoder throws(CodingError.Decoding) in
+                            switch _codingField! {
+                            case .name:
+                                name = try valueDecoder.decode(String.self)
+                            case .locale:
+                                locale = try valueDecoder.decode(String.self)
+                            case .unknown:
+                                break
+                            }
+                        }
+                        guard let name else {
+                            throw CodingError.dataCorrupted(debugDescription: "Missing required field 'name'")
+                        }
+                        return Config(name: name, locale: locale ?? "en")
+                    }
+                }
+            }
+            """,
+            macros: codableTestMacros
+        )
+    }
 
     @Test func aliasFullRoundtrip() {
         AssertMacroExpansion(

--- a/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
+++ b/Tests/NewCodableMacrosTests/CommonCodableMacroTests.swift
@@ -479,7 +479,33 @@ struct CommonCodableMacroTests {
             macros: codableTestMacros
         )
     }
-
+    
+    @Test func varWithoutTypeAnnotationProducesDiagnostic() {
+        AssertMacroExpansion(
+            """
+            @CommonCodable
+            struct Config {
+                let name: String
+                var locale = "en"
+            }
+            """,
+            expandedSource: """
+            struct Config {
+                let name: String
+                var locale = "en"
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@CommonCodable requires all stored properties to have explicit type annotations",
+                    line: 4,
+                    column: 9
+                )
+            ],
+            macros: codableTestMacros
+        )
+    }
+    
     @Test func aliasFullRoundtrip() {
         AssertMacroExpansion(
             """

--- a/Tests/NewCodableTests/CommonMacroIntegrationTests.swift
+++ b/Tests/NewCodableTests/CommonMacroIntegrationTests.swift
@@ -81,6 +81,12 @@ struct CommonCodableStructWithDefaultedProperty {
     let bar: String
 }
 
+@CommonCodable
+struct CommonCodableStructWithVarDefaultProperty {
+    let name: String
+    var locale: String = "en"
+}
+
 // Public types exercise access-level propagation in the generated extensions.
 
 @CommonEncodable
@@ -376,5 +382,31 @@ struct CommonCodableMacroIntegrationTests {
         #expect(json2 == #"{"pair":{"_0":"hello","_1":99}}"#)
         let decoded2 = try NewJSONDecoder().decode(CommonWrapper.self, from: data2)
         #expect(decoded2 == pair)
+    }
+    
+    @Test func varDefaultValueUsedWhenFieldMissing() throws {
+        let json = #"{"name":"Yeo"}"#
+        let data = Data(json.utf8)
+        let decoded = try NewJSONDecoder().decode(CommonCodableStructWithVarDefaultProperty.self, from: data)
+        #expect(decoded.name == "Yeo")
+        #expect(decoded.locale == "en")
+    }
+
+    @Test func varDefaultValueOverriddenByProvidedField() throws {
+        let json = #"{"name":"Yeo","locale":"ko"}"#
+        let data = Data(json.utf8)
+        let decoded = try NewJSONDecoder().decode(CommonCodableStructWithVarDefaultProperty.self, from: data)
+        #expect(decoded.name == "Yeo")
+        #expect(decoded.locale == "ko")
+    }
+
+    @Test func varDefaultValueRoundTrip() throws {
+        let original = CommonCodableStructWithVarDefaultProperty(name: "Yeo")
+        let data = try NewJSONEncoder().encode(original)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"name":"Yeo","locale":"en"}"#)
+        let decoded = try NewJSONDecoder().decode(CommonCodableStructWithVarDefaultProperty.self, from: data)
+        #expect(decoded.name == "Yeo")
+        #expect(decoded.locale == "en")
     }
 }


### PR DESCRIPTION
Resolves #2001
Allow var initializer expressions to be used as default values during macro expansion

### Motivation:
When analyzing the macro expansion flow, I traced how `extractDetailedStoredProperties` builds each `DetailedStoredProperty`. The key field is `defaultExpr: String?`, which feeds into `isRequired`:
```swift
var isRequired: Bool { !isOptional && defaultExpr == nil }
```

I found that `defaultExpr` is populated solely by `defaultValueExpression(from:)`, which only looks for `@CodableDefault` attributes. The var binding's initializer expression (e.g. `= []`) is never read.

This means `var items: [String] = []` produces `defaultExpr: nil`, making `isRequired: true`, and decoding fails when `items` is absent from the payload — even though the developer explicitly provided a default value.

The fix is one line: fall back to `binding.initializer?.value.trimmedDescription` when no `@CodableDefault` is present. This value is then passed into the generated decode code as:
```swift
items: items ?? []
```
making the field optional in the decoded payload as intended.

### Modifications:
In `extractDetailedStoredProperties` (SharedMacroInfrastructure.swift), after attempting to extract a default value from `@CodableDefault`, fall back to the var binding's initializer expression if no attribute is present:
```swift
let resolvedDefaultExpr = defaultExpr ?? binding.initializer?.value.trimmedDescription
```

This string is then used downstream in code generation, producing expressions like:
```swift
items: items ?? []
```

### Result:
```swift
var items: [String] = []  // now recognized as non-required
var required: Int // still required, no change
```
```swift
decode(BlogPost.self, from: #"{"required": 1}"#)
// Before: error, `items` treated as required field
// After: success, BlogPost(required: 1, items: [])
```

### Testing:
- `NewCodableMacros` and `NewCodableMacrosTests` targets build successfully with the Swift nightly toolchain (swift-DEVELOPMENT-SNAPSHOT-2026-06-24-a).

- However, running tests was not possible locally — `swift test` attempts to build the full package including the `NewCodable` runtime, which fails to compile with the available nightly toolchain (swift-DEVELOPMENT-SNAPSHOT-2026-06-24-a). This appears to be a pre-existing issue unrelated to this change.

- Happy to add or run tests once the runtime build is unblocked.