### PR TITLE
URL/Components.host should not decode %00

### DIFF
--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -186,7 +186,7 @@ public struct URLComponents: Hashable, Equatable, Sendable {
                 guard let encodedHost else { return nil }
                 guard !encodedHost.isEmpty else { return "" }
                 if didPercentEncodeHost {
-                    return Parser.percentDecode(encodedHost)
+                    return Parser.percentDecode(encodedHost, excluding: [0])
                 } else {
                     return Parser.IDNADecodeHost(encodedHost)
                 }

--- a/Sources/FoundationEssentials/URL/URLEncoder.swift
+++ b/Sources/FoundationEssentials/URL/URLEncoder.swift
@@ -46,6 +46,9 @@ internal struct PercentDecodingASCIIExclusionMask: RawRepresentable {
 
     static let none = Self(rawValue: 0)
 
+    // Don't decode "%00" to "\0"
+    static let null = Self(rawValue: 0x1)
+
     // Don't decode "%2F" to "/" or "%00" to "\0"
     static let posixPath = Self(rawValue: 0x800000000001)
 

--- a/Sources/FoundationEssentials/URL/URL_Impl.swift
+++ b/Sources/FoundationEssentials/URL/URL_Impl.swift
@@ -447,7 +447,7 @@ extension _URL {
                 // Return IDNA-encoded host, which is technically not percent-encoded
                 return encodedHost
             } else {
-                return URLEncoder.percentDecode(string: encodedHost)
+                return URLEncoder.percentDecode(string: encodedHost, excludingASCII: .null)
             }
         }()
 

--- a/Sources/FoundationEssentials/URL/URL_Swift.swift
+++ b/Sources/FoundationEssentials/URL/URL_Swift.swift
@@ -426,12 +426,12 @@ internal final class _SwiftURL: Sendable, Hashable, Equatable {
                 return Parser.percentEncode(decoded, component: .host)
             } else if encodedComponents.contains(.host) {
                 if _parseInfo.didPercentEncodeHost {
-                    return Parser.percentDecode(encodedHost)
+                    return Parser.percentDecode(encodedHost, excluding: [0])
                 }
                 // Return IDNA-encoded host, which is technically not percent-encoded
                 return encodedHost
             } else {
-                return Parser.percentDecode(encodedHost, encoding: _encoding)
+                return Parser.percentDecode(encodedHost, excluding: [0], encoding: _encoding)
             }
         }
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -3606,6 +3606,69 @@ private struct URLTests {
         #expect(comp.path == "/my\u{0}path")
     }
 
+    @Test func hostDoesNotDecodeNULL() throws {
+        let decodedHost = "front.host\u{0}.example.com"
+        let encodedHost = "front.host%00.example.com"
+
+        func containsNULL(_ string: String?) -> Bool {
+            string?.utf8.contains(0) ?? false
+        }
+
+        // A parsed host is kept exactly as written, so "%00" must survive both
+        // the encoded and the decoded getters.
+        let url = try #require(URL(string: "https://\(encodedHost)/"))
+        #expect(url.host(percentEncoded: true) == encodedHost)
+        #expect(url.host(percentEncoded: false) == encodedHost)
+
+        let comp = try #require(URLComponents(string: "https://\(encodedHost)/"))
+        #expect(comp.percentEncodedHost == encodedHost)
+        #expect(comp.encodedHost == encodedHost)
+        #expect(comp.host == encodedHost)
+        #expect(comp.string == "https://\(encodedHost)/")
+        #expect(comp.url?.host(percentEncoded: false) == encodedHost)
+
+        // "https" requires an IDNA-encoded host, and IDNA cannot encode a NUL
+        // byte, so setting this host may invalidate the components entirely,
+        // making `.string` and `.url` nil. Either way, the getters must return
+        // the NUL percent-encoded, never as an embedded NUL byte.
+        var httpsComponents = URLComponents()
+        httpsComponents.scheme = "https"
+        httpsComponents.percentEncodedHost = encodedHost
+        httpsComponents.path = "/"
+        #expect(httpsComponents.percentEncodedHost == encodedHost)
+        #expect(httpsComponents.encodedHost == encodedHost)
+        #expect(httpsComponents.host == encodedHost)
+        #expect(!containsNULL(httpsComponents.string))
+        #expect(!containsNULL(httpsComponents.url?.host(percentEncoded: false)))
+
+        httpsComponents.host = decodedHost
+        #expect(httpsComponents.percentEncodedHost == encodedHost)
+        #expect(httpsComponents.encodedHost == encodedHost)
+        #expect(httpsComponents.host == encodedHost)
+        #expect(!containsNULL(httpsComponents.string))
+        #expect(!containsNULL(httpsComponents.url?.host(percentEncoded: false)))
+
+        // "imap" hosts are always percent-encoded instead of IDNA-encoded, so
+        // the components stay valid and we can check the full round trip.
+        var setPercentEncoded = URLComponents()
+        setPercentEncoded.scheme = "imap"
+        setPercentEncoded.percentEncodedHost = encodedHost
+        setPercentEncoded.path = "/"
+        #expect(setPercentEncoded.percentEncodedHost == encodedHost)
+        #expect(setPercentEncoded.host == encodedHost)
+        #expect(setPercentEncoded.string == "imap://\(encodedHost)/")
+        #expect(setPercentEncoded.url?.host(percentEncoded: false) == encodedHost)
+
+        var setDecoded = URLComponents()
+        setDecoded.scheme = "imap"
+        setDecoded.host = decodedHost
+        setDecoded.path = "/"
+        #expect(setDecoded.percentEncodedHost == encodedHost)
+        #expect(setDecoded.host == encodedHost)
+        #expect(setDecoded.string == "imap://\(encodedHost)/")
+        #expect(setDecoded.url?.host(percentEncoded: false) == encodedHost)
+    }
+
     @Test func standardizedAfterAppending() throws {
         // After appending ".." to a relative URL with a base, standardizing
         // resolves the dot segment against the resolved absolute path.


### PR DESCRIPTION
Don't decode `%00` to `NUL` in the `URL/URLComponents` host methods.

### Motivation:

Decoding `%00` to `NUL` can lead to unexpected behavior if a client later interops with a C string-taking function.

### Modifications:

Exclude `%00` from the percent-encoded sequences that are decoded.

### Result:

`%00` is not decoded in `URLComponents.host` or `URL.host` methods.

### Testing:

New unit test verifying behavior.
