### PR TITLE
Implement SF-0042: Data Manipulation with Spans

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -317,7 +317,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///
     /// - Parameters:
     ///   - capacity: The storage capacity of the new data.
-    ///   - initializer: A callback that gets called at most once to directly populate newly reserved storage within the data. The function is allowed to add fewer than `capacity` bytes. The data is initialized with however many bytes the callback adds to the output raw span before it returns (or before it throws an error).
+    ///   - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The function is allowed to add fewer than `capacity` bytes. The data is initialized with however many bytes the callback adds to the output raw span before it returns (or before it throws an error).
     @_alwaysEmitIntoClient
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public init<E: Error>(
@@ -565,11 +565,11 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
-    /// Arbitrarily edit the storage underlying this data by invoking a user-supplied closure with a mutable `OutputRawSpan` view over it. This method calls its function argument at most once, allowing it to arbitrarily modify the contents of the output span it is given. The argument is free to add, remove or reorder any items; however, it is not allowed to replace the span or change its capacity.
+    /// Arbitrarily edit the storage underlying this data by invoking a user-supplied closure with a mutable `OutputRawSpan` view over it. This method calls its function argument exactly once, allowing it to arbitrarily modify the contents of the output span it is given. The argument is free to add, remove or reorder any items; however, it is not allowed to replace the span or change its capacity.
     ///
     /// When the function argument finishes (whether by returning or throwing an error) the data instance is updated to match the final contents of the output span.
     ///
-    /// - Parameter body: A function that edits the contents of this data through an `OutputRawSpan` argument. This method invokes this function at most once.
+    /// - Parameter body: A function that edits the contents of this data through an `OutputRawSpan` argument. This method invokes this function exactly once.
     /// - Returns: This method returns the result of its function argument.
     @_alwaysEmitIntoClient
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
@@ -651,7 +651,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///
     /// - Parameters:
     ///    - newByteCount: The number of bytes to append to the data.
-    ///    - initializer: A callback that gets called at most once to directly populate newly reserved storage within the data. The function is allowed to initialize fewer than `newByteCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
+    ///    - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The function is allowed to initialize fewer than `newByteCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public mutating func append<E: Error>(
@@ -837,7 +837,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - Parameters:
     ///    - newBytesCount: The maximum number of bytes to insert into the data.
     ///    - index: The position at which to insert the new items. `index` must be a valid index in the data, or equal to the data's `endIndex` (in which case the new bytes are appended to the end of the data).
-    ///    - initializer: A callback that gets called at most once to directly populate newly reserved storage within the data. The function is always called with an empty output span.
+    ///    - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The function is always called with an empty output span.
     @_alwaysEmitIntoClient
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func insert<E: Error>(
@@ -1001,7 +1001,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - Parameters:
     ///   - subrange: The subrange of the data to replace. The bounds of the range must be valid indices in the data.
     ///   - newBytesCount: The maximum number of new bytes to insert in place of the old subrange.
-    ///   - initializer: A callback that gets called at most once to directly populate newly reserved storage within the data. The function is always called with an empty output raw span.
+    ///   - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The function is always called with an empty output raw span.
     @_alwaysEmitIntoClient
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func replaceSubrange<E: Error>(

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -643,23 +643,24 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
-    /// Append a given number of bytes to the end of this data by populating output raw span.
+    /// Append a given number of bytes to the end of this data by populating an output raw span.
     ///
     /// If the capacity of the data isn't sufficient to perform the append, then this reallocates the data's storage to extend its capacity.
     ///
     /// If the callback fails to fully populate its output raw span or if it throws an error, then the data keeps all items that were successfully initialized before the callback terminated the operation.
     ///
     /// - Parameters:
-    ///    - newByteCount: The number of bytes to append to the data.
-    ///    - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The function is allowed to initialize fewer than `newByteCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
+    ///    - newBytesCount: The number of bytes to append to the data.
+    ///    A callback that gets called exactly once to directly populate newly reserved storage within the data.
+    ///    - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The callback is always called with an empty output span. The callback is allowed to initialize fewer than `newBytesCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public mutating func append<E: Error>(
-        addingCount newByteCount: Int,
+        addingCount newBytesCount: Int,
         initializingWith initializer: (_ span: inout OutputRawSpan) throws(E) -> Void
     ) throws(E) {
-        precondition(newByteCount >= 0, "newByteCount must not be negative")
-        try _representation.append(addingCount: newByteCount, initializer)
+        precondition(newBytesCount >= 0, "newBytesCount must not be negative")
+        try _representation.append(addingCount: newBytesCount, initializer)
     }
 
     /// Copies the bytes of a raw span to the end of this data.
@@ -812,7 +813,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
-    /// Inserts a given number of new bytes into this data at the specified position, using a callback to directly initialize data storage by populating an output raw span.
+    /// Inserts a given number of new bytes into this data at the specified index, using a callback to directly initialize data storage by populating an output raw span.
     ///
     /// Existing bytes in the data's storage are moved towards the back as needed to make room for the new bytes.
     ///
@@ -837,7 +838,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - Parameters:
     ///    - newBytesCount: The maximum number of bytes to insert into the data.
     ///    - index: The position at which to insert the new items. `index` must be a valid index in the data, or equal to the data's `endIndex` (in which case the new bytes are appended to the end of the data).
-    ///    - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The function is always called with an empty output span.
+    ///    - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The callback is always called with an empty output span. The callback is allowed to initialize fewer than `newBytesCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
     @_alwaysEmitIntoClient
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func insert<E: Error>(
@@ -848,17 +849,17 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         try self.replaceSubrange(index ..< index, addingCount: newBytesCount, initializingWith: initializer)
     }
 
-    /// Copies the bytes of a raw span into this data at the specified position.
+    /// Copies the bytes of a raw span into this data at the specified index.
     ///
     /// The new bytes are inserted before the byte currently at the specified index. If you pass the data's `endIndex` as the `index` parameter, then the new bytes are appended to the end of the data.
     ///
-    /// All existing bytes at or following the specified position are moved to make room for the new bytes.
+    /// All existing bytes at or following the specified index are moved to make room for the new bytes.
     ///
     /// If the capacity of the data isn't sufficient to perform the insertion, then this reallocates the data's storage to extend its capacity.
     ///
     /// - Parameters:
     ///    - newBytes: The new bytes to insert into the data.
-    ///    - index: The position at which to insert the new bytes. It must be a valid index of the data.
+    ///    - index: The position at which to insert the new bytes. `index`  must be a valid index in the data, or equal to the data's `endIndex` (in which case the new bytes are appended to the end of the data).
     @_alwaysEmitIntoClient
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func insert(copying newBytes: RawSpan, at index: Int) {
@@ -1001,7 +1002,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - Parameters:
     ///   - subrange: The subrange of the data to replace. The bounds of the range must be valid indices in the data.
     ///   - newBytesCount: The maximum number of new bytes to insert in place of the old subrange.
-    ///   - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The function is always called with an empty output raw span.
+    ///   - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The callback is always called with an empty output span. The callback is allowed to initialize fewer than `newBytesCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
     @_alwaysEmitIntoClient
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func replaceSubrange<E: Error>(
@@ -1009,14 +1010,23 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         addingCount newBytesCount: Int,
         initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
     ) throws(E) -> Void {
-        precondition(newBytesCount >= 0, "newByteCount must not be negative")
+        precondition(newBytesCount >= 0, "newBytesCount must not be negative")
         try _representation.replaceSubrange(subrange, addingCount: newBytesCount, initializingWith: initializer)
     }
 
 
     /// Replaces the specified subrange of bytes by copying the bytes of the given raw span.
     ///
-    /// This method has the effect of removing the specified range of bytes from the data and inserting the new bytes starting at the same location. The number of new bytes need not match the number of bytes being removed.
+    /// The number of new bytes need not match the number of bytes being removed.
+    ///
+    /// This method has the same overall effect as calling
+    ///
+    ///     try data.removeSubrange(subrange)
+    ///     try data.insert(
+    ///       copying: newBytes,
+    ///       at: subrange.lowerBound)
+    ///
+    /// However, it performs faster (by a constant factor) by avoiding moving some bytes in the data twice.
     ///
     /// If the capacity of the data isn't sufficient to perform the replacement, then this reallocates the data's storage to extend its capacity.
     ///

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -254,6 +254,19 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _representation = _Representation(capacity: capacity)
     }
 
+    /// Creates a new data with the specified capacity, holding a copy of the bytes of the given span.
+    ///
+    /// - Parameters:
+    ///   - capacity: The storage capacity of the new data, or nil to allocate just enough capacity to store the bytes of the span.
+    ///   - span: The span whose bytes to copy into the new data. The span must not contain more than `capacity` bytes.
+    @_alwaysEmitIntoClient
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    public init(capacity: Int? = nil, copying span: RawSpan) {
+        self.init(capacity: capacity ?? span.byteCount) {
+            $0._append(copying: span)
+        }
+    }
+
     /// Creates a new data buffer with the specified count of zeroed bytes.
     ///
     /// - parameter count: The number of bytes the data initially contains.
@@ -286,50 +299,33 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///     - Parameters:
     ///       - span: An `OutputRawSpan` covering uninitialized memory with
     ///         space for the specified number of bytes.
-    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    @available(macOS, introduced: 10.14.4, deprecated, renamed: "init(capacity:initializingWith:)")
+    @available(iOS, introduced: 12.2, deprecated, renamed: "init(capacity:initializingWith:)")
+    @available(watchOS, introduced: 5.2, deprecated, renamed: "init(capacity:initializingWith:)")
+    @available(tvOS, introduced: 12.2, deprecated, renamed: "init(capacity:initializingWith:)")
+    @available(visionOS, introduced: 1.0, deprecated, renamed: "init(capacity:initializingWith:)")
     @_alwaysEmitIntoClient
-    @_spi(_) // TODO: Remove pending API surface amendment
+    @_spi(_) // TODO: Remove after no clients are using this
     public init<E: Error>(
         rawCapacity capacity: Int,
         initializingWith initializer: (_ span: inout OutputRawSpan) throws(E) -> Void
     ) throws(E) {
-        precondition(capacity >= 0, "capacity must not be negative")
-        _representation = try _Representation(capacity: capacity, initializer)
+        try self.init(capacity: capacity, initializingWith: initializer)
     }
 
-    /// Creates a data instance with the specified capacity, and then calls the given
-    /// closure with an output span covering the instance's uninitialized memory.
-    ///
-    /// Inside the closure, initialize elements by appending to the `OutputSpan`.
-    /// The `OutputSpan` keeps track of the initialized memory, ensuring
-    /// safety. Its `count` at the end of the closure will become the `count` of
-    /// the newly-initialized instance of `Data`.
-    ///
-    /// - Note: While the resulting `Data` may have a capacity larger than the
-    ///   requested amount, the `OutputSpan` passed to the closure will cover
-    ///   exactly the number of bytes requested.
+    /// Creates a new data with the specified capacity, directly initializing its storage using an output raw span.
     ///
     /// - Parameters:
-    ///   - capacity: The number of bytes to allocate space for in the new `Data`.
-    ///   - initializer: A closure to initialize the allocated memory.
-    ///     - Parameters:
-    ///       - span: An `OutputSpan` covering uninitialized memory with
-    ///         space for the specified number of elements.
-    // TODO: Make public pending API surface amendment
+    ///   - capacity: The storage capacity of the new data.
+    ///   - initializer: A callback that gets called at most once to directly populate newly reserved storage within the data. The function is allowed to add fewer than `capacity` bytes. The data is initialized with however many bytes the callback adds to the output raw span before it returns (or before it throws an error).
+    @_alwaysEmitIntoClient
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-    internal init<E: Error>(
+    public init<E: Error>(
         capacity: Int,
-        initializingWith initializer: (_ span: inout OutputSpan<UInt8>) throws(E) -> Void
+        initializingWith initializer: (_ span: inout OutputRawSpan) throws(E) -> Void
     ) throws(E) {
-        self = try Data(rawCapacity: capacity) { output throws(E) in
-            try output.withUnsafeMutableBytes { (bytes, count) throws(E) in
-                try bytes.withMemoryRebound(to: UInt8.self) { buffer throws(E) in
-                    var span = OutputSpan<UInt8>(buffer: buffer, initializedCount: 0)
-                    try initializer(&span)
-                    count = span.finalize(for: buffer)
-                }
-            }
-        }
+        precondition(capacity >= 0, "capacity must not be negative")
+        _representation = try _Representation(capacity: capacity, initializer)
     }
 
     /// Creates a data buffer with memory content without copying the bytes.
@@ -569,6 +565,18 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
+    /// Arbitrarily edit the storage underlying this data by invoking a user-supplied closure with a mutable `OutputRawSpan` view over it. This method calls its function argument at most once, allowing it to arbitrarily modify the contents of the output span it is given. The argument is free to add, remove or reorder any items; however, it is not allowed to replace the span or change its capacity.
+    ///
+    /// When the function argument finishes (whether by returning or throwing an error) the data instance is updated to match the final contents of the output span.
+    ///
+    /// - Parameter body: A function that edits the contents of this data through an `OutputRawSpan` argument. This method invokes this function at most once.
+    /// - Returns: This method returns the result of its function argument.
+    @_alwaysEmitIntoClient
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    public mutating func edit<E: Error, R: ~Copyable>(_ body: (inout OutputRawSpan) throws(E) -> R) throws(E) -> R {
+        try _representation.edit(body)
+    }
+
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
     public var mutableSpan: MutableSpan<UInt8> {
@@ -635,73 +643,36 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
-    /// Grows this data to have enough capacity for the specified number of
-    /// bytes, then calls the closure with an output span covering the requested
-    /// amount of uninitialized memory.
+    /// Append a given number of bytes to the end of this data by populating output raw span.
     ///
-    /// Inside the closure, initialize elements by appending to `span`. It
-    /// ensures safety by keeping track of the initialized memory.
-    /// At the end of the closure, `span`'s `count` elements will have
-    /// been appended to this `Data` instance.
+    /// If the capacity of the data isn't sufficient to perform the append, then this reallocates the data's storage to extend its capacity.
     ///
-    /// If the closure throws an error, the items appended until that point
-    /// will remain in the `Data` instance.
+    /// If the callback fails to fully populate its output raw span or if it throws an error, then the data keeps all items that were successfully initialized before the callback terminated the operation.
     ///
     /// - Parameters:
-    ///   - uninitializedCount: The number of new elements the `Data` should have
-    ///     space for.
-    ///   - initializer: A closure to initialize memory.
-    ///     - Parameters:
-    ///       - span: An `OutputRawSpan` covering uninitialized memory with
-    ///         space for the specified number of additional bytes.
-    // TODO: Make public pending SE-0527 naming discussion
+    ///    - newByteCount: The number of bytes to append to the data.
+    ///    - initializer: A callback that gets called at most once to directly populate newly reserved storage within the data. The function is allowed to initialize fewer than `newByteCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     @_alwaysEmitIntoClient
-    internal mutating func append<E: Error>(
-        addingRawCapacity uninitializedCount: Int,
+    public mutating func append<E: Error>(
+        addingCount newByteCount: Int,
         initializingWith initializer: (_ span: inout OutputRawSpan) throws(E) -> Void
     ) throws(E) {
-        precondition(uninitializedCount >= 0, "uninitializedCount must not be negative")
-        try _representation.append(addingCapacity: uninitializedCount, initializer)
+        precondition(newByteCount >= 0, "newByteCount must not be negative")
+        try _representation.append(addingCount: newByteCount, initializer)
     }
 
-    /// Grows this data to have enough capacity for the specified number of
-    /// bytes, then calls the closure with an output span covering the requested
-    /// amount of uninitialized memory.
+    /// Copies the bytes of a raw span to the end of this data.
     ///
-    /// Inside the closure, initialize elements by appending to `span`. It
-    /// ensures safety by keeping track of the initialized memory.
-    /// At the end of the closure, `span`'s `count` elements will have
-    /// been appended to this `Data` instance.
-    ///
-    /// If the closure throws an error, the items appended until that point
-    /// will remain in the `Data` instance.
+    /// If the capacity of the data isn't sufficient to perform the append, then this reallocates the data's storage to extend its capacity.
     ///
     /// - Parameters:
-    ///   - uninitializedCount: The number of new elements the array should have
-    ///     space for.
-    ///   - initializer: A closure to initialize memory.
-    ///     - Parameters:
-    ///       - span: An `OutputSpan` covering uninitialized memory with
-    ///         space for the specified number of additional elements.
-    // TODO: Make public pending SE-0527 naming discussion
-    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    ///    - newBytes: A raw span whose contents to copy into the data.
     @_alwaysEmitIntoClient
-    internal mutating func append<E: Error>(
-        addingCapacity uninitializedCount: Int,
-        initializingWith initializer: (_ span: inout OutputSpan<UInt8>) throws(E) -> Void
-    ) throws(E) {
-        try self.append(addingRawCapacity: uninitializedCount) { output throws(E) in
-            try output.withUnsafeMutableBytes { (bytes, count) throws(E) in
-                try bytes.withMemoryRebound(to: UInt8.self) { buffer throws(E) in
-                    var span = OutputSpan<UInt8>(buffer: buffer, initializedCount: 0)
-                    defer {
-                        count = span.finalize(for: buffer)
-                        span = OutputSpan()
-                    }
-                    try initializer(&span)
-                }
-            }
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    public mutating func append(copying newBytes: RawSpan) {
+        self.append(addingCount: newBytes.byteCount) {
+            $0._append(copying: newBytes)
         }
     }
 
@@ -841,6 +812,61 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
+    /// Inserts a given number of new bytes into this data at the specified position, using a callback to directly initialize data storage by populating an output raw span.
+    ///
+    /// Existing bytes in the data's storage are moved towards the back as needed to make room for the new bytes.
+    ///
+    /// If the capacity of the data isn't sufficient to perform the insertion, then this reallocates the data's storage to extend its capacity.
+    ///
+    ///     var prefix: RawSpan = /* a raw span containing the bytes 11, 99 */
+    ///     var buffer = Data(capacity: 20, copying: prefix)
+    ///     var i: UInt8 = 0
+    ///     buffer.insert(addingCount: 3, at: 1) { target in
+    ///       while !target.isFull {
+    ///         target.append(i)
+    ///         i += 1
+    ///       }
+    ///     }
+    ///     // `buffer` now contains the bytes 11, 0, 1, 2, and 99
+    ///
+    /// If the callback fails to fully populate its output raw span or if it throws an error, then the data keeps all items that were successfully initialized before the callback terminated the insertion.
+    ///
+    /// Partial insertions create a gap in data storage that needs to be closed by moving already inserted bytes to their correct positions given
+    /// the adjusted count. This adds some overhead compared to adding exactly as many items as promised.
+    ///
+    /// - Parameters:
+    ///    - newBytesCount: The maximum number of bytes to insert into the data.
+    ///    - index: The position at which to insert the new items. `index` must be a valid index in the data, or equal to the data's `endIndex` (in which case the new bytes are appended to the end of the data).
+    ///    - initializer: A callback that gets called at most once to directly populate newly reserved storage within the data. The function is always called with an empty output span.
+    @_alwaysEmitIntoClient
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    public mutating func insert<E: Error>(
+        addingCount newBytesCount: Int,
+        at index: Int,
+        initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+    ) throws(E) {
+        try self.replaceSubrange(index ..< index, addingCount: newBytesCount, initializingWith: initializer)
+    }
+
+    /// Copies the bytes of a raw span into this data at the specified position.
+    ///
+    /// The new bytes are inserted before the byte currently at the specified index. If you pass the data's `endIndex` as the `index` parameter, then the new bytes are appended to the end of the data.
+    ///
+    /// All existing bytes at or following the specified position are moved to make room for the new bytes.
+    ///
+    /// If the capacity of the data isn't sufficient to perform the insertion, then this reallocates the data's storage to extend its capacity.
+    ///
+    /// - Parameters:
+    ///    - newBytes: The new bytes to insert into the data.
+    ///    - index: The position at which to insert the new bytes. It must be a valid index of the data.
+    @_alwaysEmitIntoClient
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    public mutating func insert(copying newBytes: RawSpan, at index: Int) {
+        self.insert(addingCount: newBytes.byteCount, at: index) {
+            $0._append(copying: newBytes)
+        }
+    }
+
     #if FOUNDATION_FRAMEWORK
     /// Replace a region of bytes in the data with new data.
     ///
@@ -949,6 +975,64 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     @inlinable // This is @inlinable as trivially forwarding.
     public mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer, count cnt: Int) {
         _representation.replaceSubrange(subrange, with: bytes, count: cnt)
+    }
+
+    /// Replaces the specified range of bytes by a given count of new bytes, using a callback to directly initialize data storage by populating
+    /// an output raw span.
+    ///
+    /// The number of new bytes need not match the number of bytes being removed.
+    ///
+    /// This method has the same overall effect as calling
+    ///
+    ///     try data.removeSubrange(subrange)
+    ///     try data.insert(
+    ///       addingCount: newBytesCount,
+    ///       at: subrange.lowerBound,
+    ///       initializingWith: initializer)
+    ///
+    /// However, it performs faster (by a constant factor) by avoiding moving some bytes in the data twice.
+    ///
+    /// If the capacity of the data isn't sufficient to perform the replacement, then this reallocates the data's storage to extend its capacity.
+    ///
+    /// If the callback fails to fully populate its output raw span or if it throws an error, then the data keeps all bytes that were successfully initialized before the callback terminated the replacement.
+    ///
+    /// Partial replacements create a gap in data storage that needs to be closed by moving subsequent bytes to their correct positions given the adjusted count. This adds some overhead compared to adding exactly as many bytes as promised.
+    ///
+    /// - Parameters:
+    ///   - subrange: The subrange of the data to replace. The bounds of the range must be valid indices in the data.
+    ///   - newBytesCount: The maximum number of new bytes to insert in place of the old subrange.
+    ///   - initializer: A callback that gets called at most once to directly populate newly reserved storage within the data. The function is always called with an empty output raw span.
+    @_alwaysEmitIntoClient
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    public mutating func replaceSubrange<E: Error>(
+        _ subrange: Range<Int>,
+        addingCount newBytesCount: Int,
+        initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+    ) throws(E) -> Void {
+        precondition(newBytesCount >= 0, "newByteCount must not be negative")
+        try _representation.replaceSubrange(subrange, addingCount: newBytesCount, initializingWith: initializer)
+    }
+
+
+    /// Replaces the specified subrange of bytes by copying the bytes of the given raw span.
+    ///
+    /// This method has the effect of removing the specified range of bytes from the data and inserting the new bytes starting at the same location. The number of new bytes need not match the number of bytes being removed.
+    ///
+    /// If the capacity of the data isn't sufficient to perform the replacement, then this reallocates the data's storage to extend its capacity.
+    ///
+    /// If you pass a zero-length range as the `subrange` parameter, this method inserts the bytes of `newBytes` at `subrange.lowerBound`. Calling the `insert(copying:at:)` method instead is preferred in this case.
+    ///
+    /// Likewise, if you pass a zero-length raw span as the `newBytes` parameter, this method removes the bytes in the given subrange without replacement. Calling the `removeSubrange(_:)` method instead is preferred in this case.
+    ///
+    /// - Parameters:
+    ///   - subrange: The subrange of the data to replace. The bounds of the range must be valid indices in the data.
+    ///   - newBytes: The new bytes to copy into the data.
+    @_alwaysEmitIntoClient
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    public mutating func replaceSubrange(_ subrange: Range<Int>, copying newBytes: RawSpan) {
+        self.replaceSubrange(subrange, addingCount: newBytes.byteCount) {
+            $0._append(copying: newBytes)
+        }
     }
 
     @_alwaysEmitIntoClient

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -267,7 +267,7 @@ extension Data {
             }
         }
         
-        @inlinable
+        @usableFromInline
         mutating func replaceSubrange(_ subrange: Range<Index>, with replacementBytes: UnsafeRawPointer?, count replacementLength: Int) {
             self.replaceSubrange(subrange, addingCount: replacementLength) { outputSpan in
                 outputSpan._append(copying: UnsafeRawBufferPointer(start: replacementBytes, count: replacementLength).bytes)

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -267,30 +267,53 @@ extension Data {
             }
         }
         
-        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        @inlinable
         mutating func replaceSubrange(_ subrange: Range<Index>, with replacementBytes: UnsafeRawPointer?, count replacementLength: Int) {
+            self.replaceSubrange(subrange, addingCount: replacementLength) { outputSpan in
+                outputSpan._append(copying: UnsafeRawBufferPointer(start: replacementBytes, count: replacementLength).bytes)
+            }
+        }
+
+        @_alwaysEmitIntoClient
+        @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+        mutating func replaceSubrange<E: Error>(
+            _ subrange: Range<Int>,
+            addingCount newByteCount: Int,
+            initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+        ) throws(E) -> Void {
             assert(subrange.lowerBound <= MemoryLayout<Buffer>.size)
             assert(subrange.upperBound <= MemoryLayout<Buffer>.size)
-            assert(count - (subrange.upperBound - subrange.lowerBound) + replacementLength <= MemoryLayout<Buffer>.size)
+            assert(count - (subrange.upperBound - subrange.lowerBound) + newByteCount <= MemoryLayout<Buffer>.size)
             precondition(subrange.lowerBound >= 0 && subrange.lowerBound <= length, "index \(subrange.lowerBound) is out of bounds of 0..<\(length)")
             precondition(subrange.upperBound >= 0 && subrange.upperBound <= length, "index \(subrange.upperBound) is out of bounds of 0..<\(length)")
-            let currentLength = count
-            let resultingLength = currentLength - (subrange.upperBound - subrange.lowerBound) + replacementLength
-            let shift = resultingLength - currentLength
-            Swift.withUnsafeMutableBytes(of: &bytes) { mutableBytes in
-                /* shift the trailing bytes */
-                let start = subrange.lowerBound
-                let length = subrange.upperBound - subrange.lowerBound
-                if shift != 0 {
-                    memmove(mutableBytes.baseAddress!.advanced(by: start + replacementLength), mutableBytes.baseAddress!.advanced(by: start + length), currentLength - start - length)
+            let startingCount = count
+            var resultingLength = length
+            defer { length = resultingLength }
+            return try Swift.withUnsafeMutableBytes(of: &bytes) { mutableBytes throws(E) in
+                let replacedLength = subrange.upperBound - subrange.lowerBound
+                var trailingLocation = subrange.lowerBound + newByteCount
+                let trailingLength = startingCount - subrange.upperBound
+                // Make room for the insertion if needed (we don't shrink / shift forward yet to avoid 2 moves if the output span isn't fully filled)
+                if newByteCount > replacedLength {
+                    memmove(mutableBytes.baseAddress!.advanced(by: trailingLocation), mutableBytes.baseAddress!.advanced(by: subrange.upperBound), trailingLength)
+                } else {
+                    trailingLocation = subrange.upperBound
                 }
-                if replacementLength != 0 {
-                    memmove(mutableBytes.baseAddress!.advanced(by: start), replacementBytes!, replacementLength)
+                let buffer = UnsafeMutableRawBufferPointer(start: mutableBytes.baseAddress!.advanced(by: subrange.lowerBound), count: newByteCount)
+                var span = OutputRawSpan(buffer: buffer, initializedCount: 0)
+                defer {
+                    let insertedLength = span.finalize(for: buffer)
+                    span = OutputRawSpan()
+                    let trailingDestination = subrange.lowerBound + insertedLength
+                    if trailingLocation != trailingDestination {
+                        memmove(mutableBytes.baseAddress!.advanced(by: trailingDestination), mutableBytes.baseAddress!.advanced(by: trailingLocation), trailingLength)
+                    }
+                    resultingLength = UInt8(trailingDestination + trailingLength)
                 }
+                return try initializer(&span)
             }
-            length = UInt8(resultingLength)
         }
-        
+
         @inlinable // This is @inlinable as trivially computable.
         func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
             precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")

--- a/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
@@ -285,7 +285,27 @@ extension Data {
             let resultingUpper = upper - (subrange.upperBound - subrange.lowerBound) + cnt
             slice = slice.lowerBound..<HalfInt(resultingUpper)
         }
-        
+
+        @_alwaysEmitIntoClient
+        @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+        mutating func replaceSubrange<E: Error>(
+            _ subrange: Range<Int>,
+            addingCount newBytesCount: Int,
+            initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+        ) throws(E) -> Void {
+            precondition(startIndex <= subrange.lowerBound, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.lowerBound <= endIndex, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= subrange.upperBound, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.upperBound <= endIndex, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            ensureUniqueReference()
+            var endIndex = endIndex
+            defer {
+                slice = slice.lowerBound ..< HalfInt(endIndex)
+            }
+            try storage.replaceSubrange(subrange, endIndex: &endIndex, addingCount: newBytesCount, initializingWith: initializer)
+        }
+
         @inlinable // This is @inlinable as reasonably small.
         func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
             precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")

--- a/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
@@ -268,7 +268,27 @@ extension Data {
             let resultingUpper = upper - (subrange.upperBound - subrange.lowerBound) + cnt
             slice.range = slice.range.lowerBound..<resultingUpper
         }
-        
+
+        @_alwaysEmitIntoClient
+        @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+        mutating func replaceSubrange<E: Error>(
+            _ subrange: Range<Int>,
+            addingCount newBytesCount: Int,
+            initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+        ) throws(E) -> Void {
+            precondition(startIndex <= subrange.lowerBound, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.lowerBound <= endIndex, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= subrange.upperBound, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.upperBound <= endIndex, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            ensureUniqueReference()
+            var endIndex = endIndex
+            defer {
+                slice.range = slice.lowerBound ..< endIndex
+            }
+            try storage.replaceSubrange(subrange, endIndex: &endIndex, addingCount: newBytesCount, initializingWith: initializer)
+        }
+
         @inlinable // This is @inlinable as reasonably small.
         func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
             precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")

--- a/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
@@ -304,6 +304,44 @@ extension Data {
             }
         }
 
+        @_alwaysEmitIntoClient
+        @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+        mutating func edit<E: Error, R: ~Copyable>(_ body: (inout OutputRawSpan) throws(E) -> R) throws(E) -> R {
+            switch self {
+            case .empty:
+                var span = OutputRawSpan()
+                return try body(&span)
+            case .inline(var inline):
+                var length = inline.length
+                defer {
+                    inline.length = length
+                    self = .inline(inline)
+                }
+                return try Swift.withUnsafeMutableBytes(of: &inline.bytes) { buffer throws(E) in
+                    var span = OutputRawSpan(buffer: buffer, initializedCount: count)
+                    defer {
+                        length = UInt8(span.finalize(for: buffer))
+                        span = OutputRawSpan()
+                    }
+                    return try body(&span)
+                }
+            case .slice(var slice):
+                self = .empty
+                slice.ensureUniqueReference()
+                defer { self = .slice(slice) }
+                return try slice.storage.edit(range: &slice.range, body)
+            case .large(var slice):
+                self = .empty
+                slice.ensureUniqueReference()
+                var range = slice.range
+                defer {
+                    slice.slice.range = range
+                    self = .large(slice)
+                }
+                return try slice.storage.edit(range: &range, body)
+            }
+        }
+
         @inline(__always)
         @_alwaysEmitIntoClient
         func withUnsafeBytes<E, Result: ~Copyable>(_ apply: (UnsafeRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
@@ -424,17 +462,17 @@ extension Data {
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         @_alwaysEmitIntoClient
         mutating func append<E: Error>(
-            addingCapacity uninitializedCount: Int,
+            addingCount newByteCount: Int,
             _ initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
-            let newCapacity = count + uninitializedCount
+            let newCapacity = count + newByteCount
 
             func appendInline(_ inline: consuming InlineData) throws(E) {
                 if InlineData.canStore(count: newCapacity) {
                     defer {
                         self = (inline.count == 0) ? .empty : .inline(inline)
                     }
-                    try inline.append(uninitializedCount, initializer)
+                    try inline.append(newByteCount, initializer)
                 } else {
                     let storage = __DataStorage(capacity: newCapacity)
                     inline.withUnsafeBytes { storage.append($0.baseAddress!, length: $0.count) }
@@ -448,7 +486,7 @@ extension Data {
                             self = .large(LargeSlice(storage, count: newCount))
                         }
                     }
-                    try storage.withUninitializedBytes(extraCapacity: uninitializedCount, location: inline.count, &appendedCount, initializer)
+                    try storage.withUninitializedBytes(extraCapacity: newByteCount, location: inline.count, &appendedCount, initializer)
                 }
             }
 
@@ -461,17 +499,17 @@ extension Data {
                 if InlineSlice.canStore(count: newCapacity) {
                     self = .empty
                     defer { self = .slice(slice) }
-                    try slice.append(uninitializedCount, initializer)
+                    try slice.append(newByteCount, initializer)
                 } else {
                     self = .empty
                     var newSlice = LargeSlice(slice)
                     defer { self = .large(newSlice) }
-                    try newSlice.append(uninitializedCount, initializer)
+                    try newSlice.append(newByteCount, initializer)
                 }
             case .large(var slice):
                 self = .empty
                 defer { self = .large(slice) }
-                try slice.append(uninitializedCount, initializer)
+                try slice.append(newByteCount, initializer)
             }
         }
 
@@ -604,7 +642,96 @@ extension Data {
                 }
             }
         }
-        
+
+        @_alwaysEmitIntoClient
+        @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+        public mutating func replaceSubrange<E: Error>(
+            _ subrange: Range<Int>,
+            addingCount cnt: Int,
+            initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+        ) throws(E) -> Void {
+            switch self {
+            case .empty:
+                precondition(subrange.lowerBound == 0 && subrange.upperBound == 0, "range \(subrange) out of bounds of 0..<0")
+                if cnt == 0 {
+                    return
+                } else if InlineData.canStore(count: cnt) {
+                    var inline = InlineData()
+                    defer {
+                        self = (inline.count == 0) ? .empty : .inline(inline)
+                    }
+                    try inline.append(cnt, initializer)
+                } else {
+                    let storage = __DataStorage(capacity: cnt)
+                    var size = 0
+                    defer {
+                        if InlineSlice.canStore(count: size) {
+                            self = .slice(InlineSlice(storage, count: size))
+                        } else {
+                            self = .large(LargeSlice(storage, count: size))
+                        }
+                    }
+                    try storage.withUninitializedBytes(extraCapacity: cnt, location: 0, &size, initializer)
+                }
+            case .inline(var inline):
+                precondition(subrange.lowerBound >= 0 && subrange.lowerBound <= inline.count, "index \(subrange.lowerBound) is out of bounds of 0..<\(inline.count)")
+                precondition(subrange.upperBound >= 0 && subrange.upperBound <= inline.count, "index \(subrange.upperBound) is out of bounds of 0..<\(inline.count)")
+                let resultingCount = inline.count + cnt - (subrange.upperBound - subrange.lowerBound)
+                if resultingCount == 0 {
+                    self = .empty
+                    var span = OutputRawSpan()
+                    try initializer(&span)
+                } else if InlineData.canStore(count: resultingCount) {
+                    defer { self = .inline(inline) }
+                    try inline.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                } else if InlineSlice.canStore(count: resultingCount) {
+                    var slice = InlineSlice(inline)
+                    defer { self = .slice(slice) }
+                    try slice.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                } else {
+                    var slice = LargeSlice(inline)
+                    defer { self = .large(slice) }
+                    try slice.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                }
+            case .slice(var slice):
+                let resultingUpper = slice.endIndex + cnt - (subrange.upperBound - subrange.lowerBound)
+                if slice.startIndex == 0 && resultingUpper == 0 {
+                    self = .empty
+                } else if slice.startIndex == 0 && InlineData.canStore(count: resultingUpper) {
+                    self = .empty
+                    defer { self = .inline(InlineData(slice, count: slice.count))}
+                    try slice.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                } else if InlineSlice.canStore(count: resultingUpper) {
+                    self = .empty
+                    defer { self = .slice(slice) }
+                    try slice.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                } else {
+                    self = .empty
+                    var newSlice = LargeSlice(slice)
+                    defer { self = .large(newSlice) }
+                    try newSlice.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                }
+            case .large(var slice):
+                let resultingUpper = slice.endIndex + cnt - (subrange.upperBound - subrange.lowerBound)
+                if slice.startIndex == 0 && resultingUpper == 0 {
+                    self = .empty
+                } else if slice.startIndex == 0 && InlineData.canStore(count: resultingUpper) {
+                    self = .empty
+                    defer { self = .inline(InlineData(slice, count: resultingUpper - slice.startIndex)) }
+                    try slice.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                } else if InlineSlice.canStore(count: slice.startIndex) && InlineSlice.canStore(count: resultingUpper) {
+                    self = .empty
+                    var newSlice = InlineSlice(slice)
+                    defer { self = .slice(newSlice) }
+                    try newSlice.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                } else {
+                    self = .empty
+                    defer { self = .large(slice) }
+                    try slice.replaceSubrange(subrange, addingCount: cnt, initializingWith: initializer)
+                }
+            }
+        }
+
         @inlinable // This is @inlinable as trivially forwarding.
         subscript(index: Index) -> UInt8 {
             get {

--- a/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
@@ -130,13 +130,20 @@ extension Data {
             }
         }
 
+        @_alwaysEmitIntoClient
+        @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+        mutating func edit<E: Error, R: ~Copyable>(_ body: (inout OutputRawSpan) throws(E) -> R) throws(E) -> R {
+            self.ensureUniqueReference()
+            return try _storage.edit(range: &_slice, body)
+        }
+
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         @_alwaysEmitIntoClient
         mutating func append<E: Error>(
-            addingCapacity uninitializedCount: Int,
+            addingCount newBytesCount: Int,
             _ initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
-            reserveCapacity(count + uninitializedCount)
+            reserveCapacity(count + newBytesCount)
             var appendedCount = 0
             defer {
                 let newUpperBound = _slice.upperBound + appendedCount
@@ -146,7 +153,7 @@ extension Data {
                     _slice = _slice.lowerBound..<newUpperBound
                 }
             }
-            try _storage.withUninitializedBytes(extraCapacity: uninitializedCount, location: endIndex, &appendedCount, initializer)
+            try _storage.withUninitializedBytes(extraCapacity: newBytesCount, location: endIndex, &appendedCount, initializer)
         }
         
         @_alwaysEmitIntoClient @inline(__always)
@@ -204,7 +211,30 @@ extension Data {
             let resultingUpper = upper - (subrange.upperBound - subrange.lowerBound) + cnt
             _slice = _slice.lowerBound..<resultingUpper
         }
-        
+
+        @_alwaysEmitIntoClient
+        @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+        mutating func replaceSubrange<E: Error>(
+            _ subrange: Range<Int>,
+            addingCount newBytesCount: Int,
+            initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+        ) throws(E) -> Void {
+            precondition(startIndex <= subrange.lowerBound, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.upperBound <= endIndex, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            if subrange.isEmpty && newBytesCount == 0 { return }
+
+            ensureUniqueReference()
+            var endIndex = endIndex
+            defer {
+                _slice = _slice.lowerBound ..< endIndex
+                if _slice.lowerBound == 0 && endIndex == 0 {
+                    _storage = .empty
+                }
+            }
+            try _storage.replaceSubrange(subrange, endIndex: &endIndex, addingCount: newBytesCount, initializingWith: initializer)
+        }
+
         @_alwaysEmitIntoClient
         subscript(index: Index) -> UInt8 {
             get {

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -554,7 +554,7 @@ internal final class __DataStorage : @unchecked Sendable {
         }
         // Make room for the insertion if needed (we don't shrink / shift forward yet to avoid 2 moves if the output span isn't fully filled)
         if newByteCount > replacedLength {
-            memmove(mutableBytes!.advanced(by: trailingLocation), mutableBytes!.advanced(by: subrange.upperBound), trailingLength)
+            mutableBytes!.advanced(by: trailingLocation).copyMemory(from: mutableBytes!.advanced(by: subrange.upperBound), byteCount: trailingLength)
         } else {
             trailingLocation = subrange.upperBound
         }
@@ -565,7 +565,7 @@ internal final class __DataStorage : @unchecked Sendable {
             span = OutputRawSpan()
             let trailingDestination = subrange.lowerBound + insertedLength
             if trailingLocation != trailingDestination {
-                memmove(mutableBytes!.advanced(by: trailingDestination), mutableBytes!.advanced(by: trailingLocation), trailingLength)
+                mutableBytes!.advanced(by: trailingDestination).copyMemory(from: mutableBytes!.advanced(by: trailingLocation), byteCount: trailingLength)
             }
             let newLength = trailingDestination - _offset + trailingLength
             if insertedLength > replacedLength {

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -454,6 +454,19 @@ internal final class __DataStorage : @unchecked Sendable {
         return try initializer(&outputSpan)
     }
 
+    @_alwaysEmitIntoClient
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    func edit<E: Error, R: ~Copyable>(range: inout Range<Int>, _ body: (inout OutputRawSpan) throws(E) -> R) throws(E) -> R {
+        let buffer = UnsafeMutableRawBufferPointer(start: mutableBytes?.advanced(by: range.lowerBound), count: _offset + capacity - range.lowerBound)
+        var span = OutputRawSpan(buffer: buffer, initializedCount: range.count)
+        defer {
+            let updatedInitialized = span.finalize(for: buffer)
+            span = OutputRawSpan()
+            range = Range(uncheckedBounds: (range.lowerBound, range.lowerBound + updatedInitialized))
+        }
+        return try body(&span)
+    }
+
     @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
     func get(_ index: Int) -> UInt8 {
         // index must have already been validated by the caller
@@ -520,7 +533,51 @@ internal final class __DataStorage : @unchecked Sendable {
             setLength(resultingLength)
         }
     }
-    
+
+    @_alwaysEmitIntoClient
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+    func replaceSubrange<E: Error>(
+        _ subrange: Range<Int>,
+        endIndex: inout Int,
+        addingCount newByteCount: Int,
+        initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+    ) throws(E) -> Void {
+        let replacedLength = subrange.upperBound &- subrange.lowerBound
+        var trailingLocation = subrange.lowerBound + newByteCount
+        let trailingLength = _length - (subrange.upperBound - _offset)
+        let resultingLength = _length - replacedLength + newByteCount
+        if resultingLength > _length {
+            ensureUniqueBufferReference(growingTo: resultingLength)
+            _length = resultingLength
+        } else {
+            ensureUniqueBufferReference()
+        }
+        // Make room for the insertion if needed (we don't shrink / shift forward yet to avoid 2 moves if the output span isn't fully filled)
+        if newByteCount > replacedLength {
+            memmove(mutableBytes!.advanced(by: trailingLocation), mutableBytes!.advanced(by: subrange.upperBound), trailingLength)
+        } else {
+            trailingLocation = subrange.upperBound
+        }
+        let buffer = UnsafeMutableRawBufferPointer(start: mutableBytes!.advanced(by: subrange.lowerBound), count: newByteCount)
+        var span = OutputRawSpan(buffer: buffer, initializedCount: 0)
+        defer {
+            let insertedLength = span.finalize(for: buffer)
+            span = OutputRawSpan()
+            let trailingDestination = subrange.lowerBound + insertedLength
+            if trailingLocation != trailingDestination {
+                memmove(mutableBytes!.advanced(by: trailingDestination), mutableBytes!.advanced(by: trailingLocation), trailingLength)
+            }
+            let newLength = trailingDestination - _offset + trailingLength
+            if insertedLength > replacedLength {
+                _length = newLength
+            } else if insertedLength < replacedLength {
+                setLength(newLength)
+            }
+            endIndex += insertedLength - replacedLength
+        }
+        return try initializer(&span)
+    }
+
     @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
     func resetBytes(in range_: Range<Int>) {
         let range = range_.lowerBound - _offset ..< range_.upperBound - _offset

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -463,6 +463,12 @@ internal final class __DataStorage : @unchecked Sendable {
             let updatedInitialized = span.finalize(for: buffer)
             span = OutputRawSpan()
             range = Range(uncheckedBounds: (range.lowerBound, range.lowerBound + updatedInitialized))
+            let resultingLength = range.upperBound - _offset
+            if resultingLength > _length {
+                _length = resultingLength
+            } else if resultingLength < _length {
+                setLength(resultingLength)
+            }
         }
         return try body(&span)
     }

--- a/Sources/FoundationEssentials/Span+Utils.swift
+++ b/Sources/FoundationEssentials/Span+Utils.swift
@@ -88,3 +88,17 @@ extension Span<UInt8> {
         return false
     }
 }
+
+extension OutputRawSpan {
+    @_alwaysEmitIntoClient
+    mutating func _append(copying span: RawSpan) {
+        precondition(self.freeCapacity >= span.byteCount, "Insufficient space to copy the provided span (have \(self.freeCapacity) bytes for writing \(span.byteCount) bytes)")
+        self.withUnsafeMutableBytes { buffer, initializedCount in
+            let dest = UnsafeMutableRawBufferPointer(rebasing: buffer.suffix(from: initializedCount))
+            span.withUnsafeBytes { src in
+                dest.copyMemory(from: src)
+                initializedCount += src.count
+            }
+        }
+    }
+}

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -202,21 +202,21 @@ private final class DataTests {
         struct LocalError: Error, Equatable {}
 
         // Initialize the inline representation
-        var data = Data(rawCapacity: 1) {
+        var data = Data(capacity: 1) {
             #expect($0.freeCapacity == 1)
             $0.append(42)
         }
         expectInlineIfLegacyABI(data)
         #expect(data.count == 1)
 
-        data = Data(rawCapacity: 0) {
+        data = Data(capacity: 0) {
             #expect($0.freeCapacity == 0)
         }
         expectEmptyRepresentation(data)
         #expect(data.count == 0)
 
         #expect(throws: LocalError()) {
-            data = try Data(rawCapacity: 2) {
+            data = try Data(capacity: 2) {
                 $0.append(42)
                 throw LocalError()
             }
@@ -225,7 +225,7 @@ private final class DataTests {
 
         let anInlineSliceSize = 96
         // Initialize an "inline slice"
-        data = Data(rawCapacity: anInlineSliceSize) {
+        data = Data(capacity: anInlineSliceSize) {
             #expect($0.freeCapacity == anInlineSliceSize)
             $0.append(42)
         }
@@ -233,13 +233,37 @@ private final class DataTests {
         #expect(data.count == 1)
     }
 
-    @Test func initializationWithOutputSpanOfUInt8() throws {
-        let data = Data(capacity: 1) {
-            #expect($0.freeCapacity == 1)
-            $0.append(42)
+    @Test func initializationWithRawSpan() async throws {
+        var d = Data(copying: RawSpan())
+        #expect(d.count == 0)
+        d.edit {
+            // Empty datas are special cased and shouldn't have an allocation
             #expect($0.freeCapacity == 0)
         }
-        #expect(data.count == 1)
+
+        d = Data(copying: Array<UInt8>(repeating: 1, count: 3).span.bytes)
+        #expect(d.count == 3)
+        #expect(d == Data([1, 1, 1]))
+
+        d = Data(copying: Array<UInt8>(repeating: 1, count: 100).span.bytes)
+        #expect(d.count == 100)
+        #expect(d == Data(Array<UInt8>(repeating: 1, count: 100)))
+
+        d = Data(capacity: 10, copying: Array<UInt8>(repeating: 1, count: 3).span.bytes)
+        #expect(d.count == 3)
+        #expect(d == Data([1, 1, 1]))
+        d.edit {
+            #expect($0.freeCapacity >= 7)
+        }
+
+        #if FOUNDATION_EXIT_TESTS
+        await #expect(processExitsWith: .failure) {
+            _ = Data(capacity: -1, copying: RawSpan())
+        }
+        await #expect(processExitsWith: .failure) {
+            _ = Data(capacity: 1, copying: Array<UInt8>(repeating: 1, count: 3).span.bytes)
+        }
+        #endif
     }
 
     @Test func mutableData() {
@@ -375,6 +399,87 @@ private final class DataTests {
         helloWorld.replaceSubrange(0..<0, with: hello)
 
         #expect(helloWorld == expected)
+    }
+
+    @Test func insertWithOutputRawSpan() {
+        struct LocalError: Error, Equatable {}
+        let insertedValue: UInt8 = (7..<252).randomElement()!
+
+        // Insert in the inline representation
+        var data = Data()
+        data.insert(addingCount: 8, at: 0) {
+            #expect($0.freeCapacity == 8)
+        }
+        expectEmptyRepresentation(data)
+        #expect(data.count == 0)
+
+        data = Data()
+        try? data.insert(addingCount: 1, at: 0) {
+            #expect($0.freeCapacity == 1)
+            $0.append(insertedValue)
+            throw LocalError()
+        }
+        expectInlineIfLegacyABI(data)
+        #expect(data.count == 1)
+        #expect(data[0] == insertedValue)
+
+        data = Data(0..<4)
+        let count0 = data.count
+        data.insert(addingCount: 20, at: 2) {
+            #expect($0.freeCapacity == 20)
+        }
+        expectSliceIfLegacyABI(data)
+        #expect(data.count == count0)
+
+        try? data.insert(addingCount: 20, at: 2) {
+            #expect($0.freeCapacity == 20)
+            $0.append(repeating: insertedValue, count: 20, as: UInt8.self)
+            let full = $0.isFull
+            #expect(full)
+            throw LocalError()
+        }
+        expectSliceIfLegacyABI(data)
+        #expect(data.count == 24)
+        #expect(data[2] == insertedValue)
+        #expect(data.last == 3)
+
+        // Insert into the `InlineSlice` representation
+        data = Data(0..<23)
+        data.insert(addingCount: 20, at: 20) {
+            $0.append(insertedValue)
+        }
+        #expect(data.count == 24)
+        #expect(data[20] == insertedValue)
+        #expect(data.last == 22)
+        try? data.insert(addingCount: 1, at: 2) {
+            $0.append(insertedValue)
+            throw LocalError()
+        }
+        expectSliceIfLegacyABI(data)
+        #expect(data.count == 25)
+        #expect(data[2] == insertedValue)
+    }
+
+    @Test func insertWithRawSpan() {
+        var d = Data()
+        d.insert(copying: RawSpan(), at: 0)
+        #expect(d.count == 0)
+        d.edit {
+            #expect($0.freeCapacity == 0)
+        }
+
+        d.insert(copying: CollectionOfOne<UInt8>(1).span.bytes, at: 0)
+        #expect(d.count == 1)
+        #expect(d[0] == 1)
+
+        d.insert(copying: Array<UInt8>(repeating: 1, count: 100).span.bytes, at: 0)
+        #expect(d.count == 101)
+        #expect(d.allSatisfy { $0 == 1 })
+
+        d = Data()
+        d.insert(copying: Array<UInt8>(repeating: 1, count: 100).span.bytes, at: 0)
+        #expect(d.count == 100)
+        #expect(d.allSatisfy { $0 == 1 })
     }
 
     @Test func loops() {
@@ -1027,15 +1132,14 @@ private final class DataTests {
 
         // Append to the inline representation
         var data = Data()
-        print("NOW!!!")
-        data.append(addingRawCapacity: 8) {
+        data.append(addingCount: 8) {
             #expect($0.freeCapacity == 8)
         }
         expectEmptyRepresentation(data)
         #expect(data.count == 0)
 
         data = Data()
-        try? data.append(addingRawCapacity: 1) {
+        try? data.append(addingCount: 1) {
             #expect($0.freeCapacity == 1)
             $0.append(appendedValue)
             throw LocalError()
@@ -1046,13 +1150,13 @@ private final class DataTests {
 
         data = Data(0..<4)
         let count0 = data.count
-        data.append(addingRawCapacity: 20) {
+        data.append(addingCount: 20) {
             #expect($0.freeCapacity == 20)
         }
         expectSliceIfLegacyABI(data)
         #expect(data.count == count0)
 
-        try? data.append(addingRawCapacity: 20) {
+        try? data.append(addingCount: 20) {
             #expect($0.freeCapacity == 20)
             $0.append(repeating: appendedValue, count: 20, as: UInt8.self)
             let full = $0.isFull
@@ -1065,18 +1169,40 @@ private final class DataTests {
 
         // Append to the `InlineSlice` representation
         data = Data(0..<23)
-        data.append(addingRawCapacity: 20) {
+        data.append(addingCount: 20) {
           $0.append(appendedValue)
         }
         #expect(data.count == 24)
         #expect(data.last == appendedValue)
-        try? data.append(addingRawCapacity: 1) {
+        try? data.append(addingCount: 1) {
             $0.append(appendedValue)
             throw LocalError()
         }
         expectSliceIfLegacyABI(data)
         #expect(data.count == 25)
         #expect(data.last == appendedValue)
+    }
+
+    @Test func appendWithRawSpan() {
+        var d = Data()
+        d.append(copying: RawSpan())
+        #expect(d.count == 0)
+        d.edit {
+            #expect($0.freeCapacity == 0)
+        }
+
+        d.append(copying: CollectionOfOne<UInt8>(1).span.bytes)
+        #expect(d.count == 1)
+        #expect(d[0] == 1)
+
+        d.append(copying: Array<UInt8>(repeating: 1, count: 100).span.bytes)
+        #expect(d.count == 101)
+        #expect(d.allSatisfy { $0 == 1 })
+
+        d = Data()
+        d.append(copying: Array<UInt8>(repeating: 1, count: 100).span.bytes)
+        #expect(d.count == 100)
+        #expect(d.allSatisfy { $0 == 1 })
     }
 
     @Test func appendToSlicedInlineSlicesWithOutputRawSpan() {
@@ -1086,14 +1212,14 @@ private final class DataTests {
         #expect(data.count <= capacity(data))
         var slice = data[20..<80]
         #expect(slice.count <= capacity(slice))
-        slice.append(addingRawCapacity: 2) {
+        slice.append(addingCount: 2) {
             $0.append(appendedValue)
         }
         #expect(slice.last == appendedValue)
 
         slice = data[20..<80]
         _ = consume data
-        slice.append(addingRawCapacity: 2) {
+        slice.append(addingCount: 2) {
             $0.append(appendedValue)
         }
         #expect(slice.last == appendedValue)
@@ -1106,9 +1232,9 @@ private final class DataTests {
             var slice = original.suffix(1)
             #expect(slice.count == 1)
             let startCapacity = capacity(slice)
-            slice.append(addingCapacity: 25) {
+            slice.append(addingCount: 25) {
                 #expect($0.freeCapacity == 25)
-                $0.append(repeating: 1, count: 25)
+                $0.append(repeating: 1, count: 25, as: UInt8.self)
                 #expect($0.isFull == true)
             }
             #expect(capacity(slice) != startCapacity, "Appending did not trigger a reallocation")
@@ -1125,9 +1251,9 @@ private final class DataTests {
             }
             #expect(slice.count == 1)
             let startCapacity = capacity(slice)
-            slice.append(addingCapacity: 25) {
+            slice.append(addingCount: 25) {
                 #expect($0.freeCapacity == 25)
-                $0.append(repeating: 1, count: 25)
+                $0.append(repeating: 1, count: 25, as: UInt8.self)
                 #expect($0.isFull == true)
             }
             #expect(capacity(slice) != startCapacity, "Appending did not trigger a reallocation")
@@ -2380,6 +2506,147 @@ private final class DataTests {
             #expect($0.count == 5)
         }
     }
+
+    @Test func edit() {
+        var d = Data()
+        d.edit {
+            #expect($0.byteCount == 0)
+            #expect($0.freeCapacity == 0)
+        }
+
+        d = Data([1])
+        var didAppend = d.edit {
+            #expect($0.byteCount == 1)
+            if !$0.isFull {
+                $0.append(2)
+                return true
+            }
+            return false
+        }
+        if didAppend {
+            #expect(d.count == 2)
+            #expect(d == Data([1, 2]))
+        }
+
+        d = Data([1])
+        d.edit {
+            $0.removeAll()
+        }
+        #expect(d.isEmpty)
+        d.edit {
+            // Editing does not shrink allocation
+            #expect($0.byteCount == 0)
+            #expect($0.freeCapacity > 0)
+        }
+
+        d = Data(repeating: 1, count: 100)
+        didAppend = d.edit {
+            #expect($0.byteCount == 100)
+            if !$0.isFull {
+                $0.append(2)
+                return true
+            }
+            return false
+        }
+        if didAppend {
+            #expect(d.count == 101)
+            #expect(d.last == 2)
+        }
+
+        d = Data(repeating: 1, count: 100)
+        d.edit {
+            $0.removeLast(20)
+        }
+        #expect(d.count == 80)
+        d.edit {
+            #expect($0.byteCount == 80)
+            #expect($0.freeCapacity >= 20)
+            $0.removeAll()
+        }
+        #expect(d.isEmpty)
+        d.edit {
+            // Editing does not shrink allocation
+            #expect($0.byteCount == 0)
+            #expect($0.freeCapacity > 0)
+        }
+
+        d = Data(repeating: 1, count: 10)
+        #expect(throws: CocoaError.self) {
+            try d.edit {
+                var ms = $0.mutableBytes
+                ms[0] = 2
+                $0.removeLast()
+                throw CocoaError(.featureUnsupported)
+            }
+        }
+        #expect(d.count == 9)
+        #expect(d[0] == 2)
+
+        d = Data(repeating: 1, count: 100)
+        #expect(throws: CocoaError.self) {
+            try d.edit {
+                var ms = $0.mutableBytes
+                ms[0] = 2
+                $0.removeLast()
+                throw CocoaError(.featureUnsupported)
+            }
+        }
+        #expect(d.count == 99)
+        #expect(d[0] == 2)
+    }
+
+    @Test func replaceSubrangeOutputRawSpan() {
+        var d = Data()
+        try? d.replaceSubrange(0 ..< 0, addingCount: 0) {
+            #expect($0.freeCapacity == 0)
+            throw CocoaError(.featureUnsupported)
+        }
+        #expect(d.count == 0)
+        d.edit {
+            #expect($0.freeCapacity == 0)
+        }
+
+        try? d.replaceSubrange(0 ..< 0, addingCount: 5) {
+            #expect($0.freeCapacity == 5)
+            throw CocoaError(.featureUnsupported)
+        }
+        #expect(d.count == 0)
+        expectEmptyRepresentation(d)
+
+        try? d.replaceSubrange(0 ..< 0, addingCount: 5) {
+            $0.append(2)
+            throw CocoaError(.featureUnsupported)
+        }
+        #expect(d.count == 1)
+        #expect(d[0] == 2)
+
+
+        d = Data(repeating: 2, count: 10)
+        try? d.replaceSubrange(1 ..< 4, addingCount: 100) {
+            $0.append(3)
+            throw CocoaError(.featureUnsupported)
+        }
+        #expect(d.count == 8)
+        #expect(d[0] == 2)
+        #expect(d[1] == 3)
+        #expect(d[2] == 2)
+
+        d = Data(repeating: 2, count: 10)
+        try? d.replaceSubrange(1 ..< 4, addingCount: 100) {
+            $0.append(repeating: 4, count: 20, as: UInt8.self)
+            throw CocoaError(.featureUnsupported)
+        }
+        #expect(d.count == 27)
+        #expect(d[0] == 2)
+        #expect(d[1] == 4)
+
+        d = Data(repeating: 2, count: 20)
+        try? d.replaceSubrange(1 ..< 6, addingCount: 5) {
+            $0.append(repeating: 4, count: 5, as: UInt8.self)
+            throw CocoaError(.featureUnsupported)
+        }
+        #expect(d.count == 20)
+    }
 }
 
 // MARK: - Base64 Encode/Decode Tests
@@ -3396,7 +3663,7 @@ struct LargeDataTests {
     @Test func largeRepresentationOutputRawSpanInitAndAppend() throws {
         struct LocalError: Error, Equatable {}
 
-        var data = Data(rawCapacity: largeCount) {
+        var data = Data(capacity: largeCount) {
             #expect($0.freeCapacity == largeCount)
             $0.append(repeating: .max, count: $0.freeCapacity, as: UInt8.self)
         }
@@ -3404,13 +3671,13 @@ struct LargeDataTests {
         #expect(data.count == largeCount)
 
         // exercise `LargeSlice.append()`
-        data.append(addingRawCapacity: 20) {
+        data.append(addingCount: 20) {
             #expect($0.freeCapacity == 20)
             $0.append(51)
         }
         #expect(data.count == largeCount+1)
         #expect(data.last == 51)
-        try? data.append(addingRawCapacity: 10) {
+        try? data.append(addingCount: 10) {
             #expect($0.freeCapacity == 10)
             $0.append(52)
             throw LocalError()
@@ -3420,7 +3687,7 @@ struct LargeDataTests {
 
         // transform from the `InlineData` form to the `LargeSlice` form
         data = Data([1, 2, 3])
-        data.append(addingRawCapacity: largeCount) {
+        data.append(addingCount: largeCount) {
             #expect($0.freeCapacity == largeCount)
             $0.append(repeating: .max, count: $0.freeCapacity, as: UInt8.self)
         }
@@ -3429,7 +3696,7 @@ struct LargeDataTests {
 
         // transform from the `InlineSlice` form to the `LargeSlice` form
         data = Data(0..<24)
-        data.append(addingRawCapacity: largeCount) {
+        data.append(addingCount: largeCount) {
             #expect($0.freeCapacity == largeCount)
             $0.append(repeating: .max, count: $0.freeCapacity, as: UInt8.self)
         }
@@ -3445,14 +3712,14 @@ struct LargeDataTests {
         #expect(data.count <= capacity(data))
         var slice = data.dropFirst(100).dropLast(100)
         #expect(slice.count <= capacity(slice))
-        slice.append(addingRawCapacity: 2) {
+        slice.append(addingCount: 2) {
             $0.append(appendedValue)
         }
         #expect(slice.last == appendedValue)
 
         slice = data.dropFirst(100).dropLast(100)
         _ = consume data
-        slice.append(addingRawCapacity: 2) {
+        slice.append(addingCount: 2) {
             $0.append(appendedValue)
         }
         #expect(slice.last == appendedValue)
@@ -3532,9 +3799,9 @@ struct LargeDataTests {
             var slice = original.suffix(1)
             #expect(slice.count == 1)
             let startCapacity = capacity(slice)
-            slice.append(addingCapacity: 25) {
+            slice.append(addingCount: 25) {
                 #expect($0.freeCapacity == 25)
-                $0.append(repeating: 1, count: 25)
+                $0.append(repeating: 1, count: 25, as: UInt8.self)
                 #expect($0.isFull == true)
             }
             #expect(capacity(slice) != startCapacity, "Appending did not trigger a reallocation")
@@ -3551,9 +3818,9 @@ struct LargeDataTests {
             }
             #expect(slice.count == 1)
             let startCapacity = capacity(slice)
-            slice.append(addingCapacity: 25) {
+            slice.append(addingCount: 25) {
                 #expect($0.freeCapacity == 25)
-                $0.append(repeating: 1, count: 25)
+                $0.append(repeating: 1, count: 25, as: UInt8.self)
                 #expect($0.isFull == true)
             }
             #expect(capacity(slice) != startCapacity, "Appending did not trigger a reallocation")

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2551,6 +2551,9 @@ private final class DataTests {
         if didAppend {
             #expect(d.count == 101)
             #expect(d.last == 2)
+            d.withUnsafeBytes { #expect($0.count == 101) }
+            d.replaceSubrange(100 ..< 101, copying: RawSpan())
+            #expect(d.count == 100)
         }
 
         d = Data(repeating: 1, count: 100)


### PR DESCRIPTION
### Motivation:

Implements the APIs approved in SF-0042

### Modifications:

Implements the APIs approved in SF-0042

### Result:

`Data` can now be mutated using `RawSpan` and `OutputRawSpan`

### Testing:

Unit tests updated / additional unit tests added
