### PR TITLE
Fix URL.description for long data: URLs

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Impl.swift
+++ b/Sources/FoundationEssentials/URL/URL_Impl.swift
@@ -1391,8 +1391,8 @@ extension _URL {
     var description: String {
         var urlString = relativeString
         if isDataURL && urlString.utf8.count > 128 {
-            let prefix = urlString.utf8.prefix(120)
-            let suffix = urlString.utf8.suffix(8)
+            let prefix = Substring(urlString.utf8.prefix(120))
+            let suffix = Substring(urlString.utf8.suffix(8))
             urlString = "\(prefix) ... \(suffix)"
         }
         if let _baseURL {

--- a/Sources/FoundationEssentials/URL/URL_Swift.swift
+++ b/Sources/FoundationEssentials/URL/URL_Swift.swift
@@ -912,8 +912,8 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
     var description: String {
         var urlString = relativeString
         if let scheme, scheme.lowercased().utf8.elementsEqual(Self.dataSchemeUTF8), urlString.utf8.count > 128 {
-            let prefix = urlString.utf8.prefix(120)
-            let suffix = urlString.utf8.suffix(8)
+            let prefix = Substring(urlString.utf8.prefix(120))
+            let suffix = Substring(urlString.utf8.suffix(8))
             urlString = "\(prefix) ... \(suffix)"
         }
         if let baseURL {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -2554,6 +2554,31 @@ private struct URLTests {
         #expect(absoluteURL.absoluteString == "https://example.com/dir/caf%C3%A9")
     }
 
+    @Test func dataURLDescriptionTruncation() throws {
+        // Short data: URLs are described in full
+        let shortDataURL = try #require(URL(string: "data:text/plain,hello"))
+        #expect(shortDataURL.description == shortDataURL.absoluteString)
+        #expect(shortDataURL.debugDescription == shortDataURL.description)
+
+        // data: URLs longer than 128 bytes are truncated
+        // as "<120-byte prefix> ... <8-byte suffix>".
+        let payload = String(repeating: "A", count: 200)
+        let longDataURL = try #require(URL(string: "data:text/plain;base64,\(payload)"))
+        #expect(longDataURL.absoluteString.utf8.count > 128)
+
+        let description = longDataURL.description
+        #expect(description.utf8.count == 133)
+        #expect(description.hasPrefix("data:text/plain;base64,"))
+        #expect(description.hasSuffix(" ... AAAAAAAA"))
+        #expect(description != longDataURL.absoluteString)
+        #expect(longDataURL.debugDescription == description)
+
+        // Non-data URLs are never truncated, even when longer than 128 bytes
+        let longHTTPURL = try #require(URL(string: "https://example.com/\(payload)"))
+        #expect(longHTTPURL.absoluteString.utf8.count > 128)
+        #expect(longHTTPURL.description == longHTTPURL.absoluteString)
+    }
+
 #if FOUNDATION_FRAMEWORK
     @Test func componentsBridging() {
         var nsURLComponents = NSURLComponents(


### PR DESCRIPTION
Fix `URL.description` for long data: URLs so that it prints the actual bytes instead of `UTF8View` objects.

### Motivation:

For long (>128 character) data: URLs, `description` incorrectly prints the `UTF8View` objects containing the first 120 and last 8 bytes instead of the bytes themselves.

### Modifications:

Convert each `UTF8View` to `Substring` before performing String interpolation.

### Result:

Long data: URLs return the expected `<first 120 bytes> ... <last 8 bytes>` description.

### Testing:

New unit test to validate description format.
