### PR TITLE
Adopt @export(implementation)

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -131,7 +131,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
     /// operation.
     ///
     /// - Complexity: O(*n*)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public var count: Int {
     #if FOUNDATION_FRAMEWORK
         if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
@@ -161,7 +161,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         return j
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func index(_ i: AttributedString.Index, offsetBy distance: Int) -> AttributedString.Index {
     #if FOUNDATION_FRAMEWORK
         if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
@@ -180,7 +180,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         return j
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func index(
         _ i: AttributedString.Index,
         offsetBy distance: Int,
@@ -213,7 +213,7 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         return Index(j, version: _guts.version)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func distance(from start: AttributedString.Index, to end: AttributedString.Index) -> Int {
     #if FOUNDATION_FRAMEWORK
         if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -348,7 +348,7 @@ extension AttributedString.Runs: BidirectionalCollection {
         }
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func distance(from start: Index, to end: Index) -> Int {
         #if FOUNDATION_FRAMEWORK || os(macOS)
         if #available(macOS 26, iOS 26, tvOS 26, watchOS 26, visionOS 26, *) {
@@ -376,7 +376,7 @@ extension AttributedString.Runs: BidirectionalCollection {
         return dist
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func index(_ i: Index, offsetBy distance: Int) -> Index {
     #if FOUNDATION_FRAMEWORK || os(macOS)
         if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
@@ -408,7 +408,7 @@ extension AttributedString.Runs: BidirectionalCollection {
         return idx
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func index(_ i: Index, offsetBy distance: Int, limitedBy limit: Index) -> Index? {
         // This is the stdlib's default implementation for RandomAccessCollection types.
         // (It's _far_ more efficient than the O(n) algorithm that used to apply here by default,

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -134,7 +134,7 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
     /// - Complexity: O(1) if the collection conforms to
     ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
     ///   of the collection.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public var count: Int {
     #if FOUNDATION_FRAMEWORK
         if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
@@ -171,7 +171,7 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
         return j
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func index(
         _ i: AttributedString.Index,
         offsetBy distance: Int,
@@ -204,7 +204,7 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
         return Index(j, version: _guts.version)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func distance(
         from start: AttributedString.Index,
         to end: AttributedString.Index

--- a/Sources/FoundationEssentials/AttributedString/Collection Stdlib Defaults.swift
+++ b/Sources/FoundationEssentials/AttributedString/Collection Stdlib Defaults.swift
@@ -14,12 +14,12 @@
 // FIXME: The stdlib should expose these as callable entry points.
 
 extension Collection {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal var _defaultCount: Int {
     distance(from: startIndex, to: endIndex)
   }
   
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _defaultDistanceForward(from start: Index, to end: Index) -> Int {
     precondition(start <= end,
                  "Only BidirectionalCollections can have end come before start")
@@ -32,7 +32,7 @@ extension Collection {
     return count
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _defaultAdvanceForward(_ i: Index, by n: Int) -> Index {
     precondition(n >= 0,
                  "Only BidirectionalCollections can be advanced by a negative amount")
@@ -44,7 +44,7 @@ extension Collection {
     return i
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _defaultAdvanceForward(
     _ i: Index, by n: Int, limitedBy limit: Index
   ) -> Index? {
@@ -63,7 +63,7 @@ extension Collection {
 }
 
 extension BidirectionalCollection {
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _defaultDistance(from start: Index, to end: Index) -> Int {
     var start = start
     var count = 0
@@ -84,7 +84,7 @@ extension BidirectionalCollection {
     return count
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _defaultIndex(_ i: Index, offsetBy distance: Int) -> Index {
     if distance >= 0 {
       return _defaultAdvanceForward(i, by: distance)
@@ -96,7 +96,7 @@ extension BidirectionalCollection {
     return i
   }
 
-  @_alwaysEmitIntoClient
+  @export(implementation)
   internal func _defaultIndex(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index? {

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -28,7 +28,7 @@ extension String {
     }
 
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ characters: AttributedString.CharacterView) {
         #if FOUNDATION_FRAMEWORK || os(macOS)
         guard #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) else {

--- a/Sources/FoundationEssentials/Data/ContiguousBytes.swift
+++ b/Sources/FoundationEssentials/Data/ContiguousBytes.swift
@@ -69,7 +69,7 @@ extension ContiguousBytes where Self: ~Escapable, Self: ~Copyable {
     ///
     /// - note: Calling `withBytes` multiple times does not guarantee that
     ///         the same span will be passed in every time.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
 #if !hasFeature(Embedded)
@@ -95,7 +95,7 @@ extension ContiguousBytes where Self: ~Escapable, Self: ~Copyable {
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Array : ContiguousBytes where Element == UInt8 {
     // FIXME: Generalize to R: ~Copyable when withUnsafeBufferPointer does
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         try withUnsafeBufferPointer { (buffer) throws(E) in
@@ -108,7 +108,7 @@ extension Array : ContiguousBytes where Element == UInt8 {
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension ArraySlice : ContiguousBytes where Element == UInt8 {
     // FIXME: Generalize to R: ~Copyable when withUnsafeBufferPointer does
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         try withUnsafeBufferPointer { (buffer) throws(E) in
@@ -120,7 +120,7 @@ extension ArraySlice : ContiguousBytes where Element == UInt8 {
 // FIXME: When possible, expand conformance to `where Element : Trivial`.
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension ContiguousArray : ContiguousBytes where Element == UInt8 {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(span.bytes)
@@ -147,12 +147,12 @@ extension UnsafeRawBufferPointer : ContiguousBytes {
     }
     #endif
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(self)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(bytes)
@@ -174,12 +174,12 @@ extension UnsafeMutableRawBufferPointer : ContiguousBytes {
     }
     #endif
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(bytes)
@@ -202,12 +202,12 @@ extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
     }
     #endif
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(span.bytes)
@@ -230,12 +230,12 @@ extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
     }
     #endif
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(UnsafeRawBufferPointer(self))
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(span.bytes)
@@ -258,12 +258,12 @@ extension EmptyCollection : ContiguousBytes where Element == UInt8 {
     }
     #endif
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try body(UnsafeRawBufferPointer(start: nil, count: 0))
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(RawSpan())
@@ -286,7 +286,7 @@ extension CollectionOfOne : ContiguousBytes where Element == UInt8 {
     }
     #endif
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         let element = self.first!
         return try Swift.withUnsafeBytes(of: element) { (buffer) throws(E) in
@@ -295,7 +295,7 @@ extension CollectionOfOne : ContiguousBytes where Element == UInt8 {
     }
 
     // FIXME: Generalize to R: ~Copyable when withUnsafeBufferPointer does
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         let element = self.first!
@@ -322,7 +322,7 @@ extension Slice : ContiguousBytes where Base : ContiguousBytes {
     }
     #endif
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         let offset = base.distance(from: base.startIndex, to: self.startIndex)
         #if !hasFeature(Embedded)
@@ -352,7 +352,7 @@ extension Slice : ContiguousBytes where Base : ContiguousBytes {
 extension RawSpan: ContiguousBytes { }
 
 extension RawSpan {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(self)
     }
@@ -362,7 +362,7 @@ extension RawSpan {
 extension MutableRawSpan: ContiguousBytes { }
 
 extension MutableRawSpan {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(bytes)
     }
@@ -372,12 +372,12 @@ extension MutableRawSpan {
 extension OutputRawSpan: ContiguousBytes { }
 
 extension OutputRawSpan {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         try bytes.withUnsafeBytes(body)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         try body(bytes)
     }
@@ -387,12 +387,12 @@ extension OutputRawSpan {
 extension UTF8Span: ContiguousBytes { }
 
 extension UTF8Span {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         try span.withUnsafeBytes(body)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         return try body(span.bytes)
     }
@@ -402,7 +402,7 @@ extension UTF8Span {
 extension Span: ContiguousBytes where Element == UInt8 { }
 
 extension Span where Element == UInt8 {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         try body(bytes)
     }
@@ -412,7 +412,7 @@ extension Span where Element == UInt8 {
 extension MutableSpan: ContiguousBytes where Element == UInt8 { }
 
 extension MutableSpan where Element == UInt8 {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         try body(bytes)
     }
@@ -422,12 +422,12 @@ extension MutableSpan where Element == UInt8 {
 extension OutputSpan: ContiguousBytes where Element == UInt8 { }
 
 extension OutputSpan where Element == UInt8 {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         try span.withUnsafeBytes(body)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         try body(span.bytes)
     }
@@ -437,12 +437,12 @@ extension OutputSpan where Element == UInt8 {
 extension InlineArray: ContiguousBytes where Element == UInt8 { }
 
 extension InlineArray where Element == UInt8 {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         return try span.withUnsafeBytes(body)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withBytes<R: ~Copyable, E>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
         try body(span.bytes)
     }

--- a/Sources/FoundationEssentials/Data/Data+WritingOptions.swift
+++ b/Sources/FoundationEssentials/Data/Data+WritingOptions.swift
@@ -18,20 +18,20 @@
 extension Data.WritingOptions {
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     private var fileProtectionPart: RawValue {
         self.rawValue & 0xf0000000
     }
 
     // All non-file protection options use the remaining bits
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     private var optionsPart: RawValue {
         self.rawValue & ~0xf0000000
     }
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func contains(_ member: Data.WritingOptions) -> Bool {
         if member.fileProtectionPart != 0 {
             // If member specifies a file protection level, self must have the exact same level
@@ -43,7 +43,7 @@ extension Data.WritingOptions {
     }
 
     @discardableResult
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func insert(_ newMember: Data.WritingOptions) -> (inserted: Bool, memberAfterInsert: Data.WritingOptions) {
         let inserted = !self.contains(newMember)
         self.formUnion(newMember)
@@ -51,7 +51,7 @@ extension Data.WritingOptions {
     }
 
     @discardableResult
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func remove(_ member: Data.WritingOptions) -> Data.WritingOptions? {
         // Remove the file protection if self has the same protection level as member
         let removeProtection = self.fileProtectionPart == member.fileProtectionPart
@@ -65,7 +65,7 @@ extension Data.WritingOptions {
         }
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func formUnion(_ other: Data.WritingOptions) {
         // It is not possible to combine two different file protection levels; we must select one to keep.
         // To preserve the invariant that x.contains(e) implies x.union(y).contains(e), we keep self's protection.
@@ -74,7 +74,7 @@ extension Data.WritingOptions {
         self = Self(rawValue: newProtection | (self.optionsPart | other.optionsPart))
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func formIntersection(_ other: Data.WritingOptions) {
         let newProtection: RawValue
         if self.fileProtectionPart == other.fileProtectionPart {
@@ -87,7 +87,7 @@ extension Data.WritingOptions {
         self = Self(rawValue: newProtection | (self.optionsPart & other.optionsPart))
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func formSymmetricDifference(_ other: Data.WritingOptions) {
         var newProtection: RawValue
         if self.fileProtectionPart == other.fileProtectionPart {
@@ -106,7 +106,7 @@ extension Data.WritingOptions {
         self = Self(rawValue: newProtection | (self.optionsPart ^ other.optionsPart))
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func isSubset(of other: Data.WritingOptions) -> Bool {
         // If self specifies a file protection, other must have the exact same protection
         // (a specific protection level is not a subset of a different protection level)

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -119,7 +119,7 @@ internal func __DataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ leng
 }
 
 
-@_alwaysEmitIntoClient
+@export(implementation)
 internal func _withStackOrHeapBuffer(capacity: Int, _ body: (UnsafeMutableBufferPointer<UInt8>) -> Void) {
     guard capacity > 0 else {
         body(UnsafeMutableBufferPointer(start: nil, count: 0))
@@ -259,7 +259,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - Parameters:
     ///   - capacity: The storage capacity of the new data, or nil to allocate just enough capacity to store the bytes of the span.
     ///   - span: The span whose bytes to copy into the new data. The span must not contain more than `capacity` bytes.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public init(capacity: Int? = nil, copying span: RawSpan) {
         self.init(capacity: capacity ?? span.byteCount) {
@@ -304,7 +304,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     @available(watchOS, introduced: 5.2, deprecated, renamed: "init(capacity:initializingWith:)")
     @available(tvOS, introduced: 12.2, deprecated, renamed: "init(capacity:initializingWith:)")
     @available(visionOS, introduced: 1.0, deprecated, renamed: "init(capacity:initializingWith:)")
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @_spi(_) // TODO: Remove after no clients are using this
     public init<E: Error>(
         rawCapacity capacity: Int,
@@ -318,7 +318,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - Parameters:
     ///   - capacity: The storage capacity of the new data.
     ///   - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The function is allowed to add fewer than `capacity` bytes. The data is initialized with however many bytes the callback adds to the output raw span before it returns (or before it throws an error).
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public init<E: Error>(
         capacity: Int,
@@ -356,7 +356,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ data: Data) {
         #if DATA_LEGACY_ABI
         switch data._representation {
@@ -385,7 +385,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ elements: some Sequence<UInt8> & ContiguousBytes) {
         if let data = _specialize(elements, for: Data.self) {
             self.init(data)
@@ -398,7 +398,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @abi(init(fastCheckElements elements: some Sequence<UInt8>))
     public init(_ elements: some Sequence<UInt8>) {
         if let data = _specialize(elements, for: Data.self) {
@@ -519,7 +519,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withUnsafeBytes<E, ResultType: ~Copyable>(_ body: (UnsafeRawBufferPointer) throws(E) -> ResultType) throws(E) -> ResultType {
         try _representation.withUnsafeBytes(body)
     }
@@ -538,7 +538,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
 #endif // DATA_LEGACY_ABI
 
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public var bytes: RawSpan {
         @_lifetime(borrow self)
         borrowing get {
@@ -547,7 +547,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public var span: Span<UInt8> {
         @_lifetime(borrow self)
         borrowing get {
@@ -557,7 +557,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public var mutableBytes: MutableRawSpan {
         @_lifetime(&self)
         mutating get {
@@ -571,14 +571,14 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///
     /// - Parameter body: A function that edits the contents of this data through an `OutputRawSpan` argument. This method invokes this function exactly once.
     /// - Returns: This method returns the result of its function argument.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func edit<E: Error, R: ~Copyable>(_ body: (inout OutputRawSpan) throws(E) -> R) throws(E) -> R {
         try _representation.edit(body)
     }
 
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public var mutableSpan: MutableSpan<UInt8> {
         @_lifetime(&self)
         mutating get {
@@ -591,7 +591,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public func withContiguousStorageIfAvailable<E, ResultType: ~Copyable>(
       _ body: (_ buffer: UnsafeBufferPointer<UInt8>) throws(E) -> ResultType
     ) throws(E) -> ResultType? {
@@ -601,7 +601,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     }
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func withUnsafeMutableBytes<E, ResultType: ~Copyable>(_ body: (UnsafeMutableRawBufferPointer) throws(E) -> ResultType) throws(E) -> ResultType {
         try _representation.withUnsafeMutableBytes(body)
     }
@@ -654,7 +654,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///    A callback that gets called exactly once to directly populate newly reserved storage within the data.
     ///    - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The callback is always called with an empty output span. The callback is allowed to initialize fewer than `newBytesCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func append<E: Error>(
         addingCount newBytesCount: Int,
         initializingWith initializer: (_ span: inout OutputRawSpan) throws(E) -> Void
@@ -669,7 +669,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///
     /// - Parameters:
     ///    - newBytes: A raw span whose contents to copy into the data.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func append(copying newBytes: RawSpan) {
         self.append(addingCount: newBytes.byteCount) {
@@ -685,7 +685,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _append(buffer)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func append(_ byte: UInt8) {
         Swift.withUnsafeBytes(of: byte) { buffer in
             _representation.append(contentsOf: buffer)
@@ -707,7 +707,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
 
     /// Appends the bytes in the specified sequence to the end of the data.
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func append(contentsOf elements: some Sequence<UInt8> & ContiguousBytes) {
         // Since the sequence is already contiguous, access the underlying raw memory directly.
         elements.withUnsafeBytes {
@@ -718,7 +718,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
 
     /// Appends the bytes in the specified sequence to the end of the data.
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @abi(mutating func append(fastContentsof elements: some Sequence<UInt8>))
     public mutating func append(contentsOf elements: some Sequence<UInt8>) {
         // The sequence might be able to provide direct access to typed memory.
@@ -806,7 +806,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _representation.resetBytes(in: range)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func insert(_ newElement: UInt8, at i: Index) {
         Swift.withUnsafeBytes(of: newElement) { buffer in
             _representation.replaceSubrange(i ..< i, with: buffer.baseAddress, count: buffer.count)
@@ -839,7 +839,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///    - newBytesCount: The maximum number of bytes to insert into the data.
     ///    - index: The position at which to insert the new items. `index` must be a valid index in the data, or equal to the data's `endIndex` (in which case the new bytes are appended to the end of the data).
     ///    - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The callback is always called with an empty output span. The callback is allowed to initialize fewer than `newBytesCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func insert<E: Error>(
         addingCount newBytesCount: Int,
@@ -860,7 +860,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - Parameters:
     ///    - newBytes: The new bytes to insert into the data.
     ///    - index: The position at which to insert the new bytes. `index`  must be a valid index in the data, or equal to the data's `endIndex` (in which case the new bytes are appended to the end of the data).
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func insert(copying newBytes: RawSpan, at index: Int) {
         self.insert(addingCount: newBytes.byteCount, at: index) {
@@ -909,7 +909,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///   - subrange: The range in the data to replace.
     ///   - newElements: The replacement bytes.
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func replaceSubrange(_ subrange: Range<Index>, with newElements: some Collection<UInt8> & ContiguousBytes) {
         newElements.withUnsafeBytes { buffer in
             _representation.replaceSubrange(subrange, with: buffer.baseAddress, count: buffer.count)
@@ -925,7 +925,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///   - subrange: The range in the data to replace.
     ///   - newElements: The replacement bytes.
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @abi(mutating func repalceSubrangeFast(_ subrange: Range<Index>, with newElements: some Collection<UInt8>))
     public mutating func replaceSubrange(_ subrange: Range<Index>, with newElements: some Collection<UInt8>) {
         let replaced: Void? = newElements.withContiguousStorageIfAvailable { buffer in
@@ -1003,7 +1003,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     ///   - subrange: The subrange of the data to replace. The bounds of the range must be valid indices in the data.
     ///   - newBytesCount: The maximum number of new bytes to insert in place of the old subrange.
     ///   - initializer: A callback that gets called exactly once to directly populate newly reserved storage within the data. The callback is always called with an empty output span. The callback is allowed to initialize fewer than `newBytesCount` bytes. The data is extended by however many bytes the callback appends to the output raw span before it returns (or throws an error).
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func replaceSubrange<E: Error>(
         _ subrange: Range<Int>,
@@ -1037,7 +1037,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - Parameters:
     ///   - subrange: The subrange of the data to replace. The bounds of the range must be valid indices in the data.
     ///   - newBytes: The new bytes to copy into the data.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     public mutating func replaceSubrange(_ subrange: Range<Int>, copying newBytes: RawSpan) {
         self.replaceSubrange(subrange, addingCount: newBytes.byteCount) {
@@ -1045,7 +1045,7 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         }
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @discardableResult
     public mutating func remove(at position: Index) -> UInt8 {
         precondition(!isEmpty, "Can't remove from an empty collection")
@@ -1055,13 +1055,13 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         return result
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func removeSubrange(_ bounds: Range<Index>) {
         // Avoids using EmptyCollection below like the default implementation since EmptyCollection does not implement withContiguousStorageIfAvailable and the as? ContiguousBytes check triggers an expensive dynamic cast
         replaceSubrange(bounds, with: UnsafeRawBufferPointer(start: nil, count: 0))
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
         if !keepCapacity {
             self = Data()

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -83,7 +83,7 @@ extension Data {
         }
         
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         init<E: Error>(
             rawCapacity: Int,
             initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
@@ -156,7 +156,7 @@ extension Data {
         }
 
         @inline(__always)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         func withUnsafeBytes<E, Result: ~Copyable>(_ apply: (UnsafeRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             try Swift.withUnsafeBytes(of: bytes) { [count = Int(length)] (rawBuffer) throws(E) -> Result in
                 try apply(UnsafeRawBufferPointer(start: rawBuffer.baseAddress, count: count))
@@ -175,7 +175,7 @@ extension Data {
         }
 
         @inline(__always)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func withUnsafeMutableBytes<E, Result: ~Copyable>(_ apply: (UnsafeMutableRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             try Swift.withUnsafeMutableBytes(of: &bytes) { [count = Int(length)] (rawBuffer) throws(E) -> Result in
                 try apply(UnsafeMutableRawBufferPointer(start: rawBuffer.baseAddress, count: count))
@@ -214,7 +214,7 @@ extension Data {
         }
         
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func append<E: Error>(
             _ extraCapacity: Int, _ initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
@@ -274,7 +274,7 @@ extension Data {
             }
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         mutating func replaceSubrange<E: Error>(
             _ subrange: Range<Int>,

--- a/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
@@ -136,7 +136,7 @@ extension Data {
         #if FOUNDATION_FRAMEWORK
         @abi(mutating func __implementation_reserveCapacity(_ minimumCapacity: Int))
         #endif
-        @_alwaysEmitIntoClient // Ensures that newer clients who may be using `__DataStorage.withUninitializedBytes` always use a new copy of reserveCapacity
+        @export(implementation) // Ensures that newer clients who may be using `__DataStorage.withUninitializedBytes` always use a new copy of reserveCapacity
         mutating func reserveCapacity(_ minimumCapacity: Int) {
             ensureUniqueReference()
             // the current capacity can be zero (representing externally owned buffer), and count can be greater than the capacity
@@ -179,7 +179,7 @@ extension Data {
         }
 
         @inline(__always)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         func withUnsafeBytes<E, Result: ~Copyable>(_ apply: (UnsafeRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             try storage.withUnsafeBytes(in: range, apply: apply)
         }
@@ -196,7 +196,7 @@ extension Data {
         }
 
         @inline(__always)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func withUnsafeMutableBytes<E, Result: ~Copyable>(_ apply: (UnsafeMutableRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             ensureUniqueReference()
             return try storage.withUnsafeMutableBytes(in: range, apply: apply)
@@ -227,7 +227,7 @@ extension Data {
         }
         
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func append<E: Error>(
             _ extraCapacity: Int, _ initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
@@ -286,7 +286,7 @@ extension Data {
             slice = slice.lowerBound..<HalfInt(resultingUpper)
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         mutating func replaceSubrange<E: Error>(
             _ subrange: Range<Int>,

--- a/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
@@ -135,7 +135,7 @@ extension Data {
         #if FOUNDATION_FRAMEWORK
         @abi(mutating func __implementation_reserveCapacity(_ minimumCapacity: Int))
         #endif
-        @_alwaysEmitIntoClient // Ensures that newer clients who may be using `__DataStorage.withUninitializedBytes` always use a new copy of reserveCapacity
+        @export(implementation) // Ensures that newer clients who may be using `__DataStorage.withUninitializedBytes` always use a new copy of reserveCapacity
         mutating func reserveCapacity(_ minimumCapacity: Int) {
             ensureUniqueReference()
             // the current capacity can be zero (representing externally owned buffer), and count can be greater than the capacity
@@ -168,7 +168,7 @@ extension Data {
         }
 
         @inline(__always)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         func withUnsafeBytes<E, Result: ~Copyable>(_ apply: (UnsafeRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             try storage.withUnsafeBytes(in: range, apply: apply)
         }
@@ -185,7 +185,7 @@ extension Data {
         }
 
         @inline(__always)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func withUnsafeMutableBytes<E, Result: ~Copyable>(_ apply: (UnsafeMutableRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             ensureUniqueReference()
             return try storage.withUnsafeMutableBytes(in: range, apply: apply)
@@ -215,7 +215,7 @@ extension Data {
         }
         
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func append<E: Error>(
             _ extraCapacity: Int, _ initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
@@ -269,7 +269,7 @@ extension Data {
             slice.range = slice.range.lowerBound..<resultingUpper
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         mutating func replaceSubrange<E: Error>(
             _ subrange: Range<Int>,

--- a/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
@@ -99,7 +99,7 @@ extension Data {
         }
 
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         init<E: Error>(
             capacity: Int, _ initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
@@ -240,7 +240,7 @@ extension Data {
             }
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         var bytes: RawSpan {
             @_lifetime(borrow self)
@@ -269,7 +269,7 @@ extension Data {
         }
 
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         var mutableBytes: MutableRawSpan {
             @_lifetime(&self)
             mutating get {
@@ -304,7 +304,7 @@ extension Data {
             }
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         mutating func edit<E: Error, R: ~Copyable>(_ body: (inout OutputRawSpan) throws(E) -> R) throws(E) -> R {
             switch self {
@@ -343,7 +343,7 @@ extension Data {
         }
 
         @inline(__always)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         func withUnsafeBytes<E, Result: ~Copyable>(_ apply: (UnsafeRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             switch self {
             case .empty:
@@ -372,7 +372,7 @@ extension Data {
         }
 
         @inline(__always)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func withUnsafeMutableBytes<E, Result: ~Copyable>(_ apply: (UnsafeMutableRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             switch self {
             case .empty:
@@ -460,7 +460,7 @@ extension Data {
         }
 
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func append<E: Error>(
             addingCount newByteCount: Int,
             _ initializer: (inout OutputRawSpan) throws(E) -> Void
@@ -643,7 +643,7 @@ extension Data {
             }
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         public mutating func replaceSubrange<E: Error>(
             _ subrange: Range<Int>,

--- a/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
@@ -19,7 +19,7 @@ extension Data {
     @usableFromInline
     @frozen
     internal struct _Representation : Sendable {
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         static var empty: _Representation {
             _Representation(.empty, count: 0)
         }
@@ -27,7 +27,7 @@ extension Data {
         @usableFromInline var _storage: __DataStorage
         @usableFromInline var _slice: Range<Int>
 
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         init(_ buffer: UnsafeRawBufferPointer) {
             let count = buffer.count
             guard let address = buffer.baseAddress, count > 0 else {
@@ -37,7 +37,7 @@ extension Data {
             self.init(__DataStorage(bytes: address, length: count), count: count)
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         init(_ buffer: UnsafeRawBufferPointer, owner: AnyObject) {
             let count = buffer.count
             let storage = __DataStorage(bytes: UnsafeMutableRawPointer(mutating: buffer.baseAddress), length: count, copy: false, deallocator: { _, _ in
@@ -46,7 +46,7 @@ extension Data {
             self.init(storage, count: count)
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         init(capacity: Int) {
             guard capacity > 0 else {
                 self = .empty
@@ -55,7 +55,7 @@ extension Data {
             self.init(__DataStorage(capacity: capacity), count: 0)
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         init(count: Int) {
             guard count > 0 else {
                 self = .empty
@@ -64,13 +64,13 @@ extension Data {
             self.init(__DataStorage(length: count), count: count)
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         init(_ storage: __DataStorage, count: Int) {
             _storage = storage
             _slice = 0 ..< count
         }
 
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         mutating func ensureUniqueReference() {
             if !isKnownUniquelyReferenced(&_storage) {
                 _storage = _storage.mutableCopy(_slice)
@@ -78,7 +78,7 @@ extension Data {
         }
         
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         init<E: Error>(
             capacity: Int, _ initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
@@ -97,7 +97,7 @@ extension Data {
             reserveCapacity(1)
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func reserveCapacity(_ minimumCapacity: Int) {
             ensureUniqueReference()
             // the current capacity can be zero (representing externally owned buffer), and count can be greater than the capacity
@@ -106,7 +106,7 @@ extension Data {
             _storage.ensureUniqueBufferReference(growingTo: prefixLength + Swift.max(minimumCapacity, count))
         }
         
-        @_alwaysEmitIntoClient
+        @export(implementation)
         var count: Int {
             @inline(__always)
             get {
@@ -130,7 +130,7 @@ extension Data {
             }
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         mutating func edit<E: Error, R: ~Copyable>(_ body: (inout OutputRawSpan) throws(E) -> R) throws(E) -> R {
             self.ensureUniqueReference()
@@ -138,7 +138,7 @@ extension Data {
         }
 
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func append<E: Error>(
             addingCount newBytesCount: Int,
             _ initializer: (inout OutputRawSpan) throws(E) -> Void
@@ -156,23 +156,23 @@ extension Data {
             try _storage.withUninitializedBytes(extraCapacity: newBytesCount, location: endIndex, &appendedCount, initializer)
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         func withUnsafeBytes<Result: ~Copyable, E>(_ apply: (UnsafeRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             try _storage.withUnsafeBytes(in: _slice, apply: apply)
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         mutating func withUnsafeMutableBytes<Result: ~Copyable, E>(_ apply: (UnsafeMutableRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
             ensureUniqueReference()
             return try _storage.withUnsafeMutableBytes(in: _slice, apply: apply)
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Index, _ stop: inout Bool) -> Void) {
             _storage.enumerateBytes(in: _slice, block)
         }
         
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
             guard let address = buffer.baseAddress, buffer.count > 0 else { return }
             ensureUniqueReference()
@@ -185,7 +185,7 @@ extension Data {
             _slice = _slice.lowerBound..<_slice.upperBound + buffer.count
         }
         
-        @_alwaysEmitIntoClient
+        @export(implementation)
         mutating func resetBytes(in range: Range<Index>) {
             precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
             ensureUniqueReference()
@@ -212,7 +212,7 @@ extension Data {
             _slice = _slice.lowerBound..<resultingUpper
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         mutating func replaceSubrange<E: Error>(
             _ subrange: Range<Int>,
@@ -235,7 +235,7 @@ extension Data {
             try _storage.replaceSubrange(subrange, endIndex: &endIndex, addingCount: newBytesCount, initializingWith: initializer)
         }
 
-        @_alwaysEmitIntoClient
+        @export(implementation)
         subscript(index: Index) -> UInt8 {
             get {
                 precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
@@ -250,7 +250,7 @@ extension Data {
             }
         }
         
-        @_alwaysEmitIntoClient
+        @export(implementation)
         subscript(bounds: Range<Index>) -> Data {
             get {
                 precondition(_slice.startIndex <= bounds.lowerBound, "Range \(bounds) out of bounds \(_slice)")
@@ -265,17 +265,17 @@ extension Data {
             }
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         var startIndex: Int {
             _assumeNonNegative(_slice.lowerBound)
         }
         
-        @_alwaysEmitIntoClient @inline(__always)
+        @export(implementation) @inline(__always)
         var endIndex: Int {
             _assumeNonNegative(_slice.upperBound)
         }
         
-        @_alwaysEmitIntoClient
+        @export(implementation)
         func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
             precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
             precondition(range.upperBound <= endIndex, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
@@ -292,7 +292,7 @@ extension Data {
         }
 
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         var bytes: RawSpan {
             let buffer = unsafe UnsafeRawBufferPointer(
                 start: _storage.mutableBytes?.advanced(by: _slice.startIndex), count: _slice.count
@@ -302,7 +302,7 @@ extension Data {
         }
 
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-        @_alwaysEmitIntoClient
+        @export(implementation)
         public var mutableBytes: MutableRawSpan {
             @_lifetime(&self)
             mutating get {

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -176,7 +176,7 @@ internal final class __DataStorage : @unchecked Sendable {
     }
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     func withUnsafeBytes<E, Result: ~Copyable>(in range: Range<Int>, apply: (UnsafeRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
         if let _bytes {
             return try apply(UnsafeRawBufferPointer(start: _bytes.advanced(by: range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
@@ -202,7 +202,7 @@ internal final class __DataStorage : @unchecked Sendable {
 #endif // DATA_LEGACY_ABI
 
     @inline(__always)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     func withUnsafeMutableBytes<E, Result: ~Copyable>(in range: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws(E) -> Result) throws(E) -> Result {
         if let _bytes {
             return try apply(UnsafeMutableRawBufferPointer(start: _bytes.advanced(by: range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
@@ -438,7 +438,7 @@ internal final class __DataStorage : @unchecked Sendable {
     }
     
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-    @_alwaysEmitIntoClient
+    @export(implementation)
     func withUninitializedBytes<Result: ~Copyable, E: Error>(
       extraCapacity: Int, location: Int, _ appendedCount: inout Int, _ initializer: (inout OutputRawSpan) throws(E) -> Result
     ) throws(E) -> Result {
@@ -454,7 +454,7 @@ internal final class __DataStorage : @unchecked Sendable {
         return try initializer(&outputSpan)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     func edit<E: Error, R: ~Copyable>(range: inout Range<Int>, _ body: (inout OutputRawSpan) throws(E) -> R) throws(E) -> R {
         let buffer = UnsafeMutableRawBufferPointer(start: mutableBytes?.advanced(by: range.lowerBound), count: _offset + capacity - range.lowerBound)
@@ -540,7 +540,7 @@ internal final class __DataStorage : @unchecked Sendable {
         }
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
     func replaceSubrange<E: Error>(
         _ subrange: Range<Int>,

--- a/Sources/FoundationEssentials/Locale/Locale+Components.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Components.swift
@@ -938,1209 +938,1209 @@ package struct ICUCLDRKey : Hashable {
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.LanguageCode {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ainu: Locale.LanguageCode { Locale.LanguageCode("ain") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var albanian: Locale.LanguageCode { Locale.LanguageCode("sq") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var amharic: Locale.LanguageCode { Locale.LanguageCode("am") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var apacheWestern: Locale.LanguageCode { Locale.LanguageCode("apw") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var arabic: Locale.LanguageCode { Locale.LanguageCode("ar") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var armenian: Locale.LanguageCode { Locale.LanguageCode("hy") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var assamese: Locale.LanguageCode { Locale.LanguageCode("as") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var assyrian: Locale.LanguageCode { Locale.LanguageCode("syr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var azerbaijani: Locale.LanguageCode { Locale.LanguageCode("az") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bangla: Locale.LanguageCode { Locale.LanguageCode("bn") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var belarusian: Locale.LanguageCode { Locale.LanguageCode("be") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bodo: Locale.LanguageCode { Locale.LanguageCode("brx") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bulgarian: Locale.LanguageCode { Locale.LanguageCode("bg") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var burmese: Locale.LanguageCode { Locale.LanguageCode("my") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cantonese: Locale.LanguageCode { Locale.LanguageCode("yue") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var catalan: Locale.LanguageCode { Locale.LanguageCode("ca") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cherokee: Locale.LanguageCode { Locale.LanguageCode("chr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var chinese: Locale.LanguageCode { Locale.LanguageCode("zh") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var croatian: Locale.LanguageCode { Locale.LanguageCode("hr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var czech: Locale.LanguageCode { Locale.LanguageCode("cs") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var danish: Locale.LanguageCode { Locale.LanguageCode("da") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var dhivehi: Locale.LanguageCode { Locale.LanguageCode("dv") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var dogri: Locale.LanguageCode { Locale.LanguageCode("doi") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var dutch: Locale.LanguageCode { Locale.LanguageCode("nl") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var dzongkha: Locale.LanguageCode { Locale.LanguageCode("dz") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var english: Locale.LanguageCode { Locale.LanguageCode("en") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var estonian: Locale.LanguageCode { Locale.LanguageCode("et") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var faroese: Locale.LanguageCode { Locale.LanguageCode("fo") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var finnish: Locale.LanguageCode { Locale.LanguageCode("fi") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var french: Locale.LanguageCode { Locale.LanguageCode("fr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var fula: Locale.LanguageCode { Locale.LanguageCode("ff") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var georgian: Locale.LanguageCode { Locale.LanguageCode("ka") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var german: Locale.LanguageCode { Locale.LanguageCode("de") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var greek: Locale.LanguageCode { Locale.LanguageCode("el") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var gujarati: Locale.LanguageCode { Locale.LanguageCode("gu") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hawaiian: Locale.LanguageCode { Locale.LanguageCode("haw") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hebrew: Locale.LanguageCode { Locale.LanguageCode("he") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hindi: Locale.LanguageCode { Locale.LanguageCode("hi") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hungarian: Locale.LanguageCode { Locale.LanguageCode("hu") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var icelandic: Locale.LanguageCode { Locale.LanguageCode("is") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var igbo: Locale.LanguageCode { Locale.LanguageCode("ig") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var indonesian: Locale.LanguageCode { Locale.LanguageCode("id") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var irish: Locale.LanguageCode { Locale.LanguageCode("ga") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var italian: Locale.LanguageCode { Locale.LanguageCode("it") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var japanese: Locale.LanguageCode { Locale.LanguageCode("ja") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kannada: Locale.LanguageCode { Locale.LanguageCode("kn") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kashmiri: Locale.LanguageCode { Locale.LanguageCode("ks") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kazakh: Locale.LanguageCode { Locale.LanguageCode("kk") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var khmer: Locale.LanguageCode { Locale.LanguageCode("km") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var konkani: Locale.LanguageCode { Locale.LanguageCode("kok") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var korean: Locale.LanguageCode { Locale.LanguageCode("ko") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kurdish: Locale.LanguageCode { Locale.LanguageCode("ku") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kurdishSorani: Locale.LanguageCode { Locale.LanguageCode("ckb") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kyrgyz: Locale.LanguageCode { Locale.LanguageCode("ky") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var lao: Locale.LanguageCode { Locale.LanguageCode("lo") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var latvian: Locale.LanguageCode { Locale.LanguageCode("lv") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var lithuanian: Locale.LanguageCode { Locale.LanguageCode("lt") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var macedonian: Locale.LanguageCode { Locale.LanguageCode("mk") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var maithili: Locale.LanguageCode { Locale.LanguageCode("mai") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var malay: Locale.LanguageCode { Locale.LanguageCode("ms") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var malayalam: Locale.LanguageCode { Locale.LanguageCode("ml") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var maltese: Locale.LanguageCode { Locale.LanguageCode("mt") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var manipuri: Locale.LanguageCode { Locale.LanguageCode("mni") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var māori: Locale.LanguageCode { Locale.LanguageCode("mi") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var marathi: Locale.LanguageCode { Locale.LanguageCode("mr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var mongolian: Locale.LanguageCode { Locale.LanguageCode("mn") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var navajo: Locale.LanguageCode { Locale.LanguageCode("nv") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var nepali: Locale.LanguageCode { Locale.LanguageCode("ne") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var norwegian: Locale.LanguageCode { Locale.LanguageCode("no") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var norwegianBokmål: Locale.LanguageCode { Locale.LanguageCode("nb") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var norwegianNynorsk: Locale.LanguageCode { Locale.LanguageCode("nn") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var odia: Locale.LanguageCode { Locale.LanguageCode("or") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var pashto: Locale.LanguageCode { Locale.LanguageCode("ps") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var persian: Locale.LanguageCode { Locale.LanguageCode("fa") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var polish: Locale.LanguageCode { Locale.LanguageCode("pl") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var portuguese: Locale.LanguageCode { Locale.LanguageCode("pt") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var punjabi: Locale.LanguageCode { Locale.LanguageCode("pa") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var rohingya: Locale.LanguageCode { Locale.LanguageCode("rhg") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var romanian: Locale.LanguageCode { Locale.LanguageCode("ro") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var russian: Locale.LanguageCode { Locale.LanguageCode("ru") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var samoan: Locale.LanguageCode { Locale.LanguageCode("sm") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sanskrit: Locale.LanguageCode { Locale.LanguageCode("sa") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var santali: Locale.LanguageCode { Locale.LanguageCode("sat") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var serbian: Locale.LanguageCode { Locale.LanguageCode("sr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sindhi: Locale.LanguageCode { Locale.LanguageCode("sd") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sinhala: Locale.LanguageCode { Locale.LanguageCode("si") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var slovak: Locale.LanguageCode { Locale.LanguageCode("sk") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var slovenian: Locale.LanguageCode { Locale.LanguageCode("sl") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var spanish: Locale.LanguageCode { Locale.LanguageCode("es") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var swahili: Locale.LanguageCode { Locale.LanguageCode("sw") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var swedish: Locale.LanguageCode { Locale.LanguageCode("sv") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tagalog: Locale.LanguageCode { Locale.LanguageCode("tl") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tajik: Locale.LanguageCode { Locale.LanguageCode("tg") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tamil: Locale.LanguageCode { Locale.LanguageCode("ta") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var telugu: Locale.LanguageCode { Locale.LanguageCode("te") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var thai: Locale.LanguageCode { Locale.LanguageCode("th") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tibetan: Locale.LanguageCode { Locale.LanguageCode("bo") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tongan: Locale.LanguageCode { Locale.LanguageCode("to") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var turkish: Locale.LanguageCode { Locale.LanguageCode("tr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var turkmen: Locale.LanguageCode { Locale.LanguageCode("tk") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ukrainian: Locale.LanguageCode { Locale.LanguageCode("uk") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var urdu: Locale.LanguageCode { Locale.LanguageCode("ur") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var uyghur: Locale.LanguageCode { Locale.LanguageCode("ug") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var uzbek: Locale.LanguageCode { Locale.LanguageCode("uz") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var vietnamese: Locale.LanguageCode { Locale.LanguageCode("vi") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var welsh: Locale.LanguageCode { Locale.LanguageCode("cy") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var yiddish: Locale.LanguageCode { Locale.LanguageCode("yi") }
 }
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Region {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var afghanistan: Locale.Region { Locale.Region("AF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ålandIslands: Locale.Region { Locale.Region("AX") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var albania: Locale.Region { Locale.Region("AL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var algeria: Locale.Region { Locale.Region("DZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var americanSamoa: Locale.Region { Locale.Region("AS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var andorra: Locale.Region { Locale.Region("AD") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var angola: Locale.Region { Locale.Region("AO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var anguilla: Locale.Region { Locale.Region("AI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var antarctica: Locale.Region { Locale.Region("AQ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var antiguaBarbuda: Locale.Region { Locale.Region("AG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var argentina: Locale.Region { Locale.Region("AR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var armenia: Locale.Region { Locale.Region("AM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var aruba: Locale.Region { Locale.Region("AW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ascensionIsland: Locale.Region { Locale.Region("AC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var australia: Locale.Region { Locale.Region("AU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var austria: Locale.Region { Locale.Region("AT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var azerbaijan: Locale.Region { Locale.Region("AZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bahamas: Locale.Region { Locale.Region("BS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bahrain: Locale.Region { Locale.Region("BH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bangladesh: Locale.Region { Locale.Region("BD") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var barbados: Locale.Region { Locale.Region("BB") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var belarus: Locale.Region { Locale.Region("BY") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var belgium: Locale.Region { Locale.Region("BE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var belize: Locale.Region { Locale.Region("BZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var benin: Locale.Region { Locale.Region("BJ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bermuda: Locale.Region { Locale.Region("BM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bhutan: Locale.Region { Locale.Region("BT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bolivia: Locale.Region { Locale.Region("BO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bosniaHerzegovina: Locale.Region { Locale.Region("BA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var botswana: Locale.Region { Locale.Region("BW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bouvetIsland: Locale.Region { Locale.Region("BV") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var brazil: Locale.Region { Locale.Region("BR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var britishVirginIslands: Locale.Region { Locale.Region("VG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var brunei: Locale.Region { Locale.Region("BN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bulgaria: Locale.Region { Locale.Region("BG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var burkinaFaso: Locale.Region { Locale.Region("BF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var burundi: Locale.Region { Locale.Region("BI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cambodia: Locale.Region { Locale.Region("KH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cameroon: Locale.Region { Locale.Region("CM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var canada: Locale.Region { Locale.Region("CA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var canaryIslands: Locale.Region { Locale.Region("IC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var capeVerde: Locale.Region { Locale.Region("CV") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var caribbeanNetherlands: Locale.Region { Locale.Region("BQ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var caymanIslands: Locale.Region { Locale.Region("KY") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var centralAfricanRepublic: Locale.Region { Locale.Region("CF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ceutaMelilla: Locale.Region { Locale.Region("EA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var chad: Locale.Region { Locale.Region("TD") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var chagosArchipelago: Locale.Region { Locale.Region("IO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var chile: Locale.Region { Locale.Region("CL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var chinaMainland: Locale.Region { Locale.Region("CN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var christmasIsland: Locale.Region { Locale.Region("CX") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var clippertonIsland: Locale.Region { Locale.Region("CP") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cocosIslands: Locale.Region { Locale.Region("CC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var colombia: Locale.Region { Locale.Region("CO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var comoros: Locale.Region { Locale.Region("KM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var congoBrazzaville: Locale.Region { Locale.Region("CG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var congoKinshasa: Locale.Region { Locale.Region("CD") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cookIslands: Locale.Region { Locale.Region("CK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var costaRica: Locale.Region { Locale.Region("CR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var côteDIvoire: Locale.Region { Locale.Region("CI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var croatia: Locale.Region { Locale.Region("HR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cuba: Locale.Region { Locale.Region("CU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var curaçao: Locale.Region { Locale.Region("CW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cyprus: Locale.Region { Locale.Region("CY") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var czechia: Locale.Region { Locale.Region("CZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var denmark: Locale.Region { Locale.Region("DK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var diegoGarcia: Locale.Region { Locale.Region("DG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var djibouti: Locale.Region { Locale.Region("DJ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var dominica: Locale.Region { Locale.Region("DM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var dominicanRepublic: Locale.Region { Locale.Region("DO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ecuador: Locale.Region { Locale.Region("EC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var egypt: Locale.Region { Locale.Region("EG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var elSalvador: Locale.Region { Locale.Region("SV") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var equatorialGuinea: Locale.Region { Locale.Region("GQ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var eritrea: Locale.Region { Locale.Region("ER") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var estonia: Locale.Region { Locale.Region("EE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var eswatini: Locale.Region { Locale.Region("SZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ethiopia: Locale.Region { Locale.Region("ET") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var falklandIslands: Locale.Region { Locale.Region("FK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var faroeIslands: Locale.Region { Locale.Region("FO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var fiji: Locale.Region { Locale.Region("FJ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var finland: Locale.Region { Locale.Region("FI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var france: Locale.Region { Locale.Region("FR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var frenchGuiana: Locale.Region { Locale.Region("GF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var frenchPolynesia: Locale.Region { Locale.Region("PF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var frenchSouthernTerritories: Locale.Region { Locale.Region("TF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var gabon: Locale.Region { Locale.Region("GA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var gambia: Locale.Region { Locale.Region("GM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var georgia: Locale.Region { Locale.Region("GE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var germany: Locale.Region { Locale.Region("DE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ghana: Locale.Region { Locale.Region("GH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var gibraltar: Locale.Region { Locale.Region("GI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var greece: Locale.Region { Locale.Region("GR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var greenland: Locale.Region { Locale.Region("GL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var grenada: Locale.Region { Locale.Region("GD") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var guadeloupe: Locale.Region { Locale.Region("GP") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var guam: Locale.Region { Locale.Region("GU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var guatemala: Locale.Region { Locale.Region("GT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var guernsey: Locale.Region { Locale.Region("GG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var guinea: Locale.Region { Locale.Region("GN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var guineaBissau: Locale.Region { Locale.Region("GW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var guyana: Locale.Region { Locale.Region("GY") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var haiti: Locale.Region { Locale.Region("HT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var heardMcdonaldIslands: Locale.Region { Locale.Region("HM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var honduras: Locale.Region { Locale.Region("HN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hongKong: Locale.Region { Locale.Region("HK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hungary: Locale.Region { Locale.Region("HU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var iceland: Locale.Region { Locale.Region("IS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var india: Locale.Region { Locale.Region("IN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var indonesia: Locale.Region { Locale.Region("ID") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var iran: Locale.Region { Locale.Region("IR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var iraq: Locale.Region { Locale.Region("IQ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ireland: Locale.Region { Locale.Region("IE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var isleOfMan: Locale.Region { Locale.Region("IM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var israel: Locale.Region { Locale.Region("IL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var italy: Locale.Region { Locale.Region("IT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var jamaica: Locale.Region { Locale.Region("JM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var japan: Locale.Region { Locale.Region("JP") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var jersey: Locale.Region { Locale.Region("JE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var jordan: Locale.Region { Locale.Region("JO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kazakhstan: Locale.Region { Locale.Region("KZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kenya: Locale.Region { Locale.Region("KE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kiribati: Locale.Region { Locale.Region("KI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kosovo: Locale.Region { Locale.Region("XK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kuwait: Locale.Region { Locale.Region("KW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kyrgyzstan: Locale.Region { Locale.Region("KG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var laos: Locale.Region { Locale.Region("LA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var latvia: Locale.Region { Locale.Region("LV") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var lebanon: Locale.Region { Locale.Region("LB") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var lesotho: Locale.Region { Locale.Region("LS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var liberia: Locale.Region { Locale.Region("LR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var libya: Locale.Region { Locale.Region("LY") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var liechtenstein: Locale.Region { Locale.Region("LI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var lithuania: Locale.Region { Locale.Region("LT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var luxembourg: Locale.Region { Locale.Region("LU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var macao: Locale.Region { Locale.Region("MO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var madagascar: Locale.Region { Locale.Region("MG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var malawi: Locale.Region { Locale.Region("MW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var malaysia: Locale.Region { Locale.Region("MY") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var maldives: Locale.Region { Locale.Region("MV") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var mali: Locale.Region { Locale.Region("ML") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var malta: Locale.Region { Locale.Region("MT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var marshallIslands: Locale.Region { Locale.Region("MH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var martinique: Locale.Region { Locale.Region("MQ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var mauritania: Locale.Region { Locale.Region("MR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var mauritius: Locale.Region { Locale.Region("MU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var mayotte: Locale.Region { Locale.Region("YT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var mexico: Locale.Region { Locale.Region("MX") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var micronesia: Locale.Region { Locale.Region("FM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var moldova: Locale.Region { Locale.Region("MD") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var monaco: Locale.Region { Locale.Region("MC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var mongolia: Locale.Region { Locale.Region("MN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var montenegro: Locale.Region { Locale.Region("ME") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var montserrat: Locale.Region { Locale.Region("MS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var morocco: Locale.Region { Locale.Region("MA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var mozambique: Locale.Region { Locale.Region("MZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var myanmar: Locale.Region { Locale.Region("MM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var namibia: Locale.Region { Locale.Region("NA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var nauru: Locale.Region { Locale.Region("NR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var nepal: Locale.Region { Locale.Region("NP") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var netherlands: Locale.Region { Locale.Region("NL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var newCaledonia: Locale.Region { Locale.Region("NC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var newZealand: Locale.Region { Locale.Region("NZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var nicaragua : Locale.Region { Locale.Region("NI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var niger: Locale.Region { Locale.Region("NE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var nigeria: Locale.Region { Locale.Region("NG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var niue: Locale.Region { Locale.Region("NU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var norfolkIsland: Locale.Region { Locale.Region("NF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var northernMarianaIslands: Locale.Region { Locale.Region("MP") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var northMacedonia: Locale.Region { Locale.Region("MK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var norway: Locale.Region { Locale.Region("NO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var oman: Locale.Region { Locale.Region("OM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var pakistan: Locale.Region { Locale.Region("PK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var palau: Locale.Region { Locale.Region("PW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var palestinianTerritories: Locale.Region { Locale.Region("PS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var panama: Locale.Region { Locale.Region("PA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var papuaNewGuinea: Locale.Region { Locale.Region("PG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var paraguay: Locale.Region { Locale.Region("PY") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var peru: Locale.Region { Locale.Region("PE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var philippines: Locale.Region { Locale.Region("PH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var pitcairnIslands: Locale.Region { Locale.Region("PN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var poland: Locale.Region { Locale.Region("PL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var portugal: Locale.Region { Locale.Region("PT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var puertoRico: Locale.Region { Locale.Region("PR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var qatar: Locale.Region { Locale.Region("QA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var réunion: Locale.Region { Locale.Region("RE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var romania: Locale.Region { Locale.Region("RO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var russia: Locale.Region { Locale.Region("RU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var rwanda: Locale.Region { Locale.Region("RW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var saintBarthélemy: Locale.Region { Locale.Region("BL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var saintHelena: Locale.Region { Locale.Region("SH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var saintKittsNevis: Locale.Region { Locale.Region("KN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var saintLucia: Locale.Region { Locale.Region("LC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var saintMartin: Locale.Region { Locale.Region("MF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var saintPierreMiquelon: Locale.Region { Locale.Region("PM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var saintVincentGrenadines: Locale.Region { Locale.Region("VC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var samoa: Locale.Region { Locale.Region("WS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sanMarino: Locale.Region { Locale.Region("SM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sãoToméPríncipe: Locale.Region { Locale.Region("ST") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var saudiArabia: Locale.Region { Locale.Region("SA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var senegal: Locale.Region { Locale.Region("SN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var serbia: Locale.Region { Locale.Region("RS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var seychelles: Locale.Region { Locale.Region("SC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sierraLeone: Locale.Region { Locale.Region("SL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var singapore: Locale.Region { Locale.Region("SG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sintMaarten: Locale.Region { Locale.Region("SX") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var slovakia: Locale.Region { Locale.Region("SK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var slovenia: Locale.Region { Locale.Region("SI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var solomonIslands: Locale.Region { Locale.Region("SB") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var somalia: Locale.Region { Locale.Region("SO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var southAfrica: Locale.Region { Locale.Region("ZA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var southGeorgiaSouthSandwichIslands: Locale.Region { Locale.Region("GS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var southKorea: Locale.Region { Locale.Region("KR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var southSudan: Locale.Region { Locale.Region("SS") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var spain: Locale.Region { Locale.Region("ES") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sriLanka: Locale.Region { Locale.Region("LK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var suriname: Locale.Region { Locale.Region("SR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var svalbardJanMayen: Locale.Region { Locale.Region("SJ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sweden: Locale.Region { Locale.Region("SE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var switzerland: Locale.Region { Locale.Region("CH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var taiwan: Locale.Region { Locale.Region("TW") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tajikistan: Locale.Region { Locale.Region("TJ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tanzania: Locale.Region { Locale.Region("TZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var thailand: Locale.Region { Locale.Region("TH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var timorLeste: Locale.Region { Locale.Region("TL") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var togo: Locale.Region { Locale.Region("TG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tokelau: Locale.Region { Locale.Region("TK") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tonga: Locale.Region { Locale.Region("TO") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var trinidadTobago: Locale.Region { Locale.Region("TT") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tristanDaCunha: Locale.Region { Locale.Region("TA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tunisia: Locale.Region { Locale.Region("TN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var turkey: Locale.Region { Locale.Region("TR") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var turkmenistan: Locale.Region { Locale.Region("TM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var turksCaicosIslands: Locale.Region { Locale.Region("TC") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tuvalu: Locale.Region { Locale.Region("TV") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var uganda: Locale.Region { Locale.Region("UG") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ukraine: Locale.Region { Locale.Region("UA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var unitedArabEmirates: Locale.Region { Locale.Region("AE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var unitedKingdom: Locale.Region { Locale.Region("GB") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var unitedStates: Locale.Region { Locale.Region("US") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var unitedStatesOutlyingIslands: Locale.Region { Locale.Region("UM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var unitedStatesVirginIslands: Locale.Region { Locale.Region("VI") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var uruguay: Locale.Region { Locale.Region("UY") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var uzbekistan: Locale.Region { Locale.Region("UZ") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var vanuatu: Locale.Region { Locale.Region("VU") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var vaticanCity: Locale.Region { Locale.Region("VA") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var venezuela: Locale.Region { Locale.Region("VE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var vietnam: Locale.Region { Locale.Region("VN") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var wallisFutuna: Locale.Region { Locale.Region("WF") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var westernSahara: Locale.Region { Locale.Region("EH") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var yemen: Locale.Region { Locale.Region("YE") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var zambia: Locale.Region { Locale.Region("ZM") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var zimbabwe: Locale.Region { Locale.Region("ZW") }
 
     // MARK: - Region codes for specifying language variants
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var world: Locale.Region { Locale.Region("001") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var latinAmerica: Locale.Region { Locale.Region("419") }
 }
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Script {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var adlam: Locale.Script { Locale.Script("Adlm") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var arabic: Locale.Script { Locale.Script("Arab") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var arabicNastaliq: Locale.Script { Locale.Script("Aran") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var armenian: Locale.Script { Locale.Script("Armn") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var bangla: Locale.Script { Locale.Script("Beng") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cherokee: Locale.Script { Locale.Script("Cher") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var cyrillic: Locale.Script { Locale.Script("Cyrl") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var devanagari: Locale.Script { Locale.Script("Deva") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var ethiopic: Locale.Script { Locale.Script("Ethi") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var georgian: Locale.Script { Locale.Script("Geor") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var greek: Locale.Script { Locale.Script("Grek") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var gujarati: Locale.Script { Locale.Script("Gujr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var gurmukhi: Locale.Script { Locale.Script("Guru") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hanifiRohingya: Locale.Script { Locale.Script("Rohg") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hanSimplified: Locale.Script { Locale.Script("Hans") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hanTraditional: Locale.Script { Locale.Script("Hant") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hebrew: Locale.Script { Locale.Script("Hebr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var hiragana: Locale.Script { Locale.Script("Hira") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var japanese: Locale.Script { Locale.Script("Jpan") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var kannada: Locale.Script { Locale.Script("Knda") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var katakana: Locale.Script { Locale.Script("Kana") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var khmer: Locale.Script { Locale.Script("Khmr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var korean: Locale.Script { Locale.Script("Kore") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var lao: Locale.Script { Locale.Script("Laoo") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var latin: Locale.Script { Locale.Script("Latn") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var malayalam: Locale.Script { Locale.Script("Mlym") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var meiteiMayek: Locale.Script { Locale.Script("Mtei") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var myanmar: Locale.Script { Locale.Script("Mymr") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var odia: Locale.Script { Locale.Script("Orya") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var olChiki: Locale.Script { Locale.Script("Olck") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var sinhala: Locale.Script { Locale.Script("Sinh") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var syriac: Locale.Script { Locale.Script("Syrc") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tamil: Locale.Script { Locale.Script("Taml") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var telugu: Locale.Script { Locale.Script("Telu") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var thaana: Locale.Script { Locale.Script("Thaa") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var thai: Locale.Script { Locale.Script("Thai") }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static var tibetan: Locale.Script { Locale.Script("Tibt") }
 }
 

--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -197,12 +197,12 @@ public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConverti
         }
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func allowKeyPath(_ keyPath: AnyKeyPath & Sendable, identifier: String) {
         self.allowKeyPath(keyPath as AnyKeyPath, identifier: identifier)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public mutating func disallowKeyPath(_ keyPath: AnyKeyPath & Sendable) {
         self.disallowKeyPath(keyPath as AnyKeyPath)
     }

--- a/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
@@ -192,7 +192,7 @@ extension PredicateExpressions {
     
     // A temporary workaround to a compiler bug that changes the ABI when adding the & Sendable constraint
     // Should be removed and the above function should be made public when rdar://131764614 is resolved
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public static func build_KeyPath<Root, Value>(root: Root, keyPath: Swift.KeyPath<Root.Output, Value> & Sendable) -> PredicateExpressions.KeyPath<Root, Value> {
         PredicateExpressions.build_KeyPath(root: root, keyPath: keyPath as Swift.KeyPath<Root.Output, Value>)
     }

--- a/Sources/FoundationEssentials/Span+Utils.swift
+++ b/Sources/FoundationEssentials/Span+Utils.swift
@@ -90,7 +90,7 @@ extension Span<UInt8> {
 }
 
 extension OutputRawSpan {
-    @_alwaysEmitIntoClient
+    @export(implementation)
     mutating func _append(copying span: RawSpan) {
         precondition(self.freeCapacity >= span.byteCount, "Insufficient space to copy the provided span (have \(self.freeCapacity) bytes for writing \(span.byteCount) bytes)")
         self.withUnsafeMutableBytes { buffer, initializedCount in

--- a/Sources/FoundationEssentials/String/String+Encoding.swift
+++ b/Sources/FoundationEssentials/String/String+Encoding.swift
@@ -65,7 +65,7 @@ extension String.Encoding : Hashable {
         return rawValue.hashValue
     }
 
-    @_alwaysEmitIntoClient // Introduced in 5.1
+    @export(implementation) // Introduced in 5.1
     public func hash(into hasher: inout Hasher) {
         // Note: `hash(only:)` is only defined here because we also define
         // `hashValue`.

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -234,7 +234,7 @@ public struct TimeZone : Hashable, Equatable, Sendable {
         _tz.localizedName(for: style, locale: locale)
     }
 
-    @_alwaysEmitIntoClient @_disfavoredOverload
+    @export(implementation) @_disfavoredOverload
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public static var gmt: TimeZone { TimeZone(secondsFromGMT: 0)! }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointFormatStyle.swift
@@ -606,7 +606,7 @@ public extension FormatStyle where Self == FloatingPointFormatStyle<Double> {
     /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryFloatingPoint`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -617,7 +617,7 @@ public extension FormatStyle where Self == FloatingPointFormatStyle<Float> {
     /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryFloatingPoint`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -628,7 +628,7 @@ public extension FormatStyle where Self == FloatingPointFormatStyle<Double>.Perc
     /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryFloatingPoint`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -639,7 +639,7 @@ public extension FormatStyle where Self == FloatingPointFormatStyle<Float>.Perce
     /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryFloatingPoint`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -663,7 +663,7 @@ public extension FormatStyle {
     /// - Parameter code: The currency code to use, such as `EUR` or `JPY`. See ISO-4217 for
     ///   a list of valid codes.
     /// - Returns: A floating-point format style that uses the specified currency code.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static func currency<Value>(code: String) -> Self where Self == FloatingPointFormatStyle<Value>.Currency {
         return Self(code: code)
     }
@@ -677,7 +677,7 @@ public extension FormatStyle where Self == FloatingPointFormatStyle<Float16> {
     /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryFloatingPoint`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -688,7 +688,7 @@ public extension FormatStyle where Self == FloatingPointFormatStyle<Float16>.Per
     /// Use this type property when the call point allows the use of ``FloatingPointFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryFloatingPoint`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 #endif

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
@@ -645,7 +645,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -657,7 +657,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int16> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -669,7 +669,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int32> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -681,7 +681,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int64> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -693,7 +693,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int8> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -705,7 +705,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -717,7 +717,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt16> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -729,7 +729,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt32> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -741,7 +741,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt64> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -753,7 +753,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt8> {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var number: Self { Self() }
 }
 
@@ -767,7 +767,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -779,7 +779,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int16>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -791,7 +791,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int32>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -803,7 +803,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int64>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -815,7 +815,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<Int8>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -827,7 +827,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -839,7 +839,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt16>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -851,7 +851,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt32>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -863,7 +863,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt64>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 
@@ -875,7 +875,7 @@ public extension FormatStyle where Self == IntegerFormatStyle<UInt8>.Percent {
     /// Use this type property when the call point allows the use of ``IntegerFormatStyle``.
     /// You typically do this when calling the `formatted` methods of types that conform to
     /// `BinaryInteger`.
-    @_alwaysEmitIntoClient
+    @export(implementation)
     static var percent: Self { Self() }
 }
 

--- a/Sources/FoundationInternationalization/String/KeyPathComparator.swift
+++ b/Sources/FoundationInternationalization/String/KeyPathComparator.swift
@@ -65,32 +65,32 @@ public struct KeyPathComparator<Compared>: SortComparator {
 
     // A temporary workaround to a compiler bug that changes the ABI when adding the & Sendable constraint
     // Should be removed and the related functions should be made public when rdar://131764614 is resolved
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value> & Sendable, order: SortOrder = .forward) {
         self.init(keyPath as KeyPath<Compared, Value>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value?> & Sendable, order: SortOrder = .forward) {
         self.init(keyPath as KeyPath<Compared, Value?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value> & Sendable, comparator: Comparator) where Comparator.Compared == Value {
         self.init(keyPath as KeyPath<Compared, Value>, comparator: comparator)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?> & Sendable, comparator: Comparator) where Comparator.Compared == Value {
         self.init(keyPath as KeyPath<Compared, Value?>, comparator: comparator)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value> & Sendable, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
         self.init(keyPath as KeyPath<Compared, Value>, comparator: comparator, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?> & Sendable, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
         self.init(keyPath as KeyPath<Compared, Value?>, comparator: comparator, order: order)
     }

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -236,209 +236,209 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     
     // A temporary workaround to a compiler bug that changes the ABI when adding the & Sendable constraint
     // Should be removed and the related functions should be made public when rdar://131764614 is resolved
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init<Value>(_ keyPath: KeyPath<Compared, Value> & Sendable, order: SortOrder = .forward) where Value: Comparable {
         self.init(keyPath as KeyPath<Compared, Value>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init<Value>(_ keyPath: KeyPath<Compared, Value?> & Sendable, order: SortOrder = .forward) where Value: Comparable {
         self.init(keyPath as KeyPath<Compared, Value?>, order: order)
     }
     
     #if FOUNDATION_FRAMEWORK
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
         self.init(keyPath as KeyPath<Compared, String>, comparator: comparator)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
         self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.init(keyPath as KeyPath<Compared, String>, comparator: comparator, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Bool> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Bool>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Bool?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Bool?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Double> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Double>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Double?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Double?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Float> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Float>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Float?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Float?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int8> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int8>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int8?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int8?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int16> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int16>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int16?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int16?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int32> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int32>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int32?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int32?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int64> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int64>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int64?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int64?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Int?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Int?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt8> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt8>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt8?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt8?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt16> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt16>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt16?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt16?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt32> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt32>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt32?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt32?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt64> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt64>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt64?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt64?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UInt?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UInt?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Date> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Date>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, Date?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, Date?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UUID> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UUID>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, UUID?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, UUID?>, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, String>, comparator: comparator)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, String>, comparator: comparator, order: order)
     }
     
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator, order: order)
     }
@@ -1172,7 +1172,7 @@ extension NSSortDescriptor {
         self.init(_sortDescriptor: sortDescriptor)
     }
 
-    @_alwaysEmitIntoClient
+    @export(implementation)
     public convenience init<Compared>(_sortDescriptor: SortDescriptor<Compared>) {
         self.init(_sortDescriptor)
     }


### PR DESCRIPTION
### Motivation:

`@export(implementation)` is the new (non-underscored) way to spell `@_alwaysEmitIntoClient` so we can adopt the new, recommended syntax compatibly

### Modifications:

Find/replace all `@_alwaysEmitIntoClient` with `@export(implementation)`

### Result:

swift-foundation uses the newer recommended syntax for expressing this behavior

### Testing:

Verified that the project still builds successfully
