### PR TITLE
[CI] Avoid Skipping Required Checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,9 +6,6 @@ permissions:
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-    paths-ignore:
-      - '*.md'
-      - 'Proposals/**'
 
 jobs:
   tests:


### PR DESCRIPTION
Avoids skipping checks that are required for merging a PR

### Motivation:

Now that we require GitHub Action CI to pass, we can't skip them under certain conditions. Ideally we would still mark these runs as passes when only markdown files are changed. However, there isn't a great, supported way to do that per the GitHub documentation: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks

### Modifications:

Remove the `paths-ignore` filter on the pull request workflow

### Result:

GHA workflows always trigger on all PRs

### Testing:

N/A
