### PR TITLE
Optimize `SortComparator` by up to 10x

### DIFF
--- a/Sources/FoundationEssentials/SortComparator.swift
+++ b/Sources/FoundationEssentials/SortComparator.swift
@@ -239,6 +239,7 @@ extension Sequence {
     /// - Parameters:
     ///   - comparator: the comparator to use in ordering elements
     /// - Returns: an array of the elements sorted using `comparator`.
+    @inlinable
     public func sorted<Comparator: SortComparator>(using comparator: Comparator) -> [Element] where Comparator.Compared == Element {
         return self.sorted {
             comparator.compare($0, $1) == .orderedAscending
@@ -254,6 +255,7 @@ extension Sequence {
     ///   sorting the sequence's elements. Any subsequent comparators are used
     ///   to further refine the order of elements with equal values.
     /// - Returns: an array of the elements sorted using `comparators`.
+    @inlinable
     public func sorted<S: Sequence, Comparator: SortComparator>(using comparators: S) -> [Element] where
         S.Element == Comparator,
         Element == Comparator.Compared
@@ -273,6 +275,7 @@ extension Sequence {
     /// comparator to be used in sorting the sequence's elements. Any subsequent
     /// comparators are used to further refine the order of elements with equal
     /// values.
+    @inlinable
     public func compare<Comparator: SortComparator>(_ lhs: Comparator.Compared, _ rhs: Comparator.Compared) -> ComparisonResult where Element == Comparator {
         for comparator in self {
             let result = comparator.compare(lhs, rhs)
@@ -287,6 +290,7 @@ extension MutableCollection where Self: RandomAccessCollection {
     /// Sorts the collection using the given comparator to compare elements.
     /// - Parameters:
     ///     - comparator: the sort comparator used to compare elements.
+    @inlinable
     public mutating func sort<Comparator: SortComparator>(using comparator: Comparator) where Comparator.Compared == Element {
         self.sort {
             comparator.compare($0, $1) == .orderedAscending
@@ -301,6 +305,7 @@ extension MutableCollection where Self: RandomAccessCollection {
     ///   first comparator specifies the primary comparator to be used in
     ///   sorting the sequence's elements. Any subsequent comparators are used
     ///   to further refine the order of elements with equal values.
+    @inlinable
     public mutating func sort<S: Sequence, Comparator: SortComparator>(using comparators: S) where S.Element == Comparator, Element == Comparator.Compared {
         self.sort {
             comparators.compare($0, $1) == .orderedAscending

--- a/Sources/FoundationInternationalization/String/KeyPathComparator.swift
+++ b/Sources/FoundationInternationalization/String/KeyPathComparator.swift
@@ -23,33 +23,46 @@ public struct KeyPathComparator<Compared>: SortComparator {
 
     /// The sort order that the comparator uses to compare properties.
     public var order: SortOrder {
-        get {
-            comparator.order
-        }
-        set {
-            comparator.order = newValue
-        }
+        didSet { comparator.order = order }
     }
 
+    /// A type-erased copy of the underlying comparator, retained only for the cold paths: `==`, `hash(into:)`, and keeping `order` observable. It is never consulted by `compare(_:_:)`.
     var comparator: AnySortComparator
 
-    private let extractField: @Sendable (Compared) -> Any
+    /// The hot path: a fully-typed comparison of two `Compared` values that extracts the keyed field and compares it *in forward order*, with no `Any` boxing and no dynamic casts. `compare(_:_:)` applies the current `order` on top via `withOrder`.
+    private let _compare: @Sendable (Compared, Compared) -> ComparisonResult
 
-    /// Get the field at `cachedOffset` if there is one, otherwise
-    /// access the field directly through the keypath.
-    private static func getField<T>(ofType fieldType: T.Type, offset maybeOffset: Int?, from base: Compared, fallback keyPath: KeyPath<Compared, T>) -> T {
-        guard let offset = maybeOffset else {
-            return base[keyPath: keyPath]
-        }
+    /// Reads the field of type `T` at a known stored-property `offset` within `base`. `T` is passed as an argument rather than a metatype captured by the caller's `@Sendable` closure, which would be non-`Sendable`.
+    @inline(always)
+    private static func getField<T>(offset: Int, from base: Compared, as type: T.Type) -> T {
         return withUnsafePointer(to: base) { pointer in
-            let rawPointer = UnsafeRawPointer(pointer)
-            return rawPointer
+            UnsafeRawPointer(pointer)
                 .advanced(by: offset)
-                .assumingMemoryBound(to: fieldType)
+                .assumingMemoryBound(to: T.self)
                 .pointee
         }
     }
-    
+
+    /// Builds the fully-typed forward comparison closure for a field of type `Field` compared by `fieldComparator` (which must be in `.forward` order).
+    ///
+    /// This is the cast-free hot path: the field is read as its concrete type and `fieldComparator.compare` is invoked directly, so no value is ever boxed into `Any` and no dynamic cast occurs per comparison. When the field is a stored property (`offset != nil`) it is read at its byte offset; otherwise it is accessed through the key path.
+    private static func makeCompare<Field, FieldComparator: SortComparator>(
+        keyPath: KeyPath<Compared, Field> & Sendable,
+        offset: Int?,
+        fieldComparator: FieldComparator
+    ) -> @Sendable (Compared, Compared) -> ComparisonResult where FieldComparator.Compared == Field {
+        if let offset {
+            return { lhs, rhs in
+                let lhsField = getField(offset: offset, from: lhs, as: Field.self)
+                let rhsField = getField(offset: offset, from: rhs, as: Field.self)
+                return fieldComparator.compare(lhsField, rhsField)
+            }
+        }
+        return { lhs, rhs in
+            fieldComparator.compare(lhs[keyPath: keyPath], rhs[keyPath: keyPath])
+        }
+    }
+
     // A temporary workaround to a compiler bug that changes the ABI when adding the & Sendable constraint
     // Should be removed and the related functions should be made public when rdar://131764614 is resolved
     @_alwaysEmitIntoClient
@@ -95,26 +108,26 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /*public*/ @usableFromInline init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) {
         let sendableKP = keyPath._unsafeAssumeSendable
         self.keyPath = sendableKP
+        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
         if Value.self is String.Type {
 #if FOUNDATION_FRAMEWORK
-            self.comparator = AnySortComparator(String.StandardComparator.localizedStandard)
+            let stringComparator = String.StandardComparator.localizedStandard
 #else
             // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, use the lexical default
             // https://github.com/apple/swift-foundation/issues/284
-            self.comparator = AnySortComparator(String.StandardComparator.lexical)
+            let stringComparator = String.StandardComparator.lexical
 #endif
+            self.comparator = AnySortComparator(stringComparator)
+            // `Value` is statically opaque but dynamically `String`; retype the key path once here (not per comparison) so the hot path is fully typed and captures no non-Sendable metatype.
+            let stringKeyPath = sendableKP as! (KeyPath<Compared, String> & Sendable)
+            self._compare = Self.makeCompare(keyPath: stringKeyPath, offset: cachedOffset, fieldComparator: stringComparator)
         } else {
-            self.comparator = AnySortComparator(ComparableComparator<Value>())
-        }
-        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
-        self.extractField = {
-            Self.getField(
-                ofType: Value.self,
-                offset: cachedOffset,
-                from: $0,
-                fallback: sendableKP)
+            let fieldComparator = ComparableComparator<Value>()
+            self.comparator = AnySortComparator(fieldComparator)
+            self._compare = Self.makeCompare(keyPath: sendableKP, offset: cachedOffset, fieldComparator: fieldComparator)
         }
         self.order = order
+        self.comparator.order = order
     }
 
     /// Creates a `KeyPathComparator` that orders values based on an optional
@@ -133,26 +146,26 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /*public*/ @usableFromInline init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) {
         let sendableKP = keyPath._unsafeAssumeSendable
         self.keyPath = sendableKP
+        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
         if Value.self is String.Type {
 #if FOUNDATION_FRAMEWORK
-            self.comparator = AnySortComparator(OptionalComparator(String.StandardComparator.localizedStandard))
+            let fieldComparator = OptionalComparator(String.StandardComparator.localizedStandard)
 #else
             // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, use the lexical default
             // https://github.com/apple/swift-foundation/issues/284
-            self.comparator = AnySortComparator(OptionalComparator(String.StandardComparator.lexical))
+            let fieldComparator = OptionalComparator(String.StandardComparator.lexical)
 #endif
+            self.comparator = AnySortComparator(fieldComparator)
+            // Retype `KeyPath<Compared, Value?>` -> `KeyPath<Compared, String?>` once here so the hot path is fully typed (see the non-optional case).
+            let stringKeyPath = sendableKP as! (KeyPath<Compared, String?> & Sendable)
+            self._compare = Self.makeCompare(keyPath: stringKeyPath, offset: cachedOffset, fieldComparator: fieldComparator)
         } else {
-            self.comparator = AnySortComparator(OptionalComparator(ComparableComparator<Value>()))
-        }
-        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
-        self.extractField = {
-            Self.getField(
-                ofType: Value?.self,
-                offset: cachedOffset,
-                from: $0,
-                fallback: sendableKP) as Any
+            let fieldComparator = OptionalComparator(ComparableComparator<Value>())
+            self.comparator = AnySortComparator(fieldComparator)
+            self._compare = Self.makeCompare(keyPath: sendableKP, offset: cachedOffset, fieldComparator: fieldComparator)
         }
         self.order = order
+        self.comparator.order = order
     }
 
     /// Creates a `KeyPathComparator` with the given `keyPath` and
@@ -167,15 +180,13 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /*public*/ @usableFromInline init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value>, comparator: Comparator) where Comparator.Compared == Value {
         let sendableKP = keyPath._unsafeAssumeSendable
         self.keyPath = sendableKP
-        self.comparator = AnySortComparator(comparator)
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
-        self.extractField = {
-            Self.getField(
-                ofType: Value.self,
-                offset: cachedOffset,
-                from: $0,
-                fallback: sendableKP)
-        }
+        self.comparator = AnySortComparator(comparator)
+        var forwardComparator = comparator
+        forwardComparator.order = .forward
+        self._compare = Self.makeCompare(keyPath: sendableKP, offset: cachedOffset, fieldComparator: forwardComparator)
+        self.order = comparator.order
+        self.comparator.order = comparator.order
     }
 
     /// Creates a `KeyPathComparator` with the given `keyPath` to an optional
@@ -193,15 +204,14 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /*public*/ @usableFromInline init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?>, comparator: Comparator) where Comparator.Compared == Value {
         let sendableKP = keyPath._unsafeAssumeSendable
         self.keyPath = sendableKP
-        self.comparator = AnySortComparator(OptionalComparator(comparator))
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
-        self.extractField = {
-            Self.getField(
-                ofType: Value?.self,
-                offset: cachedOffset,
-                from: $0,
-                fallback: sendableKP) as Any
-        }
+        self.comparator = AnySortComparator(OptionalComparator(comparator))
+        var forwardComparator = comparator
+        forwardComparator.order = .forward
+        let forwardOptional = OptionalComparator(forwardComparator)
+        self._compare = Self.makeCompare(keyPath: sendableKP, offset: cachedOffset, fieldComparator: forwardOptional)
+        self.order = comparator.order
+        self.comparator.order = comparator.order
     }
 
     /// Creates a `KeyPathComparator` with the given `keyPath`,
@@ -214,16 +224,13 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /*public*/ @usableFromInline init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value>, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
         let sendableKP = keyPath._unsafeAssumeSendable
         self.keyPath = sendableKP
-        self.comparator = AnySortComparator(comparator)
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
-        self.extractField = {
-            Self.getField(
-                ofType: Value.self,
-                offset: cachedOffset,
-                from: $0,
-                fallback: sendableKP)
-        }
+        self.comparator = AnySortComparator(comparator)
+        var forwardComparator = comparator
+        forwardComparator.order = .forward
+        self._compare = Self.makeCompare(keyPath: sendableKP, offset: cachedOffset, fieldComparator: forwardComparator)
         self.order = order
+        self.comparator.order = order
     }
 
     /// Creates a `KeyPathComparator` with the given `keyPath`,
@@ -239,16 +246,14 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /*public*/ @usableFromInline init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?>, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
         let sendableKP = keyPath._unsafeAssumeSendable
         self.keyPath = sendableKP
-        self.comparator = AnySortComparator(OptionalComparator(comparator))
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
-        self.extractField = {
-            Self.getField(
-                ofType: Value?.self,
-                offset: cachedOffset,
-                from: $0,
-                fallback: sendableKP) as Any
-        }
+        self.comparator = AnySortComparator(OptionalComparator(comparator))
+        var forwardComparator = comparator
+        forwardComparator.order = .forward
+        let forwardOptional = OptionalComparator(forwardComparator)
+        self._compare = Self.makeCompare(keyPath: sendableKP, offset: cachedOffset, fieldComparator: forwardOptional)
         self.order = order
+        self.comparator.order = order
     }
 
     /// Provides the relative ordering of two items according to the ordering of the properties that the comparator's key path references.
@@ -260,9 +265,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
     ///   - rhs: The second property to compare.
     /// - Returns: The relative ordering for the compared properties.
     public func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
-        let lhsField = extractField(lhs)
-        let rhsField = extractField(rhs)
-        return self.comparator.compare(lhsField, rhsField)
+        return _compare(lhs, rhs).withOrder(order)
     }
 
     public static func ==(lhs: Self, rhs: Self) -> Bool {


### PR DESCRIPTION
Uses the benchmarks from: https://github.com/swiftlang/swift-foundation/pull/2094

Every `KeyPathComparator.compare(_:_:)` went through a type-erased path. 
Both fields were boxed into `Any` and dynamically cast back to their concrete type on each comparison, dispatched through `AnySortComparator`. 
The `sorted(using:)` /`sort(using:)` wrappers were not `@inlinable`, so the standard library sort could not specialize on the element type nor the Sequence type, running into issue of Collection.subscript.\_read to allocate. 
## Changes
- `KeyPathComparator` holds a typed `_compare` closure built once at init that reads each field as its concrete type and compares it directly removing per-compare `Any `boxing and dynamic casts.
- `compare(_:_:)` applies `order` on top via `ComparisonResult.withOrder.` the type-erased comparator is retained only for `==` / `hash(into:)`.
- The `sorted(using:)` / `sort(using:)` / `compare` wrappers are now `@inlinable`, letting the standard library sort specialize the operations on the concrete `Sequence`.

## Benchmarks — CPU (p50, ms)
M4 Max, 100k elements per sort.

### `KeyPathComparator` — value element (`Entry`, 168-byte struct)

| key | before | after | speedup |
|---|--:|--:|--:|
| single-int | 414 | 117 | 3.5x |
| two-int | 693 | 129 | 5.4x |
| single-optional | 547 | 155 | 3.5x |
| single-string | 475 | 179 | 2.7x |
| two-string | 972 | 236 | 4.1x |
| single-computed | 624 | 244 | 2.6x |

### `KeyPathComparator` — reference element (`EntryObject`)

| key | before | after | speedup |
|---|--:|--:|--:|
| single-int | 388 | 97 | 4.0x |
| two-int | 664 | 101 | 6.6x |
| single-optional | 525 | 132 | 4.0x |
| single-string | 463 | 156 | 3.0x |
| two-string | 989 | 235 | 4.2x |
| single-computed | 539 | 150 | 3.6x |

### `ComparableComparator` (used directly)

| collection | before | after | speedup |
|---|--:|--:|--:|
| `[Int]` | 85 | 12 | 7.1x |
| `[String]` | 108 | 34 | 3.2x |

### Custom closure-based comparator — value element (`Entry`)

| key | before | after | speedup |
|---|--:|--:|--:|
| single-int | 158 | 100 | 1.6x |
| two-int | 381 | 107 | 3.6x |
| single-optional | 154 | 97 | 1.6x |
| single-string | 164 | 110 | 1.5x |
| two-string | 460 | 129 | 3.6x |
| single-computed | 151 | 95 | 1.6x |

### Custom closure-based comparator — reference element (`EntryObject`)

| key | before | after | speedup |
|---|--:|--:|--:|
| single-int | 90 | 23 | 3.9x |
| two-int | 300 | 28 | 10.7x |
| single-optional | 90 | 23 | 3.9x |
| single-string | 101 | 32 | 3.2x |
| two-string | 390 | 58 | 6.7x |
| single-computed | 85 | 19 | 4.5x |

Those are good improvement but we are still (sometimes far) away from a "hand written" version.
### Lower-bound floor (plain `sorted(by:)`) — value element (`Entry`)

| key | before | after | speedup |
|---|--:|--:|--:|
| single-int | 88 | 92 | 1.0x |
| two-int | 87 | 90 | 1.0x |
| single-optional | 87 | 92 | 0.9x |
| single-string | 92 | 94 | 1.0x |
| two-string | 100 | 103 | 1.0x |
| single-computed | 85 | 87 | 1.0x |

### Lower-bound floor (plain `sorted(by:)`) — reference element (`EntryObject`)

| key | before | after | speedup |
|---|--:|--:|--:|
| single-int | 19 | 19 | 1.0x |
| two-int | 19 | 19 | 1.0x |
| single-optional | 18 | 19 | 0.9x |
| single-string | 25 | 26 | 1.0x |
| two-string | 42 | 43 | 1.0x |
| single-computed | 16 | 16 | 1.0x |

## Benchmarks — allocations (total mallocs per sort)

`mallocCountTotal` is deterministic (identical p0–p100) and essentially as low as we can go.

### `KeyPathComparator` — value element (`Entry`)

| key | before | after |
|---|--:|--:|
| single-int | 4,969,548 | 7 |
| two-int | 9,867,359 | 7 |
| single-optional | 4,890,301 | 7 |
| single-string | 4,915,428 | 7 |
| two-string | 12,603,734 | 7 |
| single-computed | 4,826,292 | 7 |

### `KeyPathComparator` — reference element (`EntryObject`)

| key | before | after |
|---|--:|--:|
| single-int | 4,969,548 | 7 |
| two-int | 9,867,359 | 7 |
| single-optional | 4,890,301 | 7 |
| single-string | 4,915,428 | 7 |
| two-string | 12,603,734 | 7 |
| single-computed | 4,826,292 | 7 |

### `ComparableComparator` (used directly)

| collection | before | after |
|---|--:|--:|
| `[Int]` | 2,582,473 | 7 |
| `[String]` | 2,550,715 | 7 |

### Custom closure-based comparator — value element (`Entry`)

| key | before | after |
|---|--:|--:|
| single-int | 2,582,473 | 7 |
| two-int | 7,437,607 | 7 |
| single-optional | 2,563,911 | 7 |
| single-string | 2,550,715 | 7 |
| two-string | 9,264,661 | 7 |
| single-computed | 2,521,063 | 7 |

### Custom closure-based comparator — reference element (`EntryObject`)

| key | before | after |
|---|--:|--:|
| single-int | 2,582,473 | 7 |
| two-int | 7,437,607 | 7 |
| single-optional | 2,563,911 | 7 |
| single-string | 2,550,715 | 7 |
| two-string | 9,264,661 | 7 |
| single-computed | 2,521,063 | 7 |

### Lower-bound floor (plain `sorted(by:)`) — value element (`Entry`)

| key | before | after |
|---|--:|--:|
| single-int | 7 | 7 |
| two-int | 7 | 7 |
| single-optional | 7 | 7 |
| single-string | 7 | 7 |
| two-string | 7 | 7 |
| single-computed | 7 | 7 |

### Lower-bound floor (plain `sorted(by:)`) — reference element (`EntryObject`)

| key | before | after |
|---|--:|--:|
| single-int | 7 | 7 |
| two-int | 7 | 7 |
| single-optional | 7 | 7 |
| single-string | 7 | 7 |
| two-string | 7 | 7 |
| single-computed | 7 | 7 |
