### PR TITLE
Correct BOM detection for files with unknown encoding

### DIFF
--- a/Sources/FoundationEssentials/String/String+IO.swift
+++ b/Sources/FoundationEssentials/String/String+IO.swift
@@ -279,31 +279,31 @@ extension String {
 
 extension String {
     internal init?(dataOfUnknownEncoding data: Data, usedEncoding: inout Encoding) {
-        let len = data.count
-        let encoding: Encoding
-        if len >= 4 && (
-            (data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00) ||
-            (data[0] == 0x00 && data[1] == 0x00 && data[3] == 0xFE && data[4] == 0xFF)) {
-            // Looks like UTF32
-            encoding = .utf32
-        } else if len >= 2 {
-            if ((len & 1) == 0) && ((data[0] == 0xfe && data[1] == 0xff) || (data[0] == 0xff && data[1] == 0xfe)) {
-                // Looks like Unicode
-                encoding = .unicode
-            } else {
-                // Fallback
-                encoding = .utf8
+        var encoding: Encoding?
+        let bytes = data.bytes
+        let len = bytes.byteCount
+
+        if len >= 4 {
+            let potentialBOM = bytes.load(fromByteOffset: 0, as: UInt32.self)
+            if potentialBOM == 0xFFFE0000 || potentialBOM == 0x0000FEFF {
+                // Looks like UTF32
+                encoding = .utf32
             }
-        } else {
-            // Fallback, short string
-            encoding = .utf8
         }
-        
-        guard let str = String(data: data, encoding: encoding) else {
+
+        if encoding == nil && len >= 2 && (len & 1) == 0 {
+            let potentialBOM = bytes.load(fromByteOffset: 0, as: UInt16.self)
+            if potentialBOM == 0xFEFF || potentialBOM == 0xFFFE {
+                encoding = .unicode
+            }
+        }
+
+        let encodingToUse = encoding ?? .utf8
+        guard let str = String(data: data, encoding: encodingToUse) else {
             return nil
         }
         
-        usedEncoding = encoding
+        usedEncoding = encodingToUse
         self = str
     }
 }

--- a/Sources/FoundationEssentials/String/String+IO.swift
+++ b/Sources/FoundationEssentials/String/String+IO.swift
@@ -283,7 +283,7 @@ extension String {
         let bytes = data.bytes
         let len = bytes.byteCount
 
-        if len >= 4 {
+        if len >= MemoryLayout<UInt32>.size {
             let potentialBOM = bytes.load(fromByteOffset: 0, as: UInt32.self)
             if potentialBOM == 0xFFFE0000 || potentialBOM == 0x0000FEFF {
                 // Looks like UTF32
@@ -291,7 +291,7 @@ extension String {
             }
         }
 
-        if encoding == nil && len >= 2 && (len & 1) == 0 {
+        if encoding == nil && len >= MemoryLayout<UInt16>.size && (len & 1) == 0 {
             let potentialBOM = bytes.load(fromByteOffset: 0, as: UInt16.self)
             if potentialBOM == 0xFEFF || potentialBOM == 0xFFFE {
                 encoding = .unicode

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -1178,14 +1178,111 @@ private struct StringTests {
         }
     }
 
-    @Test func init_contentsOfFile_usedEncoding() throws {
-        try withTemporaryStringFile { existingURL, nonExistentURL in
+    @Test(arguments: [String.Encoding.utf8, .utf16, .utf32])
+    func init_contentsOfFile_usedEncoding(encoding: String.Encoding) throws {
+        try withTemporaryStringFile(encoding: encoding) { existingURL, nonExistentURL in
             var usedEncoding = String.Encoding(rawValue: 0)
             let content = try String(contentsOfFile: existingURL.path(), usedEncoding: &usedEncoding)
-            #expect(0 != usedEncoding.rawValue)
+            #expect(usedEncoding == encoding)
             #expect(temporaryFileContents == content)
         }
+    }
 
+    @Test
+    func init_contentsOfFile_usedEncoding_unknown() throws {
+        // UTF-32 BOM (no content)
+        try withTemporaryFile(contents: Data([0xFF, 0xFE, 0x00, 0x00])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf32)
+            #expect(content.isEmpty)
+        }
+        try withTemporaryFile(contents: Data([0x00, 0x00, 0xFE, 0xFF])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf32)
+            #expect(content.isEmpty)
+        }
+
+        // UTF-32 BOM (with content)
+        try withTemporaryFile(contents: Data([0xFF, 0xFE, 0x00, 0x00, UInt8(ascii: "A"), 0x00, 0x00, 0x00])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf32)
+            #expect(content == "A")
+        }
+        try withTemporaryFile(contents: Data([0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, UInt8(ascii: "A")])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf32)
+            #expect(content == "A")
+        }
+
+        // UTF-16 BOM (no content)
+        try withTemporaryFile(contents: Data([0xFF, 0xFE])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf16)
+            #expect(content.isEmpty)
+        }
+        try withTemporaryFile(contents: Data([0xFE, 0xFF])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf16)
+            #expect(content.isEmpty)
+        }
+
+        // UTF-16 BOM (with content)
+        try withTemporaryFile(contents: Data([0xFF, 0xFE, UInt8(ascii: "A"), 0x00])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf16)
+            #expect(content == "A")
+        }
+        try withTemporaryFile(contents: Data([0xFE, 0xFF, 0x00, UInt8(ascii: "A")])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf16)
+            #expect(content == "A")
+        }
+
+        // UTF-8 BOM (no content)
+        try withTemporaryFile(contents: Data([0xEF, 0xBB, 0xBF])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf8)
+            #expect(content.isEmpty)
+        }
+
+        // UTF-8 BOM (with content)
+        try withTemporaryFile(contents: Data([0xEF, 0xBB, 0xBF, UInt8(ascii: "A")])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf8)
+            #expect(content == "A")
+        }
+
+        // No BOM (no content)
+        try withTemporaryFile(contents: Data()) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf8)
+            #expect(content.isEmpty)
+        }
+
+        // No BOM (with content)
+        try withTemporaryFile(contents: Data([UInt8(ascii: "A")])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf8)
+            #expect(content == "A")
+        }
+        try withTemporaryFile(contents: Data([UInt8(ascii: "A"), UInt8(ascii: "A"), UInt8(ascii: "A"), UInt8(ascii: "A"), UInt8(ascii: "A")])) { url in
+            var usedEncoding = String.Encoding(rawValue: 0)
+            let content = try String(contentsOfFile: url.path, usedEncoding: &usedEncoding)
+            #expect(usedEncoding == .utf8)
+            #expect(content == "AAAAA")
+        }
     }
 
 
