### PR TITLE
Use empty UUID in SortComparatorBenchmark

### DIFF
--- a/Benchmarks/Benchmarks/SortComparator/BenchmarkSortComparator.swift
+++ b/Benchmarks/Benchmarks/SortComparator/BenchmarkSortComparator.swift
@@ -41,6 +41,7 @@ fileprivate struct Entry {
     fileprivate let _computedProperty: Double?
     /// Computed property: exercises the key-path getter (no stored-field offset).
     var computedProperty: Double? { _computedProperty }
+    // Not used in comparisons directly, but used to have Entry contain a resilient type instead of all frozen types
     let id: UUID
 }
 
@@ -192,7 +193,7 @@ private func makeEntries(count: Int) -> [Entry] {
             str1: stringPool[Int(rng.next() % UInt64(stringPool.count))],
             str2: randomString(using: &rng),
             _computedProperty: computed,
-            id: UUID.random(using: &rng)))
+            id: UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))))
     }
     return entries
 }

--- a/Benchmarks/Benchmarks/SortComparator/BenchmarkSortComparator.swift
+++ b/Benchmarks/Benchmarks/SortComparator/BenchmarkSortComparator.swift
@@ -41,6 +41,7 @@ fileprivate struct Entry {
     fileprivate let _computedProperty: Double?
     /// Computed property: exercises the key-path getter (no stored-field offset).
     var computedProperty: Double? { _computedProperty }
+    let id: UUID
 }
 
 /// The same fields as `Entry`, but a `final class`, so the element is a
@@ -56,6 +57,7 @@ fileprivate final class EntryObject: Sendable {
     let str2: String
     private let _computedProperty: Double?
     var computedProperty: Double? { _computedProperty }
+    let id: UUID
 
     init(_ e: Entry) {
         int0 = e.int0
@@ -66,6 +68,7 @@ fileprivate final class EntryObject: Sendable {
         str1 = e.str1
         str2 = e.str2
         _computedProperty = e.computedProperty
+        id = e.id
     }
 }
 
@@ -188,7 +191,8 @@ private func makeEntries(count: Int) -> [Entry] {
             str0: randomString(using: &rng),
             str1: stringPool[Int(rng.next() % UInt64(stringPool.count))],
             str2: randomString(using: &rng),
-            _computedProperty: computed))
+            _computedProperty: computed,
+            id: UUID.random(using: &rng)))
     }
     return entries
 }


### PR DESCRIPTION
Followup to the conversation in #2174 to re-add the UUID property but initialize it to all zeroes to preserve the non-resilient behavior while avoiding the API with availability
