### PR TITLE
Add an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+# Test and benchmark inputs are byte-for-byte fixtures rather than source: many
+# deliberately end without a trailing newline, some use CR or CRLF line endings
+# on purpose (see Tests/FoundationEssentialsTests/Resources/JSON5/spec/new-lines,
+# which has its own .editorconfig and marks its contents binary in .gitattributes),
+# and others are binary property lists. Editors must not normalize any of that.
+[Tests/**/Resources/**]
+charset = unset
+end_of_line = unset
+indent_style = unset
+indent_size = unset
+insert_final_newline = unset
+
+[Benchmarks/**/Resources/**]
+charset = unset
+end_of_line = unset
+indent_style = unset
+indent_size = unset
+insert_final_newline = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,9 +8,15 @@ end_of_line = lf
 indent_style = space
 indent_size = 4
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{yml,yaml}]
 indent_size = 2
+
+# Markdown gives two trailing spaces the meaning of a hard line break, which the
+# proposals under Proposals/ rely on.
+[*.md]
+trim_trailing_whitespace = false
 
 # Test and benchmark inputs are byte-for-byte fixtures rather than source: many
 # deliberately end without a trailing newline, some use CR or CRLF line endings
@@ -23,6 +29,7 @@ end_of_line = unset
 indent_style = unset
 indent_size = unset
 insert_final_newline = unset
+trim_trailing_whitespace = unset
 
 [Benchmarks/**/Resources/**]
 charset = unset
@@ -30,3 +37,4 @@ end_of_line = unset
 indent_style = unset
 indent_size = unset
 insert_final_newline = unset
+trim_trailing_whitespace = unset


### PR DESCRIPTION
### Motivation

Resolves #2119.

### Modifications

Adds a root `.editorconfig`. The values are derived from what this repository actually uses rather than copied from [swiftlang/swift's file](https://github.com/swiftlang/swift/pull/78087), which sets two-space indentation because that repository is mostly C++:

| | setting | basis |
|---|---|---|
| default | `indent_size = 4`, `indent_style = space` | Swift sources; also matches `.h`/`.c` under `Sources/_FoundationCShims` and the `CMakeLists.txt` files (456 four-space indents vs 12 two-space). Consistent with the `"indentation": { "spaces": 4 }` proposed in #2052. No tracked source file indents with tabs. |
| `*.{yml,yaml}` | `indent_size = 2` | the workflows and `.spi.yml` |
| default | `end_of_line = lf`, `charset = utf-8`, `insert_final_newline = true` | no tracked file outside test resources uses CRLF, all of them decode as UTF-8, and all but nine end with a newline |

### Test and benchmark resources are excluded

This is the part worth reviewing. Files under `Tests/**/Resources/**` and `Benchmarks/**/Resources/**` are byte-for-byte parser input rather than source, so every property is `unset` for them:

- 90 of the 214 test resource files deliberately end **without** a trailing newline, including the `fail*.json` cases whose whole purpose is to be rejected;
- several are binary property lists;
- `Tests/FoundationEssentialsTests/Resources/JSON5/spec/new-lines/` stores the same content with CR, LF and CRLF endings on purpose. That directory already carries its own `.editorconfig` and a `.gitattributes` marking its contents `binary`.

That nested `.editorconfig` does not set `root = true`, so without this exclusion a root file would leak `insert_final_newline = true` into it and an editor would append a newline to fixtures that exist precisely to test newline handling.

I verified the resolution with the reference `editorconfig` implementation. Spot checks:

```
Sources/FoundationEssentials/Data/Data+Writing.swift      indent_size=4  end_of_line=lf  insert_final_newline=true
.github/workflows/pull_request.yml                        indent_size=2  end_of_line=lf  insert_final_newline=true
Tests/.../Resources/JSON/fail/fail1.json                  all unset
Tests/.../Resources/JSON5/spec/new-lines/comment-cr.json5 end_of_line=cr (nested config still wins), rest unset
Benchmarks/Benchmarks/JSON/Resources/twitter.json         all unset
```

### Deliberate omissions

- **`trim_trailing_whitespace`** — 297 of the 442 Swift files currently contain trailing whitespace. Enabling it would make editors rewrite unrelated lines the moment anyone saves one of those files, producing large incidental diffs. It seemed better to leave this out than to pair the config with a repository-wide whitespace sweep, but I'm happy to add it (with or without that sweep) if you'd prefer.
- **`max_line_length`** — left to `.swift-format` (#2052 proposes `"lineLength": 250`) so that there is one source of truth rather than two that can drift.

Nine tracked files outside test resources do not end with a newline today (`LICENSE.md`, six documents under `Proposals/`, `Data+Writing.swift` and `Sources/FoundationEssentials/Predicate/CMakeLists.txt`). I left them untouched to keep this to a single file — `Proposals/` in particular holds accepted, archived documents. Let me know if you'd rather they were fixed here.

### Result

Editors that support EditorConfig pick up this repository's conventions automatically, without normalizing test fixtures.
