### PR TITLE
[Proposal] PredicateExpressions API for nil comparisons without Equatable conformance within #Predicates

### DIFF
--- a/Proposals/0035-nil-comparisons-without-equatable.md
+++ b/Proposals/0035-nil-comparisons-without-equatable.md
@@ -52,7 +52,7 @@ If both sides are `nil`, fall back to `build_Equal(lhs:rhs:)`. Note that `#Predi
 Each builder works by wrapping the non-`Equatable` variable expression in an `OptionalFlatMap`, whose initializer accepts a closure that can evaluate to different outputs based on whether a given input value is present. If a value is present, the closure should discard it and return `Value(true)`. Then, that optional result is compared to `nil` with the binary operator given by the name of the method. This approach is analogous to using a branch of an `if let` conditional binding as a comparand, for which existing API does not constrain the input to `Equatable` types.
 
 ```swift
-@available(FoundationPreview 6.4, *)
+@available(FoundationPreview 6.5, *)
 extension PredicateExpressions {
     public static func build_Equal<LHS, Wrapped>(
         lhs: LHS,

--- a/Proposals/0035-nil-comparisons-without-equatable.md
+++ b/Proposals/0035-nil-comparisons-without-equatable.md
@@ -2,11 +2,14 @@
 
 * Proposal: [SF-0035](0035-nil-comparisons-without-equatable.md)
 * Authors: [Matthew Turk](https://github.com/MatthewTurk247)
-* Review Manager: Jeremy S
-* Status: **Accepted**
+* Review Manager: TBD
+* Status: **Pitch**
 * Bug: [swiftlang/swift-foundation#711](https://github.com/swiftlang/swift-foundation/issues/711)
-* Implementation: [swiftlang/swift-foundation#1765](https://github.com/swiftlang/swift-foundation/pull/1765)
-* Review: ([pitch](https://forums.swift.org/t/pitch-support-for-nil-comparisons-without-equatable-conformance/84684) [review](https://forums.swift.org/t/review-sf-0035-predicateexpressions-api-for-nil-comparisons-without-equatable-conformance-within-predicates/84817))
+
+## Revision history
+
+* **v1** Initial version
+* **v2** Replaced overloads with new builder functions
 
 ## Introduction/Motivation
 
@@ -29,82 +32,65 @@ This outcome is inconsistent with the semantics of the Swift standard library, w
 
 ## Proposed solution and example
 
-To better align the `#Predicate` experience with that of Swift itself, I propose a new set of `build_Equal(lhs:rhs:)` and `build_NotEqual(lhs:rhs:)` overloads. These overloads cover the special cases of an expansion where either parameter is an instance of `NilLiteral`. The above example would leverage this one:
+To better align the `#Predicate` experience with that of Swift itself, I propose a new set of builder functions. These overloads cover the special cases of an expansion where either parameter is an instance of `NilLiteral`. The above example would leverage this one:
 
 ```swift
 public static func build_Equal<LHS, Wrapped>(
     lhs: LHS,
-    rhs: NilLiteral<Wrapped>
+    nilLiteral: NilLiteral<Wrapped>
 ) -> Equal<OptionalFlatMap<LHS, Wrapped, Value<Bool>, Bool>, Value<Bool?>>
 ```
 
 ## Detailed design
 
-Each overload works by wrapping the non-`Equatable` variable expression in an `OptionalFlatMap`, whose initializer accepts a closure that can evaluate to different outputs based on whether a given input value is present. If a value is present, the closure should discard it and return `Value(true)`. Then, that optional result is compared to `nil` with the binary operator given by the name of the overload. This approach is analogous to using a branch of an `if let` conditional binding as a comparand, for which existing API does not constrain the input to `Equatable` types.
+Upon inspecting the operands of an equality or inequality, if either syntax node is of type `NilLiteralExprSyntax`, then `#Predicate` should produce argument labels of  `nilLiteral` and `lhs` or `rhs`.
+
+Emit `build_Equal` in the `==`  case and use the `nilLiteral` label for the `nil` side. For the other argument, use the label associated with whichever side remains. Emit `build_NotEqual` in the `!=` case and follow the aforementioned procedure to place the argument labels.
+
+If both sides are `nil`, fall back to `build_Equal(lhs:rhs:)`. Note that `#Predicate` may then require an explicit type annotation.
+
+Each builder works by wrapping the non-`Equatable` variable expression in an `OptionalFlatMap`, whose initializer accepts a closure that can evaluate to different outputs based on whether a given input value is present. If a value is present, the closure should discard it and return `Value(true)`. Then, that optional result is compared to `nil` with the binary operator given by the name of the method. This approach is analogous to using a branch of an `if let` conditional binding as a comparand, for which existing API does not constrain the input to `Equatable` types.
 
 ```swift
 @available(FoundationPreview 6.4, *)
 extension PredicateExpressions {
     public static func build_Equal<LHS, Wrapped>(
         lhs: LHS,
-        rhs: NilLiteral<Wrapped>
+        nilLiteral: NilLiteral<Wrapped>
     ) -> Equal<OptionalFlatMap<LHS, Wrapped, Value<Bool>, Bool>, Value<Bool?>>
 
     public static func build_Equal<Wrapped, RHS>(
-        lhs: NilLiteral<Wrapped>,
+        nilLiteral: NilLiteral<Wrapped>,
         rhs: RHS
     ) -> Equal<Value<Bool?>, OptionalFlatMap<RHS, Wrapped, Value<Bool>, Bool>>
 
     public static func build_NotEqual<LHS, Wrapped>(
         lhs: LHS,
-        rhs: NilLiteral<Wrapped>
+        nilLiteral: NilLiteral<Wrapped>
     ) -> NotEqual<OptionalFlatMap<LHS, Wrapped, Value<Bool>, Bool>, Value<Bool?>>
 
     public static func build_NotEqual<Wrapped, RHS>(
-        lhs: NilLiteral<Wrapped>,
+        nilLiteral: NilLiteral<Wrapped>,
         rhs: RHS
     ) -> NotEqual<Value<Bool?>, OptionalFlatMap<RHS, Wrapped, Value<Bool>, Bool>>
 }
 ```
 
-With Swift’s method resolution, the compiler can choose the most specific overload available, so these will be preferred over the broader ones in ambiguous cases.
-
 ## Impact on existing code
 
-Given that the overloads are purely additive and the macro will still generate the same source code as before, there should be no breaking changes.
-
-The new method resolution paths may, however, affect observed compiler performance, particularly for predicate code that already heavily relies on type inference. Below is a summary of compiling sample source files, using an SDK without these new overloads and using an SDK with them.
-
-| Number of predicates in file | Type check time without new overloads (s) | Type check time with new overloads (s) |
-|------------------------------|-------------------------------------------|----------------------------------------|
-| 10                           | 6.073                                     | 6.135                                  |
-| 20                           | 8.599                                     | 8.398                                  |
-| 30                           | 11.129                                    | 11.466                                 |
-| 40                           | 13.802                                    | 13.732                                 |
-| 50                           | 16.266                                    | 16.199                                 |
-| 60                           | 18.933                                    | 18.866                                 |
-| 70                           | 21.265                                    | 21.458                                 |
-| 80                           | 23.999                                    | 23.999                                 |
-| 90                           | 26.466                                    | 26.599                                 |
-| 100                          | 29.065                                    | 28.999                                 |
-| 110                          | 31.599                                    | 31.666                                 |
-| 120                          | 34.399                                    | 34.466                                 |
-| 130                          | 37.266                                    | 36.665                                 |
-| 140                          | 39.985                                    | 39.274                                 |
-| 150                          | 42.437                                    | 42.099                                 |
-| 160                          | 44.547                                    | 44.798                                 |
-| 170                          | 47.298                                    | 47.282                                 |
-| 180                          | 49.497                                    | 49.577                                 |
-| 190                          | 52.414                                    | 52.251                                 |
-| 200                          | 55.247                                    | 54.831                                 |
-
-At a glance, an impact on performance is not noticeable.
+Given that the builder functions are purely additive and do not collide with existing symbols in the SDK, there should be no breaking changes.
 
 ## Alternatives considered
 
 ### Relaxing requirements for existing `build_Equal(lhs:rhs:)` and `build_NotEqual(lhs:rhs:)` methods
 
 This would require relaxing several `Equatable` requirements elsewhere in the `#Predicate` infrastructure and public API. Such drastic changes could break existing evaluation functions or lead to other unforeseen consequences.
+
+### Overloading `build_Equal(lhs:rhs:)` and `build_NotEqual(lhs:rhs:)`
+
+An earlier version of this proposal shared the same `OptionalFlatMap` mechanism and likewise accepted a `NilLiteral` directly, differing only in that it kept the existing `lhs` and `rhs` argument labels. Reusing those labels made the new functions overloads of `build_Equal(lhs:rhs:)` and `build_NotEqual(lhs:rhs:)`. The overloading approach succeeded in preliminary testing, but building downstream raised issues. For a small number of projects using anonymous closure arguments, an SDK with the new overloads apparently pushed the Swift type checker to a “tipping point,” beyond which it would time out or fail to resolve as expected. Breaking downstream build routines in the name of a modest quality-of-life improvement is not acceptable.
+
+The revised functions have a distinct `nilLiteral` label, and `#Predicate` selects the correct one by inspecting the operands, which shifts that responsibility of method resolution from the type checker to the macro.
 
 ### Introducing a new operator or expression type
 

--- a/Proposals/0035-nil-comparisons-without-equatable.md
+++ b/Proposals/0035-nil-comparisons-without-equatable.md
@@ -1,9 +1,9 @@
-# Support for `nil` comparisons without `Equatable` conformance
+# `PredicateExpressions` API for `nil` comparisons without `Equatable` conformance within `#Predicate`s
 
 * Proposal: [SF-0035](0035-nil-comparisons-without-equatable.md)
 * Authors: [Matthew Turk](https://github.com/MatthewTurk247)
-* Review Manager: TBD
-* Status: **Pitch**
+* Review Manager: [Jeremy Schonfeld](https://github.com/jmschonfeld)
+* Status: **Review (2026-07-22...2026-07-29**
 * Bug: [swiftlang/swift-foundation#711](https://github.com/swiftlang/swift-foundation/issues/711)
 
 ## Revision history


### PR DESCRIPTION
This revision of #1735 changes the argument labels of four new builder functions in `PredicateExpressions`.