### PR TITLE
Support combining .atomic and .withoutOverwriting in Data.write(to:options:)

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -166,6 +166,44 @@ private func cleanupTemporaryDirectory(at inPath: String?) {
     try? FileManager.default.removeItem(atPath: inPath)
 }
 
+#if !os(Windows) && !os(WASI) && !os(Emscripten)
+private enum ExclusiveRenameResult {
+    case success
+    /// The rename failed. `errno` is `EEXIST` when the destination exists.
+    case failure(errno: Int32)
+    /// This file system implements neither an exclusive rename nor hard links, so the rename cannot be performed without the risk of replacing the destination.
+    case unsupported
+}
+
+/// Renames `name` in `fromDirfd` to `newName` in `toDirfd`, failing rather than replacing an existing destination.
+private func renameatWithoutOverwriting(_ fromDirfd: Int32, _ name: UnsafePointer<CChar>, _ toDirfd: Int32, _ newName: UnsafePointer<CChar>) -> ExclusiveRenameResult {
+#if canImport(Darwin)
+    if renameatx_np(fromDirfd, name, toDirfd, newName, UInt32(RENAME_EXCL)) == 0 {
+        return .success
+    }
+    // A file system that does not implement RENAME_EXCL reports ENOTSUP; some report EINVAL for the unrecognized flag instead. Either way, fall through to link(2) rather than reporting a failure that is really about the flag.
+    guard errno == ENOTSUP || errno == EINVAL else {
+        return .failure(errno: errno)
+    }
+#endif
+    // renameat2(RENAME_NOREPLACE) is Linux-specific and is not declared by every C library we support, so use link(2), which atomically fails with EEXIST when the destination exists.
+    if linkat(fromDirfd, name, toDirfd, newName, 0) == 0 {
+        // Removing the old name is best effort: on failure the caller unlinks the temporary file anyway.
+        _ = unlinkat(fromDirfd, name, 0)
+        return .success
+    }
+    switch errno {
+    case EEXIST:
+        return .failure(errno: EEXIST)
+    case EPERM, ENOTSUP, EOPNOTSUPP, EMLINK, EXDEV, ENOSYS:
+        // Hard links are unavailable here. POSIX specifies EPERM for a file system that does not support link(2) at all, which is what FAT-derived file systems report.
+        return .unsupported
+    default:
+        return .failure(errno: errno)
+    }
+}
+#endif
+
 /// Creates a temporary file for atomic writing of `inPath` in the destination's parent directory.
 /// If `destDirfd` is -1, then `destinationPath` should be the full path.
 #if os(WASI) || os(Emscripten)
