### PR TITLE
Honor omitPaddingCharacter when base64 encoding with line breaks

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -380,7 +380,7 @@ extension Base64 {
         length: inout Int,
         options: Data.Base64EncodingOptions
     ) {
-        let omitPaddingCharacter = false
+        let omitPaddingCharacter = options.contains(.omitPaddingCharacter)
 
         assert(options.contains(.lineLength64Characters) || options.contains(.lineLength76Characters))
 

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2556,6 +2556,70 @@ extension DataTests {
 
     }
 
+    @Test func base64Encode_omitPaddingWithLineBreaks() {
+        #expect(
+            Data(repeating: 0xFF, count: 1).base64EncodedString(options: [.lineLength76Characters, .omitPaddingCharacter]) ==
+            "/w"
+        )
+        #expect(
+            Data(repeating: 0xFF, count: 2).base64EncodedString(options: [.lineLength76Characters, .omitPaddingCharacter]) ==
+            "//8"
+        )
+        #expect(
+            Data(repeating: 0xFF, count: 3).base64EncodedString(options: [.lineLength76Characters, .omitPaddingCharacter]) ==
+            "////"
+        )
+
+        // a full first line followed by a partial last line that needs padding
+        #expect(
+            Data(repeating: 0, count: 49).base64EncodedString(options: [.lineLength64Characters, .omitPaddingCharacter]) ==
+            """
+            AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\r\n\
+            AA
+            """
+        )
+        #expect(
+            Data(repeating: 0, count: 50).base64EncodedString(options: [.lineLength64Characters, .omitPaddingCharacter]) ==
+            """
+            AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\r\n\
+            AAA
+            """
+        )
+    }
+
+    @Test func base64Encode_omitPaddingWithLineBreaksMatchesUnbrokenOutput() {
+        let lineLengthOptions: [Data.Base64EncodingOptions] = [.lineLength64Characters, .lineLength76Characters]
+        let lineEndOptions: [Data.Base64EncodingOptions] = [
+            [], .endLineWithCarriageReturn, .endLineWithLineFeed, [.endLineWithCarriageReturn, .endLineWithLineFeed]
+        ]
+
+        for count in 0..<260 {
+            let data = Data((0..<count).map { UInt8($0 % 256) })
+
+            for lineLength in lineLengthOptions {
+                for lineEnd in lineEndOptions {
+                    let options: Data.Base64EncodingOptions = [lineLength, lineEnd, .omitPaddingCharacter]
+                    let padded = data.base64EncodedString(options: [lineLength, lineEnd])
+                    let expected = String(padded.filter { $0 != "=" })
+
+                    let string = data.base64EncodedString(options: options)
+                    #expect(string == expected, "count: \(count), options: \(options.rawValue)")
+
+                    // `base64EncodedData` keeps the full allocated capacity, so a mismatch here
+                    // means the computed capacity did not match what was actually written.
+                    let encodedData = data.base64EncodedData(options: options)
+                    #expect(encodedData == Data(expected.utf8), "count: \(count), options: \(options.rawValue)")
+                    #expect(encodedData.count == string.utf8.count, "count: \(count), options: \(options.rawValue)")
+
+                    #expect(
+                        data.base64EncodedData(options: [lineLength, lineEnd]) == Data(padded.utf8),
+                        "count: \(count), options: \(options.rawValue)"
+                    )
+                }
+            }
+        }
+    }
+
     @Test func base64Decode_emptyString() {
         #expect(Data() == Data(base64Encoded: ""))
     }


### PR DESCRIPTION
_Fix an out-of-bounds write when base64 encoding with `.omitPaddingCharacter` and a line-length option._

### Motivation:

Resolves #2149.

`Data.base64EncodedString(options:)` and `Data.base64EncodedData(options:)` write past the end of their output buffer when `.omitPaddingCharacter` is combined with `.lineLength64Characters` or `.lineLength76Characters`:

```swift
let data = Data(repeating: 0xFF, count: 1)
_ = data.base64EncodedString(options: [.lineLength76Characters, .omitPaddingCharacter])
// Swift/UnsafeBufferPointer.swift:791: Fatal error
```

`encodeComputeCapacity(bytes:options:)` shrinks the output buffer by 1–2 bytes when `.omitPaddingCharacter` is set and the input length is not a multiple of 3, but `_encodeWithLineBreaks(input:buffer:length:options:)` — the path taken whenever a line-length option is set — hardcodes `let omitPaddingCharacter = false` and always writes the `=` padding. The buffer is sized for output without padding while the encoder writes output with padding.

This affects every input whose length is not a multiple of 3, with either line-length option and any combination of line-ending options. In debug builds it hits the `UnsafeMutableBufferPointer` bounds check and traps; in release builds that check is a `_debugPrecondition` and is compiled out, so the write lands past the end of the allocation.

The hardcoded `false` looks like a missed call site in #1195, which introduced the option: it replaced the identical line in `_encode` with `options.contains(.omitPaddingCharacter)` and taught `encodeComputeCapacity` about the option, but left this one unchanged.

### Modifications:

`_encodeWithLineBreaks` now reads the flag from the options instead of hardcoding `false`, matching `_encode`.

Honoring the option is also what makes the existing capacity computation correct rather than merely safe. `encodeToData` discards the length written back by `_encode` and returns a `Data` of the full computed capacity, so the capacity has to match the number of bytes written exactly — over-allocating leaves trailing NUL bytes and under-allocating is the out-of-bounds write. Comparing `encodeComputeCapacity` against the number of bytes `_encodeWithLineBreaks` writes, for every input length in `0...20000` across all eight combinations of line-length and line-ending options, now matches exactly in every case, with and without `.omitPaddingCharacter`.

The alternative — ignoring `.omitPaddingCharacter` when a line-length option is set and dropping the capacity reduction in that case — would also fix the crash, but the option is documented without any such carve-out, and Darwin's `NSData` offers no precedent since it does not implement this option at all.

### Result:

`.omitPaddingCharacter` works together with the line-length options and produces the padded output minus the trailing `=` characters:

```swift
Data(repeating: 0xFF, count: 1)
    .base64EncodedString(options: [.lineLength76Characters, .omitPaddingCharacter])  // "/w"

Data(repeating: 0, count: 49)
    .base64EncodedString(options: [.lineLength64Characters, .omitPaddingCharacter])
// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\r\nAA
```

### Testing:

Two tests added to `DataTests`:

- `base64Encode_omitPaddingWithLineBreaks` checks the expected output for the inputs that previously overflowed, including a case with a full first line followed by a partial last line that needs padding.
- `base64Encode_omitPaddingWithLineBreaksMatchesUnbrokenOutput` sweeps input lengths `0..<260` across both line-length options and all four line-ending combinations, and checks that the output equals the padded output with `=` removed. It asserts this for `base64EncodedString` and for `base64EncodedData` and checks that their lengths agree, so an over-allocated buffer (trailing NUL bytes in the `Data` result, as in #1535) fails the test as well as an under-allocated one.

Both tests fail on `main` and pass with the fix. The existing base64 tests continue to pass.
