### PR TITLE
Revert "Atomic file writes don't update permissions atomically"

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,6 @@ jobs:
       enable_cross_pr_testing: true
       enable_android_sdk_build: true
       android_sdk_versions: '["nightly-6.4.x"]'
-      android_sdk_triples: '["aarch64-unknown-linux-android28", "armv7-unknown-linux-android28", "x86_64-unknown-linux-android28"]'
 
   cmake_build:
     name: Build (CMake)

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -54,38 +54,7 @@ private func openFileDescriptorProtected(path: UnsafePointer<CChar>, flags: Int3
     return open(path, flags, 0o666)
 #endif
 }
-
-#if !os(Windows)
-/// at-style equivalent of `openFileDescriptorProtected` that takes a parent dirfd plus a relative name.
-private func openatFileDescriptorProtected(dirfd: Int32, name: UnsafePointer<CChar>, flags: Int32, options: Data.WritingOptions, mode: mode_t) -> Int32 {
-#if FOUNDATION_FRAMEWORK
-    return _NSOpenAtFileDescriptor_Protected(dirfd, name, Int(flags), options, Int(mode))
-#else
-    return openat(dirfd, name, flags, mode)
 #endif
-}
-#endif
-#endif
-
-#if !os(Windows)
-private var minimalOpenFlagsForDirectories: Int32 {
-#if canImport(Darwin)
-    O_SEARCH
-#elseif os(WASI)
-    O_DIRECTORY | O_RDONLY
-#else
-    O_DIRECTORY | O_PATH
-#endif
-}
-#endif
-
-#if !os(Windows)
-private typealias TemporaryFilePermissions = mode_t
-#else
-// Presently unimplemented on Windows
-private typealias TemporaryFilePermissions = Void
-#endif
-
 
 private func writeToFileDescriptorWithProgress(_ fd: Int32, buffer: RawSpan, reportProgress: Bool) throws -> Int {
     // Fetch this once
@@ -164,30 +133,22 @@ private func cleanupTemporaryDirectory(at inPath: String?) {
     try? FileManager.default.removeItem(atPath: inPath)
 }
 
-/// Creates a temporary file for atomic writing of `inPath` in the destination's parent directory.
-/// If `destDirfd` is -1, then `destinationPath` should be the full path.
+/// Caller is responsible for calling `close` on the `Int32` file descriptor.
 #if os(WASI)
 @available(*, unavailable, message: "WASI does not have temporary directories")
 #endif
-private func createTemporaryFile(destDirfd: Int32, destinationPath: String, inPath: borrowing some FileSystemRepresentable & ~Copyable, options: Data.WritingOptions, permissions: TemporaryFilePermissions, variant: String? = nil) throws -> (Int32, String) {
+private func createTemporaryFile(at destinationPath: String, inPath: borrowing some FileSystemRepresentable & ~Copyable, prefix: String, options: Data.WritingOptions, variant: String? = nil) throws -> (Int32, String) {
 #if os(WASI)
     // WASI does not have temp directories
     throw CocoaError(.featureUnsupported)
 #else
-    // When `destDirfd == -1`, build a full-path template and open the file by path.
-    // Otherwise the template is a basename only and the file is created relative to
-    // `destDirfd` via openat.
-    let pidString = String(ProcessInfo.processInfo.processIdentifier, radix: 16, uppercase: true)
-    let template: String
-    if destDirfd == -1 {
-        var directoryPath = destinationPath.deletingLastPathComponent()
-        if !directoryPath.isEmpty && directoryPath.last! != "/" {
-            directoryPath.append("/")
-        }
-        template = directoryPath + ".dat.nosync" + pidString + ".XXXXXX"
-    } else {
-        template = ".dat.nosync" + pidString + ".XXXXXX"
+    var directoryPath = destinationPath
+    if !directoryPath.isEmpty && directoryPath.last! != "/" {
+        directoryPath.append("/")
     }
+    
+    let pidString = String(ProcessInfo.processInfo.processIdentifier, radix: 16, uppercase: true)
+    let template = directoryPath + prefix + pidString + ".XXXXXX"
     let maxCount = 7
     for _ in 0 ..< maxCount {
 #if FOUNDATION_FRAMEWORK
@@ -200,23 +161,10 @@ private func createTemporaryFile(destDirfd: Int32, destinationPath: String, inPa
                 return (nil, errno)
             }
             defer { free(uniqueTempFile) }
-            let fd: Int32
-            let returnedName: String
-            if destDirfd == -1 {
-                returnedName = String(cString: uniqueTempFile)
-                fd = openFileDescriptorProtected(path: uniqueTempFile, flags: O_CREAT | O_EXCL | O_RDWR, options: options)
-            } else {
-                returnedName = String(cString: uniqueTempFile).lastPathComponent
-                fd = returnedName.withFileSystemRepresentation { basenameRep -> Int32 in
-                    guard let basenameRep else {
-                        errno = EINVAL
-                        return -1
-                    }
-                    return openatFileDescriptorProtected(dirfd: destDirfd, name: basenameRep, flags: O_CREAT | O_EXCL | O_RDWR, options: options, mode: permissions)
-                }
-            }
+            let fd = openFileDescriptorProtected(path: uniqueTempFile, flags: O_CREAT | O_EXCL | O_RDWR, options: options)
             if fd >= 0 {
-                return ((fd, returnedName), nil)
+                // Got a good fd
+                return ((fd, String(cString: uniqueTempFile)), nil)
             }
             return (nil, errno)
         }
@@ -238,37 +186,26 @@ private func createTemporaryFile(destDirfd: Int32, destinationPath: String, inPa
         // Otherwise, fall through to mktemp below
 #endif
         
-        let result: (Int32, String)? = try template.withMutableFileSystemRepresentation { templateFileSystemRep in
+        let result = try template.withMutableFileSystemRepresentation { templateFileSystemRep -> (Int32, String)? in
             guard let templateFileSystemRep else {
                 throw CocoaError(.fileWriteInvalidFileName)
             }
             
             // The warning diligently tells us we shouldn't be using mktemp() because blindly opening the returned path opens us up to a TOCTOU race. However, in this case, we're being careful by doing O_CREAT|O_EXCL and repeating, just like the implementation of mkstemp.
-            // Furthermore, we can't compatibly switch to mkstemp()/mkstemp_dprotected_np() until we have the ability to set fchmod correctly, which requires the ability to query the current umask, which we don't have. (22033100)
+            // Furthermore, we can't compatibly switch to mkstemp() until we have the ability to set fchmod correctly, which requires the ability to query the current umask, which we don't have. (22033100)
 #if os(Windows)
             guard _mktemp_s(templateFileSystemRep, strlen(templateFileSystemRep) + 1) == 0 else {
                 throw CocoaError.errorWithFilePath(inPath, errno: errno, reading: false, variant: variant)
+            }
+            let fd = try String(cString: templateFileSystemRep).withNTPathRepresentation {
+                openFileDescriptorProtected(path: $0, flags: _O_BINARY | _O_CREAT | _O_EXCL | _O_RDWR, options: options)
             }
 #else
             guard mktemp(templateFileSystemRep) != nil else {
                 throw CocoaError.errorWithFilePath(inPath, errno: errno, reading: false, variant: variant)
             }
+            let fd = openFileDescriptorProtected(path: templateFileSystemRep, flags: O_CREAT | O_EXCL | O_RDWR, options: options)
 #endif
-
-            let fd: Int32
-#if os(Windows)
-            assert(destDirfd == -1, "openat is unavailable on Windows")
-            fd = try String(cString: templateFileSystemRep).withNTPathRepresentation {
-                openFileDescriptorProtected(path: $0, flags: _O_BINARY | _O_CREAT | _O_EXCL | _O_RDWR, options: options)
-            }
-#else
-            if destDirfd == -1 {
-                fd = openFileDescriptorProtected(path: templateFileSystemRep, flags: O_CREAT | O_EXCL | O_RDWR, options: options)
-            } else {
-                fd = openatFileDescriptorProtected(dirfd: destDirfd, name: templateFileSystemRep, flags: O_CREAT | O_EXCL | O_RDWR, options: options, mode: permissions)
-            }
-#endif
-
             if fd >= 0 {
                 // Got a good fd
                 return (fd, String(cString: templateFileSystemRep))
@@ -297,13 +234,12 @@ private func createTemporaryFile(destDirfd: Int32, destinationPath: String, inPa
 #endif // os(WASI)
 }
 
-/// Returns `(file descriptor, temporary file name, temporary directory file descriptor, temporary directory path)`
-/// Caller is responsible for calling `close` on the `fd: Int32` file descriptor and calling `cleanupTemporaryDirectory` on the temporary directory path. The temporary directory path may be nil, if it does not need to be cleaned up.
-/// Caller must also close the `tempDirfd: Int32` file descriptor if it's different than `fd`.
+/// Returns `(file descriptor, temporary file path, temporary directory path)`
+/// Caller is responsible for calling `close` on the `Int32` file descriptor and calling `cleanupTemporaryDirectory` on the temporary directory path. The temporary directory path may be nil, if it does not need to be cleaned up.
 #if os(WASI)
 @available(*, unavailable, message: "WASI does not have temporary directories")
 #endif
-private func createProtectedTemporaryFile(destDirfd: Int32, destinationPath: String, inPath: borrowing some FileSystemRepresentable & ~Copyable, options: Data.WritingOptions, permissions: TemporaryFilePermissions, variant: String? = nil) throws -> (fd: Int32, name: String, tempDirfd: Int32, cleanupPath: String?) {
+private func createProtectedTemporaryFile(at destinationPath: String, inPath: borrowing some FileSystemRepresentable & ~Copyable, options: Data.WritingOptions, variant: String? = nil) throws -> (Int32, String, String?) {
 #if os(WASI)
     // WASI does not have temp directories
     throw CocoaError(.featureUnsupported)
@@ -312,54 +248,43 @@ private func createProtectedTemporaryFile(destDirfd: Int32, destinationPath: Str
     if _foundation_sandbox_check(getpid(), nil) != 0 {
         // Convert the path back into a string
         let url = URL(fileURLWithPath: destinationPath, isDirectory: false)
-        let replacementDir: String
+        var temporaryDirectoryPath: String
         do {
-            replacementDir = try FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: url, create: true).path(percentEncoded: false)
+            temporaryDirectoryPath = try FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: url, create: true).path(percentEncoded: false)
         } catch {
             if let variant, let cocoaError = error as? CocoaError {
                 let code = cocoaError.code
                 var userInfo = cocoaError.userInfo
                 userInfo[NSUserStringVariantErrorKey] = variant
-
+                
                 throw CocoaError(code, userInfo: userInfo)
             } else {
                 throw error
             }
         }
-
+        
         let updatedOptions = _NSDataWritingOptionsForRelocatedAtomicWrite(options, destinationPath)
-        let basename = destinationPath.lastPathComponent
-        let openedDirfd = replacementDir.withFileSystemRepresentation { rep -> Int32 in
-            guard let rep else {
-                errno = EINVAL
-                return -1
+        
+        let auxFile = temporaryDirectoryPath.appendingPathComponent(destinationPath.lastPathComponent)
+        return try auxFile.withFileSystemRepresentation { auxFileFileSystemRep in
+            guard let auxFileFileSystemRep else {
+                throw CocoaError(.fileWriteInvalidFileName)
             }
-            return open(rep, minimalOpenFlagsForDirectories)
-        }
-        if openedDirfd < 0 {
-            let savedErrno = errno
-            cleanupTemporaryDirectory(at: replacementDir)
-            throw CocoaError.errorWithFilePath(inPath, errno: savedErrno, reading: false, variant: variant)
-        }
-        let fd: Int32 = basename.withFileSystemRepresentation { basenameRep in
-            guard let basenameRep else {
-                errno = EINVAL
-                return -1
+            let fd = openFileDescriptorProtected(path: auxFileFileSystemRep, flags: O_CREAT | O_EXCL | O_RDWR, options: updatedOptions)
+            if fd >= 0 {
+                return (fd, auxFile, temporaryDirectoryPath)
+            } else {
+                let savedErrno = errno
+                cleanupTemporaryDirectory(at: temporaryDirectoryPath)
+                throw CocoaError.errorWithFilePath(inPath, errno: savedErrno, reading: false, variant: variant)
             }
-            return openatFileDescriptorProtected(dirfd: openedDirfd, name: basenameRep, flags: O_CREAT | O_EXCL | O_RDWR, options: updatedOptions, mode: permissions)
         }
-        if fd < 0 {
-            let savedErrno = errno
-            close(openedDirfd)
-            cleanupTemporaryDirectory(at: replacementDir)
-            throw CocoaError.errorWithFilePath(inPath, errno: savedErrno, reading: false, variant: variant)
-        }
-        return (fd, basename, openedDirfd, replacementDir)
     }
 #endif
-
-    let (fd, name) = try createTemporaryFile(destDirfd: destDirfd, destinationPath: destinationPath, inPath: inPath, options: options, permissions: permissions, variant: variant)
-    return (fd, name, destDirfd, nil)
+    
+    let temporaryDirectoryPath = destinationPath.deletingLastPathComponent()
+    let (fd, auxFile) = try createTemporaryFile(at: temporaryDirectoryPath, inPath: inPath, prefix: ".dat.nosync", options: options, variant: variant)
+    return (fd, auxFile, nil)
 #endif // os(WASI)
 }
 
@@ -454,7 +379,7 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
     // TODO: Somehow avoid copying back and forth to a String to hold the path
 
 #if os(Windows)
-    var (fd, auxPath, _, temporaryDirectoryPath) = try createProtectedTemporaryFile(destDirfd: -1, destinationPath: inPath.path, inPath: inPath, options: options, permissions: (), variant: "Folder")
+    var (fd, auxPath, temporaryDirectoryPath) = try createProtectedTemporaryFile(at: inPath.path, inPath: inPath, options: options, variant: "Folder")
 
     // Cleanup temporary directory
     defer { cleanupTemporaryDirectory(at: temporaryDirectoryPath) }
@@ -570,56 +495,48 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
         }
     }
 #else
-    let newPath = inPath.path
-
-    // When capturing the original file's mode, which we'll restore on the new file, we need to pin down the directory that we're obtaining it from to avoid TOCTOU style races. We'll do the same with the temporary directory, then use `renameat`, which will ensure that we place the file in the intended directory even in the face of a concurrent directory symlink swap.
-    let parentPath = newPath.deletingLastPathComponent()
-    let newBasename = newPath.lastPathComponent
-    
-    // If the path is just a file name, it's implicitly relative to the CWD, so we'll open "." to pin that directory, as opposed to using AT_FDCWD.
-    let parentPathToOpen = parentPath.isEmpty ? "." : parentPath
-    let destDirfd: Int32 = try parentPathToOpen.withFileSystemRepresentation { parentFSRep in
-        guard let parentFSRep else {
+    try inPath.withFileSystemRepresentation { inPathFileSystemRep in
+        guard let inPathFileSystemRep else {
             throw CocoaError(.fileWriteInvalidFileName)
         }
-        let fd = open(parentFSRep, minimalOpenFlagsForDirectories)
-        guard fd >= 0 else {
-            throw CocoaError.errorWithFilePath(inPath, errno: errno, reading: false, variant: "Folder")
-        }
-        return fd
-    }
-    defer { close(destDirfd) }
-
-    try newBasename.withFileSystemRepresentation { basenameRep in
-        guard let basenameRep else {
-            throw CocoaError(.fileWriteInvalidFileName)
-        }
-
+        
         var mode: mode_t?
-        var preRenameState = stat()
-        let result = fstatat(destDirfd, basenameRep, &preRenameState, AT_SYMLINK_NOFOLLOW)
+        
+#if FOUNDATION_FRAMEWORK
+        var newPath = inPath.path
+        var preRenameAttributes = PreRenameAttributes()
+        var attrs = attrlist(bitmapcount: u_short(ATTR_BIT_MAP_COUNT), reserved: 0, commonattr: attrgroup_t(ATTR_CMN_OBJTYPE | ATTR_CMN_ACCESSMASK | ATTR_CMN_FULLPATH), volattr: .init(), dirattr: .init(), fileattr: .init(ATTR_FILE_LINKCOUNT), forkattr: .init())
+        // Provide FSOPT_UNIQUE to ensure that the file is a regular file with a single hard link (so that we can rely on ATTR_CMN_FULLPATH)
+        let result = getattrlist(inPathFileSystemRep, &attrs, &preRenameAttributes, MemoryLayout<PreRenameAttributes>.size, .init(FSOPT_NOFOLLOW | FSOPT_UNIQUE))
         if result == 0 {
-            mode = mode_t(preRenameState.st_mode) & ~S_IFMT
-        } else if (errno != ENOENT) && (errno != ENAMETOOLONG) {
+            // Use the path from the buffer
+            mode = mode_t(preRenameAttributes.mode)
+            // Copy the contents of the getattrlist buffer for the string into a Swift String
+            withUnsafePointer(to: preRenameAttributes.fullPathBuf) { ptrToTuple in
+                // The length of the string is passed back to us in the same struct as the C string itself
+                // n.b. Length includes the null-termination byte. Use this size for the buffer.
+                let length = Int(preRenameAttributes.fullPathAttr.attr_length)
+                ptrToTuple.withMemoryRebound(to: CChar.self, capacity: length) { pointer in
+                    newPath = String(cString: pointer)
+                }
+            }
+        } else if (errno != ENOENT) && (errno != ENAMETOOLONG) && (errno != ENOTCAPABLE) {
             throw CocoaError.errorWithFilePath(inPath, errno: errno, reading: false)
         }
-
-        // If we captured an existing file's mode, open the temp at the most restrictive mode that still lets us write to it (0o200) so other users' processes can't read or modify the half-written contents; fchmod restores the real mode after rename. For a brand-new file, use 0666 (subject to umask) so open(2)'s usual semantics apply.
-        let tempOpenMode: TemporaryFilePermissions = (mode != nil) ? 0o200 : 0o666
-
-        // tempDirfd is the file descriptor of the temporary file's parent directory, which COULD be the same exact file descriptor as destDirfd.
-        let (fd, auxName, tempDirfd, temporaryDirectoryPath) = try createProtectedTemporaryFile(destDirfd: destDirfd, destinationPath: newPath, inPath: inPath, options: options, permissions: tempOpenMode, variant: "Folder")
-
+#else
+        let newPath = inPath.path
+#endif
+        
+        var (fd, auxPath, temporaryDirectoryPath) = try createProtectedTemporaryFile(at: newPath, inPath: inPath, options: options, variant: "Folder")
+        
         guard fd >= 0 else {
             let savedErrno = errno
-            if tempDirfd != destDirfd { close(tempDirfd) }
             // Cleanup temporary directory
             cleanupTemporaryDirectory(at: temporaryDirectoryPath)
             throw CocoaError.errorWithFilePath(inPath, errno: savedErrno, reading: false)
         }
         
         defer { close(fd) }
-        defer { if tempDirfd != destDirfd { close(tempDirfd) } }
         
         let parentProgress = (reportProgress && Progress.current() != nil) ? Progress(totalUnitCount: Int64(buffer.byteCount)) : nil
         
@@ -628,9 +545,9 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
         } catch {
             let savedError = errno
             
-            auxName.withFileSystemRepresentation { auxNameRep in
-                guard let auxNameRep else { return }
-                _ = unlinkat(tempDirfd, auxNameRep, 0)
+            auxPath.withFileSystemRepresentation { pathFileSystemRep in
+                guard let pathFileSystemRep else { return }
+                unlink(pathFileSystemRep)
             }
             cleanupTemporaryDirectory(at: temporaryDirectoryPath)
             
@@ -641,67 +558,91 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
             }
         }
         
-        // Before renaming the file in place, make sure it has the right file mode so that their modification looks atomic
-        if let mode {
-            fchmod(fd, mode)
-        }
-
         writeExtendedAttributes(fd: fd, attributes: attributes)
 
-        try auxName.withFileSystemRepresentation { auxNameRep in
-            guard let auxNameRep else {
+        try auxPath.withFileSystemRepresentation { auxPathFileSystemRep in
+            guard let auxPathFileSystemRep else {
                 // The aux path is not a valid file name
                 throw CocoaError(.fileWriteInvalidFileName)
             }
             
-            if renameat(tempDirfd, auxNameRep, destDirfd, basenameRep) != 0 {
-                if errno == EINVAL {
-                    // rename() fails on DOS file systems if newname already exists.
-                    // Makes "atomically" next to meaningless, but...
-                    // We try a little harder but this is not thread-safe nor atomic
-                    
-                    let (fd2, auxName2, tempDirfd2, temporaryDirectoryPath2) = try createProtectedTemporaryFile(destDirfd: destDirfd, destinationPath: newPath, inPath: inPath, options: options, permissions: tempOpenMode)
-                    close(fd2)
-                    try auxName2.withFileSystemRepresentation { auxName2Rep in
-                        guard let auxName2Rep else {
-                            // The aux path (2) is not a valid file name
-                            throw CocoaError(.fileWriteInvalidFileName)
-                        }
+            try newPath.withFileSystemRepresentation { newPathFileSystemRep in
+                guard let newPathFileSystemRep else {
+                    // The new path is not a valid file name
+                    throw CocoaError(.fileWriteInvalidFileName)
+                }
+                
+                if rename(auxPathFileSystemRep, newPathFileSystemRep) != 0 {
+                    if errno == EINVAL {
+                        // rename() fails on DOS file systems if newname already exists.
+                        // Makes "atomically" next to meaningless, but...
+                        // We try a little harder but this is not thread-safe nor atomic
                         
-                        _ = unlinkat(tempDirfd2, auxName2Rep, 0)
-                        
-                        if renameat(destDirfd, basenameRep, tempDirfd2, auxName2Rep) != 0 || renameat(tempDirfd, auxNameRep, destDirfd, basenameRep) != 0 {
-                            // Swap failed
-                            let savedErrno = errno
-                            _ = unlinkat(tempDirfd2, auxName2Rep, 0)
-                            _ = unlinkat(tempDirfd, auxNameRep, 0)
-                            if tempDirfd2 != destDirfd { close(tempDirfd2) }
-                            cleanupTemporaryDirectory(at: temporaryDirectoryPath)
+                        let (fd2, auxPath2, temporaryDirectoryPath2) = try createProtectedTemporaryFile(at: newPath, inPath: inPath, options: options)
+                        close(fd2)
+                        try auxPath2.withFileSystemRepresentation { auxPath2FileSystemRep in
+                            guard let auxPath2FileSystemRep else {
+                                // The aux path (2) is not a valid file name
+                                throw CocoaError(.fileWriteInvalidFileName)
+                            }
+                            
+                            unlink(auxPath2FileSystemRep)
+                            
+                            if rename(newPathFileSystemRep, auxPath2FileSystemRep) != 0 || rename(auxPathFileSystemRep, newPathFileSystemRep) != 0 {
+                                // Swap failed
+                                let savedErrno = errno
+                                unlink(auxPath2FileSystemRep)
+                                unlink(auxPathFileSystemRep)
+                                cleanupTemporaryDirectory(at: temporaryDirectoryPath)
+                                cleanupTemporaryDirectory(at: temporaryDirectoryPath2)
+                                throw CocoaError.errorWithFilePath(inPath, errno: savedErrno, reading: false)
+                            }
+                            
+                            unlink(auxPath2FileSystemRep)
                             cleanupTemporaryDirectory(at: temporaryDirectoryPath2)
-                            throw CocoaError.errorWithFilePath(inPath, errno: savedErrno, reading: false)
                         }
                         
-                        _ = unlinkat(tempDirfd2, auxName2Rep, 0)
-                        if tempDirfd2 != destDirfd { close(tempDirfd2) }
-                        cleanupTemporaryDirectory(at: temporaryDirectoryPath2)
+                    } else if errno == EBUSY {
+                        // EBUSY may mean it was an HFS+ file system and something (perhaps another process) still had a reference to resources (vm pages, fd) associated with the file. Try again, non-atomically.
+                        unlink(auxPathFileSystemRep)
+                        cleanupTemporaryDirectory(at: temporaryDirectoryPath)
+                        
+                        // We also throw away any other options, and do not report progress. This may or may not be a bug.
+                        return try writeToFile(path: inPath, buffer: buffer, options: [], attributes: attributes, reportProgress: false)
+                    } else {
+                        let savedErrno = errno
+                        unlink(auxPathFileSystemRep)
+                        cleanupTemporaryDirectory(at: temporaryDirectoryPath)
+                        throw CocoaError.errorWithFilePath(inPath, errno: savedErrno, reading: false)
                     }
-                    
-                } else if errno == EBUSY {
-                    // EBUSY may mean it was an HFS+ file system and something (perhaps another process) still had a reference to resources (vm pages, fd) associated with the file. Try again, non-atomically.
-                    _ = unlinkat(tempDirfd, auxNameRep, 0)
-                    cleanupTemporaryDirectory(at: temporaryDirectoryPath)
-                    
-                    // We also throw away any other options, and do not report progress. This may or may not be a bug.
-                    return try writeToFile(path: inPath, buffer: buffer, options: [], attributes: attributes, reportProgress: false)
-                } else {
-                    let savedErrno = errno
-                    _ = unlinkat(tempDirfd, auxNameRep, 0)
-                    cleanupTemporaryDirectory(at: temporaryDirectoryPath)
-                    throw CocoaError.errorWithFilePath(inPath, errno: savedErrno, reading: false)
+                }
+                
+                cleanupTemporaryDirectory(at: temporaryDirectoryPath)
+                
+                if let mode {
+                    // Try to change the mode if the path has not changed. Do our best, but don't report an error.
+#if FOUNDATION_FRAMEWORK
+                    var attrs = attrlist(bitmapcount: u_short(ATTR_BIT_MAP_COUNT), reserved: 0, commonattr: attrgroup_t(ATTR_CMN_FULLPATH), volattr: .init(), dirattr: .init(), fileattr: .init(), forkattr: .init())
+                    var buffer = FullPathAttributes()
+                    let result = fgetattrlist(fd, &attrs, &buffer, MemoryLayout<FullPathAttributes>.size, .init(FSOPT_NOFOLLOW | FSOPT_UNIQUE))
+                    // Compare the last one to this one
+                    if result == 0 {
+                        withUnsafePointer(to: buffer.fullPathBuf) { ptrToTuple in
+                            let newPathLength = strlen(newPathFileSystemRep) + 1 // Account for the null terminator, because we compare it to fullPathLength
+                            let fullPathLength = Int(buffer.fullPathAttr.attr_length) // This includes the null terminator
+                            ptrToTuple.withMemoryRebound(to: CChar.self, capacity: fullPathLength) { newNewPathFileSystemRep in
+                                if fullPathLength == newPathLength && strncmp(newPathFileSystemRep, newNewPathFileSystemRep, fullPathLength) == 0 {
+                                    // Try to change the mode
+                                    fchmod(fd, mode)
+                                }
+                            }
+                        }
+                    }
+#else
+                    fchmod(fd, mode)
+#endif
                 }
             }
-            
-            cleanupTemporaryDirectory(at: temporaryDirectoryPath)
         }
     }
 #endif

--- a/Sources/_FoundationCShims/include/io_shims.h
+++ b/Sources/_FoundationCShims/include/io_shims.h
@@ -24,6 +24,17 @@
 // See getattrlist for an explanation of the layout of these structs.
 
 #pragma pack(push, 1)
+typedef struct PreRenameAttributes {
+    u_int32_t length;
+    fsobj_type_t fileType;
+    u_int32_t mode;
+    attrreference_t fullPathAttr;
+    u_int32_t nlink;
+    char fullPathBuf[PATH_MAX];
+} PreRenameAttributes;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
 typedef struct FullPathAttributes {
     u_int32_t length;
     attrreference_t fullPathAttr;

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -212,9 +212,8 @@ private final class DataIOTests {
         #expect(readData == data)
     }
 
-    // Atomic writes must succeed when the destination is read-only.
+    // Atomic writes must succeed when the destination is read-only, and the resulting file must not retain the read-only state.
     // On POSIX this is the behavior of rename(2). On Windows, SetFileInformationByHandle with FileRenameInfoEx returns ERROR_ACCESS_DENIED for a FILE_ATTRIBUTE_READONLY destination even with FILE_RENAME_FLAG_POSIX_SEMANTICS | FILE_RENAME_FLAG_REPLACE_IF_EXISTS. So the read-only attribute is cleared and the rename is retried.
-    // The resulting file retains the read-only attribute. (Not yet on Windows).
     @Test
     func atomicWriteReplacesReadOnlyDestination() throws {
         let initial = Data("initial".utf8)
@@ -231,11 +230,12 @@ private final class DataIOTests {
         let read = try Data(contentsOf: url)
         #expect(read == next)
 
-#if !os(Windows)
-        // Check mode bits directly. Testing by expecting `try later.write(to: url)` to throw would fail for root (e.g. in Linux CI containers), since root bypasses permission checks even on a read-only file.
-        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
-        let mode = attributes[.posixPermissions] as? UInt ?? 0
-        #expect(mode == 0o400)
+#if !FOUNDATION_FRAMEWORK
+        // The path now resolves to the new temp file (the rename operation detached the old destination). Confirm it's writable by performing a subsequent non-atomic write.
+        // Skipped for FOUNDATION_FRAMEWORK: that path preserves and reapplies the destination's pre-rename mode on the new file, so the new file would still be read-only.
+        // TODO: Preserve the destination's mode across platforms.
+        let later = Data("later".utf8)
+        try later.write(to: url)
 #endif
     }
 }


### PR DESCRIPTION
This reverts the "Atomic file writes don't update permissions atomically", which should include the following
    
    - f83b9f577bbc818a7735f63e19e5da065dd765c1
    - a1e770bc37db1e9642f26b85f84e8b3ed5728da4
    - b4a91bc08f57eefebb2515cb8681cafb46ce9135
    
rdar 181819557