### PR TITLE
Fix build failure in SortComparatorBenchmarks

### DIFF
--- a/Benchmarks/Benchmarks/SortComparator/BenchmarkSortComparator.swift
+++ b/Benchmarks/Benchmarks/SortComparator/BenchmarkSortComparator.swift
@@ -41,7 +41,6 @@ fileprivate struct Entry {
     fileprivate let _computedProperty: Double?
     /// Computed property: exercises the key-path getter (no stored-field offset).
     var computedProperty: Double? { _computedProperty }
-    let id: UUID
 }
 
 /// The same fields as `Entry`, but a `final class`, so the element is a
@@ -57,7 +56,6 @@ fileprivate final class EntryObject: Sendable {
     let str2: String
     private let _computedProperty: Double?
     var computedProperty: Double? { _computedProperty }
-    let id: UUID
 
     init(_ e: Entry) {
         int0 = e.int0
@@ -68,7 +66,6 @@ fileprivate final class EntryObject: Sendable {
         str1 = e.str1
         str2 = e.str2
         _computedProperty = e.computedProperty
-        id = e.id
     }
 }
 
@@ -191,8 +188,7 @@ private func makeEntries(count: Int) -> [Entry] {
             str0: randomString(using: &rng),
             str1: stringPool[Int(rng.next() % UInt64(stringPool.count))],
             str2: randomString(using: &rng),
-            _computedProperty: computed,
-            id: UUID.random(using: &rng)))
+            _computedProperty: computed))
     }
     return entries
 }


### PR DESCRIPTION
Removes an API usage with availability from the benchmark to allow it to build

### Motivation:

#2094 introduced a new SortComparatorBenchmarks target which fails to build in the default configuration on macOS because it uses an API unavailable on all deployment targets.

### Modifications:

Removed the usage of the API since it wasn't needed (it doesn't look like it was used) to allow the target to build

### Result:

The benchmark package builds on macOS successfully with no env vars set

### Testing:

Validated the build locally