@@ -1476,6 +1573,17 @@ func withTemporaryStringFile(encoding: String.Encoding = .utf8, _ block: (_ exis
     
     let nonExisting = rootURL.appending(path: "-NonExist", directoryHint: .notDirectory)
     try block(fileURL, nonExisting)
+    try FileManager.default.removeItem(at: rootURL)
+}
+
+func withTemporaryFile(contents: Data, block: (_ url: URL) throws -> ()) throws {
+    let rootURL = URL.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let fileURL = rootURL.appending(path: "Test.txt", directoryHint: .notDirectory)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+
+    try contents.write(to: fileURL, options: .atomic)
+
+    try block(fileURL)
     try FileManager.default.removeItem(at: rootURL)
 }
 


### PR DESCRIPTION
Fixes a bug in BOM detection logic when decoding file contents as a String for files with unknown encoding

### Motivation:

When decoding a file, if the file has an xattr for the encoding we decode as that encoding, otherwise we use BOM detection to select an encoding. The BOM detection included a few logic bugs around reading from incorrect indices.

### Modifications:

Updates the BOM detection logic to use modern span-based APIs to avoid indexing issues

### Result:

BOM detection behaves as expected

Resolves rdar://182478045

### Testing:

Added a unit test to validate the behavior (unit testing previously only covered cases where the file contained the xattr)
