### PR TITLE
Add missing import for Darwin Extras

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -54,6 +54,7 @@ fileprivate let _pageSize: Int = Int(getpagesize())
 internal import _FoundationDarwinExtras
 internal import _FoundationDarwinExtras._string_runtime.xlocale
 import stdlib_h
+internal import unistd
 
 fileprivate let _pageSize: Int = Int(getpagesize())
 #elseif canImport(stdlib_h)


### PR DESCRIPTION
Adds an extra import

### Motivation:

In the environment for this build configuration, we need an extra import that was previously not present

### Modifications:

Adds the missing import statement

### Result:

Source builds successfully that required this import

### Testing:

Verified the project still builds
