### PR TITLE
Fix month rolling, the week-of-month day range, and week-year date resolution in the Chinese and Hebrew calendars

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
@@ -548,7 +548,7 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
             let end = localMidnight(extendedYear: extendedYear + 1, ordinal: 1, day: 1, in: timeZone)
             return DateInterval(start: start, duration: end.timeIntervalSince(start))
         case .yearForWeekOfYear:
-            // Deliberate divergence from ICU: ICU's chinese calendar cannot use YEAR_WOY on the fields-to-time side (chnsecal handleGetExtendedYear never reads it), so its interval degenerates to nil and its add is a no-op. We implement the Gregorian-family week-year semantics instead, like Hebrew (precedent: Japanese .era interval). If behavior identical to ICU is ever required: return nil here and delete the yearForWeekOfYear block in date(byAdding:).
+            // Deliberate divergence from ICU: ICU's chinese calendar returns nil for this interval and no-ops an add of yearForWeekOfYear, both measured. We implement the Gregorian-family week-year semantics instead, like Hebrew (precedent: Japanese .era interval). ICU is asymmetric here, it does resolve the week-year form in date(from:), and we match that exactly. If behavior identical to ICU is ever required: return nil here and delete the yearForWeekOfYear block in date(byAdding:), and leave date(from:) as it is.
             let weekYearComps = dateComponents([.yearForWeekOfYear], from: date, in: timeZone)
             guard let weekYear = weekYearComps.yearForWeekOfYear else { return nil }
             let rdStart = firstDayOfWeekYear(weekYear)
@@ -623,12 +623,31 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
     // MARK: Date ↔ DateComponents
 
     func date(from components: DateComponents) -> Date? {
+        var secondsInDay: Double = 0
+        if let hour = components.hour { secondsInDay += Double(hour) * 3600 }
+        if let minute = components.minute { secondsInDay += Double(minute) * 60 }
+        if let second = components.second { secondsInDay += Double(second) }
+        if let nanosecond = components.nanosecond { secondsInDay += Double(nanosecond) / 1e9 }
+
+        let timeZone = components.timeZone ?? timeZone
+
+        // A request carrying yearForWeekOfYear instead of year resolves through the week-year, the way the Gregorian calendar does, so the week fields we report in dateComponents can be handed back to us. yearForWeekOfYear is an extended year for this calendar (see the field conventions note above), so it is used directly rather than combined with era; the Gregorian calendar likewise skips its era adjustment once a week is specified. The week number is not clipped to the week-year: as in the Gregorian calendar, a week past the end simply runs on into the next year.
+        if components.year == nil, let weekYear = components.yearForWeekOfYear {
+            guard weekYear > Self.extendedYearLowerBound && weekYear < Self.extendedYearUpperBound else { return nil }
+            let weekOfYear = components.weekOfYear ?? 1
+            let weekday = components.weekday ?? firstWeekday
+            let dayWithinWeek = ((weekday - firstWeekday) % 7 + 7) % 7
+            let rataDie = firstDayOfWeekYear(weekYear) + (weekOfYear - 1) * 7 + dayWithinWeek
+            return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone,
+                           repeatedTimePolicy: .former, skippedTimePolicy: .former)
+        }
+
         // Missing era defaults to the CURRENT date's era (ICU fields default from now).
         let era: Int
         if let e = components.era {
             era = e
         } else {
-            let (nowExt, _, _) = fields(for: Date.now, in: components.timeZone ?? timeZone)
+            let (nowExt, _, _) = fields(for: Date.now, in: timeZone)
             era = Self.eraAndYear(extendedYear: nowExt).era
         }
         guard let yearValue = components.year else { return nil }
@@ -655,13 +674,6 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
 
         let rataDie = y.monthStartRataDie(ordinal: ordinal) + day - 1
 
-        var secondsInDay: Double = 0
-        if let hour = components.hour { secondsInDay += Double(hour) * 3600 }
-        if let minute = components.minute { secondsInDay += Double(minute) * 60 }
-        if let second = components.second { secondsInDay += Double(second) }
-        if let nanosecond = components.nanosecond { secondsInDay += Double(nanosecond) / 1e9 }
-
-        let timeZone = components.timeZone ?? timeZone
         return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone,
                        repeatedTimePolicy: .former, skippedTimePolicy: .former)
     }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
@@ -372,7 +372,7 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
             guard let span = Self.quarterSpan(extendedYear: extendedYear, ordinal: ordinal) else { return nil }
             return Range(span.firstDisplay...span.lastDisplay)
         case (.day, .weekOfMonth):
-            // The day-of-month values this week covers, the same shape the Gregorian calendar reports. A week can start before or end after the month, so clip to the month's own day range.
+            // Which days of the month this week covers, as day-of-month values. A week can start before or end after the month, so clip both ends.
             guard let week = dateInterval(of: .weekOfMonth, for: date) else { return nil }
             let (extendedYear, ordinal, _) = fields(for: date, in: timeZone)
             let monthLength = Self.yearData(extendedYear: extendedYear).monthLength(ordinal: ordinal)
@@ -381,8 +381,7 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
             let (weekStart, _): (Int, Double) = _CalendarUtility.rataDieAndSecondsInDay(localSeconds: localSeconds)
             let firstDay = max(1, weekStart - monthStart + 1)
             let lastDay = min(monthLength, weekStart - monthStart + 7)
-            guard firstDay <= lastDay else { return nil }
-            return Range(firstDay...lastDay)
+            return firstDay..<lastDay + 1
         case (.day, .quarter):
             // ICU counts calendar days here, not 86400 s chunks, the generic interval+ordinality fallback overcounts by one in DST fall-back quarters.
             let (extendedYear, ordinal, _) = fields(for: date, in: timeZone)
@@ -548,7 +547,7 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
             let end = localMidnight(extendedYear: extendedYear + 1, ordinal: 1, day: 1, in: timeZone)
             return DateInterval(start: start, duration: end.timeIntervalSince(start))
         case .yearForWeekOfYear:
-            // Deliberate divergence from ICU: ICU's chinese calendar returns nil for this interval and no-ops an add of yearForWeekOfYear, both measured. We implement the Gregorian-family week-year semantics instead, like Hebrew (precedent: Japanese .era interval). ICU is asymmetric here, it does resolve the week-year form in date(from:), and we match that exactly. If behavior identical to ICU is ever required: return nil here and delete the yearForWeekOfYear block in date(byAdding:), and leave date(from:) as it is.
+            // The year that owns a week, which can differ from the calendar year at either end of a year. ICU returns nil here for the Chinese calendar; we deliberately return a real interval, as the Gregorian and Hebrew calendars do.
             let weekYearComps = dateComponents([.yearForWeekOfYear], from: date, in: timeZone)
             guard let weekYear = weekYearComps.yearForWeekOfYear else { return nil }
             let rdStart = firstDayOfWeekYear(weekYear)
@@ -631,15 +630,14 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
 
         let timeZone = components.timeZone ?? timeZone
 
-        // A request carrying yearForWeekOfYear instead of year resolves through the week-year, the way the Gregorian calendar does, so the week fields we report in dateComponents can be handed back to us. yearForWeekOfYear is an extended year for this calendar (see the field conventions note above), so it is used directly rather than combined with era; the Gregorian calendar likewise skips its era adjustment once a week is specified. The week number is not clipped to the week-year: as in the Gregorian calendar, a week past the end simply runs on into the next year.
+        // `.yearForWeekOfYear` plus `.weekOfYear` plus `.weekday` names a date too. `.era` is unused here because `.yearForWeekOfYear` is already an extended year. A `.weekOfYear` past the end of the year runs on into the next, as in the Gregorian calendar.
         if components.year == nil, let weekYear = components.yearForWeekOfYear {
             guard weekYear > Self.extendedYearLowerBound && weekYear < Self.extendedYearUpperBound else { return nil }
             let weekOfYear = components.weekOfYear ?? 1
             let weekday = components.weekday ?? firstWeekday
             let dayWithinWeek = ((weekday - firstWeekday) % 7 + 7) % 7
             let rataDie = firstDayOfWeekYear(weekYear) + (weekOfYear - 1) * 7 + dayWithinWeek
-            return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone,
-                           repeatedTimePolicy: .former, skippedTimePolicy: .former)
+            return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone, repeatedTimePolicy: .former, skippedTimePolicy: .former)
         }
 
         // Missing era defaults to the CURRENT date's era (ICU fields default from now).
