### PR TITLE
Limit AttributedString inflection alternative supported attributes

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -497,7 +497,15 @@ extension AttributeScopes.FoundationAttributes {
         public typealias ObjectiveCValue = NSObject
         public static let name = NSAttributedString.Key.inflectionAlternative.rawValue
         public static let markdownName = "inflectionAlternative"
-        
+
+        private struct AllowedAttributes: AttributeScope {
+            let inlinePresentationIntent: InlinePresentationIntentAttribute
+            let link: LinkAttribute
+            let imageURL: ImageURLAttribute
+            let alternateDescription: AlternateDescriptionAttribute
+            let languageIdentifier: LanguageIdentifierAttribute
+        }
+
         public static func decodeMarkdown(from decoder: Decoder) throws -> AttributedString {
             let container = try decoder.singleValueContainer()
             let stringContent = try container.decode(String.self)
@@ -505,12 +513,12 @@ extension AttributeScopes.FoundationAttributes {
         }
         
         public static func objectiveCValue(for value: AttributedString) throws -> NSObject {
-            try NSAttributedString(value, including: \.foundation)
+            try NSAttributedString(value, including: AllowedAttributes.self)
         }
         
         public static func value(for object: NSObject) throws -> AttributedString {
             if let attrString = object as? NSAttributedString {
-                return try AttributedString(attrString, including: \.foundation)
+                return try AttributedString(attrString, including: AllowedAttributes.self)
             } else {
                 throw CocoaError(.coderInvalidValue)
             }

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -1840,7 +1840,18 @@ E {
             #expect(attrStr.runs.count == test.1, "Replacement of range \(NSStringFromRange(test.0)) caused a run count of \(attrStr.runs.count)")
         }
     }
-    
+
+    @Test func infiniteInflectionAlternativeConversion() throws {
+        let ns = NSMutableAttributedString(string: "Hello, world")
+        ns.setAttributes([.inflectionAlternative: ns], range: NSRange(location: 0, length: 12))
+        let attrStr = try AttributedString(ns, including: \.foundation)
+        #expect(attrStr.runs.count == 1)
+        #expect(attrStr.inflectionAlternative == AttributedString("Hello, world"))
+
+        // break retain cycle
+        ns.setAttributes([:], range: NSRange(location: 0, length: 12))
+    }
+
 #endif // FOUNDATION_FRAMEWORK
 
     // MARK: - View Tests


### PR DESCRIPTION
Limit the set of supported attributes in the value of the inflection alternative attribute of `AttributedString`s

### Motivation:

The inflection alternative does not support all attributes, so when converting to/from `NSAttributedString` we can limit the scope to only those supported

### Modifications:

Use a limited scope when converting the inflection alternative attribute

### Result:

Prevents the possibility of unbounded recursion in NSAttributedString --> AttributedString conversion

### Testing:

Added a unit test that previously crashed due to the unbounded recursion
