### PR TITLE
[CharacterSet] Add Benchmark for measuring Percent-Encoding 

### DIFF
--- a/Benchmarks/Benchmarks/CharacterSet/BenchmarkCharacterSet.swift
+++ b/Benchmarks/Benchmarks/CharacterSet/BenchmarkCharacterSet.swift
@@ -460,5 +460,13 @@ let benchmarks: @Sendable () -> Void = {
             blackHole(mailLinkQuery.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
         }
     }
+
+    let identifierToEncode = "com.apple.mail/INBOX/12345:fc1e8b2a-deadbeef"
+    let invertedCustomSet = CharacterSet(charactersIn: "%:").inverted
+    Benchmark("Percent-Encode With Inverted Custom Set") { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(identifierToEncode.addingPercentEncoding(withAllowedCharacters: invertedCustomSet))
+        }
+    }
     #endif // FOUNDATION_FRAMEWORK
 }


### PR DESCRIPTION
Adds a benchmark to measure percent-encoding using `CharacterSet`. 

### Motivation:

To measure regressions for percent-encoding cases. 

### Modifications:

Adds a benchmark.

### Result:

Nothing is expected to change. 

### Testing:

All existing tests should still pass. 
