### PR TITLE
Honor `repeatedTimePolicy` when matching nanoseconds

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -2370,13 +2370,7 @@ extension Calendar {
             return nil
         }
 
-        // Substituting nanoseconds is arithmetic on the absolute time scale, so do it
-        // directly instead of decomposing into date components and resolving them
-        // again. Within a repeated hour, one set of wall clock components maps to two
-        // instants and date(from:) always picks the first, which would discard the
-        // occurrence that dateAfterMatchingHour selected via repeatedTimePolicy.
-        // This also avoids treating nanoseconds like seconds and iterating over them,
-        // which causes a hang. <rdar://problem/30229247>
+        // Substitute nanoseconds on the absolute time scale, instead of decomposing into date components and resolving them again. Within a repeated hour, one set of wall clock components maps to two instants. date(from:) always picks the first, which would discard the occurrence that dateAfterMatchingHour selected via repeatedTimePolicy. This also avoids treating nanoseconds like seconds and iterating over them, which causes a hang. <rdar://problem/30229247>
         guard let secondRange = dateInterval(of: .second, for: startingAt) else {
             return nil
         }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -2370,11 +2370,18 @@ extension Calendar {
             return nil
         }
 
-        // This taken directly from the old algorithm.  We don't have great support for nanoseconds in general and trying to treat them like seconds causes a hang. :-/
-        // <rdar://problem/30229247>
-        var dateComp = _dateComponents(.init(.era, .year, .month, .day, .hour, .minute, .second), from: startingAt)
-        dateComp.nanosecond = nanosecond
-        return date(from: dateComp)
+        // Substituting nanoseconds is arithmetic on the absolute time scale, so do it
+        // directly instead of decomposing into date components and resolving them
+        // again. Within a repeated hour, one set of wall clock components maps to two
+        // instants and date(from:) always picks the first, which would discard the
+        // occurrence that dateAfterMatchingHour selected via repeatedTimePolicy.
+        // This also avoids treating nanoseconds like seconds and iterating over them,
+        // which causes a hang. <rdar://problem/30229247>
+        guard let secondRange = dateInterval(of: .second, for: startingAt) else {
+            return nil
+        }
+
+        return secondRange.start + Double(nanosecond) / 1_000_000_000
     }
 
     // MARK: -

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -526,15 +526,12 @@ private struct CalendarTests {
         #expect(result?.timeIntervalSinceReferenceDate == 657967500)
     }
 
