### PR TITLE
Set the creation date in setAttributes(_:ofItemAtPath:) where supported

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -157,8 +157,9 @@ extension stat {
     
     var creationDate: Date {
         #if canImport(Darwin)
-        Date(seconds: TimeInterval(st_ctimespec.tv_sec), nanoSeconds: TimeInterval(st_ctimespec.tv_nsec))
+        Date(seconds: TimeInterval(st_birthtimespec.tv_sec), nanoSeconds: TimeInterval(st_birthtimespec.tv_nsec))
         #else
+        // st_ctim records the last time the inode changed, which is the closest thing available here.
         Date(seconds: TimeInterval(st_ctim.tv_sec), nanoSeconds: TimeInterval(st_ctim.tv_nsec))
         #endif
     }

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -840,26 +840,45 @@ extension _FileManagerImpl {
                 }
             }
 
-            if let modification = attributes[.modificationDate] as? Date {
-                let seconds = modification.timeIntervalSince1601
+            // Malformed dates are dropped rather than reported as an error.
+            func fileTime(from date: Date) -> FILETIME? {
+                let seconds = date.timeIntervalSince1601
+                guard let converted = UInt64(exactly: seconds * 10000000.0) else {
+                    return nil
+                }
 
                 var uiTime: ULARGE_INTEGER = .init()
-                guard let converted = UInt64(exactly: seconds * 10000000.0) else {
-                    return
-                }
                 uiTime.QuadPart = converted
 
                 var ftTime: FILETIME = .init()
                 ftTime.dwLowDateTime = uiTime.LowPart
                 ftTime.dwHighDateTime = uiTime.HighPart
+                return ftTime
+            }
 
+            func withOptionalPointer<T, R>(to value: T?, _ body: (UnsafePointer<T>?) -> R) -> R {
+                guard let value else {
+                    return body(nil)
+                }
+                return withUnsafePointer(to: value) { body($0) }
+            }
+
+            let creationTime = (attributes[.creationDate] as? Date).flatMap(fileTime(from:))
+            let modificationTime = (attributes[.modificationDate] as? Date).flatMap(fileTime(from:))
+
+            if creationTime != nil || modificationTime != nil {
                 let hFile: HANDLE = CreateFileW($0, GENERIC_WRITE, FILE_SHARE_WRITE, nil, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nil)
                 if hFile == INVALID_HANDLE_VALUE {
                     throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: true)
                 }
                 defer { CloseHandle(hFile) }
 
-                guard SetFileTime(hFile, nil, nil, &ftTime) else {
+                let succeeded = withOptionalPointer(to: creationTime) { creation in
+                    withOptionalPointer(to: modificationTime) { modification in
+                        SetFileTime(hFile, creation, nil, modification)
+                    }
+                }
+                guard succeeded else {
                     throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: false)
                 }
             }
@@ -962,7 +981,7 @@ extension _FileManagerImpl {
                 #endif
             }
             
-            try Self._setCatInfoAttributes(attributes, path: path)
+            try Self._setCatInfoAttributes(attributes, path: path, fileSystemRepresentation: fileSystemRepresentation)
             
             if let extendedAttrs = attributes[.init("NSFileExtendedAttributes")] as? [String : Data] {
                 #if os(WASI) || os(OpenBSD) || os(Emscripten)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -127,17 +127,26 @@ extension _FileManagerImpl {
     
     private static let _catInfoKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
     private static let _swiftFoundationUnsupportedKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden]
