### PR TITLE
Add additional validation for fields in ISO8601 and HTTP string parsing

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -350,7 +350,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
         case .quarter: 1..<5
         case .weekOfMonth: 1..<5
         case .weekOfYear: 1..<53
-        case .yearForWeekOfYear: 140742..<140743
+        case .yearForWeekOfYear: -140742..<140743
         case .nanosecond: 0..<1000000000
         // There is no leap month or repeated day in Gregorian calendar
         case .isLeapMonth: 0..<1
@@ -382,7 +382,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
             let upperBound = (daysInMonthLimit + 6 + (7 - minimumDaysInFirstWeek)) / 7;
             return lowerBound ..< (upperBound + 1)
         case .weekOfYear: return 1..<54
-        case .yearForWeekOfYear: return 140742..<144684
+        case .yearForWeekOfYear: return -140742..<144684
         case .nanosecond: return 0..<1000000000
         case .isLeapMonth: return 0..<1
         case .isRepeatedDay: return 0..<1

--- a/Sources/FoundationEssentials/Formatting/Date+HTTPFormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+HTTPFormatStyle.swift
@@ -383,7 +383,8 @@ extension DateComponents {
                 try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing space after weekday")
             }
 
-            dc.day = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing or malformed day")
+            // The spec does not define a range for days, but it uses the gregorian calendar so we limit to 1...31
+            dc.day = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, range: 1..<32, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Missing or malformed day")
             try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
 
             // month-name (Jan, Feb, ... Dec)