-    /// Matches 01:20:00 on the day daylight saving time ends in Los Angeles, when
-    /// that local time occurs twice: once at -0700 and again an hour later at -0800.
+    /// Matches 01:20:00 on the day daylight saving time ends in Los Angeles, when that local time occurs twice: once at -0700 and again an hour later at -0800.
     private func firstDateMatchingRepeatedHour(nanosecond: Int?, _ repeatedTimePolicy: Calendar.RepeatedTimePolicy, _ direction: Calendar.SearchDirection = .forward) throws -> Date? {
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
 
-        // 2024-11-02T01:26:40-0700 going forward, 2024-11-04T01:20:00-0800 going
-        // backward. Both are outside the repeated hour, so the first match lands
-        // inside it either way.
+        // 2024-11-02T01:26:40-0700 going forward, 2024-11-04T01:20:00-0800 going backward. Both are outside the repeated hour, so the first match lands inside it either way.
         let start = Date(timeIntervalSince1970: direction == .forward ? 1730536000.0 : 1730712000.0)
 
         var dc = DateComponents()
@@ -547,9 +544,7 @@ private struct CalendarTests {
         return iterator.next()
     }
 
-    /// `nanosecond` must not change which occurrence is selected, and a non-zero
-    /// value must be applied on top of it rather than truncated away. The `nil`
-    /// case already behaved correctly and guards against regressing it.
+    /// `nanosecond` must not change which occurrence is selected, and a non-zero value must be applied on top of it rather than truncated away. The `nil` case already behaved correctly and guards against regressing it.
     @Test(arguments: [(nil as Int?, 0.0), (0, 0.0), (500_000_000, 0.5)])
     func datesByMatchingRepeatedTimePolicyWithNanosecond(nanosecond: Int?, fraction: TimeInterval) throws {
         let earlier = Date(timeIntervalSince1970: 1730622000.0) // 2024-11-03T01:20:00-0700
@@ -559,9 +554,7 @@ private struct CalendarTests {
         #expect(try firstDateMatchingRepeatedHour(nanosecond: nanosecond, .last) == later + fraction)
     }
 
-    /// Which occurrence each policy selects when searching backwards is existing
-    /// behavior that this test deliberately does not pin down. What it does require
-    /// is that setting `nanosecond` never changes the answer.
+    /// Which occurrence each policy selects when searching backwards is existing behavior that this test deliberately does not pin down. What it does require is that setting `nanosecond` never changes the answer.
     @Test(arguments: [Calendar.RepeatedTimePolicy.first, .last])
     func datesByMatchingRepeatedTimePolicyWithNanosecondBackward(policy: Calendar.RepeatedTimePolicy) throws {
         let reference = try #require(try firstDateMatchingRepeatedHour(nanosecond: nil, policy, .backward))
@@ -570,8 +563,7 @@ private struct CalendarTests {
         #expect(try firstDateMatchingRepeatedHour(nanosecond: 500_000_000, policy, .backward) == reference + 0.5)
     }
 
-    /// Guards the backward test against passing vacuously: the two policies must
-    /// actually disagree, otherwise no repeated hour was involved.
+    /// Guards the backward test against passing vacuously: the two policies must actually disagree, otherwise no repeated hour was involved.
     @Test func datesByMatchingRepeatedTimePolicyDiffersByPolicyBackward() throws {
         let first = try firstDateMatchingRepeatedHour(nanosecond: nil, .first, .backward)
         let last = try firstDateMatchingRepeatedHour(nanosecond: nil, .last, .backward)

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -526,6 +526,58 @@ private struct CalendarTests {
         #expect(result?.timeIntervalSinceReferenceDate == 657967500)
     }
 
+    /// Matches 01:20:00 on the day daylight saving time ends in Los Angeles, when
+    /// that local time occurs twice: once at -0700 and again an hour later at -0800.
+    private func firstDateMatchingRepeatedHour(nanosecond: Int?, _ repeatedTimePolicy: Calendar.RepeatedTimePolicy, _ direction: Calendar.SearchDirection = .forward) throws -> Date? {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+
+        // 2024-11-02T01:26:40-0700 going forward, 2024-11-04T01:20:00-0800 going
+        // backward. Both are outside the repeated hour, so the first match lands
+        // inside it either way.
+        let start = Date(timeIntervalSince1970: direction == .forward ? 1730536000.0 : 1730712000.0)
+
+        var dc = DateComponents()
+        dc.hour = 1
+        dc.minute = 20
+        dc.second = 0
+        dc.nanosecond = nanosecond
+
+        var iterator = cal.dates(byMatching: dc, startingAt: start, matchingPolicy: .strict, repeatedTimePolicy: repeatedTimePolicy, direction: direction).makeIterator()
+        return iterator.next()
+    }
+
+    /// `nanosecond` must not change which occurrence is selected, and a non-zero
+    /// value must be applied on top of it rather than truncated away. The `nil`
+    /// case already behaved correctly and guards against regressing it.
+    @Test(arguments: [(nil as Int?, 0.0), (0, 0.0), (500_000_000, 0.5)])
+    func datesByMatchingRepeatedTimePolicyWithNanosecond(nanosecond: Int?, fraction: TimeInterval) throws {
+        let earlier = Date(timeIntervalSince1970: 1730622000.0) // 2024-11-03T01:20:00-0700
+        let later = Date(timeIntervalSince1970: 1730625600.0)   // 2024-11-03T01:20:00-0800
+
+        #expect(try firstDateMatchingRepeatedHour(nanosecond: nanosecond, .first) == earlier + fraction)
+        #expect(try firstDateMatchingRepeatedHour(nanosecond: nanosecond, .last) == later + fraction)
+    }
+
+    /// Which occurrence each policy selects when searching backwards is existing
+    /// behavior that this test deliberately does not pin down. What it does require
+    /// is that setting `nanosecond` never changes the answer.
+    @Test(arguments: [Calendar.RepeatedTimePolicy.first, .last])
+    func datesByMatchingRepeatedTimePolicyWithNanosecondBackward(policy: Calendar.RepeatedTimePolicy) throws {
+        let reference = try #require(try firstDateMatchingRepeatedHour(nanosecond: nil, policy, .backward))
+
+        #expect(try firstDateMatchingRepeatedHour(nanosecond: 0, policy, .backward) == reference)
+        #expect(try firstDateMatchingRepeatedHour(nanosecond: 500_000_000, policy, .backward) == reference + 0.5)
+    }
+
+    /// Guards the backward test against passing vacuously: the two policies must
+    /// actually disagree, otherwise no repeated hour was involved.
+    @Test func datesByMatchingRepeatedTimePolicyDiffersByPolicyBackward() throws {
+        let first = try firstDateMatchingRepeatedHour(nanosecond: nil, .first, .backward)
+        let last = try firstDateMatchingRepeatedHour(nanosecond: nil, .last, .backward)
+        #expect(first != last)
+    }
+
     @Test func dayInWeekOfMonth() {
         let cal = Calendar(identifier: .chinese)
         // A very specific date for which we know a call into ICU produces an unusual result


### PR DESCRIPTION
Fix `Calendar.dates(byMatching:)` returning the wrong occurrence of a repeated hour when `DateComponents.nanosecond` is set.

### Motivation:

Resolves #483 (rdar://124640028).

`Calendar.enumerateDates` and `Calendar.dates(byMatching:)` accept a `repeatedTimePolicy` that chooses which occurrence to return when a wall clock time happens twice, at the end of daylight saving time. The policy is honored when `DateComponents.nanosecond` is `nil` and silently ignored when it is set to any value, including `0`, so callers that spell out every time component always get the earlier occurrence.

```swift
var cal = Calendar(identifier: .gregorian)
cal.timeZone = TimeZone(identifier: "America/Los_Angeles")!

var dc = DateComponents()
dc.hour = 1; dc.minute = 20; dc.second = 0
dc.nanosecond = 0   // remove this line and the result is correct

let start = Date(timeIntervalSince1970: 1730536000.0)  // 2024-11-02T01:26:40-0700
var iterator = cal.dates(byMatching: dc, startingAt: start,
                         matchingPolicy: .strict, repeatedTimePolicy: .last).makeIterator()

// expected 2024-11-03T01:20:00-0800, got 2024-11-03T01:20:00-0700
```

### Modifications:

`dateAfterMatchingHour` already applies the policy, so by the time the nanosecond step runs the candidate is the correct instant. `dateAfterMatchingNanosecond` then decomposed it into era/year/month/day/hour/minute/second, set the nanoseconds, and resolved the whole thing again through `date(from:)`. Inside a repeated hour one set of wall clock components maps to two instants and `date(from:)` always resolves to the earlier one, so the selected occurrence could not survive the round trip — the choice simply is not encoded in the components.

Substituting a nanosecond value is arithmetic on the absolute time scale rather than a calendrical operation, so the function now truncates to the start of the containing second and adds the nanoseconds. This matches the neighboring helpers: `dateAfterMatchingSecond` already truncates with `dateInterval(of: .second, for:)`, and none of them round-trip through `date(from:)`.

### Result:

`repeatedTimePolicy` is honored regardless of whether `nanosecond` is set. The fix is calendar- and timezone-agnostic, needs no public API change, and removes a `date(from:)` call from the enumeration path. Behavior outside repeated hours is unchanged.

### Testing:

Three tests added to `CalendarTests`, all around the DST transition in `America/Los_Angeles` on 2024-11-03, where local 01:20 occurs twice.

The forward test is parameterized over `nanosecond` of `nil`, `0` and `500_000_000` paired with the sub-second offset each should produce, and pins both policies to their expected instants. The `nil` case passes before the change and guards against regressing the already-working path; the `.last` cases with `nanosecond` set are the bug.

Searching backwards, the same round trip misroutes `.first` rather than `.last`. Which occurrence each policy selects in that direction is pre-existing behavior that looks surprising on its own, so rather than pin it down the backward test asserts the property this change is actually about: setting `nanosecond` must not change which instant is selected. It is parameterized over both policies and compares against the `nanosecond: nil` result. A third test asserts the two policies disagree, so the second cannot pass vacuously.

Full `FoundationEssentials`, `FoundationInternationalization` and `FoundationMacros` suites pass on Linux (1584 tests, `swiftlang/swift:nightly-main-jammy`).
