### PR TITLE
Add Buddhist and Japanese calendar implementations

### DIFF
--- a/Benchmarks/Benchmarks/Internationalization/BenchmarkCalendar.swift
+++ b/Benchmarks/Benchmarks/Internationalization/BenchmarkCalendar.swift
@@ -22,7 +22,7 @@ import Foundation
 
 #if FOUNDATION_FRAMEWORK
 // FOUNDATION_FRAMEWORK has a scheme per benchmark file, so only include one benchmark here.
-let benchmarks: @Sendable () -> Void = {
+let benchmarks = {
     calendarBenchmarks()
 }
 #endif
@@ -226,8 +226,9 @@ func calendarBenchmarks() {
     Benchmark("copyOnWritePerformance", configuration: allocationsConfiguration) { benchmark in
         var cal = Calendar(identifier: .gregorian)
         for i in benchmark.scaledIterations {
-            cal.firstWeekday = i % 2
-            assert(cal.firstWeekday == i % 2)
+            // (i % 2) + 1: firstWeekday 0 is invalid and asserts
+            cal.firstWeekday = (i % 2) + 1
+            assert(cal.firstWeekday == (i % 2) + 1)
         }
     }
     
@@ -253,7 +254,8 @@ func calendarBenchmarks() {
         for _ in benchmark.scaledIterations {
             let loc = Locale.current
             let identifier = loc.identifier
-            assert(identifier == "en_US")
+            // machine-independent: en_US assert crashes on any other locale
+            assert(!identifier.isEmpty)
         }
     }
     
@@ -262,7 +264,8 @@ func calendarBenchmarks() {
         for _ in benchmark.scaledIterations {
             let loc = Locale.autoupdatingCurrent
             let identifier = loc.identifier
-            assert(identifier == "en_US")
+            // machine-independent: en_US assert crashes on any other locale
+            assert(!identifier.isEmpty)
         }
     }
     // MARK: - Identifiers
@@ -592,6 +595,177 @@ func calendarBenchmarks() {
         for date in hebrewTestDates {
             let comps = hebrewCal.dateComponents([.year, .month, .day], from: date)
             let rt = hebrewCal.date(from: comps)
+            blackHole(rt)
+        }
+    }
+
+    // MARK: - GregorianCalendar (mirrors the per-calendar 5-bench block for cross-calendar comparison)
+
+    let gregorianCal = Calendar(identifier: .gregorian)
+    let gregorianStart = Date(timeIntervalSince1970: 1474666555.0) // 2016-09-23T14:35:55-0700
+    let christmasComponents = DateComponents(month: 12, day: 25)
+
+    Benchmark("GregorianCalendar-nextThousandChristmases") { benchmark in
+        var count = 1000
+        gregorianCal.enumerateDates(startingAfter: gregorianStart, matching: christmasComponents, matchingPolicy: .nextTime) { result, exactMatch, stop in
+            count -= 1
+            if count == 0 {
+                stop = true
+            }
+        }
+    }
+
+    Benchmark("GregorianCalendar-allocationsForFixedCalendar", configuration: allocationsConfiguration) { benchmark in
+        for _ in benchmark.scaledIterations {
+            let cal = Calendar(identifier: .gregorian)
+            let date = cal.date(byAdding: .day, value: 1, to: gregorianStart)
+            blackHole(date)
+        }
+    }
+
+    Benchmark("GregorianCalendar-copyOnWritePerformance", configuration: allocationsConfiguration) { benchmark in
+        var cal = Calendar(identifier: .gregorian)
+        for i in benchmark.scaledIterations {
+            cal.firstWeekday = (i % 2) + 1
+            blackHole(cal.firstWeekday)
+        }
+    }
+
+    let gregorianTestDates = {
+        let date = Date(timeIntervalSince1970: 1474666555.0)
+        var dates = [Date]()
+        dates.reserveCapacity(10000)
+        for i in 0...10000 {
+            dates.append(Date(timeInterval: Double(i * 86400), since: date))
+        }
+        return dates
+    }()
+
+    Benchmark("GregorianCalendar-dateComponents-yearMonthDay", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for date in gregorianTestDates {
+            let dc = gregorianCal.dateComponents([.year, .month, .day], from: date)
+            blackHole(dc)
+        }
+    }
+
+    Benchmark("GregorianCalendar-roundTripDateComponents", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for date in gregorianTestDates {
+            let comps = gregorianCal.dateComponents([.year, .month, .day], from: date)
+            let rt = gregorianCal.date(from: comps)
+            blackHole(rt)
+        }
+    }
+
+    // MARK: - BuddhistCalendar
+
+    let buddhistCal = Calendar(identifier: .buddhist)
+    let buddhistStart = Date(timeIntervalSince1970: 1474666555.0) // 2016-09-23T14:35:55-0700
+    let songkranComponents = DateComponents(month: 4, day: 13) // Songkran (Thai New Year)
+
+    Benchmark("BuddhistCalendar-nextThousandSongkrans") { benchmark in
+        var count = 1000
+        buddhistCal.enumerateDates(startingAfter: buddhistStart, matching: songkranComponents, matchingPolicy: .nextTime) { result, exactMatch, stop in
+            count -= 1
+            if count == 0 {
+                stop = true
+            }
+        }
+    }
+
+    Benchmark("BuddhistCalendar-allocationsForFixedCalendar", configuration: allocationsConfiguration) { benchmark in
+        for _ in benchmark.scaledIterations {
+            let cal = Calendar(identifier: .buddhist)
+            let date = cal.date(byAdding: .day, value: 1, to: buddhistStart)
+            blackHole(date)
+        }
+    }
+
+    Benchmark("BuddhistCalendar-copyOnWritePerformance", configuration: allocationsConfiguration) { benchmark in
+        var cal = Calendar(identifier: .buddhist)
+        for i in benchmark.scaledIterations {
+            cal.firstWeekday = (i % 2) + 1
+            blackHole(cal.firstWeekday)
+        }
+    }
+
+    let buddhistTestDates = {
+        let date = Date(timeIntervalSince1970: 1474666555.0)
+        var dates = [Date]()
+        dates.reserveCapacity(10000)
+        for i in 0...10000 {
+            dates.append(Date(timeInterval: Double(i * 86400), since: date))
+        }
+        return dates
+    }()
+
+    Benchmark("BuddhistCalendar-dateComponents-yearMonthDay", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for date in buddhistTestDates {
+            let dc = buddhistCal.dateComponents([.year, .month, .day], from: date)
+            blackHole(dc)
+        }
+    }
+
+    Benchmark("BuddhistCalendar-roundTripDateComponents", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for date in buddhistTestDates {
+            let comps = buddhistCal.dateComponents([.year, .month, .day], from: date)
+            let rt = buddhistCal.date(from: comps)
+            blackHole(rt)
+        }
+    }
+
+    // MARK: - JapaneseCalendar
+
+    let japaneseCal = Calendar(identifier: .japanese)
+    let japaneseStart = Date(timeIntervalSince1970: 1474666555.0) // 2016-09-23T14:35:55-0700
+    let childrensDayComponents = DateComponents(month: 5, day: 5) // Kodomo no Hi (Children's Day)
+
+    Benchmark("JapaneseCalendar-nextThousandChildrensDays") { benchmark in
+        var count = 1000
+        japaneseCal.enumerateDates(startingAfter: japaneseStart, matching: childrensDayComponents, matchingPolicy: .nextTime) { result, exactMatch, stop in
+            count -= 1
+            if count == 0 {
+                stop = true
+            }
+        }
+    }
+
+    Benchmark("JapaneseCalendar-allocationsForFixedCalendar", configuration: allocationsConfiguration) { benchmark in
+        for _ in benchmark.scaledIterations {
+            let cal = Calendar(identifier: .japanese)
+            let date = cal.date(byAdding: .day, value: 1, to: japaneseStart)
+            blackHole(date)
+        }
+    }
+
+    Benchmark("JapaneseCalendar-copyOnWritePerformance", configuration: allocationsConfiguration) { benchmark in
+        var cal = Calendar(identifier: .japanese)
+        for i in benchmark.scaledIterations {
+            cal.firstWeekday = (i % 2) + 1
+            blackHole(cal.firstWeekday)
+        }
+    }
+
+    let japaneseTestDates = {
+        let date = Date(timeIntervalSince1970: 1474666555.0)
+        var dates = [Date]()
+        dates.reserveCapacity(10000)
+        for i in 0...10000 {
+            dates.append(Date(timeInterval: Double(i * 86400), since: date))
+        }
+        return dates
+    }()
+
+    Benchmark("JapaneseCalendar-dateComponents-yearMonthDay", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for date in japaneseTestDates {
+            let dc = japaneseCal.dateComponents([.year, .month, .day], from: date)
+            blackHole(dc)
+        }
+    }
+
+    Benchmark("JapaneseCalendar-roundTripDateComponents", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for date in japaneseTestDates {
+            let comps = japaneseCal.dateComponents([.year, .month, .day], from: date)
+            let rt = japaneseCal.date(from: comps)
             blackHole(rt)
         }
     }

--- a/Sources/FoundationEssentials/Calendar/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Calendar/CMakeLists.txt
@@ -17,10 +17,12 @@ target_sources(FoundationEssentials PRIVATE
     CalendarConstants.swift
     CalendarUtility.swift
     Calendar_Autoupdating.swift
+    Calendar_Buddhist.swift
     Calendar_Cache.swift
     Calendar_Enumerate.swift
     Calendar_Gregorian.swift
     Calendar_Hebrew.swift
+    Calendar_Japanese.swift
     Calendar_Protocol.swift
     Calendar_Recurrence.swift
     Date+FormatStyle.swift

--- a/Sources/FoundationEssentials/Calendar/Calendar_Buddhist.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Buddhist.swift
@@ -1,0 +1,153 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Buddhist calendar. Year = Gregorian + 543, single era (BE). Delegates to `_CalendarGregorian`.
+internal final class _CalendarBuddhist: _CalendarProtocol, @unchecked Sendable {
+
+    static let yearOffset = 543
+
+    private let gregorian: _CalendarGregorian
+
+    init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
+        assert(identifier == .buddhist, "_CalendarBuddhist only handles .buddhist")
+        self.gregorian = _CalendarGregorian(identifier: .gregorian, timeZone: timeZone, locale: locale, firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDaysInFirstWeek, gregorianStartDate: gregorianStartDate)
+    }
+
+    let identifier: Calendar.Identifier = .buddhist
+
+    var locale: Locale? {
+        get { gregorian.locale }
+        set { gregorian.locale = newValue }
+    }
+
+    var timeZone: TimeZone {
+        get { gregorian.timeZone }
+        set { gregorian.timeZone = newValue }
+    }
+
+    var firstWeekday: Int {
+        get { gregorian.firstWeekday }
+        set { gregorian.firstWeekday = newValue }
+    }
+
+    var minimumDaysInFirstWeek: Int {
+        get { gregorian.minimumDaysInFirstWeek }
+        set { gregorian.minimumDaysInFirstWeek = newValue }
+    }
+
+    func copy(changingLocale: Locale?, changingTimeZone: TimeZone?, changingFirstWeekday: Int?, changingMinimumDaysInFirstWeek: Int?) -> any _CalendarProtocol {
+        let args = _CalendarUtility.resolvedCopyArgs(
+            currentTimeZone: gregorian.timeZone, changingTimeZone: changingTimeZone,
+            currentLocale: gregorian.locale, changingLocale: changingLocale,
+            currentFirstWeekday: gregorian._firstWeekday, changingFirstWeekday: changingFirstWeekday,
+            currentMinimumDaysInFirstWeek: gregorian._minimumDaysInFirstWeek, changingMinimumDaysInFirstWeek: changingMinimumDaysInFirstWeek
+        )
+        return _CalendarBuddhist(identifier: identifier, timeZone: args.timeZone, locale: args.locale, firstWeekday: args.firstWeekday, minimumDaysInFirstWeek: args.minimumDaysInFirstWeek, gregorianStartDate: nil)
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+        hasher.combine(timeZone)
+        hasher.combine(firstWeekday)
+        hasher.combine(minimumDaysInFirstWeek)
+        hasher.combine(localeIdentifier)
+        hasher.combine(preferredFirstWeekday)
+        hasher.combine(preferredMinimumDaysInFirstweek)
+    }
+
+    func supportsNextDateFastPath(for components: Calendar.ComponentSet) -> Bool { gregorian.supportsNextDateFastPath(for: components) }
+
+    // MARK: - Range
+
+    func minimumRange(of component: Calendar.Component) -> Range<Int>? {
+        if component == .era { return 0..<1 }
+        return gregorian.minimumRange(of: component)
+    }
+
+    func maximumRange(of component: Calendar.Component) -> Range<Int>? {
+        if component == .era { return 0..<1 }
+        return gregorian.maximumRange(of: component)
+    }
+
+    func range(of smaller: Calendar.Component, in larger: Calendar.Component, for date: Date) -> Range<Int>? {
+        gregorian.range(of: smaller, in: larger, for: date)
+    }
+
+    func ordinality(of smaller: Calendar.Component, in larger: Calendar.Component, for date: Date) -> Int? {
+        gregorian.ordinality(of: smaller, in: larger, for: date)
+    }
+
+    func dateInterval(of component: Calendar.Component, for date: Date) -> DateInterval? {
+        if component == .era {
+            return DateInterval(start: Date(timeIntervalSinceReferenceDate: -63113904000.0 - Calendar._maxDateIntervalDuration), duration: Calendar._maxDateIntervalDuration)
+        }
+        return gregorian.dateInterval(of: component, for: date)
+    }
+
+    func isDateInWeekend(_ date: Date) -> Bool {
+        gregorian.isDateInWeekend(date)
+    }
+
+    // MARK: - Date / DateComponents conversion
+
+    func date(from components: DateComponents) -> Date? {
+        gregorian.date(from: convertedToGregorian(components))
+    }
+
+    func dateComponents(_ components: Calendar.ComponentSet, from date: Date, in timeZone: TimeZone) -> DateComponents {
+        var dc = gregorian.dateComponents(components, from: date, in: timeZone)
+        adjustToBuddhist(&dc, requested: components)
+        return dc
+    }
+
+    func dateComponents(_ components: Calendar.ComponentSet, from date: Date) -> DateComponents {
+        var dc = gregorian.dateComponents(components, from: date)
+        adjustToBuddhist(&dc, requested: components)
+        return dc
+    }
+
+    func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date? {
+        gregorian.date(byAdding: components, to: date, wrappingComponents: wrappingComponents)
+    }
+
+    func dateComponents(_ components: Calendar.ComponentSet, from start: Date, to end: Date) -> DateComponents {
+        var dc = gregorian.dateComponents(components, from: start, to: end)
+        if components.contains(.era) { dc.era = 0 }
+        return dc
+    }
+
+    // MARK: - Fast path
+
+    func nextDate(after date: Date, matching components: DateComponents, direction: Calendar.SearchDirection) -> Date? {
+        gregorian.nextDate(after: date, matching: convertedToGregorian(components), direction: direction)
+    }
+
+    // MARK: - Helpers
+
+    private func convertedToGregorian(_ components: DateComponents) -> DateComponents {
+        var dc = components
+        if let y = dc.year { dc.year = y - Self.yearOffset }
+        dc.era = nil
+        return dc
+    }
+
+    private func adjustToBuddhist(_ dc: inout DateComponents, requested: Calendar.ComponentSet) {
+        if requested.contains(.year), let y = dc.year { dc.year = y + Self.yearOffset }
+        if requested.contains(.era) { dc.era = 0 }
+    }
+
+#if FOUNDATION_FRAMEWORK
+    func bridgeToNSCalendar() -> NSCalendar {
+        _NSSwiftCalendar(calendar: Calendar(inner: self))
+    }
+#endif
+}

--- a/Sources/FoundationEssentials/Calendar/Calendar_Buddhist.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Buddhist.swift
@@ -69,12 +69,12 @@ internal final class _CalendarBuddhist: _CalendarProtocol, @unchecked Sendable {
     // MARK: - Range
 
     func minimumRange(of component: Calendar.Component) -> Range<Int>? {
-        if component == .era { return 0..<1 }
+        if component == .era { return Range(0...0) }
         return gregorian.minimumRange(of: component)
     }
 
     func maximumRange(of component: Calendar.Component) -> Range<Int>? {
-        if component == .era { return 0..<1 }
+        if component == .era { return Range(0...0) }
         return gregorian.maximumRange(of: component)
     }
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Cache.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Cache.swift
@@ -34,13 +34,25 @@ internal import _ForSwiftFoundation
 internal func foundation_swift_hebrew_calendar_feature_enabled() -> Bool {
     _foundation_swift_hebrew_calendar_feature_enabled()
 }
+internal func foundation_swift_buddhist_calendar_feature_enabled() -> Bool {
+    return false
+}
+internal func foundation_swift_japanese_calendar_feature_enabled() -> Bool {
+    return false
+}
 #else
 internal func foundation_swift_hebrew_calendar_feature_enabled() -> Bool { return false }
+internal func foundation_swift_buddhist_calendar_feature_enabled() -> Bool { return false }
+internal func foundation_swift_japanese_calendar_feature_enabled() -> Bool { return false }
 #endif
 
 func _calendarClass(identifier: Calendar.Identifier) -> _CalendarProtocol.Type? {
     if identifier == .gregorian || identifier == .iso8601 {
         return _CalendarGregorian.self
+    } else if foundation_swift_buddhist_calendar_feature_enabled() && identifier == .buddhist {
+        return _CalendarBuddhist.self
+    } else if foundation_swift_japanese_calendar_feature_enabled() && identifier == .japanese {
+        return _CalendarJapanese.self
     } else if foundation_swift_hebrew_calendar_feature_enabled() && identifier == .hebrew {
         return _CalendarHebrew.self
     } else {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
@@ -29,7 +29,7 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
 
     /// 237 Japanese eras (Taika 645 → Reiwa 2019), sorted descending. Index values match ICU's era numbering.
     // Meiji (232) uses 1868-09-08 to match Apple's runtime ICU (CLDR canonical is 1868-10-23).
-    private static let eraData: InlineArray<237, (Int32, Int16, Int8, Int8)> = [
+    private static let eraData: InlineArray<237, (index: Int32, year: Int16, month: Int8, day: Int8)> = [
         (236, 2019, 5, 1),
         (235, 1989, 1, 8),
         (234, 1926, 12, 25),
@@ -273,7 +273,7 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
 
     private static func era(at i: Int) -> EraEntry {
         let raw = eraData[i]
-        return EraEntry(raw.0, raw.1, raw.2, raw.3)
+        return EraEntry(raw.index, raw.year, raw.month, raw.day)
     }
 
     private let gregorian: _CalendarGregorian
@@ -414,11 +414,7 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
         guard let era = eraEntry(forGregorianYear: y, month: m, day: d) else {
             return gregorian.dateInterval(of: .era, for: date)
         }
-        var startDC = DateComponents()
-        startDC.year = era.startGregorianYear
-        startDC.month = era.startMonth
-        startDC.day = era.startDay
-        startDC.hour = 0; startDC.minute = 0; startDC.second = 0
+        let startDC = DateComponents(year: era.startGregorianYear, month: era.startMonth, day: era.startDay, hour: 0, minute: 0, second: 0)
         guard let start = gregorian.date(from: startDC) else { return nil }
         let endDate: Date
         var nextEra: EraEntry? = nil
@@ -429,11 +425,7 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
             }
         }
         if let next = nextEra {
-            var endDC = DateComponents()
-            endDC.year = next.startGregorianYear
-            endDC.month = next.startMonth
-            endDC.day = next.startDay
-            endDC.hour = 0; endDC.minute = 0; endDC.second = 0
+            let endDC = DateComponents(year: next.startGregorianYear, month: next.startMonth, day: next.startDay, hour: 0, minute: 0, second: 0)
             guard let e = gregorian.date(from: endDC) else { return nil }
             endDate = e
         } else {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
@@ -330,13 +330,13 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
     // MARK: - Range
 
     func minimumRange(of component: Calendar.Component) -> Range<Int>? {
-        if component == .era { return 0..<(Self.era(at: Self.eraCount - 1).index + Self.eraCount) }
-        if component == .year { return 1..<2 }
+        if component == .era { return Range(0...Self.era(at: 0).index) }
+        if component == .year { return Range(1...1) }
         return gregorian.minimumRange(of: component)
     }
 
     func maximumRange(of component: Calendar.Component) -> Range<Int>? {
-        if component == .era { return 0..<(Self.era(at: 0).index + 1) }
+        if component == .era { return Range(0...Self.era(at: 0).index) }
         return gregorian.maximumRange(of: component)
     }
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
@@ -402,10 +402,10 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
     }
 
     private func eraEntry(byIndex index: Int) -> EraEntry? {
-        for i in 0..<Self.eraCount {
-            if Self.era(at: i).index == index { return Self.era(at: i) }
-        }
-        return nil
+        let i = Self.eraCount - 1 - index
+        guard i >= 0 && i < Self.eraCount else { return nil }
+        let era = Self.era(at: i)
+        return era.index == index ? era : nil
     }
 
     private func eraInterval(containing date: Date) -> DateInterval? {
@@ -417,14 +417,9 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
         let startDC = DateComponents(year: era.startGregorianYear, month: era.startMonth, day: era.startDay, hour: 0, minute: 0, second: 0)
         guard let start = gregorian.date(from: startDC) else { return nil }
         let endDate: Date
-        var nextEra: EraEntry? = nil
-        for i in 0..<Self.eraCount {
-            if Self.era(at: i).index == era.index && i > 0 {
-                nextEra = Self.era(at: i - 1)
-                break
-            }
-        }
-        if let next = nextEra {
+        let position = Self.eraCount - 1 - era.index
+        if position > 0 {
+            let next = Self.era(at: position - 1)
             let endDC = DateComponents(year: next.startGregorianYear, month: next.startMonth, day: next.startDay, hour: 0, minute: 0, second: 0)
             guard let e = gregorian.date(from: endDC) else { return nil }
             endDate = e

--- a/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
@@ -1,0 +1,481 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Japanese imperial calendar. Same arithmetic as Gregorian; year is reckoned within the current era. Delegates to `_CalendarGregorian`.
+internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
+
+    private struct EraEntry {
+        let index: Int
+        let startGregorianYear: Int
+        let startMonth: Int
+        let startDay: Int
+
+        init(_ index: Int32, _ year: Int16, _ month: Int8, _ day: Int8) {
+            self.index = Int(index)
+            self.startGregorianYear = Int(year)
+            self.startMonth = Int(month)
+            self.startDay = Int(day)
+        }
+    }
+
+    /// 237 Japanese eras (Taika 645 → Reiwa 2019), sorted descending. Index values match ICU's era numbering.
+    // Meiji (232) uses 1868-09-08 to match Apple's runtime ICU (CLDR canonical is 1868-10-23).
+    private static let eraData: InlineArray<237, (Int32, Int16, Int8, Int8)> = [
+        (236, 2019, 5, 1),
+        (235, 1989, 1, 8),
+        (234, 1926, 12, 25),
+        (233, 1912, 7, 30),
+        (232, 1868, 9, 8),
+        (231, 1865, 4, 7),
+        (230, 1864, 2, 20),
+        (229, 1861, 2, 19),
+        (228, 1860, 3, 18),
+        (227, 1854, 11, 27),
+        (226, 1848, 2, 28),
+        (225, 1844, 12, 2),
+        (224, 1830, 12, 10),
+        (223, 1818, 4, 22),
+        (222, 1804, 2, 11),
+        (221, 1801, 2, 5),
+        (220, 1789, 1, 25),
+        (219, 1781, 4, 2),
+        (218, 1772, 11, 16),
+        (217, 1764, 6, 2),
+        (216, 1751, 10, 27),
+        (215, 1748, 7, 12),
+        (214, 1744, 2, 21),
+        (213, 1741, 2, 27),
+        (212, 1736, 4, 28),
+        (211, 1716, 6, 22),
+        (210, 1711, 4, 25),
+        (209, 1704, 3, 13),
+        (208, 1688, 9, 30),
+        (207, 1684, 2, 21),
+        (206, 1681, 9, 29),
+        (205, 1673, 9, 21),
+        (204, 1661, 4, 25),
+        (203, 1658, 7, 23),
+        (202, 1655, 4, 13),
+        (201, 1652, 9, 18),
+        (200, 1648, 2, 15),
+        (199, 1644, 12, 16),
+        (198, 1624, 2, 30),
+        (197, 1615, 7, 13),
+        (196, 1596, 10, 27),
+        (195, 1592, 12, 8),
+        (194, 1573, 7, 28),
+        (193, 1570, 4, 23),
+        (192, 1558, 2, 28),
+        (191, 1555, 10, 23),
+        (190, 1532, 7, 29),
+        (189, 1528, 8, 20),
+        (188, 1521, 8, 23),
+        (187, 1504, 2, 30),
+        (186, 1501, 2, 29),
+        (185, 1492, 7, 19),
+        (184, 1489, 8, 21),
+        (183, 1487, 7, 29),
+        (182, 1469, 4, 28),
+        (181, 1467, 3, 3),
+        (180, 1466, 2, 28),
+        (179, 1460, 12, 21),
+        (178, 1457, 9, 28),
+        (177, 1455, 7, 25),
+        (176, 1452, 7, 25),
+        (175, 1449, 7, 28),
+        (174, 1444, 2, 5),
+        (173, 1441, 2, 17),
+        (172, 1429, 9, 5),
+        (171, 1428, 4, 27),
+        (170, 1394, 7, 5),
+        (169, 1390, 3, 26),
+        (168, 1389, 2, 9),
+        (167, 1387, 8, 23),
+        (166, 1387, 8, 22),
+        (165, 1384, 4, 28),
+        (164, 1381, 2, 10),
+        (163, 1379, 3, 22),
+        (162, 1375, 5, 27),
+        (161, 1372, 4, 1),
+        (160, 1370, 7, 24),
+        (159, 1346, 12, 8),
+        (158, 1340, 4, 28),
+        (157, 1336, 2, 29),
+        (156, 1334, 1, 29),
+        (155, 1331, 8, 9),
+        (154, 1329, 8, 29),
+        (153, 1326, 4, 26),
+        (152, 1324, 12, 9),
+        (151, 1321, 2, 23),
+        (150, 1319, 4, 28),
+        (149, 1317, 2, 3),
+        (148, 1312, 3, 20),
+        (147, 1311, 4, 28),
+        (146, 1308, 10, 9),
+        (145, 1306, 12, 14),
+        (144, 1303, 8, 5),
+        (143, 1302, 11, 21),
+        (142, 1299, 4, 25),
+        (141, 1293, 8, 5),
+        (140, 1288, 4, 28),
+        (139, 1278, 2, 29),
+        (138, 1275, 4, 25),
+        (137, 1264, 2, 28),
+        (136, 1261, 2, 20),
+        (135, 1260, 4, 13),
+        (134, 1259, 3, 26),
+        (133, 1257, 3, 14),
+        (132, 1256, 10, 5),
+        (131, 1249, 3, 18),
+        (130, 1247, 2, 28),
+        (129, 1243, 2, 26),
+        (128, 1240, 7, 16),
+        (127, 1239, 2, 7),
+        (126, 1238, 11, 23),
+        (125, 1235, 9, 19),
+        (124, 1234, 11, 5),
+        (123, 1233, 4, 15),
+        (122, 1232, 4, 2),
+        (121, 1229, 3, 5),
+        (120, 1227, 12, 10),
+        (119, 1225, 4, 20),
+        (118, 1224, 11, 20),
+        (117, 1222, 4, 13),
+        (116, 1219, 4, 12),
+        (115, 1213, 12, 6),
+        (114, 1211, 3, 9),
+        (113, 1207, 10, 25),
+        (112, 1206, 4, 27),
+        (111, 1204, 2, 20),
+        (110, 1201, 2, 13),
+        (109, 1199, 4, 27),
+        (108, 1190, 4, 11),
+        (107, 1185, 8, 14),
+        (106, 1184, 4, 16),
+        (105, 1182, 5, 27),
+        (104, 1181, 7, 14),
+        (103, 1177, 8, 4),
+        (102, 1175, 7, 28),
+        (101, 1171, 4, 21),
+        (100, 1169, 4, 8),
+        (99, 1166, 8, 27),
+        (98, 1165, 6, 5),
+        (97, 1163, 3, 29),
+        (96, 1161, 9, 4),
+        (95, 1160, 1, 10),
+        (94, 1159, 4, 20),
+        (93, 1156, 4, 27),
+        (92, 1154, 10, 28),
+        (91, 1151, 1, 26),
+        (90, 1145, 7, 22),
+        (89, 1144, 2, 23),
+        (88, 1142, 4, 28),
+        (87, 1141, 7, 10),
+        (86, 1135, 4, 27),
+        (85, 1132, 8, 11),
+        (84, 1131, 1, 29),
+        (83, 1126, 1, 22),
+        (82, 1124, 4, 3),
+        (81, 1120, 4, 10),
+        (80, 1118, 4, 3),
+        (79, 1113, 7, 13),
+        (78, 1110, 7, 13),
+        (77, 1108, 8, 3),
+        (76, 1106, 4, 9),
+        (75, 1104, 2, 10),
+        (74, 1099, 8, 28),
+        (73, 1097, 11, 21),
+        (72, 1096, 12, 17),
+        (71, 1094, 12, 15),
+        (70, 1087, 4, 7),
+        (69, 1084, 2, 7),
+        (68, 1081, 2, 10),
+        (67, 1077, 11, 17),
+        (66, 1074, 8, 23),
+        (65, 1069, 4, 13),
+        (64, 1065, 8, 2),
+        (63, 1058, 8, 29),
+        (62, 1053, 1, 11),
+        (61, 1046, 4, 14),
+        (60, 1044, 11, 24),
+        (59, 1040, 11, 10),
+        (58, 1037, 4, 21),
+        (57, 1028, 7, 25),
+        (56, 1024, 7, 13),
+        (55, 1021, 2, 2),
+        (54, 1017, 4, 23),
+        (53, 1012, 12, 25),
+        (52, 1004, 7, 20),
+        (51, 999, 1, 13),
+        (50, 995, 2, 22),
+        (49, 990, 11, 7),
+        (48, 989, 8, 8),
+        (47, 987, 4, 5),
+        (46, 985, 4, 27),
+        (45, 983, 4, 15),
+        (44, 978, 11, 29),
+        (43, 976, 7, 13),
+        (42, 973, 12, 20),
+        (41, 970, 3, 25),
+        (40, 968, 8, 13),
+        (39, 964, 7, 10),
+        (38, 961, 2, 16),
+        (37, 957, 10, 27),
+        (36, 947, 4, 22),
+        (35, 938, 5, 22),
+        (34, 931, 4, 26),
+        (33, 923, 4, 11),
+        (32, 901, 7, 15),
+        (31, 898, 4, 26),
+        (30, 889, 4, 27),
+        (29, 885, 2, 21),
+        (28, 877, 4, 16),
+        (27, 859, 4, 15),
+        (26, 857, 2, 21),
+        (25, 854, 11, 30),
+        (24, 851, 4, 28),
+        (23, 848, 6, 13),
+        (22, 834, 1, 3),
+        (21, 824, 1, 5),
+        (20, 810, 9, 19),
+        (19, 806, 5, 18),
+        (18, 782, 8, 19),
+        (17, 781, 1, 1),
+        (16, 770, 10, 1),
+        (15, 767, 8, 16),
+        (14, 765, 1, 7),
+        (13, 757, 8, 18),
+        (12, 749, 7, 2),
+        (11, 749, 4, 14),
+        (10, 729, 8, 5),
+        (9, 724, 2, 4),
+        (8, 717, 11, 17),
+        (7, 715, 9, 2),
+        (6, 708, 1, 11),
+        (5, 704, 5, 10),
+        (4, 701, 3, 21),
+        (3, 686, 7, 20),
+        (2, 672, 1, 1),
+        (1, 650, 2, 15),
+        (0, 645, 6, 19),
+    ]
+
+    private static let eraCount = 237
+
+    private static func era(at i: Int) -> EraEntry {
+        let raw = eraData[i]
+        return EraEntry(raw.0, raw.1, raw.2, raw.3)
+    }
+
+    private let gregorian: _CalendarGregorian
+
+    init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
+        assert(identifier == .japanese, "_CalendarJapanese only handles .japanese")
+        self.gregorian = _CalendarGregorian(identifier: .gregorian, timeZone: timeZone, locale: locale, firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDaysInFirstWeek, gregorianStartDate: gregorianStartDate)
+    }
+
+    let identifier: Calendar.Identifier = .japanese
+
+    var locale: Locale? {
+        get { gregorian.locale }
+        set { gregorian.locale = newValue }
+    }
+
+    var timeZone: TimeZone {
+        get { gregorian.timeZone }
+        set { gregorian.timeZone = newValue }
+    }
+
+    var firstWeekday: Int {
+        get { gregorian.firstWeekday }
+        set { gregorian.firstWeekday = newValue }
+    }
+
+    var minimumDaysInFirstWeek: Int {
+        get { gregorian.minimumDaysInFirstWeek }
+        set { gregorian.minimumDaysInFirstWeek = newValue }
+    }
+
+    func copy(changingLocale: Locale?, changingTimeZone: TimeZone?, changingFirstWeekday: Int?, changingMinimumDaysInFirstWeek: Int?) -> any _CalendarProtocol {
+        let args = _CalendarUtility.resolvedCopyArgs(
+            currentTimeZone: gregorian.timeZone, changingTimeZone: changingTimeZone,
+            currentLocale: gregorian.locale, changingLocale: changingLocale,
+            currentFirstWeekday: gregorian._firstWeekday, changingFirstWeekday: changingFirstWeekday,
+            currentMinimumDaysInFirstWeek: gregorian._minimumDaysInFirstWeek, changingMinimumDaysInFirstWeek: changingMinimumDaysInFirstWeek
+        )
+        return _CalendarJapanese(identifier: identifier, timeZone: args.timeZone, locale: args.locale, firstWeekday: args.firstWeekday, minimumDaysInFirstWeek: args.minimumDaysInFirstWeek, gregorianStartDate: nil)
+    }
+
+    func supportsNextDateFastPath(for components: Calendar.ComponentSet) -> Bool { gregorian.supportsNextDateFastPath(for: components) }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+        hasher.combine(timeZone)
+        hasher.combine(firstWeekday)
+        hasher.combine(minimumDaysInFirstWeek)
+        hasher.combine(localeIdentifier)
+        hasher.combine(preferredFirstWeekday)
+        hasher.combine(preferredMinimumDaysInFirstweek)
+    }
+
+    // MARK: - Range
+
+    func minimumRange(of component: Calendar.Component) -> Range<Int>? {
+        if component == .era { return 0..<(Self.era(at: Self.eraCount - 1).index + Self.eraCount) }
+        if component == .year { return 1..<2 }
+        return gregorian.minimumRange(of: component)
+    }
+
+    func maximumRange(of component: Calendar.Component) -> Range<Int>? {
+        if component == .era { return 0..<(Self.era(at: 0).index + 1) }
+        return gregorian.maximumRange(of: component)
+    }
+
+    func range(of smaller: Calendar.Component, in larger: Calendar.Component, for date: Date) -> Range<Int>? {
+        gregorian.range(of: smaller, in: larger, for: date)
+    }
+
+    func ordinality(of smaller: Calendar.Component, in larger: Calendar.Component, for date: Date) -> Int? {
+        gregorian.ordinality(of: smaller, in: larger, for: date)
+    }
+
+    func dateInterval(of component: Calendar.Component, for date: Date) -> DateInterval? {
+        if component == .era {
+            return eraInterval(containing: date)
+        }
+        return gregorian.dateInterval(of: component, for: date)
+    }
+
+    func isDateInWeekend(_ date: Date) -> Bool {
+        gregorian.isDateInWeekend(date)
+    }
+
+    // MARK: - Date / DateComponents conversion
+
+    func date(from components: DateComponents) -> Date? {
+        gregorian.date(from: convertedToGregorian(components))
+    }
+
+    func dateComponents(_ components: Calendar.ComponentSet, from date: Date, in timeZone: TimeZone) -> DateComponents {
+        var dc = gregorian.dateComponents(components, from: date, in: timeZone)
+        adjustToJapanese(&dc, date: date, requested: components)
+        return dc
+    }
+
+    func dateComponents(_ components: Calendar.ComponentSet, from date: Date) -> DateComponents {
+        var dc = gregorian.dateComponents(components, from: date)
+        adjustToJapanese(&dc, date: date, requested: components)
+        return dc
+    }
+
+    func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date? {
+        gregorian.date(byAdding: components, to: date, wrappingComponents: wrappingComponents)
+    }
+
+    func dateComponents(_ components: Calendar.ComponentSet, from start: Date, to end: Date) -> DateComponents {
+        gregorian.dateComponents(components, from: start, to: end)
+    }
+
+    func nextDate(after date: Date, matching components: DateComponents, direction: Calendar.SearchDirection) -> Date? {
+        gregorian.nextDate(after: date, matching: convertedToGregorian(components), direction: direction)
+    }
+
+    // MARK: - Era helpers
+
+    private func eraEntry(forGregorianYear y: Int, month m: Int, day d: Int) -> EraEntry? {
+        for i in 0..<Self.eraCount {
+            let era = Self.era(at: i)
+            if (y, m, d) >= (era.startGregorianYear, era.startMonth, era.startDay) {
+                return era
+            }
+        }
+        return nil
+    }
+
+    private func eraEntry(byIndex index: Int) -> EraEntry? {
+        for i in 0..<Self.eraCount {
+            if Self.era(at: i).index == index { return Self.era(at: i) }
+        }
+        return nil
+    }
+
+    private func eraInterval(containing date: Date) -> DateInterval? {
+        let comps = gregorian.dateComponents([.year, .month, .day], from: date)
+        guard let y = comps.year, let m = comps.month, let d = comps.day else { return nil }
+        guard let era = eraEntry(forGregorianYear: y, month: m, day: d) else {
+            return gregorian.dateInterval(of: .era, for: date)
+        }
+        var startDC = DateComponents()
+        startDC.year = era.startGregorianYear
+        startDC.month = era.startMonth
+        startDC.day = era.startDay
+        startDC.hour = 0; startDC.minute = 0; startDC.second = 0
+        guard let start = gregorian.date(from: startDC) else { return nil }
+        let endDate: Date
+        var nextEra: EraEntry? = nil
+        for i in 0..<Self.eraCount {
+            if Self.era(at: i).index == era.index && i > 0 {
+                nextEra = Self.era(at: i - 1)
+                break
+            }
+        }
+        if let next = nextEra {
+            var endDC = DateComponents()
+            endDC.year = next.startGregorianYear
+            endDC.month = next.startMonth
+            endDC.day = next.startDay
+            endDC.hour = 0; endDC.minute = 0; endDC.second = 0
+            guard let e = gregorian.date(from: endDC) else { return nil }
+            endDate = e
+        } else {
+            endDate = start.addingTimeInterval(Calendar._maxDateIntervalDuration)
+        }
+        return DateInterval(start: start, end: endDate)
+    }
+
+    // MARK: - Components conversion
+
+    private func convertedToGregorian(_ components: DateComponents) -> DateComponents {
+        var dc = components
+        if let year = dc.year {
+            // Default to latest era when era is missing (matches ICU).
+            let eraIndex = dc.era ?? Self.era(at: 0).index
+            if let eraEntry = eraEntry(byIndex: eraIndex) {
+                dc.year = year + eraEntry.startGregorianYear - 1
+            }
+        }
+        dc.era = nil
+        return dc
+    }
+
+    private func adjustToJapanese(_ dc: inout DateComponents, date: Date, requested: Calendar.ComponentSet) {
+        guard requested.contains(.era) || requested.contains(.year) else { return }
+        let probe = gregorian.dateComponents([.era, .year, .month, .day], from: date)
+        guard let y = probe.year, let m = probe.month, let d = probe.day else { return }
+        let extendedYear = probe.era == 0 ? 1 - y : y
+        if let era = eraEntry(forGregorianYear: extendedYear, month: m, day: d) {
+            if requested.contains(.era) { dc.era = era.index }
+            if requested.contains(.year) { dc.year = extendedYear - era.startGregorianYear + 1 }
+        } else {
+            // Pre-Taika: ICU clamps to the first era.
+            let first = Self.era(at: Self.eraCount - 1)
+            if requested.contains(.era) { dc.era = first.index }
+            if requested.contains(.year) { dc.year = extendedYear - first.startGregorianYear + 1 }
+        }
+    }
+
+#if FOUNDATION_FRAMEWORK
+    func bridgeToNSCalendar() -> NSCalendar {
+        _NSSwiftCalendar(calendar: Calendar(inner: self))
+    }
+#endif
+}

--- a/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Japanese.swift
@@ -27,249 +27,18 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
         }
     }
 
-    /// 237 Japanese eras (Taika 645 → Reiwa 2019), sorted descending. Index values match ICU's era numbering.
+    /// The five modern Japanese eras (Meiji 1868 → Reiwa 2019), sorted descending. Index values match ICU's era numbering (Meiji = 232 … Reiwa = 236).
+    // Following CLDR/ICU (unicode-org/icu#4019, ICU-23341), the pre-Meiji eras were dropped: dates before Meiji inherit the Gregorian era (0 = BCE, 1 = CE), so the indices are sparse (2…231 are undefined).
     // Meiji (232) uses 1868-09-08 to match Apple's runtime ICU (CLDR canonical is 1868-10-23).
-    private static let eraData: InlineArray<237, (index: Int32, year: Int16, month: Int8, day: Int8)> = [
+    private static let eraData: InlineArray<5, (index: Int32, year: Int16, month: Int8, day: Int8)> = [
         (236, 2019, 5, 1),
         (235, 1989, 1, 8),
         (234, 1926, 12, 25),
         (233, 1912, 7, 30),
         (232, 1868, 9, 8),
-        (231, 1865, 4, 7),
-        (230, 1864, 2, 20),
-        (229, 1861, 2, 19),
-        (228, 1860, 3, 18),
-        (227, 1854, 11, 27),
-        (226, 1848, 2, 28),
-        (225, 1844, 12, 2),
-        (224, 1830, 12, 10),
-        (223, 1818, 4, 22),
-        (222, 1804, 2, 11),
-        (221, 1801, 2, 5),
-        (220, 1789, 1, 25),
-        (219, 1781, 4, 2),
-        (218, 1772, 11, 16),
-        (217, 1764, 6, 2),
-        (216, 1751, 10, 27),
-        (215, 1748, 7, 12),
-        (214, 1744, 2, 21),
-        (213, 1741, 2, 27),
-        (212, 1736, 4, 28),
-        (211, 1716, 6, 22),
-        (210, 1711, 4, 25),
-        (209, 1704, 3, 13),
-        (208, 1688, 9, 30),
-        (207, 1684, 2, 21),
-        (206, 1681, 9, 29),
-        (205, 1673, 9, 21),
-        (204, 1661, 4, 25),
-        (203, 1658, 7, 23),
-        (202, 1655, 4, 13),
-        (201, 1652, 9, 18),
-        (200, 1648, 2, 15),
-        (199, 1644, 12, 16),
-        (198, 1624, 2, 30),
-        (197, 1615, 7, 13),
-        (196, 1596, 10, 27),
-        (195, 1592, 12, 8),
-        (194, 1573, 7, 28),
-        (193, 1570, 4, 23),
-        (192, 1558, 2, 28),
-        (191, 1555, 10, 23),
-        (190, 1532, 7, 29),
-        (189, 1528, 8, 20),
-        (188, 1521, 8, 23),
-        (187, 1504, 2, 30),
-        (186, 1501, 2, 29),
-        (185, 1492, 7, 19),
-        (184, 1489, 8, 21),
-        (183, 1487, 7, 29),
-        (182, 1469, 4, 28),
-        (181, 1467, 3, 3),
-        (180, 1466, 2, 28),
-        (179, 1460, 12, 21),
-        (178, 1457, 9, 28),
-        (177, 1455, 7, 25),
-        (176, 1452, 7, 25),
-        (175, 1449, 7, 28),
-        (174, 1444, 2, 5),
-        (173, 1441, 2, 17),
-        (172, 1429, 9, 5),
-        (171, 1428, 4, 27),
-        (170, 1394, 7, 5),
-        (169, 1390, 3, 26),
-        (168, 1389, 2, 9),
-        (167, 1387, 8, 23),
-        (166, 1387, 8, 22),
-        (165, 1384, 4, 28),
-        (164, 1381, 2, 10),
-        (163, 1379, 3, 22),
-        (162, 1375, 5, 27),
-        (161, 1372, 4, 1),
-        (160, 1370, 7, 24),
-        (159, 1346, 12, 8),
-        (158, 1340, 4, 28),
-        (157, 1336, 2, 29),
-        (156, 1334, 1, 29),
-        (155, 1331, 8, 9),
-        (154, 1329, 8, 29),
-        (153, 1326, 4, 26),
-        (152, 1324, 12, 9),
-        (151, 1321, 2, 23),
-        (150, 1319, 4, 28),
-        (149, 1317, 2, 3),
-        (148, 1312, 3, 20),
-        (147, 1311, 4, 28),
-        (146, 1308, 10, 9),
-        (145, 1306, 12, 14),
-        (144, 1303, 8, 5),
-        (143, 1302, 11, 21),
-        (142, 1299, 4, 25),
-        (141, 1293, 8, 5),
-        (140, 1288, 4, 28),
-        (139, 1278, 2, 29),
-        (138, 1275, 4, 25),
-        (137, 1264, 2, 28),
-        (136, 1261, 2, 20),
-        (135, 1260, 4, 13),
-        (134, 1259, 3, 26),
-        (133, 1257, 3, 14),
-        (132, 1256, 10, 5),
-        (131, 1249, 3, 18),
-        (130, 1247, 2, 28),
-        (129, 1243, 2, 26),
-        (128, 1240, 7, 16),
-        (127, 1239, 2, 7),
-        (126, 1238, 11, 23),
-        (125, 1235, 9, 19),
-        (124, 1234, 11, 5),
-        (123, 1233, 4, 15),
-        (122, 1232, 4, 2),
-        (121, 1229, 3, 5),
-        (120, 1227, 12, 10),
-        (119, 1225, 4, 20),
-        (118, 1224, 11, 20),
-        (117, 1222, 4, 13),
-        (116, 1219, 4, 12),
-        (115, 1213, 12, 6),
-        (114, 1211, 3, 9),
-        (113, 1207, 10, 25),
-        (112, 1206, 4, 27),
-        (111, 1204, 2, 20),
-        (110, 1201, 2, 13),
-        (109, 1199, 4, 27),
-        (108, 1190, 4, 11),
-        (107, 1185, 8, 14),
-        (106, 1184, 4, 16),
-        (105, 1182, 5, 27),
-        (104, 1181, 7, 14),
-        (103, 1177, 8, 4),
-        (102, 1175, 7, 28),
-        (101, 1171, 4, 21),
-        (100, 1169, 4, 8),
-        (99, 1166, 8, 27),
-        (98, 1165, 6, 5),
-        (97, 1163, 3, 29),
-        (96, 1161, 9, 4),
-        (95, 1160, 1, 10),
-        (94, 1159, 4, 20),
-        (93, 1156, 4, 27),
-        (92, 1154, 10, 28),
-        (91, 1151, 1, 26),
-        (90, 1145, 7, 22),
-        (89, 1144, 2, 23),
-        (88, 1142, 4, 28),
-        (87, 1141, 7, 10),
-        (86, 1135, 4, 27),
-        (85, 1132, 8, 11),
-        (84, 1131, 1, 29),
-        (83, 1126, 1, 22),
-        (82, 1124, 4, 3),
-        (81, 1120, 4, 10),
-        (80, 1118, 4, 3),
-        (79, 1113, 7, 13),
-        (78, 1110, 7, 13),
-        (77, 1108, 8, 3),
-        (76, 1106, 4, 9),
-        (75, 1104, 2, 10),
-        (74, 1099, 8, 28),
-        (73, 1097, 11, 21),
-        (72, 1096, 12, 17),
-        (71, 1094, 12, 15),
-        (70, 1087, 4, 7),
-        (69, 1084, 2, 7),
-        (68, 1081, 2, 10),
-        (67, 1077, 11, 17),
-        (66, 1074, 8, 23),
-        (65, 1069, 4, 13),
-        (64, 1065, 8, 2),
-        (63, 1058, 8, 29),
-        (62, 1053, 1, 11),
-        (61, 1046, 4, 14),
-        (60, 1044, 11, 24),
-        (59, 1040, 11, 10),
-        (58, 1037, 4, 21),
-        (57, 1028, 7, 25),
-        (56, 1024, 7, 13),
-        (55, 1021, 2, 2),
-        (54, 1017, 4, 23),
-        (53, 1012, 12, 25),
-        (52, 1004, 7, 20),
-        (51, 999, 1, 13),
-        (50, 995, 2, 22),
-        (49, 990, 11, 7),
-        (48, 989, 8, 8),
-        (47, 987, 4, 5),
-        (46, 985, 4, 27),
-        (45, 983, 4, 15),
-        (44, 978, 11, 29),
-        (43, 976, 7, 13),
-        (42, 973, 12, 20),
-        (41, 970, 3, 25),
-        (40, 968, 8, 13),
-        (39, 964, 7, 10),
-        (38, 961, 2, 16),
-        (37, 957, 10, 27),
-        (36, 947, 4, 22),
-        (35, 938, 5, 22),
-        (34, 931, 4, 26),
-        (33, 923, 4, 11),
-        (32, 901, 7, 15),
-        (31, 898, 4, 26),
-        (30, 889, 4, 27),
-        (29, 885, 2, 21),
-        (28, 877, 4, 16),
-        (27, 859, 4, 15),
-        (26, 857, 2, 21),
-        (25, 854, 11, 30),
-        (24, 851, 4, 28),
-        (23, 848, 6, 13),
-        (22, 834, 1, 3),
-        (21, 824, 1, 5),
-        (20, 810, 9, 19),
-        (19, 806, 5, 18),
-        (18, 782, 8, 19),
-        (17, 781, 1, 1),
-        (16, 770, 10, 1),
-        (15, 767, 8, 16),
-        (14, 765, 1, 7),
-        (13, 757, 8, 18),
-        (12, 749, 7, 2),
-        (11, 749, 4, 14),
-        (10, 729, 8, 5),
-        (9, 724, 2, 4),
-        (8, 717, 11, 17),
-        (7, 715, 9, 2),
-        (6, 708, 1, 11),
-        (5, 704, 5, 10),
-        (4, 701, 3, 21),
-        (3, 686, 7, 20),
-        (2, 672, 1, 1),
-        (1, 650, 2, 15),
-        (0, 645, 6, 19),
     ]
 
-    private static let eraCount = 237
+    private static let eraCount = 5
 
     private static func era(at i: Int) -> EraEntry {
         let raw = eraData[i]
@@ -402,7 +171,8 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
     }
 
     private func eraEntry(byIndex index: Int) -> EraEntry? {
-        let i = Self.eraCount - 1 - index
+        // Eras are stored descending, so the highest index (Reiwa) is at position 0. Indices are sparse (Meiji = 232 … Reiwa = 236); the Gregorian-inherited eras 0/1 and the gap 2…231 have no entry.
+        let i = Self.era(at: 0).index - index
         guard i >= 0 && i < Self.eraCount else { return nil }
         let era = Self.era(at: i)
         return era.index == index ? era : nil
@@ -412,12 +182,20 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
         let comps = gregorian.dateComponents([.year, .month, .day], from: date)
         guard let y = comps.year, let m = comps.month, let d = comps.day else { return nil }
         guard let era = eraEntry(forGregorianYear: y, month: m, day: d) else {
-            return gregorian.dateInterval(of: .era, for: date)
+            // Before Meiji the era is inherited from Gregorian (BCE/CE), but the CE era is interrupted by Meiji, so clip its end to Meiji's start.
+            guard let gregEra = gregorian.dateInterval(of: .era, for: date) else { return nil }
+            let meiji = Self.era(at: Self.eraCount - 1)
+            let meijiStartDC = DateComponents(year: meiji.startGregorianYear, month: meiji.startMonth, day: meiji.startDay, hour: 0, minute: 0, second: 0)
+            guard let meijiStart = gregorian.date(from: meijiStartDC) else { return gregEra }
+            if gregEra.start < meijiStart && gregEra.end > meijiStart {
+                return DateInterval(start: gregEra.start, end: meijiStart)
+            }
+            return gregEra
         }
         let startDC = DateComponents(year: era.startGregorianYear, month: era.startMonth, day: era.startDay, hour: 0, minute: 0, second: 0)
         guard let start = gregorian.date(from: startDC) else { return nil }
         let endDate: Date
-        let position = Self.eraCount - 1 - era.index
+        let position = Self.era(at: 0).index - era.index
         if position > 0 {
             let next = Self.era(at: position - 1)
             let endDC = DateComponents(year: next.startGregorianYear, month: next.startMonth, day: next.startDay, hour: 0, minute: 0, second: 0)
@@ -433,12 +211,14 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
 
     private func convertedToGregorian(_ components: DateComponents) -> DateComponents {
         var dc = components
-        if let year = dc.year {
-            // Default to latest era when era is missing (matches ICU).
-            let eraIndex = dc.era ?? Self.era(at: 0).index
-            if let eraEntry = eraEntry(byIndex: eraIndex) {
-                dc.year = year + eraEntry.startGregorianYear - 1
-            }
+        // Default to the latest era (Reiwa) when the era is unspecified, matching ICU.
+        let eraIndex = dc.era ?? Self.era(at: 0).index
+        if eraIndex <= 1 {
+            // Gregorian-inherited era (0 = BCE, 1 = CE): pass the era and year straight through for the Gregorian calendar to reckon.
+            return dc
+        }
+        if let year = dc.year, let eraEntry = eraEntry(byIndex: eraIndex) {
+            dc.year = year + eraEntry.startGregorianYear - 1
         }
         dc.era = nil
         return dc
@@ -449,14 +229,10 @@ internal final class _CalendarJapanese: _CalendarProtocol, @unchecked Sendable {
         let probe = gregorian.dateComponents([.era, .year, .month, .day], from: date)
         guard let y = probe.year, let m = probe.month, let d = probe.day else { return }
         let extendedYear = probe.era == 0 ? 1 - y : y
+        // Meiji onward, relabel to the Japanese era. Before Meiji, ICU inherits the Gregorian era (0 = BCE, 1 = CE), which `dc` already carries from the Gregorian conversion, so leave it untouched.
         if let era = eraEntry(forGregorianYear: extendedYear, month: m, day: d) {
             if requested.contains(.era) { dc.era = era.index }
             if requested.contains(.year) { dc.year = extendedYear - era.startGregorianYear + 1 }
-        } else {
-            // Pre-Taika: ICU clamps to the first era.
-            let first = Self.era(at: Self.eraCount - 1)
-            if requested.contains(.era) { dc.era = first.index }
-            if requested.contains(.year) { dc.year = extendedYear - first.startGregorianYear + 1 }
         }
     }
 

--- a/Tests/FoundationInternationalizationTests/BuddhistRecurrenceRuleParityProbe.swift
+++ b/Tests/FoundationInternationalizationTests/BuddhistRecurrenceRuleParityProbe.swift
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationInternationalization
+@testable import FoundationEssentials
+#endif
+
+/// RecurrenceRule parity probe: compares date sequences from `recurrences(of:)` between the ICU backed Buddhist calendar and `_CalendarBuddhist`.
+@Suite("Buddhist RecurrenceRule Parity Probe")
+private struct BuddhistRecurrenceRuleParityProbe {
+
+    private static func makePair() -> (icu: Calendar, ours: Calendar) {
+        var icu = Calendar(identifier: .buddhist)
+        icu.timeZone = .gmt
+        let oursInner = _CalendarBuddhist(identifier: .buddhist, timeZone: .gmt, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
+        return (icu, Calendar(inner: oursInner))
+    }
+
+    private static func g(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .gmt
+        var dc = DateComponents()
+        dc.year = y; dc.month = m; dc.day = d; dc.hour = 12; dc.timeZone = .gmt
+        return cal.date(from: dc)!
+    }
+
+    private static func collect(rule: Calendar.RecurrenceRule, from start: Date, count: Int) -> [Date] {
+        Array(rule.recurrences(of: start).prefix(count))
+    }
+
+    private static let anchors: [(label: String, date: Date)] = [
+        ("2020-01-01", g(2020, 1, 1)),
+        ("2024-06-15", g(2024, 6, 15)),
+        ("2025-09-23", g(2025, 9, 23)),
+        ("2026-06-11", g(2026, 6, 11)),
+    ]
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func yearly_christmas() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        for (label, anchor) in Self.anchors {
+            var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .yearly, end: .afterOccurrences(5))
+            rI.months = [12]; rI.daysOfTheMonth = [25]
+            var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .yearly, end: .afterOccurrences(5))
+            rO.months = [12]; rO.daysOfTheMonth = [25]
+            let i = Self.collect(rule: rI, from: anchor, count: 5)
+            let o = Self.collect(rule: rO, from: anchor, count: 5)
+            for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+                failures.append("[\(label)][\(idx)]")
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences")
+    }
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func monthly_firstOfMonth() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        for (label, anchor) in Self.anchors {
+            var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .monthly, end: .afterOccurrences(12))
+            rI.daysOfTheMonth = [1]
+            var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .monthly, end: .afterOccurrences(12))
+            rO.daysOfTheMonth = [1]
+            let i = Self.collect(rule: rI, from: anchor, count: 12)
+            let o = Self.collect(rule: rO, from: anchor, count: 12)
+            for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+                failures.append("[\(label)][\(idx)]")
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences")
+    }
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func weekly_mondays() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        for (label, anchor) in Self.anchors {
+            var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .weekly, end: .afterOccurrences(8))
+            rI.weekdays = [.every(.monday)]
+            var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .weekly, end: .afterOccurrences(8))
+            rO.weekdays = [.every(.monday)]
+            let i = Self.collect(rule: rI, from: anchor, count: 8)
+            let o = Self.collect(rule: rO, from: anchor, count: 8)
+            for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+                failures.append("[\(label)][\(idx)]")
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences")
+    }
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func yearly_thanksgivingShape() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        for (label, anchor) in Self.anchors {
+            var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .yearly, end: .afterOccurrences(5))
+            rI.months = [11]; rI.weekdays = [.nth(4, .thursday)]
+            var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .yearly, end: .afterOccurrences(5))
+            rO.months = [11]; rO.weekdays = [.nth(4, .thursday)]
+            let i = Self.collect(rule: rI, from: anchor, count: 5)
+            let o = Self.collect(rule: rO, from: anchor, count: 5)
+            for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+                failures.append("[\(label)][\(idx)]")
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences")
+    }
+}

--- a/Tests/FoundationInternationalizationTests/JapaneseGregorianEraInheritanceTests.swift
+++ b/Tests/FoundationInternationalizationTests/JapaneseGregorianEraInheritanceTests.swift
@@ -1,0 +1,149 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationInternationalization
+@testable import FoundationEssentials
+#endif
+
+/// Golden-value tests for the Japanese calendar's Gregorian era inheritance before Meiji (unicode-org/icu#4019, ICU-23341): pre-Meiji dates report the Gregorian era (0 = BCE, 1 = CE) rather than a pre-Meiji Japanese era. These are ICU-independent because the behavior only exists in unreleased ICU; the bundled ICU still has the old 237-era data.
+@Suite("Japanese Gregorian Era Inheritance")
+private struct JapaneseGregorianEraInheritanceTests {
+
+    // Era index constants (ICU numbering).
+    static let bce = 0, ce = 1, meiji = 232, taisho = 233, showa = 234, heisei = 235, reiwa = 236
+
+    private static func japanese() -> Calendar {
+        Calendar(inner: _CalendarJapanese(identifier: .japanese, timeZone: .gmt, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil))
+    }
+
+    private static func gregorianDate(era: Int, _ y: Int, _ m: Int, _ d: Int) throws -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .gmt
+        var dc = DateComponents()
+        dc.era = era; dc.year = y; dc.month = m; dc.day = d; dc.hour = 12; dc.timeZone = .gmt
+        return try #require(cal.date(from: dc))
+    }
+
+    struct EraCase: Sendable, CustomTestStringConvertible {
+        let label: String
+        let sourceEra, year, month, day: Int
+        let expectedEra, expectedYear: Int
+        var testDescription: String { label }
+    }
+
+    static let eraCases: [EraCase] = [
+        // Modern eras keep ICU numbering 232…236.
+        EraCase(label: "Reiwa 2020", sourceEra: ce, year: 2020, month: 6, day: 15, expectedEra: reiwa, expectedYear: 2),
+        EraCase(label: "Heisei start 1989-01-08", sourceEra: ce, year: 1989, month: 1, day: 8, expectedEra: heisei, expectedYear: 1),
+        EraCase(label: "Meiji start 1868-09-08", sourceEra: ce, year: 1868, month: 9, day: 8, expectedEra: meiji, expectedYear: 1),
+        // Day before Meiji, and earlier CE dates, inherit Gregorian CE (era 1) with the Gregorian year.
+        EraCase(label: "day before Meiji 1868-09-07", sourceEra: ce, year: 1868, month: 9, day: 7, expectedEra: ce, expectedYear: 1868),
+        EraCase(label: "early 1868-01-01", sourceEra: ce, year: 1868, month: 1, day: 1, expectedEra: ce, expectedYear: 1868),
+        EraCase(label: "1776-07-04", sourceEra: ce, year: 1776, month: 7, day: 4, expectedEra: ce, expectedYear: 1776),
+        EraCase(label: "0900-06-15", sourceEra: ce, year: 900, month: 6, day: 15, expectedEra: ce, expectedYear: 900),
+        // Before the Common Era inherits Gregorian BCE (era 0).
+        EraCase(label: "15 BCE", sourceEra: bce, year: 15, month: 7, day: 10, expectedEra: bce, expectedYear: 15),
+    ]
+
+    @Test(arguments: eraCases)
+    func eraAndYear(_ c: EraCase) throws {
+        let cal = Self.japanese()
+        let date = try Self.gregorianDate(era: c.sourceEra, c.year, c.month, c.day)
+        let dc = cal.dateComponents([.era, .year], from: date)
+        #expect(dc.era == c.expectedEra)
+        #expect(dc.year == c.expectedYear)
+    }
+
+    @Test func prolepticEraYearRollsIntoGregorian() throws {
+        // ICU JapaneseTest.Test5345: setting Meiji year 1, Jan 1 resolves to CE, because Meiji 1 Jan 1 = Gregorian 1868-01-01, before Meiji's Sept 8 start.
+        let cal = Self.japanese()
+        var dc = DateComponents()
+        dc.era = Self.meiji; dc.year = 1; dc.month = 1; dc.day = 1; dc.hour = 12
+        let date = try #require(cal.date(from: dc))
+        let c = cal.dateComponents([.era, .year, .month, .day], from: date)
+        #expect(c.era == Self.ce)
+        #expect(c.year == 1868)
+        #expect(c.month == 1)
+        #expect(c.day == 1)
+    }
+
+    struct RoundTrip: Sendable, CustomTestStringConvertible {
+        let era, year, month, day: Int
+        var testDescription: String { "era=\(era) year=\(year) \(month)/\(day)" }
+    }
+
+    static let roundTrips: [RoundTrip] = [
+        RoundTrip(era: reiwa, year: 2, month: 6, day: 15),
+        RoundTrip(era: heisei, year: 1, month: 1, day: 8),
+        RoundTrip(era: meiji, year: 1, month: 9, day: 8),
+        RoundTrip(era: ce, year: 1867, month: 6, day: 1),
+        RoundTrip(era: ce, year: 1500, month: 3, day: 20),
+        RoundTrip(era: bce, year: 15, month: 7, day: 10),
+    ]
+
+    @Test(arguments: roundTrips)
+    func roundTripAcrossMeijiBoundary(_ c: RoundTrip) throws {
+        let cal = Self.japanese()
+        var dc = DateComponents()
+        dc.era = c.era; dc.year = c.year; dc.month = c.month; dc.day = c.day; dc.hour = 12
+        let date = try #require(cal.date(from: dc))
+        let back = cal.dateComponents([.era, .year, .month, .day], from: date)
+        #expect(back.era == c.era)
+        #expect(back.year == c.year)
+        #expect(back.month == c.month)
+        #expect(back.day == c.day)
+    }
+
+    struct AddCase: Sendable, CustomTestStringConvertible {
+        let label: String
+        let fromEra, fromYear, fromMonth, fromDay: Int
+        let component: Calendar.Component
+        let amount: Int
+        let expectedEra, expectedYear, expectedMonth, expectedDay: Int
+        var testDescription: String { label }
+    }
+
+    // date(byAdding:) works in Gregorian year-space and only relabels the era on read-back, so crossing the Meiji lower edge downward lands on the inherited Gregorian era (CE, then BCE).
+    static let addAcrossMeijiCases: [AddCase] = [
+        AddCase(label: "Meiji 1 + day(-1) -> CE 1868", fromEra: meiji, fromYear: 1, fromMonth: 9, fromDay: 8, component: .day, amount: -1, expectedEra: ce, expectedYear: 1868, expectedMonth: 9, expectedDay: 7),
+        AddCase(label: "Meiji 1 + month(-1) -> CE 1868", fromEra: meiji, fromYear: 1, fromMonth: 9, fromDay: 8, component: .month, amount: -1, expectedEra: ce, expectedYear: 1868, expectedMonth: 8, expectedDay: 8),
+        AddCase(label: "Meiji 1 + year(-1) -> CE 1867", fromEra: meiji, fromYear: 1, fromMonth: 9, fromDay: 8, component: .year, amount: -1, expectedEra: ce, expectedYear: 1867, expectedMonth: 9, expectedDay: 8),
+        AddCase(label: "Meiji 1 + year(-1867) -> CE 1", fromEra: meiji, fromYear: 1, fromMonth: 9, fromDay: 8, component: .year, amount: -1867, expectedEra: ce, expectedYear: 1, expectedMonth: 9, expectedDay: 8),
+        AddCase(label: "Meiji 1 + year(-1868) -> BCE 1", fromEra: meiji, fromYear: 1, fromMonth: 9, fromDay: 8, component: .year, amount: -1868, expectedEra: bce, expectedYear: 1, expectedMonth: 9, expectedDay: 8),
+        AddCase(label: "Meiji 1 Dec + month(-4) -> CE 1868", fromEra: meiji, fromYear: 1, fromMonth: 12, fromDay: 1, component: .month, amount: -4, expectedEra: ce, expectedYear: 1868, expectedMonth: 8, expectedDay: 1),
+    ]
+
+    @Test(arguments: addAcrossMeijiCases)
+    func addAcrossMeijiLowerEdge(_ c: AddCase) throws {
+        let cal = Self.japanese()
+        var dc = DateComponents()
+        dc.era = c.fromEra; dc.year = c.fromYear; dc.month = c.fromMonth; dc.day = c.fromDay; dc.hour = 12
+        let from = try #require(cal.date(from: dc))
+        let result = try #require(cal.date(byAdding: c.component, value: c.amount, to: from))
+        let back = cal.dateComponents([.era, .year, .month, .day], from: result)
+        #expect(back.era == c.expectedEra)
+        #expect(back.year == c.expectedYear)
+        #expect(back.month == c.expectedMonth)
+        #expect(back.day == c.expectedDay)
+    }
+
+    @Test func eraRangeSpansBceToReiwa() {
+        let cal = Self.japanese()
+        #expect(cal.maximumRange(of: .era) == 0..<237)
+        #expect(cal.minimumRange(of: .era) == 0..<237)
+    }
+}

