### PR TITLE
Heap OOB read in JSONScanner strtof/strtod when assumesTopLevelDictionary and number is trailing

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -33,6 +33,9 @@ internal struct JSON5Scanner {
     var depth: Int = 0
     var partialMap = JSONPartialMapData()
 
+    // True if any scanned number extends to the last byte of the input.
+    var numberExtendsToEndOfBuffer: Bool = false
+
     internal struct Options {
         var assumesTopLevelDictionary = false
     }
@@ -134,8 +137,8 @@ internal struct JSON5Scanner {
 
         let map = JSONMap(mapBuffer: partialMap.mapData, dataBuffer: self.reader.bytes)
 
-        // If the input contains only a number, ensure a trailing NUL byte is available for strtod/strtof parsing.
-        if case .number = map.loadValue(at: 0)! {
+        // If any number token extends to the last byte of the input, we must give the map an owned buffer with a trailing NUL so that `strtod` (which peeks one byte past the last consumed digit) doesn't OOB read. Covers the top-level-number case and the `assumesTopLevelDictionary` case where the last value in the (brace-less) object is a number.
+        if numberExtendsToEndOfBuffer {
             map.copyInBuffer()
         }
 
@@ -362,6 +365,9 @@ internal struct JSON5Scanner {
         let start = reader.readIndex
         reader.skipNumber()
         let end = reader.readIndex
+        if reader.isEOF {
+            numberExtendsToEndOfBuffer = true
+        }
         return partialMap.record(tagType: .number, count: reader.distance(from: start, to: end), dataOffset: reader.byteOffset(at: start), with: reader)
     }
 

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -267,6 +267,9 @@ internal struct JSONScanner {
     var reader: DocumentReader
     var depth: Int = 0
     var partialMap = JSONPartialMapData()
+    
+    // True if any scanned number extends to the last byte of the input.
+    var numberExtendsToEndOfBuffer: Bool = false
 
     internal struct Options {
         var assumesTopLevelDictionary = false
@@ -376,8 +379,8 @@ internal struct JSONScanner {
 
         let map = JSONMap(mapBuffer: partialMap.mapData, dataBuffer: self.reader.bytes)
 
-        // If the input contains only a number, we have to copy the input into a form that is guaranteed to have a trailing NUL byte so that strtod doesn't perform a buffer overrun.
-        if case .number = map.loadValue(at: 0)! {
+        // If any number token extends to the last byte of the input, we must give the map an owned buffer with a trailing NUL so that `strtod` (which peeks one byte past the last consumed digit) doesn't OOB read. Covers the top-level-number case and the `assumesTopLevelDictionary` case where the last value in the (brace-less) object is a number.
+        if numberExtendsToEndOfBuffer {
             map.copyInBuffer()
         }
 
@@ -577,6 +580,9 @@ internal struct JSONScanner {
         var containsExponent = false
         reader.skipNumber(containsExponent: &containsExponent)
         let end = reader.readIndex
+        if reader.isEOF {
+            numberExtendsToEndOfBuffer = true
+        }
         return partialMap.record(tagType: containsExponent ? .numberContainingExponent : .number, count: reader.distance(from: start, to: end), dataOffset: reader.byteOffset(at: start), with: reader)
     }
 

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1581,6 +1581,25 @@ private struct JSONEncoderTests {
 
     }
 
+    @Test func assumesTopLevelDictionaryTrailingNumber() throws {
+        // A brace-less top-level dictionary whose final value is a number ends at the last byte of the input. The number parser (`strtod`) peeks one byte past the last consumed digit, so the input buffer must be copied to guarantee a trailing NUL byte. Verifies rdar://183390354.
+        let decoder = JSONDecoder()
+        decoder.assumesTopLevelDictionary = true
+
+        let intResult = try decoder.decode([String:Int].self, from: Data("\"x\" : 42".utf8))
+        #expect(intResult == ["x" : 42])
+
+        let doubleResult = try decoder.decode([String:Double].self, from: Data("\"x\" : 1.5".utf8))
+        #expect(doubleResult == ["x" : 1.5])
+
+        // JSON5 numbers can also end with a non-digit ('1.' is a valid JSON5 number). Any scanned number reaching EOF must trigger the buffer copy.
+        let json5Decoder = JSONDecoder()
+        json5Decoder.assumesTopLevelDictionary = true
+        json5Decoder.allowsJSON5 = true
+        let json5Result = try json5Decoder.decode([String:Double].self, from: Data("\"x\" : 1.".utf8))
+        #expect(json5Result == ["x" : 1.0])
+    }
+
     @Test func bomPrefixes() throws {
         let json = "\"👍🏻\""
         let decoder = JSONDecoder()


### PR DESCRIPTION
JSONDecoder uses `strtod` and `strtof` to parse numbers under the conditions that there is a known non-number character after the number, whether that be JSON structure, or a NUL terminator.

When the top level of the input is scanned and found to be a number, we copy the entire input into owned memory to ensure it has a NUL byte, whereas the provided data might not have one. We also need to do this when `assumesTopLevelDictionary = true` and the input ends in a number, because we can't guarantee that there will be JSON structure after it to terminate the `strtod/f` call.