### PR TITLE
Name the documented arguments the way the declarations name them

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
@@ -179,9 +179,9 @@ extension AttributedString.Guts {
     ///
     /// Note: this should be called _before_ the mutation takes place.
     ///
-    /// - Parameter range: The UTF-8 range in which the mutation will take place.
+    /// - Parameter utf8Range: The UTF-8 range in which the mutation will take place.
     /// - Returns: The UTF-8 range that was modified during this invalidation.
-    ///     (If no modification took place, then the result is `range`.)
+    ///     (If no modification took place, then the result is `utf8Range`.)
     func enforceAttributeConstraintsBeforeMutation(to utf8Range: Range<Int>) -> Range<Int> {
         var utf8Start = utf8Range.lowerBound
         var utf8End = utf8Range.upperBound
@@ -245,7 +245,7 @@ extension AttributedString.Guts {
     
     /// Adjusts any attributes constrained to specified run boundaries based on a mutation that has taken place. Note: this should be called _after_ the mutation takes place
     /// - Parameters:
-    ///   - range: The UTF-8 range in which the mutation has taken place (this range should be based on the resulting string)
+    ///   - utf8Range: The UTF-8 range in which the mutation has taken place (this range should be based on the resulting string)
     ///   - type: The type of mutation that was applied. Either attributes-only (eg. `attrStr.foregroundColor = .blue`) or a combination of attributes and characters (eg. `attrStr.characters[idx] = "A"` or `attrStr.replaceSubrange(range, with: otherStr)`).
     ///   - constraintsInvolved: A list of run boundary constraints for attributes involved in the mutation. This is used as a performance shortcut when very few attributes are mutated, and `nil` can be used when the information is not quickly accessible from the caller.
     func enforceAttributeConstraintsAfterMutation(

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -1902,7 +1902,7 @@ extension EncodingError {
     ///
     ///
     /// - parameter value: The value that was invalid to encode.
-    /// - parameter path: The path of `CodingKey`s taken to encode this value.
+    /// - parameter codingPath: The path of `CodingKey`s taken to encode this value.
     /// - returns: An `EncodingError` with the appropriate path and debug description.
     fileprivate static func _invalidFloatingPointValue<T : FloatingPoint>(_ value: T, at codingPath: [CodingKey]) -> EncodingError {
         let valueDescription: String

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -1442,7 +1442,7 @@ extension EncodingError {
     ///
     ///
     /// - parameter value: The value that was invalid to encode.
-    /// - parameter path: The path of `CodingKey`s taken to encode this value.
+    /// - parameter codingPath: The path of `CodingKey`s taken to encode this value.
     /// - returns: An `EncodingError` with the appropriate path and debug description.
     fileprivate static func _invalidFloatingPointValue<T : FloatingPoint>(_ value: T, at codingPath: [CodingKey]) -> EncodingError {
         let valueDescription: String


### PR DESCRIPTION
### Motivation:

4 doc comments name an argument that the declaration below them does not have, so DocC has nothing to bind the description to and drops it. Nothing warns about this: Swift has no equivalent of `-Wdocumentation`, and DocC stays silent rather than complaining

### Modifications:

`AttributedStringAttributeConstrainingBehavior` documents `range` twice. `enforceAttributeConstraintsBeforeMutation(to utf8Range:)` and `enforceAttributeConstraintsAfterMutation(in utf8Range:, ...)` both take `utf8Range`, and `range` matches neither the label nor the name. The `- Returns` line of the first one said "the result is `range`" too, so it came along and the block reads consistently

`_invalidFloatingPointValue(_ value:, at codingPath:)` documents `path` while the argument is `codingPath`. The same function sits in both `JSONDecoder.swift` and `JSONEncoder.swift`, which is what a verbatim copy of a file does to a mistake in it, so it is wrong in both

### Result:

The parameter descriptions reach the generated documentation. Comments only, no API change

### Testing:

Nothing to test, no code path changed. What I did check is the count: a pass over the tree reported these 4 before and 0 after, and the number of doc entries that bind to a real argument went from 1179 to 1183, which is the 4 renames and nothing else

btw these came out of a checker I wrote for exactly this, run over the tree and then read one by one