### PR TITLE
Correct the time separator in the `ISO8601FormatStyle` doc examples

### DIFF
--- a/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
@@ -34,7 +34,7 @@ extension Date {
     /// ```swift
     /// let now = Date()
     /// print(now.formatted(Date.ISO8601FormatStyle().dateSeparator(.dash)))
-    /// // 2021-06-21T211015Z
+    /// // 2021-06-21T21:10:15Z
     /// ```
     ///
     ///
@@ -184,12 +184,12 @@ extension Date {
         /// ```swift
         /// let aDate = Date()
         /// print(aDate.formatted(Date.ISO8601FormatStyle(dateSeparator: .omitted, dateTimeSeparator: .standard)))
-        /// // 20210622T172132Z
+        /// // 20210622T17:21:32Z
         ///
         /// if let centralStandardTimeZone = TimeZone(identifier: "CST") {
         ///    print(aDate.formatted(Date.ISO8601FormatStyle(dateSeparator: .dash, dateTimeSeparator: .space, timeZone: centralStandardTimeZone)))
         /// }
-        /// // 2021-06-22 122132-0500
+        /// // 2021-06-22 12:21:32-0500
         /// ```
         ///
         /// - Parameters:


### PR DESCRIPTION
### Motivation:

`timeSeparator` defaults to `.colon`, so a formatted ISO 8601 time contains colons. Three examples in `Date+ISO8601FormatStyle.swift` print it without them:

| Documented | Actual |
|---|---|
| `2021-06-21T211015Z` | `2021-06-21T21:10:15Z` |
| `20210622T172132Z` | `20210622T17:21:32Z` |
| `2021-06-22 122132-0500` | `2021-06-22 12:21:32-0500` |

The summary a few lines above the first one already shows the correct form, `2024-04-01T12:34:56.789Z`, so the comment contradicts itself. Someone opening Quick Help to see what the default output looks like gets the opposite.

### Modifications:

The three expected outputs in the doc comments. Nothing else.

### Result:

No functional change.

### Testing:

Ran the three examples with a fixed date and compared the result against each comment. The output depends only on the default value of `timeSeparator`, not on locale or ICU data.
