### PR TITLE
[6.4] Fix mode_t conversion from #2077 for 32-bit Android armv7

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,7 @@ jobs:
       enable_cross_pr_testing: true
       enable_android_sdk_build: true
       android_sdk_versions: '["nightly-6.4.x"]'
+      android_sdk_triples: '["aarch64-unknown-linux-android28", "armv7-unknown-linux-android28", "x86_64-unknown-linux-android28"]'
 
   cmake_build:
     name: Build (CMake)

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -599,7 +599,7 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
         var preRenameState = stat()
         let result = fstatat(destDirfd, basenameRep, &preRenameState, AT_SYMLINK_NOFOLLOW)
         if result == 0 {
-            mode = mode_t(preRenameState.st_mode & ~S_IFMT)
+            mode = mode_t(preRenameState.st_mode) & ~S_IFMT
         } else if (errno != ENOENT) && (errno != ENAMETOOLONG) {
             throw CocoaError.errorWithFilePath(inPath, errno: errno, reading: false)
         }


### PR DESCRIPTION
This was incorrectly fixed in #2084; add 32-bit Android armv7 testing to catch such build issues from now on.