@@ -647,8 +645,8 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
         if let e = components.era {
             era = e
         } else {
-            let (nowExt, _, _) = fields(for: Date.now, in: timeZone)
-            era = Self.eraAndYear(extendedYear: nowExt).era
+            let (nowExtendedYear, _, _) = fields(for: Date.now, in: timeZone)
+            era = Self.eraAndYear(extendedYear: nowExtendedYear).era
         }
         guard let yearValue = components.year else { return nil }
         guard let extendedYear = Self.extendedYear(era: era, year: yearValue),
@@ -813,52 +811,50 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
 
     // MARK: Adding
 
-    // How many components carry a non-zero value. The roll shortcuts below apply only when a single field is set, so they can wrap that one field and leave everything else alone.
-    private static func nonZeroComponentCount(_ c: DateComponents) -> Int {
-        var count = 0
-        if (c.era ?? 0) != 0 { count += 1 }
-        if (c.year ?? 0) != 0 { count += 1 }
-        if (c.month ?? 0) != 0 { count += 1 }
-        if (c.day ?? 0) != 0 { count += 1 }
-        if (c.hour ?? 0) != 0 { count += 1 }
-        if (c.minute ?? 0) != 0 { count += 1 }
-        if (c.second ?? 0) != 0 { count += 1 }
-        if (c.nanosecond ?? 0) != 0 { count += 1 }
-        if (c.weekday ?? 0) != 0 { count += 1 }
-        if (c.weekdayOrdinal ?? 0) != 0 { count += 1 }
-        if (c.weekOfMonth ?? 0) != 0 { count += 1 }
-        if (c.weekOfYear ?? 0) != 0 { count += 1 }
-        if (c.yearForWeekOfYear ?? 0) != 0 { count += 1 }
-        if (c.dayOfYear ?? 0) != 0 { count += 1 }
-        return count
-    }
-
     func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date? {
         var result = date
 
-        // Rolling a single field wraps it in place and never carries into a larger field.
-        if wrappingComponents, Self.nonZeroComponentCount(components) == 1 {
+        // How many fields carry a non-zero value.
+        func nonZeroFieldCount(_ c: DateComponents) -> Int {
+            var count = 0
+            if (c.era ?? 0) != 0 { count += 1 }
+            if (c.year ?? 0) != 0 { count += 1 }
+            if (c.month ?? 0) != 0 { count += 1 }
+            if (c.day ?? 0) != 0 { count += 1 }
+            if (c.hour ?? 0) != 0 { count += 1 }
+            if (c.minute ?? 0) != 0 { count += 1 }
+            if (c.second ?? 0) != 0 { count += 1 }
+            if (c.nanosecond ?? 0) != 0 { count += 1 }
+            if (c.weekday ?? 0) != 0 { count += 1 }
+            if (c.weekdayOrdinal ?? 0) != 0 { count += 1 }
+            if (c.weekOfMonth ?? 0) != 0 { count += 1 }
+            if (c.weekOfYear ?? 0) != 0 { count += 1 }
+            if (c.yearForWeekOfYear ?? 0) != 0 { count += 1 }
+            if (c.dayOfYear ?? 0) != 0 { count += 1 }
+            return count
+        }
+
+        // Wrapping changes one field only, so these shortcuts need exactly one field set.
+        if wrappingComponents, nonZeroFieldCount(components) == 1 {
             let timeZone = self.timeZone
-            if let d = components.day, d != 0 {
-                let (extendedYear, ordinal, curDay, secondsInDay) = fieldsAndTime(for: result, in: timeZone)
-                let y = Self.yearData(extendedYear: extendedYear)
-                let monthLen = y.monthLength(ordinal: ordinal)
-                let newDay = ((curDay - 1 + d) % monthLen + monthLen) % monthLen + 1
-                let rataDie = y.monthStartRataDie(ordinal: ordinal) + newDay - 1
-                return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone,
-                               repeatedTimePolicy: .former, skippedTimePolicy: .former)
+            if let dayAmount = components.day, dayAmount != 0 {
+                let (extendedYear, ordinal, currentDay, secondsInDay) = fieldsAndTime(for: result, in: timeZone)
+                let year = Self.yearData(extendedYear: extendedYear)
+                let monthLength = year.monthLength(ordinal: ordinal)
+                let newDay = ((currentDay - 1 + dayAmount) % monthLength + monthLength) % monthLength + 1
+                let rataDie = year.monthStartRataDie(ordinal: ordinal) + newDay - 1
+                return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone, repeatedTimePolicy: .former, skippedTimePolicy: .former)
             }
-            // The month wraps around this year's own month count, 12 or 13 when there is a leap month, so the year never carries. Walking months the way a plain add does would cross into the next year.
-            if let m = components.month, m != 0 {
-                let (extendedYear, ordinal, curDay, secondsInDay) = fieldsAndTime(for: result, in: timeZone)
-                let y = Self.yearData(extendedYear: extendedYear)
-                let monthCount = Int(y.monthCount)
-                let newOrdinal = ((ordinal - 1 + m) % monthCount + monthCount) % monthCount + 1
-                // A shorter target month clamps the day, matching the non-wrapping month add.
-                let clampedDay = min(curDay, y.monthLength(ordinal: newOrdinal))
-                let rataDie = y.monthStartRataDie(ordinal: newOrdinal) + clampedDay - 1
-                return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone,
-                               repeatedTimePolicy: .former, skippedTimePolicy: .former)
+            // Wraps over this year's month count, 13 in a leap year, so the year never changes. Adding without wrapping can cross into the next year.
+            if let monthAmount = components.month, monthAmount != 0 {
+                let (extendedYear, ordinal, currentDay, secondsInDay) = fieldsAndTime(for: result, in: timeZone)
+                let year = Self.yearData(extendedYear: extendedYear)
+                let monthCount = Int(year.monthCount)
+                let newOrdinal = ((ordinal - 1 + monthAmount) % monthCount + monthCount) % monthCount + 1
+                // A shorter target month clamps the day, as adding without wrapping does.
+                let clampedDay = min(currentDay, year.monthLength(ordinal: newOrdinal))
+                let rataDie = year.monthStartRataDie(ordinal: newOrdinal) + clampedDay - 1
+                return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone, repeatedTimePolicy: .former, skippedTimePolicy: .former)
             }
         }
 
@@ -931,7 +927,7 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
         if let wo = components.weekdayOrdinal { daysToAdd += wo * 7 }
         if let w = components.weekday { daysToAdd += w }
 
