### PR TITLE
Check lowercase "addressbook" scheme only for `URLComponents`

### DIFF
--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -466,17 +466,7 @@ internal struct RFC3986Parser {
     }
 
     private static func shouldIgnorePort(forSchemeBuffer schemeBuffer: Slice<UnsafeBufferPointer<UInt8>>) -> Bool {
-        let schemeToIgnore = "addressbook".utf8
-        guard schemeBuffer.count == schemeToIgnore.count else {
-            return false
-        }
-        for i in 0..<schemeBuffer.count {
-            let expected = schemeToIgnore[schemeToIgnore.index(schemeToIgnore.startIndex, offsetBy: i)]
-            guard schemeBuffer[i]._lowercased == expected else {
-                return false
-            }
-        }
-        return true
+        return schemeBuffer.elementsEqual("addressbook".utf8)
     }
 
     /// Fast path used during initial URL buffer parsing.


### PR DESCRIPTION
Remove case-insensitivity when checking for `"addressbook"` scheme in a `URLComponents` compatibility path.

### Motivation:

Both `NS/URL` v2 parsing and the pre-Swift `URLComponents` implementation had this compatibility path for lowercase `"addressbook"` scheme specifically. Update this to match the other implementations and simplify the logic.

### Modifications:

- Compare against lowercase `"addressbook"` scheme specifically.

### Result:

- Compatibility path is only taken for lowercase `"addressbook"` scheme, matching other parsers.

### Testing:

- Current unit tests for `NS/URL` and `URLComponents`.