### PR TITLE
Account for quota hard limits below current sizes of file system

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -776,11 +776,21 @@ extension _FileManagerImpl {
                     // For each value (total/available bytes, total/available files) report the smaller of the quota hard limit and the statfs value.
                     if quotaInfo.dqb_bhardlimit > 0 {
                         totalSizeBytes = min(quotaInfo.dqb_bhardlimit, totalSizeBytes)
-                        availSizeBytes = min(quotaInfo.dqb_bhardlimit - quotaInfo.dqb_curbytes, availSizeBytes)
+                        let remainingBytes: UInt64 = if quotaInfo.dqb_bhardlimit >= quotaInfo.dqb_curbytes {
+                            quotaInfo.dqb_bhardlimit - quotaInfo.dqb_curbytes
+                        } else {
+                            0
+                        }
+                        availSizeBytes = min(remainingBytes, availSizeBytes)
                     }
                     if (quotaInfo.dqb_ihardlimit > 0) {
                         totalFiles = min(UInt64(quotaInfo.dqb_ihardlimit), totalFiles)
-                        availFiles = min(UInt64(quotaInfo.dqb_ihardlimit - quotaInfo.dqb_curinodes), availFiles)
+                        let remaining: UInt64 = if quotaInfo.dqb_ihardlimit >= quotaInfo.dqb_curinodes {
+                            UInt64(quotaInfo.dqb_ihardlimit - quotaInfo.dqb_curinodes)
+                        } else {
+                            0
+                        }
+                        availFiles = min(remaining, availFiles)
                     }
                 }
             }


### PR DESCRIPTION
Account for the possibility that the current file system sizes may be above quota hard limits

### Motivation:

It's possible for current sizes to be above hard limits (for example, if a hard limit was lowered). We should account for this when calculating available space in `FileManager.attributesOfFileSystem(at:)`

Resolves rdar://182334926

### Modifications:

Set available nodes/bytes to `0` rather than trapping on the subtraction underflow

### Result:

The API now returns `0` available bytes/files in this state rather than trapping

### Testing:

We don't have great infrastructure to test code under quota hard limits so I haven't added a unit test, but the change is fairly trivial and I have high confidence in the change.