--- a/Tests/FoundationInternationalizationTests/JapaneseRecurrenceRuleParityProbe.swift
+++ b/Tests/FoundationInternationalizationTests/JapaneseRecurrenceRuleParityProbe.swift
@@ -1,0 +1,157 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationInternationalization
+@testable import FoundationEssentials
+#endif
+
+/// RecurrenceRule parity probe: compares date sequences from `recurrences(of:)` between the ICU backed Japanese calendar and `_CalendarJapanese`. Includes era transition tests.
+@Suite("Japanese RecurrenceRule Parity Probe")
+private struct JapaneseRecurrenceRuleParityProbe {
+
+    private static func makePair() -> (icu: Calendar, ours: Calendar) {
+        var icu = Calendar(identifier: .japanese)
+        icu.timeZone = .gmt
+        let oursInner = _CalendarJapanese(identifier: .japanese, timeZone: .gmt, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
+        return (icu, Calendar(inner: oursInner))
+    }
+
+    private static func g(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .gmt
+        var dc = DateComponents()
+        dc.year = y; dc.month = m; dc.day = d; dc.hour = 12; dc.timeZone = .gmt
+        return cal.date(from: dc)!
+    }
+
+    private static func collect(rule: Calendar.RecurrenceRule, from start: Date, count: Int) -> [Date] {
+        Array(rule.recurrences(of: start).prefix(count))
+    }
+
+    private static let anchors: [(label: String, date: Date)] = [
+        ("Heisei 2015-03-01", g(2015, 3, 1)),
+        ("Heisei→Reiwa 2018-11-15", g(2018, 11, 15)),
+        ("Reiwa 2020-01-01", g(2020, 1, 1)),
+        ("Reiwa 2024-06-15", g(2024, 6, 15)),
+        ("Reiwa 2025-09-23", g(2025, 9, 23)),
+        ("Reiwa 2026-06-11", g(2026, 6, 11)),
+    ]
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func yearly_christmas() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        for (label, anchor) in Self.anchors {
+            var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .yearly, end: .afterOccurrences(5))
+            rI.months = [12]; rI.daysOfTheMonth = [25]
+            var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .yearly, end: .afterOccurrences(5))
+            rO.months = [12]; rO.daysOfTheMonth = [25]
+            let i = Self.collect(rule: rI, from: anchor, count: 5)
+            let o = Self.collect(rule: rO, from: anchor, count: 5)
+            for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+                failures.append("[\(label)][\(idx)]")
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences")
+    }
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func yearly_constitutionDay() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        for (label, anchor) in Self.anchors {
+            var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .yearly, end: .afterOccurrences(5))
+            rI.months = [5]; rI.daysOfTheMonth = [3]
+            var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .yearly, end: .afterOccurrences(5))
+            rO.months = [5]; rO.daysOfTheMonth = [3]
+            let i = Self.collect(rule: rI, from: anchor, count: 5)
+            let o = Self.collect(rule: rO, from: anchor, count: 5)
+            for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+                failures.append("[\(label)][\(idx)]")
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences")
+    }
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func monthly_firstOfMonth() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        for (label, anchor) in Self.anchors {
+            var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .monthly, end: .afterOccurrences(12))
+            rI.daysOfTheMonth = [1]
+            var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .monthly, end: .afterOccurrences(12))
+            rO.daysOfTheMonth = [1]
+            let i = Self.collect(rule: rI, from: anchor, count: 12)
+            let o = Self.collect(rule: rO, from: anchor, count: 12)
+            for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+                failures.append("[\(label)][\(idx)]")
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences")
+    }
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func monthly_acrossHeiseiReiwaBoundary() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        let anchor = Self.g(2018, 3, 1)
+        var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .monthly, end: .afterOccurrences(24))
+        rI.daysOfTheMonth = [1]
+        var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .monthly, end: .afterOccurrences(24))
+        rO.daysOfTheMonth = [1]
+        let i = Self.collect(rule: rI, from: anchor, count: 24)
+        let o = Self.collect(rule: rO, from: anchor, count: 24)
+        for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+            failures.append("[2018-03-01][\(idx)]")
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences across Heisei→Reiwa boundary")
+    }
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func yearly_mayFirst_acrossEraBoundaries() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        for anchor in [Self.g(2017, 1, 1), Self.g(2018, 6, 15), Self.g(2019, 4, 1)] {
+            var rI = Calendar.RecurrenceRule(calendar: icu, frequency: .yearly, end: .afterOccurrences(5))
+            rI.months = [5]; rI.daysOfTheMonth = [1]
+            var rO = Calendar.RecurrenceRule(calendar: ours, frequency: .yearly, end: .afterOccurrences(5))
+            rO.months = [5]; rO.daysOfTheMonth = [1]
+            let i = Self.collect(rule: rI, from: anchor, count: 5)
+            let o = Self.collect(rule: rO, from: anchor, count: 5)
+            for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+                failures.append("[\(anchor)][\(idx)]")
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences")
+    }
+
+    @available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+    @Test func daily_acrossHeiseiReiwaBoundary() {
+        let (icu, ours) = Self.makePair()
+        var failures: [String] = []
+        let anchor = Self.g(2019, 4, 15)
+        let rI = Calendar.RecurrenceRule(calendar: icu, frequency: .daily, end: .afterOccurrences(60))
+        let rO = Calendar.RecurrenceRule(calendar: ours, frequency: .daily, end: .afterOccurrences(60))
+        let i = Self.collect(rule: rI, from: anchor, count: 60)
+        let o = Self.collect(rule: rO, from: anchor, count: 60)
+        for idx in 0..<max(i.count, o.count) where idx >= i.count || idx >= o.count || i[idx] != o[idx] {
+            failures.append("[2019-04-15][\(idx)]")
+        }
+        #expect(failures.isEmpty, "\(failures.count) divergences across era boundary")
+    }
+}