-    static func _setCatInfoAttributes(_ attributes: [FileAttributeKey : Any], path: String) throws {
+    static func _setCatInfoAttributes(_ attributes: [FileAttributeKey : Any], path: String, fileSystemRepresentation: UnsafePointer<CChar>) throws {
         let hasRelevantKeys = attributes.keys.contains(where: { _catInfoKeys.contains($0) })
         guard hasRelevantKeys else { return }
-        
+
         #if !FOUNDATION_FRAMEWORK
         // Exclude some attributes (like .creationDate) from this check since they are unconditionally, implicitly included in `attributesForItem(atPath:)` results
         if attributes.keys.contains(where: { _swiftFoundationUnsupportedKeys.contains($0) }) {
             throw CocoaError.errorWithFilePath(.featureUnsupported, path)
-        } else {
-            return // TODO: support relevant cat info keys in swift-foundation
         }
+
+        #if canImport(Darwin)
+        if let creationDate = attributes[.creationDate] as? Date {
+            try Self._setCreationDate(creationDate, path: path, fileSystemRepresentation: fileSystemRepresentation)
+        }
+        #endif
+        // On platforms that provide no way to set a file's creation date, the attribute is
+        // ignored rather than reported as unsupported: `.creationDate` is implicitly present in
+        // every `attributesOfItem(atPath:)` result, so throwing would break passing those
+        // results back to `setAttributes(_:ofItemAtPath:)` unmodified.
+        return // TODO: support the remaining cat info keys in swift-foundation
         #else
         // -setAttributes:ofItemAtPath:error: follows symlinks (<rdar://5815920>), but the NSURL resource value API doesn't, so we have to manually resolve the symlink.
         // We lie to fileURLWithPath:isDirectory: to avoid the extra stat. Since this URL isn't used as a base URL for another URL, it shouldn't make any difference.
@@ -179,6 +188,33 @@ extension _FileManagerImpl {
         try url.setResourceValues(URLResourceValues(values: urlAttributes))
         #endif
     }
+
+#if canImport(Darwin) && !FOUNDATION_FRAMEWORK
+    private static func _setCreationDate(_ date: Date, path: String, fileSystemRepresentation: UnsafePointer<CChar>) throws {
+        let interval = date.timeIntervalSince1970
+        let seconds = interval.rounded(.down)
+        // Malformed dates are dropped rather than reported as an error, matching the behavior of `.modificationDate`.
+        guard let tv_sec = time_t(exactly: seconds),
+              let tv_nsec = Int(exactly: ((interval - seconds) * 1_000_000_000).rounded()) else {
+            return
+        }
+
+        var attrs = attrlist(
+            bitmapcount: u_short(ATTR_BIT_MAP_COUNT),
+            reserved: 0,
+            commonattr: attrgroup_t(ATTR_CMN_CRTIME),
+            volattr: 0,
+            dirattr: 0,
+            fileattr: 0,
+            forkattr: 0
+        )
+        var value = timespec(tv_sec: tv_sec, tv_nsec: tv_nsec)
+        // `setAttributes(_:ofItemAtPath:)` follows symlinks, so FSOPT_NOFOLLOW is intentionally not set here.
+        guard setattrlist(fileSystemRepresentation, &attrs, &value, MemoryLayout<timespec>.size, 0) == 0 else {
+            throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
+        }
+    }
+#endif
 
 #if !os(Windows) && !os(WASI) && !os(OpenBSD) && !os(Emscripten)
     static func _setAttribute(_ key: UnsafePointer<CChar>, value: Data, at path: UnsafePointer<CChar>, followSymLinks: Bool) throws {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -138,6 +138,7 @@ extension _FileManagerImpl {
         }
         #endif
 
+        // Platforms with no way to record a creation date ignore `.creationDate` rather than reporting it as unsupported, since it is implicitly included in every `attributesOfItem(atPath:)` result and throwing would break passing such a result straight back into `setAttributes(_:ofItemAtPath:)`.
         #if canImport(Darwin)
         if let creationDate = attributes[.creationDate] as? Date {
             try Self._setCreationDate(creationDate, path: path, fileSystemRepresentation: fileSystemRepresentation)
@@ -182,7 +183,7 @@ extension _FileManagerImpl {
         guard !urlAttributes.isEmpty else { return }
         try url.setResourceValues(URLResourceValues(values: urlAttributes))
         #else
-        // TODO: support the remaining cat info keys in swift-foundation. Platforms with no way to record a creation date ignore `.creationDate` rather than reporting it as unsupported, since it is implicitly included in every `attributesOfItem(atPath:)` result and throwing would break passing such a result straight back into `setAttributes(_:ofItemAtPath:)`.
+        // TODO: support the remaining cat info keys in swift-foundation
         #endif
     }
 

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -136,18 +136,15 @@ extension _FileManagerImpl {
         if attributes.keys.contains(where: { _swiftFoundationUnsupportedKeys.contains($0) }) {
             throw CocoaError.errorWithFilePath(.featureUnsupported, path)
         }
+        #endif
 
         #if canImport(Darwin)
         if let creationDate = attributes[.creationDate] as? Date {
             try Self._setCreationDate(creationDate, path: path, fileSystemRepresentation: fileSystemRepresentation)
         }
         #endif
-        // On platforms that provide no way to set a file's creation date, the attribute is
-        // ignored rather than reported as unsupported: `.creationDate` is implicitly present in
-        // every `attributesOfItem(atPath:)` result, so throwing would break passing those
-        // results back to `setAttributes(_:ofItemAtPath:)` unmodified.
-        return // TODO: support the remaining cat info keys in swift-foundation
-        #else
+
+        #if FOUNDATION_FRAMEWORK
         // -setAttributes:ofItemAtPath:error: follows symlinks (<rdar://5815920>), but the NSURL resource value API doesn't, so we have to manually resolve the symlink.
         // We lie to fileURLWithPath:isDirectory: to avoid the extra stat. Since this URL isn't used as a base URL for another URL, it shouldn't make any difference.
         var url = URL(fileURLWithPath: path.resolvingSymlinksInPath, isDirectory: false)
@@ -182,14 +179,14 @@ extension _FileManagerImpl {
         if let extensionHidden = attributes[.extensionHidden] {
             urlAttributes[.hasHiddenExtensionKey] = extensionHidden
         }
-        if let creationDate = attributes[.creationDate] {
-            urlAttributes[.creationDateKey] = creationDate
-        }
+        guard !urlAttributes.isEmpty else { return }
         try url.setResourceValues(URLResourceValues(values: urlAttributes))
+        #else
+        // TODO: support the remaining cat info keys in swift-foundation. Platforms with no way to record a creation date ignore `.creationDate` rather than reporting it as unsupported, since it is implicitly included in every `attributesOfItem(atPath:)` result and throwing would break passing such a result straight back into `setAttributes(_:ofItemAtPath:)`.
         #endif
     }
 
-#if canImport(Darwin) && !FOUNDATION_FRAMEWORK
+#if canImport(Darwin)
     private static func _setCreationDate(_ date: Date, path: String, fileSystemRepresentation: UnsafePointer<CChar>) throws {
         let interval = date.timeIntervalSince1970
         let seconds = interval.rounded(.down)

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -909,6 +909,87 @@ private struct FileManagerTests {
         }
     }
 
+    /// Reads the creation date of an item straight from the platform's file system API.
+    ///
+    /// `attributesOfItem(atPath:)` reports the inode change time for `.creationDate` on platforms
+    /// other than Darwin, so it cannot be used to observe what `setAttributes(_:ofItemAtPath:)` wrote.
+    /// Returns `nil` on platforms that do not record a creation date.
+    private func observedCreationDate(ofItemAtPath path: String) -> Date? {
+        #if canImport(Darwin)
+        var statInfo = stat()
+        guard stat(path, &statInfo) == 0 else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: TimeInterval(statInfo.st_birthtimespec.tv_sec) + TimeInterval(statInfo.st_birthtimespec.tv_nsec) / 1_000_000_000)
+        #elseif os(Windows)
+        var info = WIN32_FILE_ATTRIBUTE_DATA()
+        let succeeded = path.withCString(encodedAs: UTF16.self) {
+            GetFileAttributesExW($0, GetFileExInfoStandard, &info)
+        }
+        guard succeeded else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: info.ftCreationTime.timeIntervalSince1970)
+        #else
+        // Linux and other platforms provide no way to set a creation date, so there is nothing to observe.
+        return nil
+        #endif
+    }
+
+    @Test func testSetAttributesCreationDate() async throws {
+        try await FilePlayground {
+            "testFile"
+            Directory("testDir") {}
+        }.test { fileManager in
+            let testDate = Date(timeIntervalSince1970: 1234567890)
+            for path in ["testFile", "testDir"] {
+                try fileManager.setAttributes([.creationDate: testDate], ofItemAtPath: path)
+                if let creationDate = self.observedCreationDate(ofItemAtPath: path) {
+                    #expect(abs(creationDate.timeIntervalSince1970 - testDate.timeIntervalSince1970) < 1.0, "Creation date of '\(path)' should be set correctly")
+                }
+            }
+
+            // Setting both dates at once must apply both rather than dropping one of them.
+            let creationTestDate = Date(timeIntervalSince1970: 1000000000)
+            let modificationTestDate = Date(timeIntervalSince1970: 1100000000)
+            try fileManager.setAttributes([.creationDate: creationTestDate, .modificationDate: modificationTestDate], ofItemAtPath: "testFile")
+            if let creationDate = self.observedCreationDate(ofItemAtPath: "testFile") {
+                #expect(abs(creationDate.timeIntervalSince1970 - creationTestDate.timeIntervalSince1970) < 1.0, "Creation date should be set when set alongside a modification date")
+            }
+            let modificationDate = try #require(try fileManager.attributesOfItem(atPath: "testFile")[.modificationDate] as? Date)
+            #expect(abs(modificationDate.timeIntervalSince1970 - modificationTestDate.timeIntervalSince1970) < 1.0, "Modification date should be set when set alongside a creation date")
+        }
+    }
+
+    @Test func setAttributesAcceptsAttributesOfItemResult() async throws {
+        try await FilePlayground {
+            "testFile"
+        }.test { fileManager in
+            // `.creationDate` is implicitly included in every `attributesOfItem(atPath:)` result, so
+            // feeding that result back in must not throw on platforms that cannot set a creation date.
+            let attributes = try fileManager.attributesOfItem(atPath: "testFile")
+            #expect(attributes[.creationDate] is Date)
+            #expect(throws: Never.self) {
+                try fileManager.setAttributes(attributes, ofItemAtPath: "testFile")
+            }
+        }
+    }
+
+    @Test func malformedCreationDateAttribute() async throws {
+        try await FilePlayground {
+            "foo"
+        }.test { fileManager in
+            let sentinelDate = self.observedCreationDate(ofItemAtPath: "foo")
+            for value in [Double.infinity, -Double.infinity, Double.nan] {
+                // Malformed creation dates should be dropped instead of throwing or crashing
+                #expect(throws: Never.self) {
+                    try fileManager.setAttributes([.creationDate : Date(timeIntervalSince1970: value)], ofItemAtPath: "foo")
+                }
+            }
+            #expect(self.observedCreationDate(ofItemAtPath: "foo") == sentinelDate)
+        }
+    }
+
     @Test func malformedModificationDateAttribute() async throws {
         let sentinelDate = Date(timeIntervalSince1970: 100)
         try await FilePlayground {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1151,8 +1151,6 @@ private struct FileManagerTests {
             File("foo", contents: randomData())
         }.test {
             let attrs = try $0.attributesOfItem(atPath: "foo")
-            // `.creationDate` is implicitly included in every result, so it must be accepted back even on platforms that cannot set it
-            #expect(attrs[.creationDate] is Date)
             try $0.setAttributes(attrs, ofItemAtPath: "foo")
         }
     }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -909,84 +909,41 @@ private struct FileManagerTests {
         }
     }
 
-    /// Reads the creation date of an item straight from the platform's file system API.
-    ///
-    /// `attributesOfItem(atPath:)` reports the inode change time for `.creationDate` on platforms
-    /// other than Darwin, so it cannot be used to observe what `setAttributes(_:ofItemAtPath:)` wrote.
-    /// Returns `nil` on platforms that do not record a creation date.
-    private func observedCreationDate(ofItemAtPath path: String) -> Date? {
-        #if canImport(Darwin)
-        var statInfo = stat()
-        guard stat(path, &statInfo) == 0 else {
-            return nil
-        }
-        return Date(timeIntervalSince1970: TimeInterval(statInfo.st_birthtimespec.tv_sec) + TimeInterval(statInfo.st_birthtimespec.tv_nsec) / 1_000_000_000)
-        #elseif os(Windows)
-        var info = WIN32_FILE_ATTRIBUTE_DATA()
-        let succeeded = path.withCString(encodedAs: UTF16.self) {
-            GetFileAttributesExW($0, GetFileExInfoStandard, &info)
-        }
-        guard succeeded else {
-            return nil
-        }
-        return Date(timeIntervalSince1970: info.ftCreationTime.timeIntervalSince1970)
-        #else
-        // Linux and other platforms provide no way to set a creation date, so there is nothing to observe.
-        return nil
-        #endif
-    }
-
-    @Test func testSetAttributesCreationDate() async throws {
+    @Test(.enabled(if: isDarwin || isWindows, "This platform does not record a creation date"))
+    func setAttributesCreationDate() async throws {
         try await FilePlayground {
             "testFile"
             Directory("testDir") {}
-        }.test { fileManager in
+        }.test {
             let testDate = Date(timeIntervalSince1970: 1234567890)
             for path in ["testFile", "testDir"] {
-                try fileManager.setAttributes([.creationDate: testDate], ofItemAtPath: path)
-                if let creationDate = self.observedCreationDate(ofItemAtPath: path) {
-                    #expect(abs(creationDate.timeIntervalSince1970 - testDate.timeIntervalSince1970) < 1.0, "Creation date of '\(path)' should be set correctly")
-                }
+                try $0.setAttributes([.creationDate: testDate], ofItemAtPath: path)
+                let creationDate = try #require(try $0.attributesOfItem(atPath: path)[.creationDate] as? Date)
+                #expect(creationDate == testDate, "Creation date of '\(path)' should be set correctly")
             }
 
-            // Setting both dates at once must apply both rather than dropping one of them.
+            // On Windows both dates are applied by a single SetFileTime call, so make sure that setting them together doesn't drop either one.
             let creationTestDate = Date(timeIntervalSince1970: 1000000000)
             let modificationTestDate = Date(timeIntervalSince1970: 1100000000)
-            try fileManager.setAttributes([.creationDate: creationTestDate, .modificationDate: modificationTestDate], ofItemAtPath: "testFile")
-            if let creationDate = self.observedCreationDate(ofItemAtPath: "testFile") {
-                #expect(abs(creationDate.timeIntervalSince1970 - creationTestDate.timeIntervalSince1970) < 1.0, "Creation date should be set when set alongside a modification date")
-            }
-            let modificationDate = try #require(try fileManager.attributesOfItem(atPath: "testFile")[.modificationDate] as? Date)
-            #expect(abs(modificationDate.timeIntervalSince1970 - modificationTestDate.timeIntervalSince1970) < 1.0, "Modification date should be set when set alongside a creation date")
+            try $0.setAttributes([.creationDate: creationTestDate, .modificationDate: modificationTestDate], ofItemAtPath: "testFile")
+            let attributes = try $0.attributesOfItem(atPath: "testFile")
+            #expect(attributes[.creationDate] as? Date == creationTestDate)
+            #expect(attributes[.modificationDate] as? Date == modificationTestDate)
         }
     }
 
-    @Test func setAttributesAcceptsAttributesOfItemResult() async throws {
+    @Test(.enabled(if: isDarwin || isWindows, "This platform does not record a creation date"))
+    func malformedCreationDateAttribute() async throws {
+        let sentinelDate = Date(timeIntervalSince1970: 100)
         try await FilePlayground {
-            "testFile"
-        }.test { fileManager in
-            // `.creationDate` is implicitly included in every `attributesOfItem(atPath:)` result, so
-            // feeding that result back in must not throw on platforms that cannot set a creation date.
-            let attributes = try fileManager.attributesOfItem(atPath: "testFile")
-            #expect(attributes[.creationDate] is Date)
-            #expect(throws: Never.self) {
-                try fileManager.setAttributes(attributes, ofItemAtPath: "testFile")
-            }
-        }
-    }
-
-    @Test func malformedCreationDateAttribute() async throws {
-        try await FilePlayground {
-            "foo"
-        }.test { fileManager in
-            let sentinelDate = self.observedCreationDate(ofItemAtPath: "foo")
+            File("foo", attributes: [.creationDate: sentinelDate])
+        }.test {
+            #expect(try $0.attributesOfItem(atPath: "foo")[.creationDate] as? Date == sentinelDate)
             for value in [Double.infinity, -Double.infinity, Double.nan] {
                 // Malformed creation dates should be dropped instead of throwing or crashing
-                #expect(throws: Never.self) {
-                    try fileManager.setAttributes([.creationDate : Date(timeIntervalSince1970: value)], ofItemAtPath: "foo")
-                }
+                try $0.setAttributes([.creationDate : Date(timeIntervalSince1970: value)], ofItemAtPath: "foo")
             }
-            #expect(self.observedCreationDate(ofItemAtPath: "foo") == sentinelDate)
+            #expect(try $0.attributesOfItem(atPath: "foo")[.creationDate] as? Date == sentinelDate)
         }
     }
 
@@ -1194,6 +1151,8 @@ private struct FileManagerTests {
             File("foo", contents: randomData())
         }.test {
             let attrs = try $0.attributesOfItem(atPath: "foo")
+            // `.creationDate` is implicitly included in every result, so it must be accepted back even on platforms that cannot set it
+            #expect(attrs[.creationDate] is Date)
             try $0.setAttributes(attrs, ofItemAtPath: "foo")
         }
     }