-        // Deliberate divergence from ICU (see dateInterval(.yearForWeekOfYear) note): ICU no-ops YEAR_WOY adds for chinese; we advance by week-years like Hebrew.
+        // Moves by whole week-years. ICU ignores this add for the Chinese calendar; see the note on `dateInterval(of: .yearForWeekOfYear)`.
         if let n = components.yearForWeekOfYear, n != 0 {
             let timeZone = self.timeZone
             let localComps = dateComponents([.yearForWeekOfYear], from: result, in: timeZone)

--- a/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
@@ -371,6 +371,18 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
             let (extendedYear, ordinal, _) = fields(for: date, in: timeZone)
             guard let span = Self.quarterSpan(extendedYear: extendedYear, ordinal: ordinal) else { return nil }
             return Range(span.firstDisplay...span.lastDisplay)
+        case (.day, .weekOfMonth):
+            // The day-of-month values this week covers, the same shape the Gregorian calendar reports. A week can start before or end after the month, so clip to the month's own day range.
+            guard let week = dateInterval(of: .weekOfMonth, for: date) else { return nil }
+            let (extendedYear, ordinal, _) = fields(for: date, in: timeZone)
+            let monthLength = Self.yearData(extendedYear: extendedYear).monthLength(ordinal: ordinal)
+            let monthStart = Self.rataDie(extendedYear: extendedYear, ordinal: ordinal, day: 1)
+            let localSeconds = week.start.timeIntervalSinceReferenceDate + Double(timeZone.secondsFromGMT(for: week.start))
+            let (weekStart, _): (Int, Double) = _CalendarUtility.rataDieAndSecondsInDay(localSeconds: localSeconds)
+            let firstDay = max(1, weekStart - monthStart + 1)
+            let lastDay = min(monthLength, weekStart - monthStart + 7)
+            guard firstDay <= lastDay else { return nil }
+            return Range(firstDay...lastDay)
         case (.day, .quarter):
             // ICU counts calendar days here, not 86400 s chunks, the generic interval+ordinality fallback overcounts by one in DST fall-back quarters.
             let (extendedYear, ordinal, _) = fields(for: date, in: timeZone)
@@ -424,7 +436,8 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
         case (.weekday, .month), (.weekdayOrdinal, .month):
             guard let day = dateComponents([.day], from: date, in: timeZone).day else { return nil }
             return (day - 1) / 7 + 1
-        case (.weekday, .weekOfYear):
+        case (.weekday, .weekOfYear), (.day, .weekOfMonth), (.weekday, .weekOfMonth):
+            // Position of the day inside its week, counting from firstWeekday.
             guard let weekday = dateComponents([.weekday], from: date, in: timeZone).weekday else { return nil }
             return ((weekday - firstWeekday + 7) % 7) + 1
         case (.hour, .day):
@@ -788,26 +801,53 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
 
     // MARK: Adding
 
+    // How many components carry a non-zero value. The roll shortcuts below apply only when a single field is set, so they can wrap that one field and leave everything else alone.
+    private static func nonZeroComponentCount(_ c: DateComponents) -> Int {
+        var count = 0
+        if (c.era ?? 0) != 0 { count += 1 }
+        if (c.year ?? 0) != 0 { count += 1 }
+        if (c.month ?? 0) != 0 { count += 1 }
+        if (c.day ?? 0) != 0 { count += 1 }
+        if (c.hour ?? 0) != 0 { count += 1 }
+        if (c.minute ?? 0) != 0 { count += 1 }
+        if (c.second ?? 0) != 0 { count += 1 }
+        if (c.nanosecond ?? 0) != 0 { count += 1 }
+        if (c.weekday ?? 0) != 0 { count += 1 }
+        if (c.weekdayOrdinal ?? 0) != 0 { count += 1 }
+        if (c.weekOfMonth ?? 0) != 0 { count += 1 }
+        if (c.weekOfYear ?? 0) != 0 { count += 1 }
+        if (c.yearForWeekOfYear ?? 0) != 0 { count += 1 }
+        if (c.dayOfYear ?? 0) != 0 { count += 1 }
+        return count
+    }
+
     func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date? {
         var result = date
 
-        // Wrap-day single-component fast path.
-        if wrappingComponents,
-           let d = components.day, d != 0,
-           (components.era ?? 0) == 0, (components.year ?? 0) == 0, (components.month ?? 0) == 0,
-           (components.weekOfYear ?? 0) == 0, (components.weekOfMonth ?? 0) == 0,
-           (components.weekdayOrdinal ?? 0) == 0, (components.weekday ?? 0) == 0,
-           (components.dayOfYear ?? 0) == 0, (components.yearForWeekOfYear ?? 0) == 0,
-           (components.hour ?? 0) == 0, (components.minute ?? 0) == 0,
-           (components.second ?? 0) == 0, (components.nanosecond ?? 0) == 0 {
+        // Rolling a single field wraps it in place and never carries into a larger field.
+        if wrappingComponents, Self.nonZeroComponentCount(components) == 1 {
             let timeZone = self.timeZone
-            let (extendedYear, ordinal, curDay, secondsInDay) = fieldsAndTime(for: result, in: timeZone)
-            let y = Self.yearData(extendedYear: extendedYear)
-            let monthLen = y.monthLength(ordinal: ordinal)
-            let newDay = ((curDay - 1 + d) % monthLen + monthLen) % monthLen + 1
-            let rataDie = y.monthStartRataDie(ordinal: ordinal) + newDay - 1
-            return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone,
-                           repeatedTimePolicy: .former, skippedTimePolicy: .former)
+            if let d = components.day, d != 0 {
+                let (extendedYear, ordinal, curDay, secondsInDay) = fieldsAndTime(for: result, in: timeZone)
+                let y = Self.yearData(extendedYear: extendedYear)
+                let monthLen = y.monthLength(ordinal: ordinal)
+                let newDay = ((curDay - 1 + d) % monthLen + monthLen) % monthLen + 1
+                let rataDie = y.monthStartRataDie(ordinal: ordinal) + newDay - 1
+                return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone,
+                               repeatedTimePolicy: .former, skippedTimePolicy: .former)
+            }
+            // The month wraps around this year's own month count, 12 or 13 when there is a leap month, so the year never carries. Walking months the way a plain add does would cross into the next year.
+            if let m = components.month, m != 0 {
+                let (extendedYear, ordinal, curDay, secondsInDay) = fieldsAndTime(for: result, in: timeZone)
+                let y = Self.yearData(extendedYear: extendedYear)
+                let monthCount = Int(y.monthCount)
+                let newOrdinal = ((ordinal - 1 + m) % monthCount + monthCount) % monthCount + 1
+                // A shorter target month clamps the day, matching the non-wrapping month add.
+                let clampedDay = min(curDay, y.monthLength(ordinal: newOrdinal))
+                let rataDie = y.monthStartRataDie(ordinal: newOrdinal) + clampedDay - 1
+                return _CalendarUtility.utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: timeZone,
+                               repeatedTimePolicy: .former, skippedTimePolicy: .former)
+            }
         }
 
         var yearsToAdd = components.year ?? 0

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -594,22 +594,17 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         if let second = components.second { secondsInDay += Double(second) }
         if let nanosecond = components.nanosecond { secondsInDay += Double(nanosecond) / 1e9 }
 
-        let tz = components.timeZone ?? timeZone
+        let resolvedTimeZone = components.timeZone ?? timeZone
 
-        // A request carrying yearForWeekOfYear instead of year resolves through the
-        // week-year, the way the Gregorian calendar does, so the week fields we report
-        // in dateComponents can be handed back to us. `firstDayOfWeekYear` already
-        // applies firstWeekday and minimumDaysInFirstWeek. The week number is not
-        // clipped to the week-year: as in the Gregorian calendar, a week past the end
-        // simply runs on into the next year.
+        // `.yearForWeekOfYear` plus `.weekOfYear` plus `.weekday` names a date too. `firstDayOfWeekYear` already accounts for `firstWeekday` and `minimumDaysInFirstWeek`. A `.weekOfYear` past the end of the year runs on into the next, as in the Gregorian calendar.
         if components.year == nil, let weekYearValue = components.yearForWeekOfYear {
+            // The Hebrew arithmetic works in Int32 years, same check as the `.year` path.
             guard weekYearValue >= Int(Int32.min) && weekYearValue <= Int(Int32.max) else { return nil }
             let weekOfYear = components.weekOfYear ?? 1
             let weekday = components.weekday ?? firstWeekday
             let dayWithinWeek = ((weekday - firstWeekday) % 7 + 7) % 7
-            let rd = firstDayOfWeekYear(Int32(weekYearValue)) &+ Int64((weekOfYear - 1) * 7 + dayWithinWeek)
-            return utcDate(fromRataDie: rd, secondsInDay: secondsInDay, in: tz,
-                          repeatedTimePolicy: .former, skippedTimePolicy: .former)
+            let rataDie = firstDayOfWeekYear(Int32(weekYearValue)) &+ Int64((weekOfYear - 1) * 7 + dayWithinWeek)
+            return utcDate(fromRataDie: rataDie, secondsInDay: secondsInDay, in: resolvedTimeZone, repeatedTimePolicy: .former, skippedTimePolicy: .former)
         }
 
         guard let yearValue = components.year else { return nil }
