### PR TITLE
Enforce lower bound check in inline Data.subscript(Range)

### DIFF
--- a/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
@@ -641,6 +641,7 @@ extension Data {
                     precondition(bounds.lowerBound == 0 && (bounds.upperBound - bounds.lowerBound) == 0, "Range \(bounds) out of bounds 0..<0")
                     return Data()
                 case .inline(let inline):
+                    precondition(bounds.lowerBound >= 0, "Range \(bounds) out of bounds 0..<\(inline.count)")
                     precondition(bounds.upperBound <= inline.count, "Range \(bounds) out of bounds 0..<\(inline.count)")
                     if bounds.lowerBound == 0 {
                         var newInline = inline

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2233,6 +2233,26 @@ private final class DataTests {
             var data = try #require("Hello World".data(using: .utf8))
             data[-1] = 4
         }
+
+        await #expect(processExitsWith: .failure) {
+            let data = try #require("Hello World".data(using: .utf8))
+            _ = data[-1 ..< 2]
+        }
+
+        await #expect(processExitsWith: .failure) {
+            let data = try #require("Hello World".data(using: .utf8))
+            _ = data[2 ..< 100]
+        }
+
+        await #expect(processExitsWith: .failure) {
+            var data = try #require("Hello World".data(using: .utf8))
+            data[-1 ..< 2] = Data()
+        }
+
+        await #expect(processExitsWith: .failure) {
+            var data = try #require("Hello World".data(using: .utf8))
+            data[2 ..< 100] = Data()
+        }
     }
 
     @Test func bounding_failure_copyBytesSourceOverflow() async {


### PR DESCRIPTION
Enforces a missing bounds check on the lower bound of the range passed to an inline Data's `subscript(Range)`

### Motivation:

Enforces a bounds check that was previously missing

### Modifications:

Adds the missing bounds check

### Result:

The program deterministically crashes when a negative lower bound is provided to the subscript

### Testing:

Unit tests added to `DataTests`
