### PR TITLE
 `truncatingIfNeeded` silently wraps large DateComponents amounts

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1934,7 +1934,7 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
 
             var unitLength = 0.0
             var keepHourInvariant = false
-            var newAmount = Int32(truncatingIfNeeded: amount)
+            var newAmount = Int32(clamping: amount)
             switch field {
             case UCAL_MILLISECOND, UCAL_MILLISECONDS_IN_DAY:
                 unitLength = 1.0
@@ -2016,9 +2016,9 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
             return result
         } else {
             if wrap {
-                ucal_roll(ucalendar, field, Int32(truncatingIfNeeded: amount), &status)
+                ucal_roll(ucalendar, field, Int32(clamping: amount), &status)
             } else {
-                ucal_add(ucalendar, field, Int32(truncatingIfNeeded: amount), &status)
+                ucal_add(ucalendar, field, Int32(clamping: amount), &status)
             }
 
             let result = ucal_getMillis(ucalendar, &status)

--- a/Tests/FoundationInternationalizationTests/CalendarICUTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarICUTests.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationInternationalization
+@testable import FoundationEssentials
+#endif
+
+@Suite("Calendar ICU", .tags(.calendar))
+private struct CalendarICUTests {
+
+    private var icuGregorianGMTCalendar:  _CalendarICU {
+        _CalendarICU(
+            identifier: .gregorian,
+            timeZone: .gmt,
+            locale: nil,
+            firstWeekday: nil,
+            minimumDaysInFirstWeek: nil,
+            gregorianStartDate: nil
+        )
+    }
+#if _pointerBitWidth(_64) // These tests require Int to be Int64
+    @Test func addingDayBeyondInt32Range() throws {
+        let cal = icuGregorianGMTCalendar
+        let base = Date(timeIntervalSinceReferenceDate: 0)
+
+        let dc = DateComponents(day: Int(Int32.max) + 1)
+
+        let result = cal.date(byAdding: dc, to: base, wrappingComponents: false)
+        let out = try #require(result)
+
+        #expect(out >= base, "adding a positive day amount must not move the date backward")
+    }
+
+    @Test func addingSecondsBeyondInt32Range() throws {
+        let cal = icuGregorianGMTCalendar
+        let base = Date(timeIntervalSinceReferenceDate: 0)
+
+        let dc = DateComponents(second: 1 << 32)
+        let result = cal.date(byAdding: dc, to: base, wrappingComponents: false)
+        let out = try #require(result)
+        #expect(abs(out.timeIntervalSince(base)) > 1.0, "adding 2^32 seconds must not be a no-op: \(out), \(base)")
+    }
+
+    @Test func addingSecondsIsMonotonicAcrossInt32Boundary() throws {
+        let cal = icuGregorianGMTCalendar
+        let base = Date(timeIntervalSinceReferenceDate: 0)
+
+        let small = DateComponents(second: Int(Int32.max))
+        let big = DateComponents(second: Int(Int32.max) + 2)
+        let resultSmall = cal.date(byAdding: small, to: base, wrappingComponents: false)
+        let resultBig = cal.date(byAdding: big, to: base, wrappingComponents: false)
+        let outSmall = try #require(resultSmall)
+        let outBig = try #require(resultBig)
+        #expect(outBig >= outSmall, "adding a larger positive amount must not produce an earlier date")
+    }
+#endif
+}


### PR DESCRIPTION
Change `truncatingIfNeeded` to `clamping` when passing in an `Int` to ICU API that takes an `Int32` to avoid wrapping a positive number into a negative one.
    
183389674
