### PR TITLE
[Test Fix] fix fileExtendedAttributes() to account for newer linux platforms

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -819,10 +819,12 @@ private struct FileManagerTests {
             let key = "org.swift.foundation.testattribute"
             #endif
             let value = Data("Hello, world".utf8)
+            let initialAttrs = try $0.attributesOfItem(atPath: "Foo")
+            let initialCount = (initialAttrs[._extendedAttributes] as? [String : Data])?.count ?? 0
             try $0.setAttributes([._extendedAttributes : [key : value]], ofItemAtPath: "Foo")
             let attrs = try $0.attributesOfItem(atPath: "Foo")
             let xattrs = try #require(attrs[._extendedAttributes] as? [String : Data])
-            #expect(xattrs.count == 1)
+            #expect(xattrs.count == initialCount + 1)
             #expect(xattrs[key] == value)
         }
     }


### PR DESCRIPTION
Update `fileExtendedAttributes` test check for a non static number of attributes

### Motivation:

On newer linux distributions, SELinux is enabled which adds an attribute to files used in containerization for security purposes. This causes the test to fail because it previously enforced files to have a single attribute after adding `org.swift.foundation.testattribute` but it didn't account for the fact that said file may have previously existing attributes.

This was discovered after moving to AL2023

### Modifications:

Updated the test to ensure a single attribute is added.

### Result:

Test pass (ensured on CI)