### PR DESCRIPTION
### Motivation

`FileManager` accepts `.creationDate` in `setAttributes(_:ofItemAtPath:)` but silently discards it in swift-foundation:

- the non-framework branch of `_setCatInfoAttributes` returned without doing anything, and
- the Windows implementation passed `nil` for `SetFileTime`'s creation time parameter, so only the modification date was ever written.

Nothing is set and nothing is thrown, so callers have no way to tell the attribute was dropped. This also caused a test to be commented out in swiftlang/swift-corelibs-foundation#5443, since `FileManager.replaceItemAt` relies on this attribute.

Resolves #1906.

### Modifications

Set the attribute on the platforms that can record it:

- **Darwin**: `setattrlist` with `ATTR_CMN_CRTIME`, in both the swift-foundation and `FOUNDATION_FRAMEWORK` builds. `FSOPT_NOFOLLOW` is deliberately not set, because `setAttributes(_:ofItemAtPath:)` follows symlinks — which is also the reason the URL resource value path has to resolve the symlink by hand. `.creationDate` is no longer handed to `setResourceValues`; that path now carries only the Finder info and `hasHiddenExtension` keys.
- **Windows**: the creation time is passed to `SetFileTime` alongside the modification time, so that setting both in a single call applies both.

`stat.creationDate` now reads `st_birthtimespec` instead of `st_ctimespec` on Darwin (the same change as #1648). Without it a creation date written by `setAttributes(_:ofItemAtPath:)` never reads back, because `setattrlist` bumps the inode change time to *now* — so the round trip reported in #1906 would keep failing. Happy to drop that hunk if #1648 lands first.

`_setCatInfoAttributes` gained a `fileSystemRepresentation` parameter; its only call site already runs inside `withFileSystemRepresentation`, so no extra conversion is introduced.

**Platforms that cannot record a creation date keep ignoring the attribute rather than throwing `featureUnsupported`.** The issue asked for an error in that case, but `.creationDate` is unconditionally included in every `attributesOfItem(atPath:)` result, so throwing would break the common pattern of passing such a result straight back into `setAttributes(_:ofItemAtPath:)` — which is exactly what the existing `getSetAttributes` test does. I'm happy to switch to throwing if reviewers prefer it, but it looked like a source-compatibility hazard worth avoiding.

While restructuring the Windows path, a malformed date now only drops that single date instead of returning early from the whole closure and skipping the remaining attributes (previously a non-representable modification date would also skip applying read-only).

### Result

`setAttributes([.creationDate: date], ofItemAtPath:)` sets the creation date on Darwin and Windows, `attributesOfItem(atPath:)` reads it back, and other platforms behave as before.

### Testing

New tests in `FileManagerTests`, both enabled on Darwin and Windows (Linux offers no way to set a creation date):

- `setAttributesCreationDate` — files and directories, plus setting `.creationDate` and `.modificationDate` together to check that Windows' single `SetFileTime` call applies both.
- `malformedCreationDateAttribute` — infinity/NaN dates are dropped rather than throwing or crashing, mirroring `malformedModificationDateAttribute`.

Both read the value back through `attributesOfItem(atPath:)` rather than through platform APIs. `getSetAttributes` additionally asserts that `.creationDate` is present in the result it feeds back in, which is what makes that round trip meaningful for this change.

Verified locally on macOS (the package build takes the non-framework path, so the Darwin change is covered): the full suite passes, and the new assertions fail without the fix. **The Windows path and the `FOUNDATION_FRAMEWORK` build are not covered by my local testing.**

I targeted `main`; happy to rebase onto a release branch if that is the preferred destination.
