### PR TITLE
test: add parameterized tests for invalid UUID strings

### DIFF
--- a/Tests/FoundationEssentialsTests/UUIDTests.swift
+++ b/Tests/FoundationEssentialsTests/UUIDTests.swift
@@ -35,9 +35,17 @@ private struct UUIDTests {
         #expect(uuidC != uuidD, "Two different UUIDs must not be equal.")
     }
 
-    @Test func invalidString() {
-        let invalid = UUID(uuidString: "Invalid UUID")
-        #expect(invalid == nil, "The convenience initializer `init?(uuidString string:)` must return nil for an invalid UUID string.")
+    @Test(arguments: [
+        "", // Empty string
+        "E621E1F8", // Too short
+        "E621E1F8-C36C-495A-93FC", // Incomplete segments
+        "E621E1F8-C36C-495A-93FC-0C247A3E6E5FFF", // Too long
+        "E621E1F8-C36C-495A-93FC-0C247A3E6E5Z", // Invalid hex character 'Z'
+        "E621E1F8_C36C_495A_93FC_0C247A3E6E5F", // Invalid separator (underscore)
+        "E621E1F8 C36C 495A 93FC 0C247A3E6E5F" // Invalid separator (spaces)
+    ])
+    func invalidString(string: String) {
+        #expect(UUID(uuidString: string) == nil, "Initializing with '\(string)' must return nil.")
     }
 
     // `uuidString` should return an uppercase string


### PR DESCRIPTION
Added parameterized tests for invalid UUID strings

### Motivation:

Currently, the unit tests for UUID only verify a single basic invalid string format ("Invalid UUID"). We need more comprehensive coverage to ensure that the `UUID(uuidString:)`initializer correctly returns nil for all types of invalid formatted strings (e.g., incorrect segment lengths, empty strings, invalid characters, and incorrect separators).

### Modifications:

- Replaced the single-case invalidString test in  `UUIDTests.swift` with a parameterized` @Test(arguments: [...]) `implementation.

- Added various invalid UUID formats (empty, too short, too long, invalid characters, wrong separators) to test the parsing boundaries.

### Result:

The unit test suite now automatically runs tests against multiple corrupt `UUID` string variations, ensuring robust validation is maintained across all platforms without introducing duplicate test code.

### Testing:
Successfully ran the FoundationEssentialsTests scheme (`UUIDTests` suite) locally on macOS via Swift Package Manager and Xcode, verifying all parameterized cases pass.