### PR TITLE
Enable additional availability diagnostics

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,10 @@ let availabilityMacros: [SwiftSetting] = versionNumbers.flatMap { version in
     }
 }
 
+let availabilityCheckingSettings: [SwiftSetting] = [
+    .unsafeFlags(["-library-level", "api", "-Xfrontend", "-require-explicit-availability=ignore"], .when(platforms: [.macOS]))
+]
+
 let featureSettings: [SwiftSetting] = [
     .enableExperimentalFeature("StrictConcurrency"),
     .enableExperimentalFeature("ImportMacroAliases"),
@@ -153,8 +157,8 @@ let package = Package(
             .enableExperimentalFeature("AllowUnsafeAttribute"),
             .enableExperimentalFeature("BuiltinModule"),
             .enableExperimentalFeature("AccessLevelOnImport"),
-            .define("DATA_LEGACY_ABI", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS]))
-          ] + availabilityMacros + featureSettings,
+            .define("DATA_LEGACY_ABI", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS])),
+          ] + availabilityMacros + featureSettings + availabilityCheckingSettings,
           linkerSettings: [
             .linkedLibrary("wasi-emulated-getpid", .when(platforms: [.wasi])),
           ]
@@ -180,7 +184,7 @@ let package = Package(
             swiftSettings: [
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .enableExperimentalFeature("Lifetimes"),
-            ] + availabilityMacros + featureSettings
+            ] + availabilityMacros + featureSettings + availabilityCheckingSettings
         ),
         .target(
             name: "FoundationInternationalization",
@@ -204,7 +208,7 @@ let package = Package(
             swiftSettings: [
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .enableExperimentalFeature("Lifetimes"),
-            ] + availabilityMacros + featureSettings
+            ] + availabilityMacros + featureSettings + availabilityCheckingSettings
         ),
         
         .testTarget(

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -350,7 +350,7 @@ extension AttributedString.Runs: BidirectionalCollection {
     
     @_alwaysEmitIntoClient
     public func distance(from start: Index, to end: Index) -> Int {
-        #if FOUNDATION_FRAMEWORK
+        #if FOUNDATION_FRAMEWORK || os(macOS)
         if #available(macOS 26, iOS 26, tvOS 26, watchOS 26, visionOS 26, *) {
             _distance(from: start, to: end)
         } else {
@@ -378,7 +378,7 @@ extension AttributedString.Runs: BidirectionalCollection {
 
     @_alwaysEmitIntoClient
     public func index(_ i: Index, offsetBy distance: Int) -> Index {
-    #if FOUNDATION_FRAMEWORK
+    #if FOUNDATION_FRAMEWORK || os(macOS)
         if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
             return _index(i, offsetBy: distance)
         }

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -30,7 +30,7 @@ extension String {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     @_alwaysEmitIntoClient
     public init(_ characters: AttributedString.CharacterView) {
-        #if FOUNDATION_FRAMEWORK
+        #if FOUNDATION_FRAMEWORK || os(macOS)
         guard #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) else {
             // Forward to the slice overload above, which somehow did end up shipping in
             // the original AttributedString release.


### PR DESCRIPTION
Enables additional diagnostics to catch availability related issues with inlined code

### Motivation:

In https://github.com/swiftlang/swift-foundation/pull/2160/changes#r3761786438 I realized that I had added code that is inlined into clients but uses other APIs with higher availability without an availability guard. The compiler did not diagnose this because the SwiftPM build does not build with the API library level by default. It'd be great to catch these issues earlier since they represent real errors in the Foundation.framework build which is built with the API library level.

### Modifications:

- Build with `-library-level API` when building on macOS
- Build with `-require-explicit-availability=ignore` to suppress warnings about types without availability. Types available on macOS without availability are generally a bug since all new types on that platform need availability. However, there are a few types that are built in the macOS package build in addition to non-Darwin but do not build in `FOUNDATION_FRAMEWORK`. These types are needed because in `FOUNDATION_FRAMEWORK` they come from ObjC headers which don't exist in the package build, but since they only ship on non-Darwin they don't have availability. To avoid warnings on these types, we disable that checking. (examples of these types include the `class FileManager`, `class ProcessInfo`, etc.)
- Updated 2 places where the macOS build calls APIs from inlined code without an availability check (`FOUNDATION_FRAMEWORK` already had the availability check, so I just extended that to the macOS package build)

### Result:

Writing inlinable code without necessary availability checks is now a compiler error

### Testing:

Validated the package still builds with this change, and validated the package with my changes from #2160 without the fix fail to build
