### PR TITLE
[6.4][Android] Build and run the tests (#2122)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,8 @@ jobs:
       enable_cross_pr_testing: true
       enable_android_sdk_build: true
       android_sdk_versions: '["nightly-6.4.x"]'
+      android_sdk_triples: '["aarch64-unknown-linux-android23", "armv7-unknown-linux-android23", "x86_64-unknown-linux-android26"]'
+      enable_android_sdk_checks: true
 
   cmake_build:
     name: Build (CMake)

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -411,8 +411,6 @@ extension Platform {
         return _strnicmp_l(s1, s2, n, Self.cLocale);
         #elseif NO_LOCALIZATION
         return strncasecmp(s1, s2, n);
-        #elseif os(Android)
-        return _stringshims_android_strncasecmp_l(s1, s2, n, Self.cLocale)
         #else
         return strncasecmp_l(s1, s2, n, Self.cLocale);
         #endif

--- a/Sources/_FoundationCShims/include/string_shims.h
+++ b/Sources/_FoundationCShims/include/string_shims.h
@@ -39,16 +39,6 @@ inline static int _stringshims_LC_ALL_MASK() {
 #include <strings.h>
 #endif
 
-#if defined(TARGET_OS_ANDROID) && TARGET_OS_ANDROID
-inline int _stringshims_android_strncasecmp_l(const char *s1, const char *s2, size_t n, locale_t locale) {
-#if __ANDROID_API__ < 23
-    return strncasecmp(s1, s2, n);
-#else
-    return strncasecmp_l(s1, s2, n, locale);
-#endif
-}
-#endif
-
 #define _STRINGSHIMS_MACROMAN_MAP_SIZE 129
 INTERNAL const uint8_t _stringshims_macroman_mapping[_STRINGSHIMS_MACROMAN_MAP_SIZE][3];
 

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -245,8 +245,12 @@ extension LargeDataTests {
     @Test func readLargeFile() throws {
         let url = URL.temporaryDirectory.appendingPathComponent("testfile-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: url) }
-        // More than 2 GB
+        // More than 2 GB, if not 32-bit
+        #if _pointerBitWidth(_32)
+        let size = 0x7FFFFFFF
+        #else
         let size = 0x80010000
+        #endif
         
         let data = generateTestData(count: size)
         

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -18,6 +18,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)
@@ -775,7 +777,7 @@ private struct DecimalTests {
         #expect(Decimal(string: "5538.0")! - Decimal(string: "2880.4")! == Decimal(string: "2657.6")!)
         #expect(Decimal(string: "2880.4")! - Decimal(5538) == Decimal(string: "-2657.6")!)
         #expect(Decimal(0x10000) - Decimal(0x1000) == Decimal(0xf000))
-#if !os(watchOS)
+#if _pointerBitWidth(_64)
         #expect(Decimal(0x1_0000_0000) - Decimal(0x1000) == Decimal(0xFFFFF000))
         #expect(Decimal(0x1_0000_0000_0000) - Decimal(0x1000) == Decimal(0xFFFFFFFFF000))
 #endif

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -23,6 +23,8 @@ import FoundationEssentials
 import Darwin
 #elseif canImport(Glibc)
 @preconcurrency import Glibc
+#elseif canImport(Android)
+import Android
 #elseif canImport(CRT)
 import CRT
 #endif

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -18,6 +18,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)

--- a/Tests/FoundationInternationalizationTests/DateComponentsTests.swift
+++ b/Tests/FoundationInternationalizationTests/DateComponentsTests.swift
@@ -29,6 +29,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)

--- a/Tests/FoundationInternationalizationTests/Formatting/DiscreteFormatStyleTestUtilities.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DiscreteFormatStyleTestUtilities.swift
@@ -25,6 +25,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -503,7 +503,7 @@ private struct NumberFormatStyleTests {
     }
 #endif // FOUNDATION_PREVIEW
 
-#if !os(watchOS) // These tests require Int to be Int64, which is not always true on watch OSs yet
+#if _pointerBitWidth(_64) // These tests require Int to be Int64, which is not true on 32-bit watchOS or Android
     @Test func currency_compactName() throws {
         let baseStyle = Decimal.FormatStyle.Currency(code: "USD", locale: Locale(identifier: "en_US")).notation(.compactName)
 
@@ -737,7 +737,7 @@ private struct NumberFormatStyleTests {
         #expect( (-92233720368547 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100E14")
         #expect((-922337203685477 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100E15")
     }
-#endif // !os(watchOS)
+#endif // _pointerBitWidth(_64)
 }
 
 extension NumberFormatStyleConfiguration.Collection {
@@ -767,7 +767,7 @@ extension IntegerFormatStyle {
     }
 }
 
-#if !os(watchOS) // These tests require Int to be 64 bits, which is not always true on watch OSs yet
+#if _pointerBitWidth(_64) // These tests require Int to be Int64, which is not true on 32-bit watchOS or Android
 @Suite("IntegerFormatStyle (Exhaustive)")
 private struct IntegerFormatStyleExhaustiveTests {
     let exhaustiveIntNumbers : [Int64] = [9223372036854775807, 922337203685477580, 92233720368547758, 9223372036854775, 922337203685477, 92233720368547, 9223372036854, 922337203685, 92233720368, 9223372036, 922337203, 92233720, 9223372, 922337, 92233, 9223, 922, 92, 9, 0, -9, -92, -922, -9223, -92233, -922337, -9223372, -92233720, -922337203, -9223372036, -92233720368, -922337203685, -9223372036854, -92233720368547, -922337203685477, -9223372036854775, -92233720368547758, -922337203685477580, -9223372036854775808 ]
@@ -1639,7 +1639,7 @@ private struct IntegerFormatStyleExhaustiveTests {
     }
 }
 
-#endif // !os(watchOS)
+#endif // _pointerBitWidth(_64)
 
 // MARK: - Attributed string
 


### PR DESCRIPTION
Push the CI down to Android API 23- API 26 on the emulator, as earlier images hang- add imports where needed, and disable or modify tests for 32-bit armv7.