@@ -422,33 +423,23 @@ extension DateComponents {
 
             try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
 
-            dc.year = try it.digits(minDigits: 4, maxDigits: 4, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            dc.year = try it.digits(minDigits: 4, maxDigits: 4, input: inputString, range: nil, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            // From the spec: The year is any numeric year 1900 or later.
+            if let y = dc.year, y < 1900 {
+                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Year out of range")
+            }
             try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
 
-            let hour = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
-            if hour < 0 || hour > 23 {
-                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Hour \(hour) is out of bounds")
-            }
-            dc.hour = hour
+            dc.hour = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, range: 0..<24, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Hour is out of bounds")
             
             try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
-            let minute = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
-            if minute < 0 || minute > 59 {
-                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Minute \(minute) is out of bounds")
-            }
-            dc.minute = minute
+            dc.minute = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, range: 0..<60, onFailure: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Minute is out of bounds")
             
             try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
-            let second = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
+            dc.second = try it.digits(minDigits: 2, maxDigits: 2, input: inputString, range: 0..<61, onFailure: Date.HTTPFormatStyle().format(Date.now))
             // second '60' is supported in the spec for leap seconds, but Foundation does not support leap seconds. 60 is adjusted to 59.
-            if second < 0 || second > 60 {
-                throw parseError(inputString, exampleFormattedString: Date.HTTPFormatStyle().format(Date.now), extendedDescription: "Second \(second) is out of bounds")
-            }
-            // Foundation does not support leap seconds. We convert 60 seconds into 59 seconds.
-            if second == 60 {
+            if dc.second == 60 {
                 dc.second = 59
-            } else {
-                dc.second = second
             }
             try it.expectCharacter(UInt8(ascii: " "), input: inputString, onFailure: Date.HTTPFormatStyle().format(Date.now))
 

--- a/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
@@ -475,12 +475,11 @@ extension DateComponents.ISO8601FormatStyle {
             
             if fields.contains(.weekOfYear) {
                 // parse day of week ('ee')
-                // ISO8601 "1" is Monday and "7" is Sunday. For our date components, 2 is Monday and 1 is Sunday. Convert below.
-                // The range is validated here and not with `maximumRange(of: .weekday)`, because the modulo below would map any value into that range.
                 let max = dateSeparator == .omitted ? 2 : nil
-                let value = try it.digits(maxDigits: max, input: inputString, range: 1..<8, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                // Validate that we are in a weekday range (1..<8 for ISO8601/Gregorian)...
+                let value = try it.digits(maxDigits: max, input: inputString, calendar: _calendar, component: .weekday, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                // ... however, ISO8601 "1" is Monday and "7" is Sunday. For our date components, 2 is Monday and 1 is Sunday. Convert here.
                 weekday = (value % 7) + 1
-
             } else if fields.contains(.month) {
                 // parse day of month ('dd')
                 let max = dateSeparator == .omitted ? 2 : nil

--- a/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/DateComponents+ISO8601FormatStyle.swift
@@ -429,11 +429,10 @@ extension DateComponents.ISO8601FormatStyle {
 
         if fields.contains(.year) {
             let max = dateSeparator == .omitted ? 4 : nil
-            let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             if fields.contains(.weekOfYear) {
-                yearForWeekOfYear = value
+                yearForWeekOfYear = try it.digits(maxDigits: max, input: inputString, calendar: _calendar, component: .yearForWeekOfYear, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             } else {
-                year = value
+                year = try it.digits(maxDigits: max, input: inputString, calendar: _calendar, component: .year, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             }
             
             needsSeparator = true
@@ -449,11 +448,7 @@ extension DateComponents.ISO8601FormatStyle {
             
             // parse month digits
             let max = dateSeparator == .omitted ? 2 : nil
-            let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-            guard _calendar.maximumRange(of: .month)!.contains(value) else {
-                throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
-            }
-            month = value
+            month = try it.digits(maxDigits: max, input: inputString, calendar: _calendar, component: .month, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
 
             needsSeparator = true
         } else if fields.contains(.weekOfYear) {
@@ -465,11 +460,7 @@ extension DateComponents.ISO8601FormatStyle {
 
             // parse week of year digits
             let max = dateSeparator == .omitted ? 2 : nil
-            let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-            guard _calendar.maximumRange(of: .weekOfYear)!.contains(value) else {
-                throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
-            }
-            weekOfYear = value
+            weekOfYear = try it.digits(maxDigits: max, input: inputString, calendar: _calendar, component: .weekOfYear, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             
             needsSeparator = true
         } else if fillMissingUnits {
@@ -484,34 +475,20 @@ extension DateComponents.ISO8601FormatStyle {
             
             if fields.contains(.weekOfYear) {
                 // parse day of week ('ee')
-                // ISO8601 "1" is Monday. For our date components, 2 is Monday. Add 1 to account for difference.
+                // ISO8601 "1" is Monday and "7" is Sunday. For our date components, 2 is Monday and 1 is Sunday. Convert below.
+                // The range is validated here and not with `maximumRange(of: .weekday)`, because the modulo below would map any value into that range.
                 let max = dateSeparator == .omitted ? 2 : nil
-                let value = (try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now)) % 7) + 1
-                
-                guard _calendar.maximumRange(of: .weekday)!.contains(value) else {
-                    throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
-                }
-                weekday = value
-                
+                let value = try it.digits(maxDigits: max, input: inputString, range: 1..<8, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                weekday = (value % 7) + 1
+
             } else if fields.contains(.month) {
                 // parse day of month ('dd')
                 let max = dateSeparator == .omitted ? 2 : nil
-                let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                guard _calendar.maximumRange(of: .day)!.contains(value) else {
-                    throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
-                }
-
-                day = value
-                
+                day = try it.digits(maxDigits: max, input: inputString, calendar: _calendar, component: .day, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             } else {
                 // parse 3 digit day of year ('DDD')
                 let max = dateSeparator == .omitted ? 3 : nil
-                let value = try it.digits(maxDigits: max, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                guard _calendar.maximumRange(of: .dayOfYear)!.contains(value) else {
-                    throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now))
-                }
-
-                dayOfYear = value
+                dayOfYear = try it.digits(maxDigits: max, input: inputString, calendar: _calendar, component: .dayOfYear, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             }
             
             needsSeparator = true
@@ -529,28 +506,40 @@ extension DateComponents.ISO8601FormatStyle {
                 }
             }
             
+            // Time ranges from RFC 3339
             switch timeSeparator {
             case .colon:
-                hour = try it.digits(input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                hour = try it.digits(maxDigits: 2, input: inputString, range: 0..<25, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                 try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                minute = try it.digits(input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                minute = try it.digits(maxDigits: 2, input: inputString, range: 0..<60, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                 try it.expectCharacter(UInt8(ascii: ":"), input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                second = try it.digits(input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                second = try it.digits(maxDigits: 2, input: inputString, range: 0..<61, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             case .omitted:
-                hour = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                minute = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
-                second = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                hour = try it.digits(maxDigits: 2, input: inputString, range: 0..<25, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                minute = try it.digits(maxDigits: 2, input: inputString, range: 0..<60, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                second = try it.digits(maxDigits: 2, input: inputString, range: 0..<61, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
             }
-            
+
+            // Foundation doesn't support leap seconds, so we round 60 to 59
+            if second == 60 {
+                second = 59
+            }
+
             // When parsing, fractional seconds are always optional (as of Swift 6.2).
             // Peek ahead and see if the next character is a period or not. If not, just continue on.
             if let next = it.peek(), next == UInt8(ascii: ".") {
                 // Looks like a fractional seconds
                 let _ = it.next() // consume the period
-                let fractionalSeconds = try it.digits(nanoseconds: true, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                // Any allowed range here
+                let fractionalSeconds = try it.digits(nanoseconds: true, input: inputString, range: nil, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                 nanosecond = fractionalSeconds
             }
-            
+
+            // An hour of 24 is allowed, but only to represent the end of the day. The rest of the time must be zero.
+            if hour == 24, minute != 0 || second != 0 || (nanosecond ?? 0) != 0 {
+                throw parseError(inputString, exampleFormattedString: Date.ISO8601FormatStyle(self).format(Date.now), extendedDescription: "An hour of 24 is only allowed as 24:00:00")
+            }
+
             needsSeparator = true
         }
         
@@ -614,7 +603,7 @@ extension DateComponents.ISO8601FormatStyle {
 
                     // parse Time Zone: ISO8601 extended hms?, with Z
                     // examples: -08:00, -07:52:58, Z
-                    let hours = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                    let hours = try it.digits(maxDigits: 2, input: inputString, range: 0..<25, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                     
                     // Expect a colon, or a minutes value, or the end.
                     let expectMinutes: Bool
@@ -641,7 +630,7 @@ extension DateComponents.ISO8601FormatStyle {
                         tzOffset = hours * 3600
                     } else {
                         // Continue on
-                        let minutes = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                        let minutes = try it.digits(maxDigits: 2, input: inputString, range: 0..<60, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
                         
                         if let maybeColon = it.peek(), maybeColon == UInt8(ascii: ":") {
                             // Throw it away
@@ -650,7 +639,13 @@ extension DateComponents.ISO8601FormatStyle {
 
                         if let secondsTens = it.peek(), isASCIIDigit(secondsTens) {
                             // We have seconds
-                            let seconds = try it.digits(maxDigits: 2, input: inputString, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                            var seconds = try it.digits(maxDigits: 2, input: inputString, range: 0..<61, onFailure: Date.ISO8601FormatStyle(self).format(Date.now))
+                            
+                            // Foundation doesn't support leap seconds, so we round 60 to 59
+                            if seconds == 60 {
+                                seconds = 59
+                            }
+
                             tzOffset = (hours * 3600) + (minutes * 60) + seconds
                         } else {
                             // If the next character is missing, that's allowed - the time can be something like just -0852 and then the string can end

--- a/Sources/FoundationEssentials/Formatting/FormatParsingUtilities.swift
+++ b/Sources/FoundationEssentials/Formatting/FormatParsingUtilities.swift
@@ -47,7 +47,7 @@ extension BufferViewIterator<UInt8> {
         }
     }
             
-    mutating func digits(minDigits: Int? = nil, maxDigits: Int? = nil, nanoseconds: Bool = false, input: String, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws -> Int {
+    mutating func digits(minDigits: Int? = nil, maxDigits: Int? = nil, nanoseconds: Bool = false, input: String, range: Range<Int>?, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws -> Int {
         // Consume all leading zeros, parse until we no longer see a digit
         var result = 0
         var count = 0
@@ -86,10 +86,23 @@ extension BufferViewIterator<UInt8> {
             throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
         }
 
+        if let range, !range.contains(result) {
+            throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
+        }
+        
         return result
     }
     
-
+    mutating func digits(minDigits: Int? = nil, maxDigits: Int? = nil, nanoseconds: Bool = false, input: String, calendar: Calendar, component: Calendar.Component, onFailure: @autoclosure () -> (String), extendedDescription: String? = nil) throws -> Int {
+        
+        let result = try digits(minDigits: minDigits, maxDigits: maxDigits, nanoseconds: nanoseconds, input: input, range: nil, onFailure: onFailure(), extendedDescription: extendedDescription)
+        
+        guard calendar.maximumRange(of: component)!.contains(result) else {
+            throw parseError(input, exampleFormattedString: onFailure(), extendedDescription: extendedDescription)
+        }
+        
+        return result
+    }
 }
 
 // Formatting helpers

--- a/Tests/FoundationEssentialsTests/Formatting/HTTPFormatStyleFormattingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/HTTPFormatStyleFormattingTests.swift
@@ -48,7 +48,7 @@ private struct HTTPFormatStyleFormattingTests {
         "Wed, 20 Jan 2025 23:02:03 GMT",
         "Thu, 20 Jan 2025 01:10:03 GMT",
         "Fri, 20 Jan 2025 01:50:59 GMT",
-        "Sat, 20 Jan 2025 01:50:60 GMT", // 60 is valid, treated as 0
+        "Sat, 20 Jan 2025 01:50:60 GMT", // 60 is valid, adjusted to 59
         "Sun, 20 Jan 2025 01:03:03 GMT",
         "20 Jan 2025 01:02:03 GMT", // Missing weekdays is ok
         "20 Jan 2025 10:02:03 GMT",
@@ -69,6 +69,7 @@ private struct HTTPFormatStyleFormattingTests {
         "Mon, 24 Nov 2025 01:03:03 GMT",
         "Mon, 22 Dec 2025 01:03:03 GMT",
         "Tue, 29 Feb 2028 01:03:03 GMT", // leap day
+        "Mon, 01 Jan 1900 00:00:00 GMT", // the earliest year allowed by the spec
     ])
     func variousInputs(good: String) {
         #expect(throws: Never.self) {
@@ -96,6 +97,17 @@ private struct HTTPFormatStyleFormattingTests {
         "Fri, 17 jan 2025 19:03:05 GMT",
         "Fri, 16 Jan 2025 25:03:05 GMT", // nonsense date
         "Fri, 30 Feb 2025 25:03:05 GMT", // nonsense date
+        "Mon, 00 Jan 2025 19:03:05 GMT", // out of bounds days
+        "Mon, 32 Jan 2025 19:03:05 GMT", // out of bounds days
+        "Mon, 99 Jan 2025 19:03:05 GMT", // out of bounds days
+        "Mon, 01 Jan 1899 19:03:05 GMT", // out of bounds year, the spec allows 1900 or later
+        "Mon, 01 Jan 0000 19:03:05 GMT", // out of bounds year
+        "Mon, 01 Jan 2025 24:03:05 GMT", // out of bounds hours
+        "Mon, 01 Jan 2025 25:03:05 GMT", // out of bounds hours
+        "Mon, 02 Jan 2025 19:60:05 GMT", // out of bounds mins
+        "Mon, 02 Jan 2025 19:62:05 GMT", // out of bounds mins
+        "Mon, 03 Jan 2025 19:03:61 GMT", // out of bounds secs, 60 is allowed for leap seconds
+        "Mon, 03 Jan 2025 19:03:70 GMT", // out of bounds secs
     ])
     func badInputs(bad: String) {
         #expect(throws: (any Error).self) {
@@ -119,16 +131,12 @@ private struct HTTPFormatStyleFormattingTests {
         #expect(parsed.second == 5)
         #expect(parsed.timeZone == TimeZone.gmt)
     }
-    
-    @Test func validatingResultOfParseVsString() throws {
-        // This date will parse correctly, but of course the value of 99 does not correspond to the actual day.
-        let strangeDate = "Mon, 99 Jan 2025 19:03:05 GMT"
-        let date = try Date(strangeDate, strategy: .http)
-        let components = try DateComponents(strangeDate, strategy: .http)
-        
-        let actualDay = Calendar(identifier: .gregorian).component(.day, from: date)
-        let componentDay = try #require(components.day)
-        #expect(actualDay != componentDay)
+
+    @Test func leapSecond() throws {
+        // Foundation does not support leap seconds, so a second of 60 is adjusted to 59
+        let parsed = try DateComponents("Sat, 20 Jan 2025 01:50:60 GMT", strategy: .http)
+        #expect(parsed.second == 59)
+        #expect(try Date("Sat, 20 Jan 2025 01:50:60 GMT", strategy: .http) == Date("Sat, 20 Jan 2025 01:50:59 GMT", strategy: .http))
     }
 }
 

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
@@ -255,6 +255,123 @@ result  : \(parsed != nil ? parsed!.debugDescription : "nil") \(parsed != nil ? 
 """)
         }
     }
+    
+    /// Values which are out of the range of the calendar's field are rejected instead of silently producing a nonsense result.
+    @Test(arguments: [
+        // Year - there is no year 0 in the era, and the calendar has a maximum year. Negative years are not part of the format.
+        "0000-01-28T15:35:46Z",
+        "144684-01-28T15:35:46Z",
+        "1234567890-01-28T15:35:46Z",
+        "-2022-01-28T15:35:46Z",
+        // Month
+        "2022-00-28T15:35:46Z",
+        "2022-13-28T15:35:46Z",
+        "2022-99-28T15:35:46Z",
+        // Day
+        "2022-01-00T15:35:46Z",
+        "2022-01-32T15:35:46Z",
+        "2022-01-99T15:35:46Z",
+        // Hour - note that 24 is allowed, but only as the end of the day
+        "2022-01-28T25:35:46Z",
+        "2022-01-28T99:35:46Z",
+        "2022-01-28T24:35:46Z",
+        "2022-01-28T24:00:01Z",
+        "2022-01-28T24:00:00.500Z",
+        // Minute
+        "2022-01-28T15:60:46Z",
+        "2022-01-28T15:99:46Z",
+        // Second - note that 60 is allowed, for leap seconds
+        "2022-01-28T15:35:61Z",
+        "2022-01-28T15:35:99Z",
+        // Fractional seconds - at most 9 digits of precision
+        "2022-01-28T15:35:46.1234567890Z",
+        // Time zone offset - at most 18 hours from GMT, and the minutes and seconds have the same range as the time
+        "2022-01-28T15:35:46+19:00",
+        "2022-01-28T15:35:46+25:00",
+        "2022-01-28T15:35:46+99:00",
+        "2022-01-28T15:35:46-19:00",
+        "2022-01-28T15:35:46+01:60",
+        "2022-01-28T15:35:46+01:99",
+        "2022-01-28T15:35:46+01:30:61",
+        "2022-01-28T15:35:46+01:30:99",
+    ])
+    func badInputs(bad: String) {
+        #expect(throws: (any Error).self) {
+            try Date(bad, strategy: .iso8601)
+        }
+        #expect(throws: (any Error).self) {
+            try DateComponents(bad, strategy: .iso8601)
+        }
+    }
+
+    /// Out of range values for the week of year format, which is not part of the default style.
+    @Test(arguments: [
+        // Week of year is 1...53
+        "2022-W00-01",
+        "2022-W54-01",
+        "2022-W99-01",
+        // Day of week is 1 (Monday) ... 7 (Sunday)
+        "2022-W01-00",
+        "2022-W01-08",
+        "2022-W01-99",
+    ])
+    func badWeekOfYearInputs(bad: String) {
+        #expect(throws: (any Error).self) {
+            try Date.ISO8601FormatStyle().year().weekOfYear().day().parse(bad)
+        }
+        #expect(throws: (any Error).self) {
+            try DateComponents.ISO8601FormatStyle().year().weekOfYear().day().parse(bad)
+        }
+    }
+
+    /// Out of range values for the ordinal day of year format, which is not part of the default style.
+    @Test(arguments: [
+        // Day of year is 1...366
+        "2022-000T15:35:46",
+        "2022-367T15:35:46",
+        "2022-999T15:35:46",
+    ])
+    func badDayOfYearInputs(bad: String) {
+        #expect(throws: (any Error).self) {
+            try Date.ISO8601FormatStyle().year().day().time(includingFractionalSeconds: false).parse(bad)
+        }
+        #expect(throws: (any Error).self) {
+            try DateComponents.ISO8601FormatStyle().year().day().time(includingFractionalSeconds: false).parse(bad)
+        }
+    }
+
+    /// The values at the edges of the allowed ranges, including those which we adjust instead of rejecting.
+    @Test func inBoundsInputs() throws {
+        let iso8601 = Date.ISO8601FormatStyle()
+
+        // Years past 9999 are allowed, up to the maximum of the calendar
+        #expect(throws: Never.self) {
+            try iso8601.parse("10000-01-28T15:35:46Z")
+        }
+        #expect(throws: Never.self) {
+            try iso8601.parse("144683-01-28T15:35:46Z")
+        }
+
+        #expect(try iso8601.parse("2022-01-01T00:00:00Z") == Date(timeIntervalSinceReferenceDate: 662688000.0))
+        #expect(try iso8601.parse("2022-12-31T23:59:59Z") == Date(timeIntervalSinceReferenceDate: 694223999.0))
+
+        // An hour of 24 means the end of the day, and the rest of the time must be zero
+        #expect(try iso8601.parse("2022-01-28T24:00:00Z") == iso8601.parse("2022-01-29T00:00:00Z"))
+        #expect(try iso8601.parse("2022-01-28T24:00:00.000Z") == iso8601.parse("2022-01-29T00:00:00Z"))
+        #expect(try Date.ISO8601FormatStyle(timeSeparator: .omitted).parse("2022-01-28T240000Z") == iso8601.parse("2022-01-29T00:00:00Z"))
+
+        // Foundation does not support leap seconds, so a second of 60 is adjusted to 59
+        #expect(try iso8601.parse("2022-01-28T15:35:60Z") == iso8601.parse("2022-01-28T15:35:59Z"))
+        #expect(try DateComponents("2022-01-28T15:35:60Z", strategy: .iso8601).second == 59)
+        #expect(try iso8601.parse("2022-01-28T15:35:46+01:30:60") == iso8601.parse("2022-01-28T15:35:46+01:30:59"))
+
+        // The time zone offset can be up to 18 hours from GMT
+        #expect(try DateComponents("2022-01-28T15:35:46+18:00", strategy: .iso8601).timeZone == TimeZone(secondsFromGMT: 18 * 3600))
+        #expect(try DateComponents("2022-01-28T15:35:46-18:00", strategy: .iso8601).timeZone == TimeZone(secondsFromGMT: -18 * 3600))
+
+        // Each value is validated against the range of its own field only. Combinations which do not exist in the calendar, like February 31st, still parse and roll over into the next month.
+        #expect(try iso8601.parse("2022-02-31T15:35:46Z") == iso8601.parse("2022-03-03T15:35:46Z"))
+    }
 }
 
 @Suite("Date ISO8601FormatStyle Pattern Matching")

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
@@ -144,7 +144,31 @@ private struct ISO8601FormatStyleParsingTests {
         let parsedY = try iso8601.year().month().day().parse(date.1)
         #expect(parsedWoY == parsedY)
     }
-    
+
+    /// The ISO 8601 day of week (1 is Monday ... 7 is Sunday) is converted to the `DateComponents` weekday (1 is Sunday ... 7 is Saturday).
+    /// The resulting `Date` can hide a mistake in that conversion, because `Calendar` resolves an out of range weekday relative to the rest of the week, so the components are checked as well.
+    @Test(arguments: [
+        ("2022-W01-01", 2, "2022-01-03"), // Monday
+        ("2022-W01-02", 3, "2022-01-04"), // Tuesday
+        ("2022-W01-03", 4, "2022-01-05"), // Wednesday
+        ("2022-W01-04", 5, "2022-01-06"), // Thursday
+        ("2022-W01-05", 6, "2022-01-07"), // Friday
+        ("2022-W01-06", 7, "2022-01-08"), // Saturday
+        ("2022-W01-07", 1, "2022-01-09"), // Sunday
+    ])
+    func weekdayOfWeekOfYear(test: (String, Int, String)) throws {
+        let (parseMe, expectedWeekday, equivalentDate) = test
+
+        let components = try DateComponents.ISO8601FormatStyle().year().weekOfYear().day().parse(parseMe)
+        #expect(components.weekday == expectedWeekday)
+        #expect(components.weekOfYear == 1)
+        #expect(components.yearForWeekOfYear == 2022)
+
+        let parsedWoY = try Date.ISO8601FormatStyle().year().weekOfYear().day().parse(parseMe)
+        let parsedY = try Date.ISO8601FormatStyle().year().month().day().parse(equivalentDate)
+        #expect(parsedWoY == parsedY)
+    }
+
     @Test func zeroLeadingDigits() throws {
         // The parser allows for an arbitrary number of 0 pads in digits, including none.
         let iso8601 = Date.ISO8601FormatStyle()


### PR DESCRIPTION
Add additional validation for fields in ISO8601 and HTTP string parsing

### Motivation:

The existing code was inconsistent in how it validated the various fields of ISO8601 and HTTP strings, which share the same underlying helper functions.

Fixes rdar://182534789

### Modifications:

Add a range and calendar/component argument to the parsing functions, and edit the call sites to use them. This also simplified some of the parsing because the range checking moved to the helper.

The change also revealed a bug in the Gregorian calendar's min and max ranges for `yearForWeekOfYear`.

### Result:

There may be some previously accepted strings that we now throw errors for.

### Testing:

New unit tests added, and some were modified to verify the new behavior.