### PR TITLE
fr_CA: 24-hour setting is incorrect

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1158,19 +1158,6 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
 
                 let calendarId = calendarIdentifier
                 let rootHourCycle = Locale.HourCycle.zeroToTwentyThree
-                if let regionOverride = _lockedRegion(&state)?.identifier {
-                    // Use the "rg" override in the identifier if there's one
-                    // ICU isn't handling `rg` keyword yet (93783223), so we do this manually: create a fake locale with the `rg` override as the language region.
-                    // Use "und" as the language code as it is irrelevant for regional preferences
-                    let tmpLocaleIdentifier = "und_\(regionOverride)"
-                    guard let icuPatternGenerator = ICUPatternGenerator.cachedPatternGenerator(localeIdentifier: tmpLocaleIdentifier, calendarIdentifier: calendarId) else {
-                        state.hourCycle = rootHourCycle
-                        return rootHourCycle
-                    }
-                    let hc = icuPatternGenerator.defaultHourCycle
-                    state.hourCycle = hc
-                    return hc
-                }
 
                 guard let icuPatternGenerator = ICUPatternGenerator.cachedPatternGenerator(localeIdentifier: identifier, calendarIdentifier: calendarId) else {
                     state.hourCycle = rootHourCycle

--- a/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
@@ -19,7 +19,7 @@ import Testing
 @testable import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
-@Suite("Locale.Components")
+@Suite("Locale.Components", .tags(.locale))
 private struct LocaleComponentsTests {
 
     @Test func regions() {
@@ -328,7 +328,7 @@ private struct LocaleComponentsTests {
     }
 }
 
-@Suite("Locale Codable")
+@Suite("Locale Codable", .tags(.locale))
 private struct LocaleCodableTests {
 
     // Test types that used to encode both `identifier` and `normalizdIdentifier` now only encodes `identifier`

--- a/Tests/FoundationInternationalizationTests/LocaleLanguageTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleLanguageTests.swift
@@ -19,7 +19,7 @@ import Testing
 @testable import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
-@Suite("Locale.Language.Components")
+@Suite("Locale.Language.Components", .tags(.locale))
 private struct LocaleLanguageComponentsTests {
 
     func verifyComponents(_ identifier: String,
@@ -57,7 +57,7 @@ private struct LocaleLanguageComponentsTests {
     }
 }
 
-@Suite("Locale.Language")
+@Suite("Locale.Language", .tags(.locale))
 private struct LocaleLanguageTests {
 
     func verify(_ identifier: String, expectedParent: Locale.Language, minBCP47: String, maxBCP47: String, langCode: Locale.LanguageCode?, script: Locale.Script?, region: Locale.Region?, lineDirection: Locale.LanguageDirection, characterDirection: Locale.LanguageDirection, sourceLocation: SourceLocation = #_sourceLocation) {

--- a/Tests/FoundationInternationalizationTests/LocaleRegionTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleRegionTests.swift
@@ -19,7 +19,7 @@ import FoundationEssentials
 import FoundationInternationalization
 #endif
 
-@Suite("Locale.Region Tests")
+@Suite("Locale.Region Tests", .tags(.locale))
 struct LocaleRegionTests {
     @Test func regionCategory() async throws {
         #expect(Locale.Region.unknown.category == nil)

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -722,6 +722,18 @@ private struct LocalePropertiesTests {
         let x = Locale.keywordValue(identifier: "ar_EG@vt=kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk", key: "vt")
         #expect(x == "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk")
     }
+
+    @Test func hourCycle() {
+        let frHourCycle = Locale(identifier: "fr_FR").hourCycle
+        #expect(frHourCycle == .zeroToTwentyThree)
+
+        // special case where fr_CA differs from CA
+        let frCAHourCycle = Locale(identifier: "fr_CA").hourCycle
+        #expect(frCAHourCycle == .zeroToTwentyThree)
+
+        let enCAHourCycle = Locale(identifier: "en_CA").hourCycle
+        #expect(enCAHourCycle == .oneToTwelve)
+    }
 }
 
 // MARK: - Bridging Tests

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -19,7 +19,11 @@ import Testing
 @testable import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
-@Suite("Locale")
+extension Testing.Tag {
+    @Tag static var locale: Self
+}
+
+@Suite("Locale", .tags(.locale))
 private struct LocaleTests {
 
     @Test func equality() {
@@ -511,7 +515,7 @@ private struct LocaleTests {
     }
 }
 
-@Suite("Locale Properties")
+@Suite("Locale Properties", .tags(.locale))
 private struct LocalePropertiesTests {
 
     func _verify(locale: Locale, expectedLanguage language: Locale.LanguageCode? = nil, script: Locale.Script? = nil, languageRegion: Locale.Region? = nil, region: Locale.Region? = nil, subdivision: Locale.Subdivision? = nil, measurementSystem: Locale.MeasurementSystem? = nil, calendar: Calendar.Identifier? = nil, hourCycle: Locale.HourCycle? = nil, currency: Locale.Currency? = nil, numberingSystem: Locale.NumberingSystem? = nil, numberingSystems: Set<Locale.NumberingSystem> = [], firstDayOfWeek: Locale.Weekday? = nil, collation: Locale.Collation? = nil, variant: Locale.Variant? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
@@ -739,7 +743,7 @@ private struct LocalePropertiesTests {
 // MARK: - Bridging Tests
 #if FOUNDATION_FRAMEWORK
 
-@Suite("Locale Bridging")
+@Suite("Locale Bridging", .tags(.locale))
 private struct LocaleBridgingTests {
     
     @available(macOS, deprecated: 13)


### PR DESCRIPTION
Previously we worked around an ICU issue where it didn't handle the "rg" keyword in locale identifiers.
    
Our implementation treats "fr_CA" as "und_CA" under the assumption that the language code doesn't take effect for determining the properties such as the preferred hour cycle of the locale.
    
However this assumption is incorrect; in this case, fr_CA has a different hour cycle preference from en_CA.

Fix: Remove this workaround altogether since the ICU issue has been addressed.