### PR TITLE
[NewCodable] Fix decodeEachElement dispatching closure on empty arrays

### DIFF
--- a/Sources/NewCodable/JSON/JSONParserDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONParserDecoder.swift
@@ -424,8 +424,7 @@ public struct JSONParserDecoder: JSONDecoderProtocol, ~Escapable {
         
         @_lifetime(self: copy self)
         public mutating func decodeEachElement(_ closure: (inout ElementDecoder) throws(CodingError.Decoding) -> Void) throws(CodingError.Decoding) {
-            // Honor `hasNext` (set by the init-time `prepareForArrayElement(first: true)`)
-            // so empty arrays don't dispatch the closure once into nothing.
+            // noop for empty array
             guard hasNext else { return }
             do throws(_JSONDecodingError) {
                 repeat {

--- a/Sources/NewCodable/JSON/JSONParserDecoder.swift
+++ b/Sources/NewCodable/JSON/JSONParserDecoder.swift
@@ -424,6 +424,9 @@ public struct JSONParserDecoder: JSONDecoderProtocol, ~Escapable {
         
         @_lifetime(self: copy self)
         public mutating func decodeEachElement(_ closure: (inout ElementDecoder) throws(CodingError.Decoding) -> Void) throws(CodingError.Decoding) {
+            // Honor `hasNext` (set by the init-time `prepareForArrayElement(first: true)`)
+            // so empty arrays don't dispatch the closure once into nothing.
+            guard hasNext else { return }
             do throws(_JSONDecodingError) {
                 repeat {
                     self.innerParser.state.currentTopCodingPathNode.pointee.incrementArrayIndex()

--- a/Tests/NewCodableTests/CodableRevolutionTests.swift
+++ b/Tests/NewCodableTests/CodableRevolutionTests.swift
@@ -1954,6 +1954,31 @@ struct NewCodableTests {
         #expect(result.items[2].capturedCodingPath[1].intValue == 2)
         #expect(result.items[2].id == 300)
     }
+
+    @Test func testDecodeEachElementEmptyArray() throws {
+        struct DoubleList: JSONDecodable, Equatable {
+            var values: [Double]
+
+            static func decode(from decoder: inout some (JSONDecoderProtocol & ~Escapable)) throws(CodingError.Decoding) -> DoubleList {
+                try decoder.decodeArray { arrayDecoder throws(CodingError.Decoding) in
+                    var values: [Double] = []
+                    try arrayDecoder.decodeEachElement { elementDecoder throws(CodingError.Decoding) in
+                        values.append(try elementDecoder.decode(Double.self))
+                    }
+                    return DoubleList(values: values)
+                }
+            }
+        }
+
+        let decoder = NewJSONDecoder()
+
+        // Empty arrays must not dispatch the element closure.
+        let empty = try decoder.decode(DoubleList.self, from: Data("[]".utf8))
+        #expect(empty.values.isEmpty)
+
+        let nonEmpty = try decoder.decode(DoubleList.self, from: Data("[1.5, 2.5]".utf8))
+        #expect(nonEmpty.values == [1.5, 2.5])
+    }
 }
 
 extension Array where Element: BinaryFloatingPoint {


### PR DESCRIPTION
@kperryua just realized I had this patch lying around for a while but had never opened a PR for it. Seems like it is still relevant.


`JSONParserDecoder.ArrayDecoder.decodeEachElement` uses a `repeat...while` loop, so it dispatches the element closure once even when the array is empty (`hasNext == false`, as computed by the init-time `prepareForArrayElement(first: true)`). The closure then tries to decode an element out of `]`, producing errors like:

```
DecodingError: Data corrupted, at path: scores[0], (Unexpected character ']'), at Line: 1 Column: 29 Offset: 28
```

for any `[]` value decoded through the generic `decodeArray` + `decodeEachElement` API.

The specialized `decode([Element].self, sizeHint:)` fast path already guards this case (which is why plain `[Double].self` decoding is unaffected), but anything using `ArrayDecoder` directly — e.g. the `InlineArray` conformance or hand-written `decode(from:)` implementations — hits the bug.

### Fix

Guard on `hasNext` at the top of `decodeEachElement` so empty arrays return without dispatching the closure.

### Testing

Added a regression test decoding `[]` and `[1.5, 2.5]` through a custom `JSONDecodable` that uses `decodeArray` + `decodeEachElement`. The empty case fails with "Unexpected character ']'" before this change and passes after; the non-empty case passes both before and after.