### PR TITLE
Validate buffer counts are non-negative in Data APIs

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -208,6 +208,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - parameter count: The number of bytes to copy.
     @inlinable // This is @inlinable as a trivial initializer.
     public init(bytes: UnsafeRawPointer, count: Int) {
+        precondition(count >= 0, "Byte count cannot be negative")
         _representation = _Representation(UnsafeRawBufferPointer(start: bytes, count: count))
     }
 
@@ -622,6 +623,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public mutating func append(_ bytes: UnsafePointer<UInt8>, count: Int) {
         if count == 0 { return }
+        precondition(count >= 0, "Byte count cannot be negative")
         _append(UnsafeBufferPointer(start: bytes, count: count))
     }
 


### PR DESCRIPTION
Add validation to Data APIs that accept separate pointer and count arguments

### Motivation:

`Unsafe(Mutable)(Raw)BufferPointer` assumes that the count is always non-negative (the compiler optimizes out any check for that). There's nothing we can do if a caller creates a malformed unsafe buffer pointer and passes it to `Data`. However, when we accept separate pointer and count arguments, we can validate the count is non-negative before forming an unsafe buffer pointer to pass to the internal `Data` functions to avoid a buffer over-read in those scenarios when `memmove` is called with a negative number.

### Modifications:

Add `precondition` checks to all public `Data` APIs that accept a separate pointer and count.

### Result:

Passing negative counts to these APIs now deterministically traps

### Testing:

`UnsafeRawBufferPointer` already traps in debug mode with non-negative pointers, and since we run tests in debug mode this already crashes in our unit tests today.