@@ -521,7 +559,9 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
             try withUnsafeTemporaryAllocation(byteCount: Int(dwSize),
                                               alignment: MemoryLayout<FILE_RENAME_INFO>.alignment) { pBuffer in
                 var pInfo = pBuffer.baseAddress?.bindMemory(to: FILE_RENAME_INFO.self, capacity: 1)
-                pInfo?.pointee.Flags = FILE_RENAME_FLAG_POSIX_SEMANTICS | FILE_RENAME_FLAG_REPLACE_IF_EXISTS
+                pInfo?.pointee.Flags = options.contains(.withoutOverwriting)
+                    ? FILE_RENAME_FLAG_POSIX_SEMANTICS
+                    : FILE_RENAME_FLAG_POSIX_SEMANTICS | FILE_RENAME_FLAG_REPLACE_IF_EXISTS
                 pInfo?.pointee.RootDirectory = nil
                 pInfo?.pointee.FileNameLength = DWORD(cbSize)
                 pBuffer.baseAddress?.advanced(by: MemoryLayout<FILE_RENAME_INFO>.offset(of: \.FileName)!)
@@ -534,8 +574,8 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
                 if !renameOk {
                     var dwError = GetLastError()
 
-                    // FileRenameInfoEx with POSIX_SEMANTICS + REPLACE_IF_EXISTS returns ERROR_ACCESS_DENIED (mapped from NTSTATUS STATUS_CANNOT_DELETE) when the destination has FILE_ATTRIBUTE_READONLY. Clear it on the destination (in line with POSIX semantics) and retry once before falling through.
-                    if dwError == ERROR_ACCESS_DENIED {
+                    // FileRenameInfoEx with POSIX_SEMANTICS + REPLACE_IF_EXISTS returns ERROR_ACCESS_DENIED (mapped from NTSTATUS STATUS_CANNOT_DELETE) when the destination has FILE_ATTRIBUTE_READONLY. Clear it on the destination (in line with POSIX semantics) and retry once before falling through. Without REPLACE_IF_EXISTS the destination is never deleted, so there is nothing to clear.
+                    if dwError == ERROR_ACCESS_DENIED && !options.contains(.withoutOverwriting) {
                         let dwAttributes = GetFileAttributesW(pwszPath)
 
                         if dwAttributes != INVALID_FILE_ATTRIBUTES
@@ -569,7 +609,10 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
                     }
 
                     // The move is across volumes or on Volumes that don't support FILE_RENAME_FLAG_POSIX_SEMANTICS, like exFat.
-                    guard MoveFileExW(pwszAuxiliaryPath, pwszPath, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING) else {
+                    let dwMoveFlags = options.contains(.withoutOverwriting)
+                        ? MOVEFILE_COPY_ALLOWED
+                        : MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING
+                    guard MoveFileExW(pwszAuxiliaryPath, pwszPath, dwMoveFlags) else {
                         throw CocoaError.errorWithFilePath(inPath, win32: GetLastError(), reading: false)
                     }
                 }
@@ -661,7 +704,22 @@ private func writeToFileAux(path inPath: borrowing some FileSystemRepresentable 
                 throw CocoaError(.fileWriteInvalidFileName)
             }
             
-            if renameat(tempDirfd, auxNameRep, destDirfd, basenameRep) != 0 {
+            if options.contains(.withoutOverwriting) {
+                // None of the fallbacks below may be used here: each of them replaces the destination if it exists.
+                switch renameatWithoutOverwriting(tempDirfd, auxNameRep, destDirfd, basenameRep) {
+                case .success:
+                    break
+                case .failure(let renameErrno):
+                    _ = unlinkat(tempDirfd, auxNameRep, 0)
+                    cleanupTemporaryDirectory(at: temporaryDirectoryPath)
+                    throw CocoaError.errorWithFilePath(inPath, errno: renameErrno, reading: false)
+                case .unsupported:
+                    // Completing the write here would mean giving up either atomicity or the guarantee that an existing file is not replaced. Report the failure instead of silently weakening one of them.
+                    _ = unlinkat(tempDirfd, auxNameRep, 0)
+                    cleanupTemporaryDirectory(at: temporaryDirectoryPath)
+                    throw CocoaError.errorWithFilePath(.featureUnsupported, newPath)
+                }
+            } else if renameat(tempDirfd, auxNameRep, destDirfd, basenameRep) != 0 {
                 if errno == EINVAL {
                     // rename() fails on DOS file systems if newname already exists.
                     // Makes "atomically" next to meaningless, but...
@@ -853,13 +911,9 @@ extension Data {
     /// - parameter url: The location to write the data into.
     /// - parameter options: Options for writing the data. Default value is `[]`.
     /// - throws: An error in the Cocoa domain, if there is an error writing to the `URL`.
+    ///
+    /// - Note: Combining `.atomic` with `.withoutOverwriting` requires an exclusive rename, which not every file system provides; where it is unavailable the write fails with `CocoaError.Code.featureUnsupported`. Releases that predate support for the combination trap on it instead of honoring it, so check the version of the running OS before relying on it.
     public func write(to url: URL, options: Data.WritingOptions = []) throws {
-#if !os(WASI) && !os(Emscripten) // `.atomic` is unavailable on WASI/Emscripten
-        if options.contains(.withoutOverwriting) && options.contains(.atomic) {
-            fatalError("withoutOverwriting is not supported with atomic")
-        }
-#endif
-        
         guard url.isFileURL else {
             throw CocoaError(.fileWriteUnsupportedScheme)
         }

--- a/Sources/FoundationEssentials/Data/Data+WritingOptions.swift
+++ b/Sources/FoundationEssentials/Data/Data+WritingOptions.swift
@@ -12,7 +12,6 @@
 
 // Data.WritingOptions is not a true OptionSet - the file protection constants act as an enum (exactly zero or one must be used)
 // while the remaining options (.atomic, .withoutOverwriting) act as an option set (any number - or none - may be selected).
-// Note: .atomic and .withoutOverwriting are mutually exclusive in practice, but that is enforced by receivers of Data.WritingOptions and not enforced in the option set itself as this may not apply to future options and is supported by their raw values
 // Below are implementations for all SetAlgebra functions that implement correct logic for the file protection enum.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data.WritingOptions {

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -91,6 +91,35 @@ private final class DataIOTests {
         // Perform an atomic write to a file that already exists
         try writeAndVerifyTestData(to: url, writeOptions: [.atomic])
     }
+
+    @Test func atomicWriteWithoutOverwriting() throws {
+        // Use a dedicated directory so that leftover temporary files can be detected reliably
+        let directory = URL.temporaryDirectory.appendingPathComponent("atomicwithoutoverwriting-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let destination = directory.appendingPathComponent("testfile")
+
+        // Writing to a destination that does not exist succeeds
+        try writeAndVerifyTestData(to: destination, writeOptions: [.atomic, .withoutOverwriting])
+
+        // Writing to an existing destination fails and leaves the existing contents untouched
+        let existing = try Data(contentsOf: destination)
+        #expect {
+            try generateTestData().write(to: destination, options: [.atomic, .withoutOverwriting])
+        } throws: {
+            ($0 as? CocoaError)?.code == .fileWriteFileExists
+        }
+        let afterFailure = try Data(contentsOf: destination)
+        #expect(afterFailure == existing)
+
+        // The failed write does not leave a temporary file behind
+        let directoryContents = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        #expect(directoryContents == ["testfile"])
+
+        // Clearing the error condition allows the write to succeed
+        try FileManager.default.removeItem(at: destination)
+        try writeAndVerifyTestData(to: destination, writeOptions: [.atomic, .withoutOverwriting])
+    }
     #endif
 
     @Test func readWriteMapped() throws {


### PR DESCRIPTION
Support combining `.atomic` and `.withoutOverwriting` in `Data.write(to:options:)`.

### Motivation:

`Data.write(to:options:)` traps with `fatalError("withoutOverwriting is not supported with atomic")` when `[.atomic, .withoutOverwriting]` are passed together.

To be precise about what this PR does and does not argue, after the review discussion below: the combination **is** documented as unsupported ("You can't combine this constant with `atomic` because `atomic` allows the system to overwrite the original file"), and for a pair of options chosen statically in source, an immediate hard failure is a reasonable contract for a documented-invalid combination — the Objective-C implementation raises `NSInvalidArgumentException` for the same reason. So this is no longer a proposal to soften the trap into a thrown error.

What it proposes is to make the combination *supported*, which removes the trap as a side effect rather than weakening it. The combination is well defined and implementable: write to a temporary file, then move it into place with an exclusive rename. Both guarantees hold at once — the destination is never observed half-written, and an existing file is never replaced.

See also #2011, which targets the same issue.

Resolves #1098

### Modifications:

The data is written to a temporary file first, as it already is for an atomic write, and the temporary file is then moved to the destination in a way that fails rather than replacing an existing file:

- **Darwin**: `renameatx_np(2)` with `RENAME_EXCL`.
- **Where that is unsupported by the file system (`ENOTSUP`, or `EINVAL` for the unrecognized flag), and on all other POSIX platforms**: `linkat(2)` followed by `unlinkat(2)`. `link(2)` atomically fails with `EEXIST` when the destination exists. (`renameat2(RENAME_NOREPLACE)` is Linux-specific and is not declared by every C library supported here.)
- **Windows**: `FileRenameInfoEx` without `FILE_RENAME_FLAG_REPLACE_IF_EXISTS`, and `MoveFileExW` without `MOVEFILE_REPLACE_EXISTING` in the cross-volume fallback.

**There is no non-atomic fallback.** Compared to the previous revision of this PR, the `lstat` + `rename` path for file systems that support neither an exclusive rename nor hard links is gone; such a write now fails with `CocoaError(.featureUnsupported)`. Silently weakening one of the two guarantees the caller asked for seems worse than reporting that they cannot both be provided.

For the same reason, none of the pre-existing fallbacks in the atomic path are reachable with `.withoutOverwriting`, since each of them replaces the destination:

- the `EINVAL` rename-swap for DOS file systems,
- the `EBUSY` retry that rewrites the file non-atomically,
- the `ERROR_ACCESS_DENIED` read-only-attribute retry on Windows (without `REPLACE_IF_EXISTS` the destination is never deleted, so there is nothing to clear).

Rebased onto #2161, which rewrote the atomic write path to use directory file descriptors; the rename helper is `renameat`-shaped accordingly.

### Result:

`Data.write(to:options:)` with `[.atomic, .withoutOverwriting]` behaves as follows:

- destination does not exist → the write completes, atomically;
- destination exists → `CocoaError(.fileWriteFileExists)`, consistent with non-atomic `.withoutOverwriting`; the existing file is untouched and the temporary file is cleaned up;
- the file system provides neither an exclusive rename nor hard links → `CocoaError(.featureUnsupported)`, with the temporary file cleaned up.

On the deployment-target question raised in review: I do not have a better answer than was already suggested. Code built against a newer SDK but running on an older OS still traps, and there is no availability annotation that can express "this combination of options became valid in version X". The doc comment on `write(to:options:)` now states both the `.featureUnsupported` case and the trap on older releases, which at least documents the pitfall rather than leaving it to be discovered at runtime.

### Testing:

`atomicWriteWithoutOverwriting` in the Data I/O suite covers:

- writing to a nonexistent destination succeeds and round-trips the contents;
- writing to an existing destination throws `.fileWriteFileExists`, leaves the existing contents untouched, and leaves no temporary file behind;
- the write succeeds again once the destination is removed.

The Data I/O suite passes on macOS, both normally (exercising `renameatx_np`) and with the `renameatx_np` branch compiled out, so that the `linkat` path used on non-Darwin platforms is exercised locally as well. The `.featureUnsupported` path is not covered by a test: it needs a file system with neither an exclusive rename nor hard links, which the test suite cannot rely on being mounted.
