### PR TITLE
1-byte OOB read in JSON5Scanner.validateLeadingZero — hex-prefix guard off-by-one

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -953,7 +953,7 @@ extension JSON5Scanner {
         case UInt8(ascii: "x"), UInt8(ascii: "X"):
             // We have to further validate that there is another digit following this one.
             let firstHexDigitIndex = jsonBytes.index(after: jsonBytes.startIndex)
-            guard firstHexDigitIndex <= jsonBytes.endIndex else {
+            guard firstHexDigitIndex < jsonBytes.endIndex else {
                 throw JSONError.unexpectedCharacter(context: "in number", ascii: jsonBytes[offset: 0], location: .sourceLocation(at: jsonBytes.startIndex, fullSource: fullSource))
             }
             let maybeHex = jsonBytes[unchecked: firstHexDigitIndex]

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -2234,6 +2234,11 @@ extension JSONEncoderTests {
                 #expect(helloGoodbyeExpectedValue == decoded)
             }
         }
+        
+        let incompleteNumberValue = "hello: 0x".data(using: .utf8)! // Incomplete hex number
+        #expect(throws: (any Error).self) {
+            try decoder.decode([String:Int].self, from: incompleteNumberValue)
+        }
 
         let arrayJSON = "[1,2,3]".data(using: .utf8)! // Assumed dictionary can't be an array
         #expect(throws: (any Error).self) {


### PR DESCRIPTION
Simple off-by-one check in JSON5Scanner only.