### PR TITLE
Relax NotificationCenterMessage async test timeout

### DIFF
--- a/Tests/FoundationEssentialsTests/NotificationCenterMessageTests.swift
+++ b/Tests/FoundationEssentialsTests/NotificationCenterMessageTests.swift
@@ -126,7 +126,7 @@ extension NotificationCenter.MessageIdentifier where Self == NotificationCenter.
 }
 #endif
 
-@Suite("NotificationCenterMessage", .timeLimit(.minutes(1)))
+@Suite("NotificationCenterMessage", .timeLimit(.minutes(2)))
 private struct NotificationCenterMessageTests {
 
     // MARK: - Basic capabilities (using MainActorMessage)


### PR DESCRIPTION
Simple change extending the async timeouts for `NotificationCenter.Message` tests from 1 minute to 2 minutes.

### Motivation:

These tests may fail on busy CI, producing false failures.

### Modifications:

One-liner change to the timeout value for only one test suite.

### Result:

`swift-testing` timeout for each test within the suite will be 2 minutes.

### Testing:

N/A