### PR TITLE
Additional Data.InlineData bounds checking

### DIFF
--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -110,7 +110,7 @@ extension Data {
             self.init(count: count)
             Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
                 slice.withUnsafeBytes { srcBuffer in
-                    dstBuffer.copyMemory(from: UnsafeRawBufferPointer(start: srcBuffer.baseAddress, count: count))
+                    dstBuffer.copyMemory(from: UnsafeRawBufferPointer(start: srcBuffer.baseAddress, count: Swift.min(count, srcBuffer.count)))
                 }
             }
         }
@@ -120,7 +120,7 @@ extension Data {
             self.init(count: count)
             Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
                 slice.withUnsafeBytes { srcBuffer in
-                    dstBuffer.copyMemory(from: UnsafeRawBufferPointer(start: srcBuffer.baseAddress, count: count))
+                    dstBuffer.copyMemory(from: UnsafeRawBufferPointer(start: srcBuffer.baseAddress, count: Swift.min(count, srcBuffer.count)))
                 }
             }
         }
@@ -239,14 +239,14 @@ extension Data {
         subscript(index: Index) -> UInt8 {
             get {
                 assert(index <= MemoryLayout<Buffer>.size)
-                precondition(index < length, "index \(index) is out of bounds of 0..<\(length)")
+                precondition(index >= 0 && index < length, "index \(index) is out of bounds of 0..<\(length)")
                 return Swift.withUnsafeBytes(of: bytes) { rawBuffer -> UInt8 in
                     return rawBuffer[index]
                 }
             }
             set(newValue) {
                 assert(index <= MemoryLayout<Buffer>.size)
-                precondition(index < length, "index \(index) is out of bounds of 0..<\(length)")
+                precondition(index >= 0 && index < length, "index \(index) is out of bounds of 0..<\(length)")
                 Swift.withUnsafeMutableBytes(of: &bytes) { rawBuffer in
                     rawBuffer[index] = newValue
                 }
@@ -272,8 +272,8 @@ extension Data {
             assert(subrange.lowerBound <= MemoryLayout<Buffer>.size)
             assert(subrange.upperBound <= MemoryLayout<Buffer>.size)
             assert(count - (subrange.upperBound - subrange.lowerBound) + replacementLength <= MemoryLayout<Buffer>.size)
-            precondition(subrange.lowerBound <= length, "index \(subrange.lowerBound) is out of bounds of 0..<\(length)")
-            precondition(subrange.upperBound <= length, "index \(subrange.upperBound) is out of bounds of 0..<\(length)")
+            precondition(subrange.lowerBound >= 0 && subrange.lowerBound <= length, "index \(subrange.lowerBound) is out of bounds of 0..<\(length)")
+            precondition(subrange.upperBound >= 0 && subrange.upperBound <= length, "index \(subrange.upperBound) is out of bounds of 0..<\(length)")
             let currentLength = count
             let resultingLength = currentLength - (subrange.upperBound - subrange.lowerBound) + replacementLength
             let shift = resultingLength - currentLength

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2164,6 +2164,11 @@ private final class DataTests {
             var data = try #require("Hello World".data(using: .utf8))
             data.replaceSubrange(5..<200, with: Data())
         }
+
+        await #expect(processExitsWith: .failure) {
+            var data = try #require("Hello World".data(using: .utf8))
+            data.replaceSubrange(-1..<1, with: Data())
+        }
     }
     
     @Test func bounding_failure_replace2() async {
@@ -2222,6 +2227,11 @@ private final class DataTests {
         await #expect(processExitsWith: .failure) {
             var data = try #require("Hello World".data(using: .utf8))
             data[100] = 4
+        }
+
+        await #expect(processExitsWith: .failure) {
+            var data = try #require("Hello World".data(using: .utf8))
+            data[-1] = 4
         }
     }
 


### PR DESCRIPTION
Adds missing bounds checking to the inline representation of `Data`

### Motivation:

Adds bounds checking that was previously missing to ensure deterministic precondition failures

### Modifications:

- Added additional bounds checking to the subscript and replaceSubrange (for negative bounds)
- Added bounds-aware checking for copying a slice into an inline data

### Result:

Invalid bounds are checked and deterministically crash

### Testing:

Added additional unit tests where appropriate
