### PR TITLE
Correct the timezone class in timezone cache

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -360,21 +360,17 @@ struct TimeZoneCache : Sendable, ~Copyable {
             }
 
             let bridgedTZ: _NSSwiftTimeZone?
-            if let innerTZ = _TimeZoneGMT(identifier: identifier) {
-                // Identifier takes a form of GMT offset such as "GMT+8"
+            if let innerTZ = _timeZoneGMTClass().init(identifier: identifier) {
+                // Identifier takes a form of GMT offset such as "GMT+8" or UTC
                 fixedTimeZones[identifier] = innerTZ
                 bridgedTZ = _NSSwiftTimeZone(timeZone: TimeZone(inner: innerTZ))
             } else {
-#if canImport(_FoundationICU)
-                if let innerTz = _TimeZoneICU(identifier: identifier) {
+                if let innerTz = _timeZoneICUClass()?.init(identifier: identifier) {
                     fixedTimeZones[identifier] = innerTz
                     bridgedTZ = _NSSwiftTimeZone(timeZone: TimeZone(inner: innerTz))
                 } else {
                     bridgedTZ = nil
                 }
-#else
-                bridgedTZ = nil
-#endif
             }
 
             if let bridgedTZ {
@@ -396,11 +392,7 @@ struct TimeZoneCache : Sendable, ~Copyable {
                 bridgedOffsetTimeZones[offset] = bridged
                 return bridged
             }
-#if canImport(_FoundationICU)
-            let maybeInnerTz = _TimeZoneGMTICU(secondsFromGMT: offset)
-#else
-            let maybeInnerTz = _TimeZoneGMT(secondsFromGMT: offset)
-#endif
+            let maybeInnerTz = _timeZoneGMTClass().init(secondsFromGMT: offset)
             if let innerTz = maybeInnerTz {
                 // In order to avoid bloating a cache with weird time zones, only cache values that are 30min offsets (including 1hr offsets).
                 let doCache = abs(offset) % 1800 == 0

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
@@ -79,10 +79,19 @@ internal final class _TimeZoneGMTICU : _TimeZoneProtocol, @unchecked Sendable {
     }
     
     package func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
-        // The GMT localized name is always the 'generic' one, as there is no variation for daylight vs standard time. Short or not depends on the style.
-        let isShort = switch style {
-        case .shortStandard, .shortDaylightSaving, .shortGeneric: true
-        default: false
+        let icuStyle: UTimeZoneDisplayNameType = switch style {
+        case .shortStandard:
+            UTIMEZONE_SHORT
+        case .shortDaylightSaving:
+            UTIMEZONE_SHORT_DST
+        case .shortGeneric:
+            UTIMEZONE_SHORT
+        case .standard:
+            UTIMEZONE_LONG
+        case .daylightSaving:
+            UTIMEZONE_LONG_DST
+        case .generic:
+            UTIMEZONE_LONG
         }
         
         // TODO: Consider implementing this ourselves
@@ -99,8 +108,9 @@ internal final class _TimeZoneGMTICU : _TimeZoneProtocol, @unchecked Sendable {
             }
 
             let result: String? = _withResizingUCharBuffer { buffer, size, status in
-                uatimezone_getDisplayName(tz, isShort ? UTIMEZONE_SHORT: UTIMEZONE_LONG, locale?.identifier ?? "", buffer, size, &status)
+                uatimezone_getDisplayName(tz, icuStyle, locale?.identifier ?? "", buffer, size, &status)
             }
+
             return result
         }
 

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -202,6 +202,38 @@ private struct TimeZoneTests {
                      "GMT+09:00", "GMT+9", "GMT+09:00", "GMT+9", "GMT+09:00", "GMT+9")
     }
 
+    @Test func timeZoneGMTOffset_extendedForms() throws {
+        let locale = Locale(identifier: "en_US")
+        func test(_ identifiers: [String], _ expectedIdentifier: String, _ expectedOffset: Int, _ expectedAbbreviation: String, _ long: String, _ short: String, daylightLong: String? = nil, daylightShort: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) throws {
+            let dLong = daylightLong ?? long
+            let dShort = daylightShort ?? short
+            for identifier in identifiers {
+                let tz = try #require(TimeZone(identifier: identifier), sourceLocation: sourceLocation)
+                #expect(tz.identifier == expectedIdentifier, sourceLocation: sourceLocation)
+                #expect(tz.secondsFromGMT() == expectedOffset, sourceLocation: sourceLocation)
+                #expect(tz.abbreviation() == expectedAbbreviation, sourceLocation: sourceLocation)
+                #expect(tz.isDaylightSavingTime() == false, sourceLocation: sourceLocation)
+                #expect(tz.nextDaylightSavingTimeTransition == nil, sourceLocation: sourceLocation)
+                #expect(tz.localizedName(for: .standard, locale: locale) == long, sourceLocation: sourceLocation)
+                #expect(tz.localizedName(for: .shortStandard, locale: locale) == short, sourceLocation: sourceLocation)
+                #expect(tz.localizedName(for: .daylightSaving, locale: locale) == dLong, sourceLocation: sourceLocation)
+                #expect(tz.localizedName(for: .shortDaylightSaving, locale: locale) == dShort, sourceLocation: sourceLocation)
+                #expect(tz.localizedName(for: .generic, locale: locale) == long, sourceLocation: sourceLocation)
+                #expect(tz.localizedName(for: .shortGeneric, locale: locale) == short, sourceLocation: sourceLocation)
+            }
+        }
+#if FOUNDATION_FRAMEWORK && canImport(_FoundationICU)
+        try test(["UTC"], "GMT", 0, "GMT", "Greenwich Mean Time", "GMT", daylightLong: "GMT+00:00", daylightShort: "GMT+0")
+#else
+        try test(["UTC"], "GMT", 0, "GMT", "Greenwich Mean Time", "GMT", daylightLong: "GMT", daylightShort: "GMT")
+#endif
+        try test(["GMT-8", "GMT-08", "GMT-0800", "GMT-08:00"], "GMT-0800", -8*3600, "GMT-8", "GMT-08:00", "GMT-8")
+        try test(["GMT+0530", "GMT+05:30", "GMT+5:30"], "GMT+0530", 5*3600 + 30*60, "GMT+5:30", "GMT+05:30", "GMT+5:30")
+        try test(["UTC+2"], "GMT+0200", 2*3600, "GMT+2", "GMT+02:00", "GMT+2")
+        try test(["GMT+14"], "GMT+1400", 14*3600, "GMT+14", "GMT+14:00", "GMT+14")
+        try test(["GMT-11"], "GMT-1100", -11*3600, "GMT-11", "GMT-11:00", "GMT-11")
+    }
+
     @Test func secondsFromGMT_RemoteDates() {
         let date = Date(timeIntervalSinceReferenceDate: -5001243627) // "1842-07-09T05:39:33+0000"
         let europeRome = TimeZone(identifier: "Europe/Rome")!
@@ -297,8 +329,13 @@ private struct TimeZoneGMTTests {
     @Test func localizedName() {
         #expect(tz.localizedName(for: .standard, locale: Locale(identifier: "en_US")) == "Greenwich Mean Time")
         #expect(tz.localizedName(for: .shortStandard, locale: Locale(identifier: "en_US")) == "GMT")
-        #expect(tz.localizedName(for: .daylightSaving, locale: Locale(identifier: "en_US")) == "Greenwich Mean Time")
+#if FOUNDATION_FRAMEWORK && canImport(_FoundationICU)
+        #expect(tz.localizedName(for: .daylightSaving, locale: Locale(identifier: "en_US")) == "GMT+00:00")
+        #expect(tz.localizedName(for: .shortDaylightSaving, locale: Locale(identifier: "en_US")) == "GMT+0")
+#else
+        #expect(tz.localizedName(for: .daylightSaving, locale: Locale(identifier: "en_US")) == "GMT")
         #expect(tz.localizedName(for: .shortDaylightSaving, locale: Locale(identifier: "en_US")) == "GMT")
+#endif
         #expect(tz.localizedName(for: .generic, locale: Locale(identifier: "en_US")) == "Greenwich Mean Time")
         #expect(tz.localizedName(for: .shortGeneric, locale: Locale(identifier: "en_US")) == "GMT")
         


### PR DESCRIPTION
Before, we used `_TimeZoneICU` for timezones such as "GMT+8" for bridged timezone. In a previous commit, we wanted to switched the FOUNDATION_FRAMEWORK to `_TimeZoneGMTICU` to follow the Swift timezone path. However I incorrectly created a `_TimeZoneGMT` instead. This caused the -[localizedName:locale:] to return nil for the affected timezones.

Consolidate the code to use the dynamic func `_timeZoneGMTClass()` everywhere, which resolves to `_TimeZoneGMTICU` on Darwin, for extra benefit to remove some duplicated code. Also update the f`unc localizedName(for style: TimeZone.NameStyle, locale: Locale?)` implementation to match what `_TimeZoneICU` does.

While we're here, change to use the dynamic `_timeZoneICUClass()` for `_timeZoneICU` too.