### PR DESCRIPTION
## Add Buddhist and Japanese calendar implementations

Composition over `_CalendarGregorian`: both calendars delegate all arithmetic and forward to the existing Gregorian implementation, overriding only era/year extraction and construction.

### Buddhist

Year = Gregorian + 543, single BE era. ~150 LOC. Composition adds negligible overhead (benchmarks match Gregorian within noise).

### Japanese

237 era table (Taika 645 through Reiwa 2019) from CLDR `supplementalData.txt`. Era lookup via linear scan of the descending sorted table. ~450 LOC (237 of which are the era data).

Era inference: when year is provided without an explicit era (as happens in the generic enumeration slow path), defaults to the latest era (Reiwa) to match ICU behavior. Pre Taika dates clamp to era 0.

### Feature flags

Both calendars are gated behind `foundation_swift_buddhist_calendar_feature_enabled()` and `foundation_swift_japanese_calendar_feature_enabled()`, off by default. `Calendar(identifier: .buddhist/.japanese)` continues routing to `_CalendarICU` until the flags are enabled.

### Testing

- `BuddhistRecurrenceRuleParityProbe.swift`: 4 tests (yearly, monthly, weekly, Thanksgiving shape) comparing ICU backed vs native implementation. Zero divergences.
- `JapaneseRecurrenceRuleParityProbe.swift`: 6 tests including 3 era transition tests (monthly across Heisei/Reiwa boundary, yearly May 1st across eras, daily across boundary). Zero divergences.
- Full suite: 1113 tests pass.

### Benchmarks

15 mirrored benchmarks (Gregorian/Buddhist/Japanese x 5 shapes). Key numbers (p50, release, arm64 M3 Max):

| Calendar | dateComponents | roundTrip | enumerate 1000 |
|---|---|---|---|
| Gregorian | 2 ns | 5 ns | 19 us |
| Buddhist | 2 ns | 5 ns | 21 us |
| Japanese | 2 ns | 5 ns | 12 us |

Zero heap allocations in all cases.

### Known limitation

Meiji era start encoded as 1868-09-08 to match Apple's runtime ICU. CLDR canonical is 1868-10-23. Documented in source.
