### PR TITLE
Switch HAS_FOUNDATION_DARWIN_EXTRAS to canImport(_FoundationDarwinExtras)

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -25,7 +25,7 @@ import WinSDK
 import WASILibc
 #elseif os(Emscripten)
 import EmscriptenLibc
-#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+#elseif canImport(_FoundationDarwinExtras)
 internal import _FoundationDarwinExtras
 #elseif canImport(stdlib_h)
 import stdlib_h

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -53,7 +53,7 @@
 @usableFromInline let memset = EmscriptenLibc.memset
 @usableFromInline let memcpy = EmscriptenLibc.memcpy
 @usableFromInline let memcmp = EmscriptenLibc.memcmp
-#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+#elseif canImport(_FoundationDarwinExtras)
 @usableFromInline let memset = _FoundationDarwinExtras.memset
 @usableFromInline let memcpy = _FoundationDarwinExtras.memcpy
 @usableFromInline let memcmp = _FoundationDarwinExtras.memcmp
@@ -94,7 +94,7 @@ import ucrt
 @preconcurrency import WASILibc
 #elseif canImport(EmscriptenLibc)
 @preconcurrency import EmscriptenLibc
-#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+#elseif canImport(_FoundationDarwinExtras)
 internal import _FoundationDarwinExtras.POSIX.sys.mman
 #elseif canImport(string_h)
 import string_h

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -24,7 +24,7 @@ import ucrt
 @preconcurrency import EmscriptenLibc
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
-#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+#elseif canImport(_FoundationDarwinExtras)
 internal import _FoundationDarwinExtras
 #elseif canImport(stdlib_h)
 import stdlib_h
@@ -46,7 +46,7 @@ internal final class __DataStorage : @unchecked Sendable {
     #endif
 
     static func allocate(_ size: Int, _ clear: Bool) -> UnsafeMutableRawPointer? {
-#if (canImport(Darwin) || HAS_FOUNDATION_DARWIN_EXTRAS) && _pointerBitWidth(_64) && !NO_TYPED_MALLOC
+#if (canImport(Darwin) || canImport(_FoundationDarwinExtras)) && _pointerBitWidth(_64) && !NO_TYPED_MALLOC
         var typeDesc = malloc_type_descriptor_v0_t()
         typeDesc.summary.layout_semantics.contains_generic_data = true
         if clear {
@@ -64,7 +64,7 @@ internal final class __DataStorage : @unchecked Sendable {
     }
     
     static func reallocate(_ ptr: UnsafeMutableRawPointer, _ newSize: Int) -> UnsafeMutableRawPointer? {
-#if (canImport(Darwin) || HAS_FOUNDATION_DARWIN_EXTRAS)  && _pointerBitWidth(_64) && !NO_TYPED_MALLOC
+#if (canImport(Darwin) || canImport(_FoundationDarwinExtras))  && _pointerBitWidth(_64) && !NO_TYPED_MALLOC
         var typeDesc = malloc_type_descriptor_v0_t()
         typeDesc.summary.layout_semantics.contains_generic_data = true
         return malloc_type_realloc(ptr, newSize, typeDesc.type_id);

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -50,7 +50,7 @@ import C.strings
 import C
 #endif
 fileprivate let _pageSize: Int = Int(getpagesize())
-#elseif HAS_FOUNDATION_DARWIN_EXTRAS
+#elseif canImport(_FoundationDarwinExtras)
 internal import _FoundationDarwinExtras
 internal import _FoundationDarwinExtras._string_runtime.xlocale
 import stdlib_h
@@ -396,16 +396,16 @@ extension Platform {
 }
 
 extension Platform {
-    #if canImport(Darwin) || HAS_FOUNDATION_DARWIN_EXTRAS
+    #if canImport(Darwin) || canImport(_FoundationDarwinExtras)
     private static var cLocale: locale_t? { /* LC_C_LOCALE */ nil }
     #elseif os(Windows)
-    private static var cLocale: _locale_t = {
+    private static let cLocale: _locale_t = {
         _create_locale(LC_ALL, "C")
     }()
     #elseif NO_C_LOCALE
     // No C locale
     #else
-    private static var cLocale: locale_t = {
+    private static let cLocale: locale_t = {
         newlocale(_stringshims_LC_ALL_MASK(), "C", locale_t(bitPattern: 0))!
     }()
     #endif


### PR DESCRIPTION
Switches the custom define for a canImport check

### Motivation:

Rather than using a custom define to declare when the module exists / needs to be imported, we can just check canImport instead

### Modifications:

Replaces `HAS_FOUNDATION_DARWIN_EXTRAS` with `canImport(_FoundationDarwinExtras)`

### Result:

Removed reliance on a custom define

### Testing:

Validated the project still builds