@@ -631,8 +626,7 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         let rd = HebrewArithmetic.fixedFromHebrew(year: year, month: biblical, day: UInt8(day))
 
         // Matches _CalendarGregorian's DST policy: skipped and repeated both resolve to .former.
-        return utcDate(fromRataDie: rd, secondsInDay: secondsInDay, in: tz,
-                      repeatedTimePolicy: .former, skippedTimePolicy: .former)
+        return utcDate(fromRataDie: rd, secondsInDay: secondsInDay, in: resolvedTimeZone, repeatedTimePolicy: .former, skippedTimePolicy: .former)
     }
 
     func dateComponents(_ components: Calendar.ComponentSet, from date: Date, in timeZone: TimeZone) -> DateComponents {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -587,6 +587,31 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
             return nil
         }
 
+        // Time-of-day in local seconds (defaults to midnight).
+        var secondsInDay: Double = 0
+        if let hour = components.hour { secondsInDay += Double(hour) * 3600 }
+        if let minute = components.minute { secondsInDay += Double(minute) * 60 }
+        if let second = components.second { secondsInDay += Double(second) }
+        if let nanosecond = components.nanosecond { secondsInDay += Double(nanosecond) / 1e9 }
+
+        let tz = components.timeZone ?? timeZone
+
+        // A request carrying yearForWeekOfYear instead of year resolves through the
+        // week-year, the way the Gregorian calendar does, so the week fields we report
+        // in dateComponents can be handed back to us. `firstDayOfWeekYear` already
+        // applies firstWeekday and minimumDaysInFirstWeek. The week number is not
+        // clipped to the week-year: as in the Gregorian calendar, a week past the end
+        // simply runs on into the next year.
+        if components.year == nil, let weekYearValue = components.yearForWeekOfYear {
+            guard weekYearValue >= Int(Int32.min) && weekYearValue <= Int(Int32.max) else { return nil }
+            let weekOfYear = components.weekOfYear ?? 1
+            let weekday = components.weekday ?? firstWeekday
+            let dayWithinWeek = ((weekday - firstWeekday) % 7 + 7) % 7
+            let rd = firstDayOfWeekYear(Int32(weekYearValue)) &+ Int64((weekOfYear - 1) * 7 + dayWithinWeek)
+            return utcDate(fromRataDie: rd, secondsInDay: secondsInDay, in: tz,
+                          repeatedTimePolicy: .former, skippedTimePolicy: .former)
+        }
+
         guard let yearValue = components.year else { return nil }
         guard yearValue >= Int(Int32.min) && yearValue <= Int(Int32.max) else { return nil }
         let year = Int32(yearValue)
@@ -605,14 +630,6 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
 
         let rd = HebrewArithmetic.fixedFromHebrew(year: year, month: biblical, day: UInt8(day))
 
-        // Time-of-day in local seconds (defaults to midnight).
-        var secondsInDay: Double = 0
-        if let hour = components.hour { secondsInDay += Double(hour) * 3600 }
-        if let minute = components.minute { secondsInDay += Double(minute) * 60 }
-        if let second = components.second { secondsInDay += Double(second) }
-        if let nanosecond = components.nanosecond { secondsInDay += Double(nanosecond) / 1e9 }
-
-        let tz = components.timeZone ?? timeZone
         // Matches _CalendarGregorian's DST policy: skipped and repeated both resolve to .former.
         return utcDate(fromRataDie: rd, secondsInDay: secondsInDay, in: tz,
                       repeatedTimePolicy: .former, skippedTimePolicy: .former)

--- a/Tests/FoundationEssentialsTests/ChineseCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/ChineseCalendarTests.swift
@@ -115,14 +115,11 @@ private struct ChineseCalendarTests {
         #expect(c.maximumRange(of: .weekOfYear) == 1..<56)
     }
 
