### PR TITLE
Allow reading WASI files that return empty size

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -368,7 +368,7 @@ internal func readBytesFromFile(path inPath: borrowing some FileSystemRepresenta
     let localProgress = (reportProgress && Progress.current() != nil) ? Progress(totalUnitCount: Int64(fileSize)) : nil
     
     if fileSize == 0 {
-        #if os(Linux) || os(Android)
+        #if os(Linux) || os(Android) || os(WASI)
         // Linux has some files that may report a size of 0 but actually have contents
         let chunkSize = 1024 * 4
         var ptr = malloc(chunkSize)!


### PR DESCRIPTION
Allows for reading files provided by WASI that report a size of 0 but have content

### Motivation:

On Linux and Android, we already allow for reading files that report an empty size because some actually have content (such as those in `/proc`). We should extend that behavior to WASI where the same situation can occur for a WASI preopened directory.

### Modifications:

Adds an `os(WASI)` to the existing `os(Linux) || os(Android)` guard for this functionality

### Result:

WASI gains the same behavior as Linux and Android here

Resolves #2120 

### Testing:

There isn't a great way to unit test this behavior as it requires a specific setup of the WASI runtime, and we don't currently run unit tests on WASI either, but this behavior is already well-tested on Linux and Android.
