### PR TITLE
Resolve `weekOfMonth` when neither day nor weekday is given

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -148,6 +148,8 @@ enum ResolvedDateComponents {
             self = .dayOfYear(year: year, dayOfYear: dayOfYear)
         } else if components.yearForWeekOfYear != nil  {
             self = .weekOfYear(year: year, weekOfYear: components.weekOfYear, weekday: components.weekday)
+        } else if let weekOfMonth = components.weekOfMonth {
+            self = .weekOfMonth(year: year, month: month, weekOfMonth: weekOfMonth, weekday: components.weekday)
         } else if components.year != nil {
             self = .day(year: year, month: month, day: components.day, weekOfYear: components.weekOfYear)
         } else if let weekOfYear = components.weekOfYear {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -154,8 +154,6 @@ enum ResolvedDateComponents {
             self = .day(year: year, month: month, day: components.day, weekOfYear: components.weekOfYear)
         } else if let weekOfYear = components.weekOfYear {
             self = .weekOfYear(year: year, weekOfYear: weekOfYear, weekday: components.weekday)
-        } else if let weekOfMonth = components.weekOfMonth {
-            self = .weekOfMonth(year: year, month: month, weekOfMonth: weekOfMonth, weekday: components.weekday)
         } else if let weekdayOrdinal = components.weekdayOrdinal {
             self = .weekdayOrdinal(year: year, month: month, weekdayOrdinal: weekdayOrdinal, weekday: components.weekday)
         } else if let weekday = components.weekday {

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1174,9 +1174,7 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
 #if FOUNDATION_FRAMEWORK // FIXME: https://github.com/swiftlang/swift-foundation-icu/issues/62
             ucal_set(ucalendar, UCAL_IS_REPEATED_DAY, 0)
 #endif
-            // ICU resolves the day-of-month / week-of-month ambiguity in favor of
-            // day-of-month, so defaulting it to 1 would make week-of-month be ignored
-            // entirely. See https://github.com/swiftlang/swift-foundation/issues/532
+            // ICU resolves the day-of-month and week-of-month ambiguity in favor of day-of-month, so defaulting the day to 1 would ignore week-of-month entirely.
             let resolvesByWeekOfMonth = components.weekOfMonth != nil && components.day == nil && components.weekday == nil
             if !resolvesByWeekOfMonth {
                 ucal_set(ucalendar, UCAL_DAY_OF_MONTH, 1)

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1174,7 +1174,13 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
 #if FOUNDATION_FRAMEWORK // FIXME: https://github.com/swiftlang/swift-foundation-icu/issues/62
             ucal_set(ucalendar, UCAL_IS_REPEATED_DAY, 0)
 #endif
-            ucal_set(ucalendar, UCAL_DAY_OF_MONTH, 1)
+            // Don't default day-of-month to 1 when the components specify a week of month
+            // (and don't also specify a day or weekday), or ICU will always resolve the
+            // ambiguity in favor of day-of-month and ignore week-of-month entirely.
+            // See https://github.com/swiftlang/swift-foundation/issues/532
+            if !(components.weekOfMonth != nil && components.day == nil && components.weekday == nil) {
+                ucal_set(ucalendar, UCAL_DAY_OF_MONTH, 1)
+            }
             ucal_set(ucalendar, UCAL_HOUR_OF_DAY, 0)
             ucal_set(ucalendar, UCAL_MINUTE, 0)
             ucal_set(ucalendar, UCAL_SECOND, 0)

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1174,11 +1174,11 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
 #if FOUNDATION_FRAMEWORK // FIXME: https://github.com/swiftlang/swift-foundation-icu/issues/62
             ucal_set(ucalendar, UCAL_IS_REPEATED_DAY, 0)
 #endif
-            // Don't default day-of-month to 1 when the components specify a week of month
-            // (and don't also specify a day or weekday), or ICU will always resolve the
-            // ambiguity in favor of day-of-month and ignore week-of-month entirely.
-            // See https://github.com/swiftlang/swift-foundation/issues/532
-            if !(components.weekOfMonth != nil && components.day == nil && components.weekday == nil) {
+            // ICU resolves the day-of-month / week-of-month ambiguity in favor of
+            // day-of-month, so defaulting it to 1 would make week-of-month be ignored
+            // entirely. See https://github.com/swiftlang/swift-foundation/issues/532
+            let resolvesByWeekOfMonth = components.weekOfMonth != nil && components.day == nil && components.weekday == nil
+            if !resolvesByWeekOfMonth {
                 ucal_set(ucalendar, UCAL_DAY_OF_MONTH, 1)
             }
             ucal_set(ucalendar, UCAL_HOUR_OF_DAY, 0)

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -220,7 +220,7 @@ private struct GregorianCalendarTests {
     // Regression test for https://github.com/swiftlang/swift-foundation/issues/532:
     // year + month + weekOfMonth (without day or weekday) resolved to the 1st of the month
     // for every weekOfMonth value instead of the correct week.
-    @Test func testDateFromComponentsWeekOfMonthWithoutWeekday() {
+    @Test func testDateFromComponentsWeekOfMonth() {
         let cal = _CalendarGregorian(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
         func test(_ dateComponents: DateComponents, expected: Date, sourceLocation: SourceLocation = #_sourceLocation) {
             let date = cal.date(from: dateComponents)
@@ -232,6 +232,11 @@ private struct GregorianCalendarTests {
         test(.init(year: 2024, month: 1, weekOfMonth: 3), expected: Date(timeIntervalSince1970: 1705190400.0)) // 2024-01-14
         test(.init(year: 2024, month: 1, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 1705795200.0)) // 2024-01-21
         test(.init(year: 2024, month: 1, weekOfMonth: 5), expected: Date(timeIntervalSince1970: 1706400000.0)) // 2024-01-28
+
+        // day and weekOfMonth together: day takes precedence, weekOfMonth is ignored.
+        test(.init(year: 2024, month: 1, day: 20, weekOfMonth: 3), expected: Date(timeIntervalSince1970: 1705708800.0)) // 2024-01-20
+        // weekOfMonth and weekday together: resolves to the given weekday within that week.
+        test(.init(year: 2024, month: 1, weekday: 4, weekOfMonth: 3), expected: Date(timeIntervalSince1970: 1705449600.0)) // 2024-01-17
     }
 
     // MARK: - DateComponents from date

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -180,25 +180,25 @@ private struct GregorianCalendarTests {
         test(.init(year: 2935, month: 6, day: -3), expected: Date(timeIntervalSince1970: 30465158400.0))
         test(.init(year: 2935, month: 6, day: 3), expected: Date(timeIntervalSince1970: 30465676800.0))
 
-        test(.init(year: 1582, month: 5, weekOfMonth: -2), expected: Date(timeIntervalSince1970: -12232857600.0))
-        test(.init(year: 1582, month: 5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: -12232857600.0))
+        test(.init(year: 1582, month: 5, weekOfMonth: -2), expected: Date(timeIntervalSince1970: -12234844800.0))
+        test(.init(year: 1582, month: 5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: -12231216000.0))
         test(.init(year: 1705, month: 2, weekOfMonth: 1), expected: Date(timeIntervalSince1970: -8359891200.0))
-        test(.init(year: 1705, month: 6, weekOfMonth: -3), expected: Date(timeIntervalSince1970: -8349523200.0))
-        test(.init(year: 1828, month: 7, weekOfMonth: 2), expected: Date(timeIntervalSince1970: -4465411200.0))
-        test(.init(year: 1828, month: 7, weekOfMonth: 5), expected: Date(timeIntervalSince1970: -4465411200.0))
-        test(.init(year: 1828, month: 11, weekOfMonth: 0), expected: Date(timeIntervalSince1970: -4454784000.0))
-        test(.init(year: 2197, month: 5, weekOfMonth: -2), expected: Date(timeIntervalSince1970: 7173878400.0))
-        test(.init(year: 2197, month: 5, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 7173878400.0))
+        test(.init(year: 1705, month: 6, weekOfMonth: -3), expected: Date(timeIntervalSince1970: -8352028800.0))
+        test(.init(year: 1828, month: 7, weekOfMonth: 2), expected: Date(timeIntervalSince1970: -4464979200.0))
+        test(.init(year: 1828, month: 7, weekOfMonth: 5), expected: Date(timeIntervalSince1970: -4463164800.0))
+        test(.init(year: 1828, month: 11, weekOfMonth: 0), expected: Date(timeIntervalSince1970: -4455302400.0))
+        test(.init(year: 2197, month: 5, weekOfMonth: -2), expected: Date(timeIntervalSince1970: 7171977600.0))
+        test(.init(year: 2197, month: 5, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 7173792000.0))
         test(.init(year: 2320, month: 2, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 11047536000.0))
-        test(.init(year: 2320, month: 6, weekOfMonth: -3), expected: Date(timeIntervalSince1970: 11057990400.0))
-        test(.init(year: 2443, month: -5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 14910566400.0))
-        test(.init(year: 2443, month: -1, weekOfMonth: -1), expected: Date(timeIntervalSince1970: 14921193600.0))
-        test(.init(year: 2443, month: 7, weekOfMonth: -1), expected: Date(timeIntervalSince1970: 14942102400.0))
-        test(.init(year: 2443, month: 7, weekOfMonth: 2), expected: Date(timeIntervalSince1970: 14942102400.0))
-        test(.init(year: 2812, month: -3, weekOfMonth: -3), expected: Date(timeIntervalSince1970: 26560396800.0))
-        test(.init(year: 2812, month: 5, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 26581392000.0))
-        test(.init(year: 2812, month: 5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 26581392000.0))
-        test(.init(year: 2935, month: 6, weekOfMonth: 0), expected: Date(timeIntervalSince1970: 30465504000.0))
+        test(.init(year: 2320, month: 6, weekOfMonth: -3), expected: Date(timeIntervalSince1970: 11055398400.0))
+        test(.init(year: 2443, month: -5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 14912208000.0))
+        test(.init(year: 2443, month: -1, weekOfMonth: -1), expected: Date(timeIntervalSince1970: 14920070400.0))
+        test(.init(year: 2443, month: 7, weekOfMonth: -1), expected: Date(timeIntervalSince1970: 14940633600.0))
+        test(.init(year: 2443, month: 7, weekOfMonth: 2), expected: Date(timeIntervalSince1970: 14942448000.0))
+        test(.init(year: 2812, month: -3, weekOfMonth: -3), expected: Date(timeIntervalSince1970: 26558236800.0))
+        test(.init(year: 2812, month: 5, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 26581219200.0))
+        test(.init(year: 2812, month: 5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 26583033600.0))
+        test(.init(year: 2935, month: 6, weekOfMonth: 0), expected: Date(timeIntervalSince1970: 30464640000.0))
 
         test(.init(weekOfYear: 20, yearForWeekOfYear: 1582), expected: Date(timeIntervalSince1970: -12231820800.0))
         test(.init(weekOfYear: -25, yearForWeekOfYear: 1705), expected: Date(timeIntervalSince1970: -8378035200.0))
@@ -215,6 +215,23 @@ private struct GregorianCalendarTests {
         test(.init(weekOfYear: -52, yearForWeekOfYear: 2812), expected: Date(timeIntervalSince1970: 26538883200.0))
         test(.init(weekOfYear: 1, yearForWeekOfYear: 2935), expected: Date(timeIntervalSince1970: 30452544000.0))
         test(.init(weekOfYear: 43, yearForWeekOfYear: 2935), expected: Date(timeIntervalSince1970: 30477945600.0))
+    }
+
+    // Regression test for https://github.com/swiftlang/swift-foundation/issues/532:
+    // year + month + weekOfMonth (without day or weekday) resolved to the 1st of the month
+    // for every weekOfMonth value instead of the correct week.
+    @Test func testDateFromComponentsWeekOfMonthWithoutWeekday() {
+        let cal = _CalendarGregorian(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
+        func test(_ dateComponents: DateComponents, expected: Date, sourceLocation: SourceLocation = #_sourceLocation) {
+            let date = cal.date(from: dateComponents)
+            #expect(date == expected, "date components: \(dateComponents)", sourceLocation: sourceLocation)
+        }
+
+        test(.init(year: 2024, month: 1, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 1703980800.0)) // 2023-12-31
+        test(.init(year: 2024, month: 1, weekOfMonth: 2), expected: Date(timeIntervalSince1970: 1704585600.0)) // 2024-01-07
+        test(.init(year: 2024, month: 1, weekOfMonth: 3), expected: Date(timeIntervalSince1970: 1705190400.0)) // 2024-01-14
+        test(.init(year: 2024, month: 1, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 1705795200.0)) // 2024-01-21
+        test(.init(year: 2024, month: 1, weekOfMonth: 5), expected: Date(timeIntervalSince1970: 1706400000.0)) // 2024-01-28
     }
 
     // MARK: - DateComponents from date

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -217,9 +217,6 @@ private struct GregorianCalendarTests {
         test(.init(weekOfYear: 43, yearForWeekOfYear: 2935), expected: Date(timeIntervalSince1970: 30477945600.0))
     }
 
-    // Regression test for https://github.com/swiftlang/swift-foundation/issues/532:
-    // year + month + weekOfMonth (without day or weekday) resolved to the 1st of the month
-    // for every weekOfMonth value instead of the correct week.
     @Test func testDateFromComponentsWeekOfMonth() {
         let cal = _CalendarGregorian(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
         func test(_ dateComponents: DateComponents, expected: Date, sourceLocation: SourceLocation = #_sourceLocation) {
@@ -233,9 +230,7 @@ private struct GregorianCalendarTests {
         test(.init(year: 2024, month: 1, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 1705795200.0)) // 2024-01-21
         test(.init(year: 2024, month: 1, weekOfMonth: 5), expected: Date(timeIntervalSince1970: 1706400000.0)) // 2024-01-28
 
-        // day and weekOfMonth together: day takes precedence, weekOfMonth is ignored.
         test(.init(year: 2024, month: 1, day: 20, weekOfMonth: 3), expected: Date(timeIntervalSince1970: 1705708800.0)) // 2024-01-20
-        // weekOfMonth and weekday together: resolves to the given weekday within that week.
         test(.init(year: 2024, month: 1, weekday: 4, weekOfMonth: 3), expected: Date(timeIntervalSince1970: 1705449600.0)) // 2024-01-17
     }
 

--- a/Tests/FoundationInternationalizationTests/CalendarICUTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarICUTests.swift
@@ -76,22 +76,17 @@ private struct CalendarICUTests {
     // https://github.com/swiftlang/swift-foundation/issues/532
     // `date(from:)` with only `weekOfMonth` set (no `day`) used to always resolve to the
     // 1st of the month because ICU's day-of-month default took priority over week-of-month.
-    @Test func dateFromComponentsWeekOfMonth() {
+    @Test(arguments: [
+        (1, Date(timeIntervalSince1970: 1703980800)), // 2023-12-31
+        (2, Date(timeIntervalSince1970: 1704585600)), // 2024-01-07
+        (3, Date(timeIntervalSince1970: 1705190400)), // 2024-01-14
+        (4, Date(timeIntervalSince1970: 1705795200)), // 2024-01-21
+        (5, Date(timeIntervalSince1970: 1706400000)), // 2024-01-28
+    ])
+    func dateFromComponentsWeekOfMonth(weekOfMonth: Int, expected: Date) {
         let icuCalendar = _CalendarICU(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
-
-        let expected: [Date] = [
-            Date(timeIntervalSince1970: 1703980800), // 2023-12-31 00:00:00 +0000
-            Date(timeIntervalSince1970: 1704585600), // 2024-01-07 00:00:00 +0000
-            Date(timeIntervalSince1970: 1705190400), // 2024-01-14 00:00:00 +0000
-            Date(timeIntervalSince1970: 1705795200), // 2024-01-21 00:00:00 +0000
-            Date(timeIntervalSince1970: 1706400000), // 2024-01-28 00:00:00 +0000
-        ]
-
-        for (i, weekOfMonth) in (1...5).enumerated() {
-            let dc = DateComponents(year: 2024, month: 1, weekOfMonth: weekOfMonth)
-            let result = icuCalendar.date(from: dc)
-            #expect(result == expected[i], "weekOfMonth \(weekOfMonth): got \(String(describing: result)), expected \(expected[i])")
-        }
+        let components = DateComponents(year: 2024, month: 1, weekOfMonth: weekOfMonth)
+        #expect(icuCalendar.date(from: components) == expected)
     }
 
     // Parity check: `_CalendarICU` and `_CalendarGregorian` must agree on `date(from:)` when

--- a/Tests/FoundationInternationalizationTests/CalendarICUTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarICUTests.swift
@@ -72,4 +72,39 @@ private struct CalendarICUTests {
         #expect(outBig >= outSmall, "adding a larger positive amount must not produce an earlier date")
     }
 #endif
+
+    // https://github.com/swiftlang/swift-foundation/issues/532
+    // `date(from:)` with only `weekOfMonth` set (no `day`) used to always resolve to the
+    // 1st of the month because ICU's day-of-month default took priority over week-of-month.
+    @Test func dateFromComponentsWeekOfMonth() {
+        let icuCalendar = _CalendarICU(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
+
+        let expected: [Date] = [
+            Date(timeIntervalSince1970: 1703980800), // 2023-12-31 00:00:00 +0000
+            Date(timeIntervalSince1970: 1704585600), // 2024-01-07 00:00:00 +0000
+            Date(timeIntervalSince1970: 1705190400), // 2024-01-14 00:00:00 +0000
+            Date(timeIntervalSince1970: 1705795200), // 2024-01-21 00:00:00 +0000
+            Date(timeIntervalSince1970: 1706400000), // 2024-01-28 00:00:00 +0000
+        ]
+
+        for (i, weekOfMonth) in (1...5).enumerated() {
+            let dc = DateComponents(year: 2024, month: 1, weekOfMonth: weekOfMonth)
+            let result = icuCalendar.date(from: dc)
+            #expect(result == expected[i], "weekOfMonth \(weekOfMonth): got \(String(describing: result)), expected \(expected[i])")
+        }
+    }
+
+    // Parity check: `_CalendarICU` and `_CalendarGregorian` must agree on `date(from:)` when
+    // only `weekOfMonth` is set. See https://github.com/swiftlang/swift-foundation/issues/532
+    @Test func dateFromComponentsWeekOfMonthMatchesGregorianBackend() {
+        let icuCalendar = _CalendarICU(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
+        let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
+
+        for weekOfMonth in 1...5 {
+            let dc = DateComponents(year: 2024, month: 1, weekOfMonth: weekOfMonth)
+            let icuResult = icuCalendar.date(from: dc)
+            let gregorianResult = gregorianCalendar.date(from: dc)
+            #expect(icuResult == gregorianResult, "weekOfMonth \(weekOfMonth): ICU returned \(String(describing: icuResult)), Gregorian returned \(String(describing: gregorianResult))")
+        }
+    }
 }

--- a/Tests/FoundationInternationalizationTests/CalendarICUTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarICUTests.swift
@@ -73,9 +73,6 @@ private struct CalendarICUTests {
     }
 #endif
 
-    // https://github.com/swiftlang/swift-foundation/issues/532
-    // `date(from:)` with only `weekOfMonth` set (no `day`) used to always resolve to the
-    // 1st of the month because ICU's day-of-month default took priority over week-of-month.
     @Test(arguments: [
         (1, Date(timeIntervalSince1970: 1703980800)), // 2023-12-31
         (2, Date(timeIntervalSince1970: 1704585600)), // 2024-01-07
@@ -85,21 +82,17 @@ private struct CalendarICUTests {
     ])
     func dateFromComponentsWeekOfMonth(weekOfMonth: Int, expected: Date) {
         let icuCalendar = _CalendarICU(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
-        let components = DateComponents(year: 2024, month: 1, weekOfMonth: weekOfMonth)
-        #expect(icuCalendar.date(from: components) == expected)
+        #expect(icuCalendar.date(from: DateComponents(year: 2024, month: 1, weekOfMonth: weekOfMonth)) == expected)
     }
 
-    // Parity check: `_CalendarICU` and `_CalendarGregorian` must agree on `date(from:)` when
-    // only `weekOfMonth` is set. See https://github.com/swiftlang/swift-foundation/issues/532
-    @Test func dateFromComponentsWeekOfMonthMatchesGregorianBackend() {
+    @Test(arguments: 1...5)
+    func dateFromComponentsWeekOfMonthMatchesGregorianBackend(weekOfMonth: Int) {
         let icuCalendar = _CalendarICU(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 1, gregorianStartDate: nil)
+        let components = DateComponents(year: 2024, month: 1, weekOfMonth: weekOfMonth)
+        let icuResult = icuCalendar.date(from: components)
+        let gregorianResult = gregorianCalendar.date(from: components)
 
-        for weekOfMonth in 1...5 {
-            let dc = DateComponents(year: 2024, month: 1, weekOfMonth: weekOfMonth)
-            let icuResult = icuCalendar.date(from: dc)
-            let gregorianResult = gregorianCalendar.date(from: dc)
-            #expect(icuResult == gregorianResult, "weekOfMonth \(weekOfMonth): ICU returned \(String(describing: icuResult)), Gregorian returned \(String(describing: gregorianResult))")
-        }
+        #expect(icuResult == gregorianResult, "ICU returned \(String(describing: icuResult)), Gregorian returned \(String(describing: gregorianResult))")
     }
 }


### PR DESCRIPTION
`Calendar.date(from:)` now honors `weekOfMonth` when the components carry no day and no weekday.

### Motivation:

`Calendar.date(from:)` returns the first of the month for every `weekOfMonth`
value when the components carry a week of month but no day and no weekday,
so the weeks of a month cannot be iterated:

```swift
for w in 1...5 {
    let d = Calendar.current.date(from: DateComponents(year: 2024, month: 1, weekOfMonth: w))!
    print(d)  // 2024-01-01 five times
}
```

Adding a weekday hides the problem, and there is no `yearForWeekOfMonth`
spelling to fall back on, so the combination has no working alternative.

Resolves #532.

### Modifications:

Both calendar backends had their own cause for the same symptom.

`_CalendarGregorian`: `ResolvedDateComponents.init` matched the `year != nil`
branch before the `weekOfMonth` branch and resolved to `.day` with a nil day,
which falls back to day 1. The `weekOfMonth` branch is now reached first.

`_CalendarICU`: `date(from:)` seeded `UCAL_DAY_OF_MONTH` with 1 before setting
the requested fields. ICU then resolves the ambiguous field combination in
favor of day of month and never looks at week of month. The default is now
skipped when the components ask for a week of month without a day or weekday.

### Result:

```
weekOfMonth 1...5 of January 2024, first weekday Sunday, minimum days in first week 1

before: 01-01  01-01  01-01  01-01  01-01
after:  12-31  01-07  01-14  01-21  01-28
```

The expected dates match the ICU output quoted in #532, and ICU4J 76.1 returns
the same five dates for the same input.

### Testing:

New regression tests for both backends, plus a check that the two backends
agree on the input from the issue.

`testDateFromComponents` in `GregorianCalendarTests` captured the previous
behavior, with several pairs of different `weekOfMonth` values expecting the
same date (for example `year: 1828, month: 7` with `weekOfMonth: 2` and
`weekOfMonth: 5` both expecting 1828-07-01). Those 17 expectations are updated.
The two rows that already held a correct date are untouched.

Full test suite passes.

### Two things worth a maintainer decision

**The Gregorian cutover year.** With the fix in place, the two backends
disagree when the components name 1582 as the year: `_CalendarICU` returns
dates 14 days later than `_CalendarGregorian`. The disabled
`GregorianCalendarCompatibilityTests` suite reports 416 such cases when run
locally. This is not new arithmetic on our side: `gregocal.cpp` adds a
hardcoded `jd += 14` for `UCAL_WEEK_OF_MONTH` in the cutover year, a line that
dates back to 2003 and has no counterpart in ICU4J. ICU4J and
`_CalendarGregorian` agree on these dates; ICU4C stands alone. Previously both
backends returned the first of the month here, so the divergence was masked
rather than absent. I have not touched cutover handling in either backend and
am happy to follow whichever direction you prefer.

**`DateComponents(year:weekOfYear:)`** has the same shape of problem and still
returns the first day of the year. `CalendarTests` documents that as
intentional ("year and weekOfYear, not valid setting so the result is just the
first day of the year"), and `yearForWeekOfYear` is the working spelling, so I
left it alone. I have the fix ready if you want it.