-    // Deliberate divergence from ICU, guarded: ICU's chinese calendar returns nil for the yearForWeekOfYear interval and no-ops an add of it, so we implement Gregorian-family week-year semantics instead (precedent: the Japanese calendar's .era interval). ICU is asymmetric here, it does resolve the week-year form in date(from:), which dateFromWeekYearComponents pins against ICU's own answers. If this test is changed to expect nil/no-op, that reversion must be an explicit decision.
-    @Test func weekYearSemantics() {
+    // ICU returns nil for this interval and ignores the add; we deliberately do neither. Changing these to expect nil is a behaviour change, not a fix.
+    @Test func weekYearSemantics() throws {
         let c = Self.chineseCalendar()
         let d = Self.date(rataDie: _CalendarAstronomy.gregorianRataDie(2025, 7, 4))
-        guard let interval = c.dateInterval(of: .yearForWeekOfYear, for: d) else {
-            #expect(Bool(false), "week-year interval must not be nil")
-            return
-        }
+        let interval = try #require(c.dateInterval(of: .yearForWeekOfYear, for: d), "the yearForWeekOfYear interval must not be nil")
         #expect(interval.start <= d && d < interval.end)
         let next = c.dateInterval(of: .yearForWeekOfYear, for: interval.end + 43_200)
         #expect(next?.start == interval.end)
@@ -167,60 +164,61 @@ private struct ChineseCalendarTests {
         }
     }
 
-    // A roll wraps the month inside its own year and never carries into the year, and it wraps around this year's own month count, 12 or 13 when there is a leap month. Regression: the wrapping path had a branch for .day but none for .month, so a roll fell through to the month walk a plain add uses, and that walk crosses year boundaries.
-    @Test func rollMonthWrapsWithinYear() {
+    // Rolling `.month` wraps over the year's month count, 13 in a leap year, and never changes the year.
+    // (relatedISOYear, expected month count, roll amount, expected month afterwards)
+    @Test(arguments: [
+        (2024, UInt8(12), 11, 2), (2024, UInt8(12), 12, 3), (2024, UInt8(12), -1, 2), (2024, UInt8(12), -11, 4),
+        (2025, UInt8(13), 11, 1), (2025, UInt8(13), 13, 3), (2025, UInt8(13), -1, 2), (2025, UInt8(13), -11, 5),
+    ])
+    func rollMonthWrapsWithinYear(iso: Int, monthCount: UInt8, amount: Int, wantMonth: Int) throws {
         let c = Self.chineseCalendar()
-        // (relatedISOYear, expected month count, roll amount, expected month afterwards)
-        let cases: [(Int, UInt8, Int, Int)] = [
-            (2024, 12, 11, 2), (2024, 12, 12, 3), (2024, 12, -1, 2), (2024, 12, -11, 4),
-            (2025, 13, 11, 1), (2025, 13, 13, 3), (2025, 13, -1, 2), (2025, 13, -11, 5),
-        ]
-        for (iso, monthCount, amount, wantMonth) in cases {
-            let y = _CalendarChinese.year(relatedISOYear: iso)
-            #expect(y.monthCount == monthCount, "fixture \(iso): month count is \(y.monthCount)")
-            let from = Self.date(rataDie: y.monthStartRataDie(ordinal: 3) + 4)   // ordinal month 3, day 5
-            let before = c.dateComponents([.year, .month, .day], from: from, in: .gmt)
-            var dc = DateComponents()
-            dc.month = amount
-            guard let rolled = c.date(byAdding: dc, to: from, wrappingComponents: true) else {
-                #expect(Bool(false), "\(iso) roll by \(amount) returned nil")
-                continue
-            }
-            let after = c.dateComponents([.year, .month, .day], from: rolled, in: .gmt)
-            #expect(after.year == before.year, "\(iso) roll by \(amount) changed the year, \(before.year ?? -1) to \(after.year ?? -1)")
-            #expect(after.month == wantMonth, "\(iso) roll by \(amount): month \(after.month ?? -1), wanted \(wantMonth)")
-            #expect(after.day == 5, "\(iso) roll by \(amount): day \(after.day ?? -1)")
-        }
-        // The same amount as a plain add does carry into the next year. That difference is the whole point of the wrapping branch, so pin it too.
-        let y = _CalendarChinese.year(relatedISOYear: 2024)
-        let from = Self.date(rataDie: y.monthStartRataDie(ordinal: 3) + 4)
+        let year = _CalendarChinese.year(relatedISOYear: iso)
+        #expect(year.monthCount == monthCount, "fixture \(iso): month count is \(year.monthCount)")
+        let from = Self.date(rataDie: year.monthStartRataDie(ordinal: 3) + 4)   // ordinal month 3, day 5
+        let before = c.dateComponents([.year, .month, .day], from: from, in: .gmt)
         var dc = DateComponents()
-        dc.month = 11
-        let added = c.date(byAdding: dc, to: from, wrappingComponents: false)
-        let before = c.dateComponents([.year], from: from, in: .gmt)
-        let after = added.map { c.dateComponents([.year, .month], from: $0, in: .gmt) }
-        #expect(after?.year == (before.year ?? 0) + 1 && after?.month == 2,
-                "add of 11 months: y\(after?.year ?? -1)/m\(after?.month ?? -1)")
+        dc.month = amount
+        let rolled = try #require(c.date(byAdding: dc, to: from, wrappingComponents: true), "\(iso) roll by \(amount) returned nil")
+        let after = c.dateComponents([.year, .month, .day], from: rolled, in: .gmt)
+        #expect(after.year == before.year, "\(iso) roll by \(amount) changed the year, \(before.year ?? -1) to \(after.year ?? -1)")
+        #expect(after.month == wantMonth, "\(iso) roll by \(amount): month \(after.month ?? -1), wanted \(wantMonth)")
+        #expect(after.day == 5, "\(iso) roll by \(amount): day \(after.day ?? -1)")
     }
 
-    // range(of: .day, in: .weekOfMonth) reports the day-of-month values the week covers, clipped to the month at both ends because a week can start before the month or run past its end. Regression: the (.day, .weekOfMonth) pair was missing from ordinality, so the generic range fallback gave up on the first lookup and returned nil.
-    @Test func dayRangeInWeekOfMonth() {
+    // The same amount added without wrapping does change the year.
+    @Test func addMonthWithoutWrappingCarriesIntoTheYear() throws {
         let c = Self.chineseCalendar()
-        let y = _CalendarChinese.year(relatedISOYear: 2024)   // 12 months, new year Feb 10; firstWeekday is Sunday here
-        // (ordinal month, day of month, expected range)
-        let cases: [(Int, Int, Range<Int>)] = [
-            (1, 1, 1..<2),      // the month starts on a Saturday, so its first week holds a single day
-            (1, 15, 9..<16),    // a whole week, clipped at neither end
-            (3, 1, 1..<6),      // first week, clipped by the month start
-            (2, 30, 29..<31),   // last week, clipped by the month end
-            (3, 29, 27..<30),   // last week, clipped by the month end
-        ]
-        for (ordinal, day, want) in cases {
-            let d = Self.date(rataDie: y.monthStartRataDie(ordinal: ordinal) + day - 1)
-            let got = c.range(of: .day, in: .weekOfMonth, for: d)
-            #expect(got == want, "ordinal \(ordinal) day \(day): \(got.map { "\($0)" } ?? "nil"), wanted \(want)")
-        }
-        // The invariant behind those pins: never nil, always inside the month, always covering the day itself. Three decades is enough to hit every weekday alignment, both month lengths and a dozen leap months.
+        let year = _CalendarChinese.year(relatedISOYear: 2024)
+        let from = Self.date(rataDie: year.monthStartRataDie(ordinal: 3) + 4)
+        var dc = DateComponents()
+        dc.month = 11
+        let added = try #require(c.date(byAdding: dc, to: from, wrappingComponents: false))
+        let before = c.dateComponents([.year], from: from, in: .gmt)
+        let after = c.dateComponents([.year, .month], from: added, in: .gmt)
+        #expect(after.year == (before.year ?? 0) + 1 && after.month == 2, "add of 11 months: y\(after.year ?? -1)/m\(after.month ?? -1)")
+    }
+
+    // Which days of the month the week covers, clipped to the month at both ends.
+    // Related ISO year 2024 has 12 months and starts on Feb 10; firstWeekday here is Sunday.
+    // (ordinal month, day of month, expected range)
+    @Test(arguments: [
+        (1, 1, 1..<2),      // the month starts on a Saturday, so its first week holds a single day
+        (1, 15, 9..<16),    // a whole week, clipped at neither end
+        (3, 1, 1..<6),      // first week, clipped by the month start
+        (2, 30, 29..<31),   // last week, clipped by the month end
+        (3, 29, 27..<30),   // last week, clipped by the month end
+    ])
+    func dayRangeInWeekOfMonth(ordinal: Int, day: Int, want: Range<Int>) {
+        let c = Self.chineseCalendar()
+        let year = _CalendarChinese.year(relatedISOYear: 2024)
+        let date = Self.date(rataDie: year.monthStartRataDie(ordinal: ordinal) + day - 1)
+        let got = c.range(of: .day, in: .weekOfMonth, for: date)
+        #expect(got == want, "ordinal \(ordinal) day \(day): \(got.map { "\($0)" } ?? "nil"), wanted \(want)")
+    }
+
+    // The range is never nil, sits inside the month, and covers the day itself. Three decades covers every weekday alignment and both month lengths.
+    @Test func dayRangeInWeekOfMonthInvariants() {
+        let c = Self.chineseCalendar()
         var failures: [String] = []
         for iso in 2000...2030 {
             let year = _CalendarChinese.year(relatedISOYear: iso)
@@ -228,27 +226,27 @@ private struct ChineseCalendarTests {
                 let length = year.monthLength(ordinal: ordinal)
                 let start = year.monthStartRataDie(ordinal: ordinal)
                 for day in 1...length {
-                    let d = Self.date(rataDie: start + day - 1)
-                    guard let r = c.range(of: .day, in: .weekOfMonth, for: d) else {
+                    let date = Self.date(rataDie: start + day - 1)
+                    guard let range = c.range(of: .day, in: .weekOfMonth, for: date) else {
                         failures.append("\(iso)/o\(ordinal)/d\(day): nil range")
                         continue
                     }
-                    if r.isEmpty || r.lowerBound < 1 || r.upperBound > length + 1 || !r.contains(day) {
-                        failures.append("\(iso)/o\(ordinal)/d\(day): \(r) in a \(length) day month")
+                    if range.isEmpty || range.lowerBound < 1 || range.upperBound > length + 1 || !range.contains(day) {
+                        failures.append("\(iso)/o\(ordinal)/d\(day): \(range) in a \(length) day month")
                     }
-                    guard let o = c.ordinality(of: .day, in: .weekOfMonth, for: d) else {
+                    guard let ordinality = c.ordinality(of: .day, in: .weekOfMonth, for: date) else {
                         failures.append("\(iso)/o\(ordinal)/d\(day): nil ordinality")
                         continue
                     }
-                    if o < 1 || o > 7 { failures.append("\(iso)/o\(ordinal)/d\(day): ordinality \(o)") }
+                    if ordinality < 1 || ordinality > 7 { failures.append("\(iso)/o\(ordinal)/d\(day): ordinality \(ordinality)") }
                 }
             }
         }
         #expect(failures.isEmpty, "\(failures.count) failures, first few: \(failures.prefix(5))")
     }
 
-    // A date can be named by yearForWeekOfYear + weekOfYear + weekday instead of era + year + month + day, and `date(from:)` has to accept that form. It used to require `.year` and returned nil for anything else. Note that yearForWeekOfYear is an extended year here, not a cycle year, so it is used directly and `era` is ignored on this path; ICU does the same. Expected values below were checked against the ICU-backed calendar and agree with it exactly.
-    @Test func dateFromWeekYearComponents() {
+    // `.yearForWeekOfYear` here is an extended year, so `era` is unused. Expected values taken from the ICU-backed calendar.
+    @Test func dateFromWeekYearComponents() throws {
         let c = Self.chineseCalendar()
         // (yearForWeekOfYear, weekOfYear, weekday, expected era, year, month, day)
         let cases: [(Int, Int, Int, Int, Int, Int, Int)] = [
@@ -267,10 +265,7 @@ private struct ChineseCalendarTests {
             dc.hour = 12
             dc.timeZone = .gmt
 
-            guard let date = c.date(from: dc) else {
-                #expect(Bool(false), "date(from:) returned nil for yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday)")
-                continue
-            }
+            let date = try #require(c.date(from: dc), "date(from:) returned nil for yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday)")
             let back = c.dateComponents([.era, .year, .month, .day, .weekday, .hour], from: date, in: .gmt)
             #expect(back.era == wantEra && back.year == wantYear && back.month == wantMonth
                     && back.day == wantDay && back.weekday == weekday && back.hour == 12,
@@ -278,13 +273,11 @@ private struct ChineseCalendarTests {
         }
     }
 
-    // The invariant behind those pins: whatever week fields we report for a date, handing them back has to return that same date. Runs over 20 years of consecutive days, and over non-default firstWeekday and minimumDaysInFirstWeek, because the week-year anchor depends on both.
+    // Week fields read from a date must return that date when passed back. `firstWeekday` and `minimumDaysInFirstWeek` are varied because the first week of a year depends on both.
     @Test func weekYearComponentsRoundTrip() {
         var failures: [String] = []
         for (firstWeekday, minimumDays) in [(nil, nil), (2, 4), (7, 1), (4, 7)] as [(Int?, Int?)] {
-            let c = _CalendarChinese(identifier: .chinese, timeZone: .gmt, locale: nil,
-                                     firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDays,
-                                     gregorianStartDate: nil)
+            let c = _CalendarChinese(identifier: .chinese, timeZone: .gmt, locale: nil, firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDays, gregorianStartDate: nil)
             let config = "fw \(firstWeekday.map(String.init) ?? "default")/md \(minimumDays.map(String.init) ?? "default")"
             var rataDie = _CalendarAstronomy.gregorianRataDie(2000, 1, 1)
             let end = _CalendarAstronomy.gregorianRataDie(2019, 12, 31)

--- a/Tests/FoundationEssentialsTests/ChineseCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/ChineseCalendarTests.swift
@@ -115,7 +115,7 @@ private struct ChineseCalendarTests {
         #expect(c.maximumRange(of: .weekOfYear) == 1..<56)
     }
 
-    // Deliberate divergence from ICU, guarded: ICU's chinese calendar cannot use YEAR_WOY on the fields-to-time side (chnsecal handleGetExtendedYear ignores it), yielding a nil interval and a no-op add; we implement Gregorian-family week-year semantics instead (precedent: the Japanese calendar's .era interval). If this test is changed to expect nil/no-op, that reversion must be an explicit decision.
+    // Deliberate divergence from ICU, guarded: ICU's chinese calendar returns nil for the yearForWeekOfYear interval and no-ops an add of it, so we implement Gregorian-family week-year semantics instead (precedent: the Japanese calendar's .era interval). ICU is asymmetric here, it does resolve the week-year form in date(from:), which dateFromWeekYearComponents pins against ICU's own answers. If this test is changed to expect nil/no-op, that reversion must be an explicit decision.
     @Test func weekYearSemantics() {
         let c = Self.chineseCalendar()
         let d = Self.date(rataDie: _CalendarAstronomy.gregorianRataDie(2025, 7, 4))
@@ -242,6 +242,68 @@ private struct ChineseCalendarTests {
                     }
                     if o < 1 || o > 7 { failures.append("\(iso)/o\(ordinal)/d\(day): ordinality \(o)") }
                 }
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) failures, first few: \(failures.prefix(5))")
+    }
+
+    // A date can be named by yearForWeekOfYear + weekOfYear + weekday instead of era + year + month + day, and `date(from:)` has to accept that form. It used to require `.year` and returned nil for anything else. Note that yearForWeekOfYear is an extended year here, not a cycle year, so it is used directly and `era` is ignored on this path; ICU does the same. Expected values below were checked against the ICU-backed calendar and agree with it exactly.
+    @Test func dateFromWeekYearComponents() {
+        let c = Self.chineseCalendar()
+        // (yearForWeekOfYear, weekOfYear, weekday, expected era, year, month, day)
+        let cases: [(Int, Int, Int, Int, Int, Int, Int)] = [
+            (5779, 16, 2, 97, 19, 4, 15),
+            (5779, 1, 1, 97, 18, 12, 28),   // week 1 begins in the previous calendar year
+            (5779, 30, 7, 97, 19, 8, 1),
+            (5780, 52, 4, 97, 21, 1, 7),    // a week past the end of the week-year runs on, it is not clamped
+            (4656, 10, 6, 78, 36, 3, 8),
+            (4651, 38, 5, 78, 31, 9, 23),
+        ]
+        for (weekYear, weekOfYear, weekday, wantEra, wantYear, wantMonth, wantDay) in cases {
+            var dc = DateComponents()
+            dc.yearForWeekOfYear = weekYear
+            dc.weekOfYear = weekOfYear
+            dc.weekday = weekday
+            dc.hour = 12
+            dc.timeZone = .gmt
+
+            guard let date = c.date(from: dc) else {
+                #expect(Bool(false), "date(from:) returned nil for yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday)")
+                continue
+            }
+            let back = c.dateComponents([.era, .year, .month, .day, .weekday, .hour], from: date, in: .gmt)
+            #expect(back.era == wantEra && back.year == wantYear && back.month == wantMonth
+                    && back.day == wantDay && back.weekday == weekday && back.hour == 12,
+                    "yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday): got e\(back.era ?? -1)/y\(back.year ?? -1)/m\(back.month ?? -1)/d\(back.day ?? -1) wd\(back.weekday ?? -1), wanted e\(wantEra)/y\(wantYear)/m\(wantMonth)/d\(wantDay) wd\(weekday)")
+        }
+    }
+
+    // The invariant behind those pins: whatever week fields we report for a date, handing them back has to return that same date. Runs over 20 years of consecutive days, and over non-default firstWeekday and minimumDaysInFirstWeek, because the week-year anchor depends on both.
+    @Test func weekYearComponentsRoundTrip() {
+        var failures: [String] = []
+        for (firstWeekday, minimumDays) in [(nil, nil), (2, 4), (7, 1), (4, 7)] as [(Int?, Int?)] {
+            let c = _CalendarChinese(identifier: .chinese, timeZone: .gmt, locale: nil,
+                                     firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDays,
+                                     gregorianStartDate: nil)
+            let config = "fw \(firstWeekday.map(String.init) ?? "default")/md \(minimumDays.map(String.init) ?? "default")"
+            var rataDie = _CalendarAstronomy.gregorianRataDie(2000, 1, 1)
+            let end = _CalendarAstronomy.gregorianRataDie(2019, 12, 31)
+            while rataDie <= end {
+                let date = Self.date(rataDie: rataDie)
+                let read = c.dateComponents([.era, .yearForWeekOfYear, .weekOfYear, .weekday, .hour], from: date, in: .gmt)
+                var dc = DateComponents()
+                dc.era = read.era
+                dc.yearForWeekOfYear = read.yearForWeekOfYear
+                dc.weekOfYear = read.weekOfYear
+                dc.weekday = read.weekday
+                dc.hour = read.hour
+                dc.timeZone = .gmt
+                if let back = c.date(from: dc) {
+                    if back != date { failures.append("\(config) rd \(rataDie): off by \(back.timeIntervalSince(date) / 86400) days") }
+                } else {
+                    failures.append("\(config) rd \(rataDie): nil")
+                }
+                rataDie += 1
             }
         }
         #expect(failures.isEmpty, "\(failures.count) failures, first few: \(failures.prefix(5))")

--- a/Tests/FoundationEssentialsTests/ChineseCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/ChineseCalendarTests.swift
@@ -166,4 +166,84 @@ private struct ChineseCalendarTests {
             #expect((dc.day ?? 0) >= 1, "\(gy)-\(gm)-\(gd)")
         }
     }
+
+    // A roll wraps the month inside its own year and never carries into the year, and it wraps around this year's own month count, 12 or 13 when there is a leap month. Regression: the wrapping path had a branch for .day but none for .month, so a roll fell through to the month walk a plain add uses, and that walk crosses year boundaries.
+    @Test func rollMonthWrapsWithinYear() {
+        let c = Self.chineseCalendar()
+        // (relatedISOYear, expected month count, roll amount, expected month afterwards)
+        let cases: [(Int, UInt8, Int, Int)] = [
+            (2024, 12, 11, 2), (2024, 12, 12, 3), (2024, 12, -1, 2), (2024, 12, -11, 4),
+            (2025, 13, 11, 1), (2025, 13, 13, 3), (2025, 13, -1, 2), (2025, 13, -11, 5),
+        ]
+        for (iso, monthCount, amount, wantMonth) in cases {
+            let y = _CalendarChinese.year(relatedISOYear: iso)
+            #expect(y.monthCount == monthCount, "fixture \(iso): month count is \(y.monthCount)")
+            let from = Self.date(rataDie: y.monthStartRataDie(ordinal: 3) + 4)   // ordinal month 3, day 5
+            let before = c.dateComponents([.year, .month, .day], from: from, in: .gmt)
+            var dc = DateComponents()
+            dc.month = amount
+            guard let rolled = c.date(byAdding: dc, to: from, wrappingComponents: true) else {
+                #expect(Bool(false), "\(iso) roll by \(amount) returned nil")
+                continue
+            }
+            let after = c.dateComponents([.year, .month, .day], from: rolled, in: .gmt)
+            #expect(after.year == before.year, "\(iso) roll by \(amount) changed the year, \(before.year ?? -1) to \(after.year ?? -1)")
+            #expect(after.month == wantMonth, "\(iso) roll by \(amount): month \(after.month ?? -1), wanted \(wantMonth)")
+            #expect(after.day == 5, "\(iso) roll by \(amount): day \(after.day ?? -1)")
+        }
+        // The same amount as a plain add does carry into the next year. That difference is the whole point of the wrapping branch, so pin it too.
+        let y = _CalendarChinese.year(relatedISOYear: 2024)
+        let from = Self.date(rataDie: y.monthStartRataDie(ordinal: 3) + 4)
+        var dc = DateComponents()
+        dc.month = 11
+        let added = c.date(byAdding: dc, to: from, wrappingComponents: false)
+        let before = c.dateComponents([.year], from: from, in: .gmt)
+        let after = added.map { c.dateComponents([.year, .month], from: $0, in: .gmt) }
+        #expect(after?.year == (before.year ?? 0) + 1 && after?.month == 2,
+                "add of 11 months: y\(after?.year ?? -1)/m\(after?.month ?? -1)")
+    }
+
+    // range(of: .day, in: .weekOfMonth) reports the day-of-month values the week covers, clipped to the month at both ends because a week can start before the month or run past its end. Regression: the (.day, .weekOfMonth) pair was missing from ordinality, so the generic range fallback gave up on the first lookup and returned nil.
+    @Test func dayRangeInWeekOfMonth() {
+        let c = Self.chineseCalendar()
+        let y = _CalendarChinese.year(relatedISOYear: 2024)   // 12 months, new year Feb 10; firstWeekday is Sunday here
+        // (ordinal month, day of month, expected range)
+        let cases: [(Int, Int, Range<Int>)] = [
+            (1, 1, 1..<2),      // the month starts on a Saturday, so its first week holds a single day
+            (1, 15, 9..<16),    // a whole week, clipped at neither end
+            (3, 1, 1..<6),      // first week, clipped by the month start
+            (2, 30, 29..<31),   // last week, clipped by the month end
+            (3, 29, 27..<30),   // last week, clipped by the month end
+        ]
+        for (ordinal, day, want) in cases {
+            let d = Self.date(rataDie: y.monthStartRataDie(ordinal: ordinal) + day - 1)
+            let got = c.range(of: .day, in: .weekOfMonth, for: d)
+            #expect(got == want, "ordinal \(ordinal) day \(day): \(got.map { "\($0)" } ?? "nil"), wanted \(want)")
+        }
+        // The invariant behind those pins: never nil, always inside the month, always covering the day itself. Three decades is enough to hit every weekday alignment, both month lengths and a dozen leap months.
+        var failures: [String] = []
+        for iso in 2000...2030 {
+            let year = _CalendarChinese.year(relatedISOYear: iso)
+            for ordinal in 1...Int(year.monthCount) {
+                let length = year.monthLength(ordinal: ordinal)
+                let start = year.monthStartRataDie(ordinal: ordinal)
+                for day in 1...length {
+                    let d = Self.date(rataDie: start + day - 1)
+                    guard let r = c.range(of: .day, in: .weekOfMonth, for: d) else {
+                        failures.append("\(iso)/o\(ordinal)/d\(day): nil range")
+                        continue
+                    }
+                    if r.isEmpty || r.lowerBound < 1 || r.upperBound > length + 1 || !r.contains(day) {
+                        failures.append("\(iso)/o\(ordinal)/d\(day): \(r) in a \(length) day month")
+                    }
+                    guard let o = c.ordinality(of: .day, in: .weekOfMonth, for: d) else {
+                        failures.append("\(iso)/o\(ordinal)/d\(day): nil ordinality")
+                        continue
+                    }
+                    if o < 1 || o > 7 { failures.append("\(iso)/o\(ordinal)/d\(day): ordinality \(o)") }
+                }
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) failures, first few: \(failures.prefix(5))")
+    }
 }

--- a/Tests/FoundationEssentialsTests/HebrewCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/HebrewCalendarTests.swift
@@ -110,8 +110,8 @@ private struct HebrewCalendarTests {
         }
     }
 
-    // A date can be named by yearForWeekOfYear + weekOfYear + weekday instead of year + month + day, and `date(from:)` has to accept that form. It used to require `.year` and returned nil for anything else, which made `NSCalendar dateWithEra:yearForWeekOfYear:weekOfYear:weekday:...` return nil. Expected values below were checked against the ICU-backed calendar and agree with it exactly.
-    @Test func dateFromWeekYearComponents() {
+    // Expected values taken from the ICU-backed calendar.
+    @Test func dateFromWeekYearComponents() throws {
         let cal = makeCalendar()
         // (yearForWeekOfYear, weekOfYear, weekday, expected year, month, day)
         let cases: [(Int, Int, Int, Int, Int, Int)] = [
@@ -131,10 +131,7 @@ private struct HebrewCalendarTests {
             dc.hour = 12
             dc.timeZone = .gmt
 
-            guard let date = cal.date(from: dc) else {
-                Issue.record("date(from:) returned nil for yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday)")
-                continue
-            }
+            let date = try #require(cal.date(from: dc), "date(from:) returned nil for yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday)")
             let back = cal.dateComponents([.year, .month, .day, .weekday, .hour], from: date, in: .gmt)
             let label = "yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday)"
             #expect(back.year == wantYear, "\(label): year \(String(describing: back.year)), wanted \(wantYear)")
@@ -145,13 +142,11 @@ private struct HebrewCalendarTests {
         }
     }
 
-    // The invariant behind those pins: whatever week fields we report for a date, handing them back has to return that same date. Runs over 20 years of consecutive days, and over non-default firstWeekday and minimumDaysInFirstWeek, because the week-year anchor depends on both.
+    // Week fields read from a date must return that date when passed back. `firstWeekday` and `minimumDaysInFirstWeek` are varied because the first week of a year depends on both.
     @Test func weekYearComponentsRoundTrip() {
         var failures: [String] = []
         for (firstWeekday, minimumDays) in [(nil, nil), (2, 4), (7, 1), (4, 7)] as [(Int?, Int?)] {
-            let cal = _CalendarHebrew(identifier: .hebrew, timeZone: .gmt, locale: nil,
-                                      firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDays,
-                                      gregorianStartDate: nil)
+            let cal = _CalendarHebrew(identifier: .hebrew, timeZone: .gmt, locale: nil, firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDays, gregorianStartDate: nil)
             let config = "fw \(firstWeekday.map(String.init) ?? "default")/md \(minimumDays.map(String.init) ?? "default")"
             // Midday on 2001-01-01 GMT, then one step per day.
             let start = Date(timeIntervalSinceReferenceDate: 43_200)

--- a/Tests/FoundationEssentialsTests/HebrewCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/HebrewCalendarTests.swift
@@ -110,4 +110,69 @@ private struct HebrewCalendarTests {
         }
     }
 
+    // A date can be named by yearForWeekOfYear + weekOfYear + weekday instead of year + month + day, and `date(from:)` has to accept that form. It used to require `.year` and returned nil for anything else, which made `NSCalendar dateWithEra:yearForWeekOfYear:weekOfYear:weekday:...` return nil. Expected values below were checked against the ICU-backed calendar and agree with it exactly.
+    @Test func dateFromWeekYearComponents() {
+        let cal = makeCalendar()
+        // (yearForWeekOfYear, weekOfYear, weekday, expected year, month, day)
+        let cases: [(Int, Int, Int, Int, Int, Int)] = [
+            (5779, 16, 2, 5779, 4, 16),
+            (5779, 1, 1, 5778, 13, 29),   // week 1 begins in the previous calendar year
+            (5779, 30, 7, 5779, 8, 1),
+            (5780, 52, 4, 5781, 1, 5),    // a week past the end of the week-year runs on, it is not clamped
+            (4656, 10, 6, 4656, 3, 8),
+            (4651, 38, 5, 4651, 10, 21),
+        ]
+        for (weekYear, weekOfYear, weekday, wantYear, wantMonth, wantDay) in cases {
+            var dc = DateComponents()
+            dc.era = 0
+            dc.yearForWeekOfYear = weekYear
+            dc.weekOfYear = weekOfYear
+            dc.weekday = weekday
+            dc.hour = 12
+            dc.timeZone = .gmt
+
+            guard let date = cal.date(from: dc) else {
+                Issue.record("date(from:) returned nil for yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday)")
+                continue
+            }
+            let back = cal.dateComponents([.year, .month, .day, .weekday, .hour], from: date, in: .gmt)
+            let label = "yWoY \(weekYear) woY \(weekOfYear) weekday \(weekday)"
+            #expect(back.year == wantYear, "\(label): year \(String(describing: back.year)), wanted \(wantYear)")
+            #expect(back.month == wantMonth, "\(label): month \(String(describing: back.month)), wanted \(wantMonth)")
+            #expect(back.day == wantDay, "\(label): day \(String(describing: back.day)), wanted \(wantDay)")
+            #expect(back.weekday == weekday, "\(label): weekday \(String(describing: back.weekday))")
+            #expect(back.hour == 12, "\(label): hour \(String(describing: back.hour))")
+        }
+    }
+
+    // The invariant behind those pins: whatever week fields we report for a date, handing them back has to return that same date. Runs over 20 years of consecutive days, and over non-default firstWeekday and minimumDaysInFirstWeek, because the week-year anchor depends on both.
+    @Test func weekYearComponentsRoundTrip() {
+        var failures: [String] = []
+        for (firstWeekday, minimumDays) in [(nil, nil), (2, 4), (7, 1), (4, 7)] as [(Int?, Int?)] {
+            let cal = _CalendarHebrew(identifier: .hebrew, timeZone: .gmt, locale: nil,
+                                      firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDays,
+                                      gregorianStartDate: nil)
+            let config = "fw \(firstWeekday.map(String.init) ?? "default")/md \(minimumDays.map(String.init) ?? "default")"
+            // Midday on 2001-01-01 GMT, then one step per day.
+            let start = Date(timeIntervalSinceReferenceDate: 43_200)
+            for dayOffset in 0..<(20 * 365) {
+                let date = start + Double(dayOffset) * 86400
+                let read = cal.dateComponents([.era, .yearForWeekOfYear, .weekOfYear, .weekday, .hour], from: date, in: .gmt)
+                var dc = DateComponents()
+                dc.era = read.era
+                dc.yearForWeekOfYear = read.yearForWeekOfYear
+                dc.weekOfYear = read.weekOfYear
+                dc.weekday = read.weekday
+                dc.hour = read.hour
+                dc.timeZone = .gmt
+                guard let back = cal.date(from: dc) else {
+                    failures.append("\(config) day \(dayOffset): nil")
+                    continue
+                }
+                if back != date { failures.append("\(config) day \(dayOffset): off by \(back.timeIntervalSince(date) / 86400) days") }
+            }
+        }
+        #expect(failures.isEmpty, "\(failures.count) failures, first few: \(failures.prefix(5))")
+    }
+
 }


### PR DESCRIPTION
Fixes two independent Chinese calendar bugs: a month roll that carried into the year, and a nil day range within a week of the month.

### Motivation:

Both showed up when running the Chinese calendar against a larger test suite.

### Modifications:

`date(byAdding:to:wrappingComponents:)` had a wrapping branch for `.day` but none for `.month`, so a month roll fell through to the same month walk a plain add uses, and that walk crosses year boundaries. Added a `.month` wrapping branch that wraps the month's ordinal position over the year's own month count, 12 or 13,.

  `date(from:)` in both calendars required `.year` and had no week of year path, so handing back the week fields `dateComponents` had just reported returned nil.  Added a week year branch built on the `firstDayOfWeekYear` helper both calendars already had, so the first week rule is reused rather than reimplemented. It is only taken when `.year` is absent, so nothing that already worked changes. For the Chinese calendar `yearForWeekOfYear` is an extended year rather than a cycle year, so it is used directly.

### Result:

`(.day, .weekOfMonth)` was not a case in ordinality, so the generic range fallback gave up on its first lookup and returned nil. Added that pair, and (.weekday, .weekOfMonth), to the existing case that computes a day's position inside its week

### Testing:

Six new tests across ChineseCalendarTests and HebrewCalendarTests, all confirmed to fail on the unfixed source and to pass with the fix.
