### PR TITLE
Relax the other NotificationCenterMessage async test suite timeout

### DIFF
--- a/Tests/FoundationEssentialsTests/NotificationCenterTests.swift
+++ b/Tests/FoundationEssentialsTests/NotificationCenterTests.swift
@@ -17,7 +17,7 @@ import Testing
 
 fileprivate final class TestObject: Sendable {}
 
-@Suite("NotificationCenter", .timeLimit(.minutes(1)))
+@Suite("NotificationCenter", .timeLimit(.minutes(2)))
 private struct NotificationCenterTests {
     @Test func defaultCenter() {
         let defaultCenter1 = NotificationCenter.default


### PR DESCRIPTION
Simple change extending the other async timeout for `NotificationCenter.Message` tests from 1 minute to 2 minutes, similar to https://github.com/swiftlang/swift-foundation/pull/2169.

### Motivation:

These tests may fail on busy CI, producing false failures.

### Modifications:

One-liner change to the timeout value for only one test suite.

### Result:

`swift-testing` timeout for each test within the suite will be 2 minutes.

### Testing:

N/A