### PR TITLE
Fix copyItem/linkItem mangling item names when the source path ends with a separator

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -1118,9 +1118,10 @@ enum _FileOperations {
         #else
         try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
             let dstLen = Platform.copyCString(dst: buffer.baseAddress!, src: dstPtr, size: FileManager.MAX_PATH_SIZE)
-            // fts builds the path of a descendant by appending its name to the source path, inserting a separator only when the source path does not already end with one. Exclude trailing separators from the prefix length so that the remainder of a descendant's path always begins with a separator.
+            // fts builds the path of a descendant by appending a separator and its name to the source path, but implementations disagree about how the trailing separators of the source path are treated: some drop one of them beforehand and some keep all of them. Ignore them entirely when determining the length of the prefix that the destination path replaces, and re-insert a single separator below.
+            let pathSeparator = CChar(UInt8(ascii: "/"))
             var srcLen = strlen(srcPtr)
-            while srcLen > 0, srcPtr[srcLen - 1] == CChar(UInt8(ascii: "/")) {
+            while srcLen > 0, srcPtr[srcLen - 1] == pathSeparator {
                 srcLen -= 1
             }
             let dstAppendPtr = buffer.baseAddress!.advanced(by: dstLen)
@@ -1135,8 +1136,18 @@ enum _FileOperations {
                     
                 case let .entry(entry):
                     let fts_path = entry.ftsEnt.fts_path!
-                    let trimmedPathPtr = fts_path.advanced(by: srcLen)
-                    Platform.copyCString(dst: dstAppendPtr, src: trimmedPathPtr, size: remainingBuffer)
+                    var trimmedPathPtr = fts_path.advanced(by: srcLen)
+                    // Skip the separators that fts kept from the source path so that the item's path relative to the source is appended to the destination as a path component
+                    while trimmedPathPtr.pointee == pathSeparator {
+                        trimmedPathPtr += 1
+                    }
+                    if trimmedPathPtr.pointee == 0 {
+                        // The source itself is copied to the destination path as-is
+                        dstAppendPtr.pointee = 0
+                    } else {
+                        dstAppendPtr.pointee = pathSeparator
+                        Platform.copyCString(dst: dstAppendPtr + 1, src: trimmedPathPtr, size: remainingBuffer - 1)
+                    }
                     
                     // we don't want to ask the delegate on the way back -up- the hierarchy if they want to copy a directory they've already seen and therefore already said "YES" to.
                     guard entry.ftsEnt.fts_info == FTS_DP || delegate.shouldPerformOnItemAtPath(String(cString: fts_path), to: String(cString: buffer.baseAddress!)) else {

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -1118,7 +1118,11 @@ enum _FileOperations {
         #else
         try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
             let dstLen = Platform.copyCString(dst: buffer.baseAddress!, src: dstPtr, size: FileManager.MAX_PATH_SIZE)
-            let srcLen = strlen(srcPtr)
+            // fts builds the path of a descendant by appending its name to the source path, inserting a separator only when the source path does not already end with one. Exclude trailing separators from the prefix length so that the remainder of a descendant's path always begins with a separator.
+            var srcLen = strlen(srcPtr)
+            while srcLen > 0, srcPtr[srcLen - 1] == CChar(UInt8(ascii: "/")) {
+                srcLen -= 1
+            }
             let dstAppendPtr = buffer.baseAddress!.advanced(by: dstLen)
             let remainingBuffer = FileManager.MAX_PATH_SIZE - dstLen
             

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -620,6 +620,24 @@ private struct FileManagerTests {
         }
     }
 
+    @Test func copyItemAtPathWithTrailingSlash() async throws {
+        try await FilePlayground {
+            Directory("dir") {
+                Directory("subdir") {
+                    "file"
+                }
+                "foo"
+            }
+        }.test { fileManager in
+            // A trailing separator on the source path must not be absorbed into the names of the copied items
+            try fileManager.copyItem(atPath: "dir/", toPath: "dir2")
+            #expect(try fileManager.subpathsOfDirectory(atPath: ".").sorted() == [
+                "dir", "dir/foo", "dir/subdir", "dir/subdir/file",
+                "dir2", "dir2/foo", "dir2/subdir", "dir2/subdir/file",
+            ])
+        }
+    }
+
     @Test func removeItemAtPath() async throws {
         try await FilePlayground {
             Directory("dir") {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -620,7 +620,7 @@ private struct FileManagerTests {
         }
     }
 
-    @Test func copyItemAtPathWithTrailingSlash() async throws {
+    @Test(arguments: ["dir/", "dir//"]) func copyItemAtPathWithTrailingSlash(_ source: String) async throws {
         try await FilePlayground {
             Directory("dir") {
                 Directory("subdir") {
@@ -628,11 +628,15 @@ private struct FileManagerTests {
                 }
                 "foo"
             }
-        }.test { fileManager in
-            // A trailing separator on the source path must not be absorbed into the names of the copied items
-            try fileManager.copyItem(atPath: "dir/", toPath: "dir2")
+        }.test(captureDelegateCalls: true) { fileManager in
+            // Trailing separators on the source path must not be absorbed into the names of the copied items
+            try fileManager.copyItem(atPath: source, toPath: "dir2")
             #expect(try fileManager.subpathsOfDirectory(atPath: ".").sorted() == [
                 "dir", "dir/foo", "dir/subdir", "dir/subdir/file",
+                "dir2", "dir2/foo", "dir2/subdir", "dir2/subdir/file",
+            ])
+            // The destination paths must be well formed no matter how many of the source path's trailing separators the platform's fts reports for descendants
+            #expect(fileManager.delegateCaptures.shouldCopy.compactMap(\.dst).sorted() == [
                 "dir2", "dir2/foo", "dir2/subdir", "dir2/subdir/file",
             ])
         }


### PR DESCRIPTION
Fix `copyItem`/`linkItem` mangling item names when the source path ends with a separator.

### Motivation:

`FileManager.copyItem(atPath:toPath:)` writes the copied items under wrong names when the source path has a trailing slash. Copying `a/b/` to `z/b` produces

```
z
├── b
├── bc
└── bfoo.txt
```

instead of nesting `c` and `foo.txt` inside `z/b`. Note that the stray items are created as siblings of the destination, outside of it.

`_linkOrCopyFile` builds each destination path by appending the descendant's path with the source prefix removed, using `strlen(srcPtr)` as the prefix length. However, `fts` appends a descendant's name to the source path and inserts a separator only when the source path does not already end with one:

| source argument | descendant `fts_path` |
| --- | --- |
| `a/b` | `a/b/foo.txt` |
| `a/b/` | `a/b/foo.txt` |

So when the source ends with a separator, the prefix length covers the separator that `fts` reused, and the remainder is appended to the destination without one.

Resolves #1266

### Modifications:

Exclude trailing separators from the prefix length, so the remainder of a descendant's path always begins with a separator.

This affects `linkItem` as well, which shares the same traversal. The paths reported to `FileManagerDelegate` are unchanged: they still come from `fts_path` as given by the caller. The Windows implementation recurses using `appendingPathComponent`, which normalizes separators, and is unaffected.

### Result:

`copyItem(atPath: "a/b/", toPath: "z/b")` now produces the same tree as `copyItem(atPath: "a/b", toPath: "z/b")`.

### Testing:

Added `copyItemAtPathWithTrailingSlash`, which copies a directory containing both a file and a nested subdirectory using a trailing-slash source path, and asserts the full resulting tree — so it also catches the stray entries the bug created next to the destination. Verified that the test fails without the change and passes with it.
