### PR TITLE
Slicing AttributedString with 5 attributes doesn't slice 5th attribute

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -679,7 +679,7 @@ extension AttributedString.Runs {
         init(runs: Runs) {
             self.runs = runs
             // FIXME: ☠️ Get these from a proper cache in runs._guts.
-            _names = [T.name, U.name, V.name, W.name]
+            _names = [T.name, U.name, V.name, W.name, X.name]
             _constraints = [
                 T.runBoundaries,
                 U.runBoundaries,

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -2015,6 +2015,150 @@ E {
         }
     }
 
+    @Test func runSlicing() {
+        var str = AttributedString()
+        for i in 0 ..< 3 {
+            var container = AttributeContainer()
+
+            str.append(AttributedString("\(i)", attributes: container))
+            container.testInt = 2
+            str.append(AttributedString("\(i)", attributes: container))
+            container.testDouble = 3.4
+            str.append(AttributedString("\(i)", attributes: container))
+            container.testString = "foo"
+            str.append(AttributedString("\(i)", attributes: container))
+            container.testBool = true
+            str.append(AttributedString("\(i)", attributes: container))
+            container.languageIdentifier = "en"
+            str.append(AttributedString("\(i)", attributes: container))
+        }
+
+        struct EquatablePack<each E: Equatable>: Equatable, CustomStringConvertible {
+            let values: (repeat each E)
+
+            init(_ values: repeat each E) {
+                self.values = (repeat each values)
+            }
+
+            var description: String {
+                String(describing: values)
+            }
+
+            static func ==(lhs: Self, rhs: Self) -> Bool {
+                for (left, right) in repeat (each lhs.values, each rhs.values) {
+                    guard left == right else { return false }
+                }
+                return true
+            }
+        }
+
+        do {
+            let testSlice = str.runs[\.testInt].map {
+                EquatablePack($0.0)
+            }
+            let expectation: [EquatablePack<Int?>] = [
+                EquatablePack(nil),
+                EquatablePack(2),
+                EquatablePack(nil),
+                EquatablePack(2),
+                EquatablePack(nil),
+                EquatablePack(2)
+            ]
+
+            #expect(testSlice == expectation)
+        }
+        do {
+            let testSlice = str.runs[\.testInt, \.testDouble].map {
+                EquatablePack($0.0, $0.1)
+            }
+            let expectation: [EquatablePack<Int?, Double?>] = [
+                EquatablePack(nil, nil),
+                EquatablePack(2, nil),
+                EquatablePack(2, 3.4),
+                EquatablePack(nil, nil),
+                EquatablePack(2, nil),
+                EquatablePack(2, 3.4),
+                EquatablePack(nil, nil),
+                EquatablePack(2, nil),
+                EquatablePack(2, 3.4),
+            ]
+
+            #expect(testSlice == expectation)
+        }
+        do {
+            let testSlice = str.runs[\.testInt, \.testDouble, \.testString].map {
+                EquatablePack($0.0, $0.1, $0.2)
+            }
+            let expectation: [EquatablePack<Int?, Double?, String?>] = [
+                EquatablePack(nil, nil, nil),
+                EquatablePack(2, nil, nil),
+                EquatablePack(2, 3.4, nil),
+                EquatablePack(2, 3.4, "foo"),
+                EquatablePack(nil, nil, nil),
+                EquatablePack(2, nil, nil),
+                EquatablePack(2, 3.4, nil),
+                EquatablePack(2, 3.4, "foo"),
+                EquatablePack(nil, nil, nil),
+                EquatablePack(2, nil, nil),
+                EquatablePack(2, 3.4, nil),
+                EquatablePack(2, 3.4, "foo"),
+            ]
+
+            #expect(testSlice == expectation)
+        }
+        do {
+            let testSlice = str.runs[\.testInt, \.testDouble, \.testString, \.testBool].map {
+                EquatablePack($0.0, $0.1, $0.2, $0.3)
+            }
+            let expectation: [EquatablePack<Int?, Double?, String?, Bool?>] = [
+                EquatablePack(nil, nil, nil, nil),
+                EquatablePack(2, nil, nil, nil),
+                EquatablePack(2, 3.4, nil, nil),
+                EquatablePack(2, 3.4, "foo", nil),
+                EquatablePack(2, 3.4, "foo", true),
+                EquatablePack(nil, nil, nil, nil),
+                EquatablePack(2, nil, nil, nil),
+                EquatablePack(2, 3.4, nil, nil),
+                EquatablePack(2, 3.4, "foo", nil),
+                EquatablePack(2, 3.4, "foo", true),
+                EquatablePack(nil, nil, nil, nil),
+                EquatablePack(2, nil, nil, nil),
+                EquatablePack(2, 3.4, nil, nil),
+                EquatablePack(2, 3.4, "foo", nil),
+                EquatablePack(2, 3.4, "foo", true),
+            ]
+
+            #expect(testSlice == expectation)
+        }
+        do {
+            let testSlice = str.runs[\.testInt, \.testDouble, \.testString, \.testBool, \.languageIdentifier].map {
+                EquatablePack($0.0, $0.1, $0.2, $0.3, $0.4)
+            }
+            let expectation: [EquatablePack<Int?, Double?, String?, Bool?, String?>] = [
+                EquatablePack(nil, nil, nil, nil, nil),
+                EquatablePack(2, nil, nil, nil, nil),
+                EquatablePack(2, 3.4, nil, nil, nil),
+                EquatablePack(2, 3.4, "foo", nil, nil),
+                EquatablePack(2, 3.4, "foo", true, nil),
+                EquatablePack(2, 3.4, "foo", true, "en"),
+                EquatablePack(nil, nil, nil, nil, nil),
+                EquatablePack(2, nil, nil, nil, nil),
+                EquatablePack(2, 3.4, nil, nil, nil),
+                EquatablePack(2, 3.4, "foo", nil, nil),
+                EquatablePack(2, 3.4, "foo", true, nil),
+                EquatablePack(2, 3.4, "foo", true, "en"),
+                EquatablePack(nil, nil, nil, nil, nil),
+                EquatablePack(2, nil, nil, nil, nil),
+                EquatablePack(2, 3.4, nil, nil, nil),
+                EquatablePack(2, 3.4, "foo", nil, nil),
+                EquatablePack(2, 3.4, "foo", true, nil),
+                EquatablePack(2, 3.4, "foo", true, "en"),
+            ]
+
+            #expect(testSlice == expectation)
+        }
+    }
+
     // MARK: - Other Tests
     
     @Test func initWithSequence() {


### PR DESCRIPTION
Corrects unexpected behavior of `AttributeSlice5`

### Motivation:

Slicing an `AttributedString` with 5 attributes should slice via all 5 attributes, not just the first 4

### Modifications:

Corrected a minor typo

### Result:

Slicing with 5 attributes behaves correctly

### Testing:

Unit test is added
