### PR TITLE
[Base64] Use Span for Input and Output when Encoding

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -133,7 +133,7 @@ extension Data {
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded string.
     public func base64EncodedString(options: Base64EncodingOptions = []) -> String {
-        Base64.encodeToString(bytes: self.span, options: options)
+        Base64.encodeToString(bytes: self.bytes, options: options)
     }
 
     /// Returns Base-64 encoded data.
@@ -141,7 +141,7 @@ extension Data {
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded data.
     public func base64EncodedData(options: Base64EncodingOptions = []) -> Data {
-        Base64.encodeToData(bytes: self.span, options: options)
+        Base64.encodeToData(bytes: self.bytes, options: options)
     }
 }
 
@@ -309,33 +309,26 @@ extension Base64 {
         UInt8(ascii: "6"), UInt8(ascii: "7"), UInt8(ascii: "8"), UInt8(ascii: "9"), UInt8(ascii: "-"), UInt8(ascii: "_"),
     ]
 
-    static func encodeToString(bytes: Span<UInt8>, options: Data.Base64EncodingOptions = []) -> String {
-        let newCapacity = self.encodeComputeCapacity(bytes: bytes.count, options: options)
+    static func encodeToString(bytes: RawSpan, options: Data.Base64EncodingOptions = []) -> String {
+        let newCapacity = self.encodeComputeCapacity(bytes: bytes.byteCount, options: options)
 
         return String(unsafeUninitializedCapacity: newCapacity) { buffer -> Int in
-            var outputSpan = OutputRawSpan(buffer: UnsafeMutableRawBufferPointer(buffer), initializedCount: 0)
+            let ptr = UnsafeMutableRawBufferPointer(buffer)
+            var outputSpan = OutputRawSpan(buffer: ptr, initializedCount: 0)
             Self._encode(input: bytes, buffer: &outputSpan, options: options)
-            return outputSpan.byteCount
+            return outputSpan.finalize(for: ptr)
         }
     }
 
-    static func encodeToData(bytes: Span<UInt8>, options: Data.Base64EncodingOptions = []) -> Data {
-        let newCapacity = self.encodeComputeCapacity(bytes: bytes.count, options: options)
+    static func encodeToData(bytes: RawSpan, options: Data.Base64EncodingOptions = []) -> Data {
+        let newCapacity = self.encodeComputeCapacity(bytes: bytes.byteCount, options: options)
 
-        return Data(capacity: newCapacity) { (buffer: inout OutputBuffer<UInt8>) in
-            var outputSpan = OutputRawSpan(
-                buffer: UnsafeMutableRawBufferPointer(
-                    start: UnsafeMutableRawPointer(buffer.start),
-                    count: buffer.capacity
-                ),
-                initializedCount: 0
-            )
-            Self._encode(input: bytes, buffer: &outputSpan, options: options)
-            buffer.initialized = outputSpan.byteCount
+        return Data(capacity: newCapacity) { (span: inout OutputRawSpan) in
+            Self._encode(input: bytes, buffer: &span, options: options)
         }
     }
 
-    static func _encode(input: Span<UInt8>, buffer: inout OutputRawSpan, options: Data.Base64EncodingOptions) {
+    static func _encode(input: RawSpan, buffer: inout OutputRawSpan, options: Data.Base64EncodingOptions) {
         if options.contains(.lineLength64Characters) || options.contains(.lineLength76Characters) {
             return self._encodeWithLineBreaks(input: input, buffer: &buffer, options: options)
         }
@@ -343,16 +336,16 @@ extension Base64 {
         let omitPaddingCharacter = options.contains(.omitPaddingCharacter)
 
         Self.withEncodingTables(options: options) { (e0, e1) throws(Never) -> Void in
-            let to = input.count / 3 * 3
+            let to = input.byteCount / 3 * 3
 
             self.loopEncode(e0, e1, input: input.extracting(0..<to), output: &buffer)
 
-            if to < input.count {
+            if to < input.byteCount {
                 let index = to
 
                 let i1 = input[unchecked: index] // fine, since index = to and to < input.count
-                let i2 = index &+ 1 < input.count ? input[unchecked: index &+ 1] : nil // range check in the same line
-                let i3 = index &+ 2 < input.count ? input[unchecked: index &+ 2] : nil // range check in the same line
+                let i2 = index &+ 1 < input.byteCount ? input[unchecked: index &+ 1] : nil // range check in the same line
+                let i3 = index &+ 2 < input.byteCount ? input[unchecked: index &+ 2] : nil // range check in the same line
 
                 buffer.append(e0[i1])
 
@@ -379,7 +372,7 @@ extension Base64 {
     }
 
     static func _encodeWithLineBreaks(
-        input: borrowing Span<UInt8>,
+        input: borrowing RawSpan,
         buffer: inout OutputRawSpan,
         options: Data.Base64EncodingOptions
     ) {
@@ -393,7 +386,7 @@ extension Base64 {
             57
         }
 
-        let lines = input.count / lineLength
+        let lines = input.byteCount / lineLength
 
         let separatorByte1: UInt8
         let separatorByte2: UInt8?
@@ -416,7 +409,7 @@ extension Base64 {
             //       can never wrap.
 
             // first full line
-            if input.count >= lineLength {
+            if input.byteCount >= lineLength {
                 self.loopEncode(e0, e1, input: input.extracting(0..<lineLength), output: &buffer)
             }
 
@@ -433,22 +426,22 @@ extension Base64 {
             }
 
             // last line beginning
-            if lines > 0 && lines * lineLength < input.count {
+            if lines > 0 && lines * lineLength < input.byteCount {
                 buffer.append(separatorByte1)
                 if let separatorByte2 {
                     buffer.append(separatorByte2)
                 }
             }
-            let to = input.count / 3 * 3
+            let to = input.byteCount / 3 * 3
             self.loopEncode(e0, e1, input: input.extracting((lines * lineLength)..<to), output: &buffer)
 
             // last 2-4 bytes
-            if to < input.count {
+            if to < input.byteCount {
                 let index = to
 
                 let i1 = input[index]
-                let i2 = index + 1 < input.count ? input[index + 1] : nil
-                let i3 = index + 2 < input.count ? input[index + 2] : nil
+                let i2 = index + 1 < input.byteCount ? input[index + 1] : nil
+                let i3 = index + 2 < input.byteCount ? input[index + 2] : nil
 
                 buffer.append(e0[i1])
 
@@ -476,18 +469,18 @@ extension Base64 {
     private static func loopEncode(
         _ e0: Base64EncodingTable,
         _ e1: Base64EncodingTable,
-        input: borrowing Span<UInt8>,
+        input: borrowing RawSpan,
         output: inout OutputRawSpan
     ) {
-        assert(input.count.isMultiple(of: 3))
-        assert(output.freeCapacity >= 4 * (input.count / 3))
+        assert(input.byteCount.isMultiple(of: 3))
+        assert(output.freeCapacity >= 4 * (input.byteCount / 3))
         // Note: It's safe to use overflowing math here, as input and output are valid pointers
         //       with a length that is smaller than Int here. For this reason index and outIndex
         //       can never wrap.
         output.withUnsafeMutableBytes { outPtr, initializedCount in
             var index = 0
             var outIndex = initializedCount
-            while index < input.count {
+            while index < input.byteCount {
                 let i1 = input[unchecked: index]
                 let i2 = input[unchecked: index &+ 1]
                 let i3 = input[unchecked: index &+ 2]

--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -309,27 +309,13 @@ extension Base64 {
         UInt8(ascii: "6"), UInt8(ascii: "7"), UInt8(ascii: "8"), UInt8(ascii: "9"), UInt8(ascii: "-"), UInt8(ascii: "_"),
     ]
 
-    static func encodeToBytes(bytes: Span<UInt8>, options: Data.Base64EncodingOptions) -> [UInt8] {
-        let newCapacity = self.encodeComputeCapacity(bytes: bytes.count, options: options)
-
-        return [UInt8](unsafeUninitializedCapacity: newCapacity) { buffer, length in
-            var outputSpan = OutputRawSpan(buffer: UnsafeMutableRawBufferPointer(buffer), initializedCount: 0)
-            Self._encode(input: bytes, buffer: &outputSpan, options: options)
-        }
-    }
-
     static func encodeToString(bytes: Span<UInt8>, options: Data.Base64EncodingOptions = []) -> String {
         let newCapacity = self.encodeComputeCapacity(bytes: bytes.count, options: options)
 
-        if #available(OSX 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
-            return String(unsafeUninitializedCapacity: newCapacity) { buffer -> Int in
-                var outputSpan = OutputRawSpan(buffer: UnsafeMutableRawBufferPointer(buffer), initializedCount: 0)
-                Self._encode(input: bytes, buffer: &outputSpan, options: options)
-                return outputSpan.byteCount
-            }
-        } else {
-            let bytes: [UInt8] = self.encodeToBytes(bytes: bytes, options: options)
-            return String(decoding: bytes, as: Unicode.UTF8.self)
+        return String(unsafeUninitializedCapacity: newCapacity) { buffer -> Int in
+            var outputSpan = OutputRawSpan(buffer: UnsafeMutableRawBufferPointer(buffer), initializedCount: 0)
+            Self._encode(input: bytes, buffer: &outputSpan, options: options)
+            return outputSpan.byteCount
         }
     }
 

--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -337,7 +337,6 @@ extension Base64 {
         let newCapacity = self.encodeComputeCapacity(bytes: bytes.count, options: options)
 
         return Data(capacity: newCapacity) { (buffer: inout OutputBuffer<UInt8>) in
-            var length = 0
             var outputSpan = OutputRawSpan(
                 buffer: UnsafeMutableRawBufferPointer(
                     start: UnsafeMutableRawPointer(buffer.start),
@@ -365,9 +364,9 @@ extension Base64 {
             if to < input.count {
                 let index = to
 
-                let i1 = input[index]
-                let i2 = index &+ 1 < input.count ? input[index &+ 1] : nil
-                let i3 = index &+ 2 < input.count ? input[index &+ 2] : nil
+                let i1 = input[unchecked: index] // fine, since index = to and to < input.count
+                let i2 = index &+ 1 < input.count ? input[unchecked: index &+ 1] : nil // range check in the same line
+                let i3 = index &+ 2 < input.count ? input[unchecked: index &+ 2] : nil // range check in the same line
 
                 buffer.append(e0[i1])
 

--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -133,7 +133,7 @@ extension Data {
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded string.
     public func base64EncodedString(options: Base64EncodingOptions = []) -> String {
-        Base64.encodeToString(bytes: self, options: options)
+        Base64.encodeToString(bytes: self.span, options: options)
     }
 
     /// Returns Base-64 encoded data.
@@ -141,7 +141,7 @@ extension Data {
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded data.
     public func base64EncodedData(options: Base64EncodingOptions = []) -> Data {
-        Base64.encodeToData(bytes: self, options: options)
+        Base64.encodeToData(bytes: self.span, options: options)
     }
 }
 
@@ -309,79 +309,58 @@ extension Base64 {
         UInt8(ascii: "6"), UInt8(ascii: "7"), UInt8(ascii: "8"), UInt8(ascii: "9"), UInt8(ascii: "-"), UInt8(ascii: "_"),
     ]
 
-    static func encodeToBytes<Buffer: Collection>(bytes: Buffer, options: Data.Base64EncodingOptions)
-        -> [UInt8] where Buffer.Element == UInt8
-    {
+    static func encodeToBytes(bytes: Span<UInt8>, options: Data.Base64EncodingOptions) -> [UInt8] {
         let newCapacity = self.encodeComputeCapacity(bytes: bytes.count, options: options)
 
-        if let result = bytes.withContiguousStorageIfAvailable({ input -> [UInt8] in
-            [UInt8](unsafeUninitializedCapacity: newCapacity) { buffer, length in
-                Self._encode(input: input, buffer: buffer, length: &length, options: options)
-            }
-        }) {
-            return result
+        return [UInt8](unsafeUninitializedCapacity: newCapacity) { buffer, length in
+            var outputSpan = OutputRawSpan(buffer: UnsafeMutableRawBufferPointer(buffer), initializedCount: 0)
+            Self._encode(input: bytes, buffer: &outputSpan, options: options)
         }
-
-        return self.encodeToBytes(bytes: Array(bytes), options: options)
     }
 
-    static func encodeToString<Buffer: Collection>(bytes: Buffer, options: Data.Base64EncodingOptions = [])
-        -> String where Buffer.Element == UInt8
-    {
+    static func encodeToString(bytes: Span<UInt8>, options: Data.Base64EncodingOptions = []) -> String {
         let newCapacity = self.encodeComputeCapacity(bytes: bytes.count, options: options)
 
         if #available(OSX 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
-            if let result = bytes.withContiguousStorageIfAvailable({ input -> String in
-                String(unsafeUninitializedCapacity: newCapacity) { buffer -> Int in
-                    var length = newCapacity
-                    Self._encode(input: input, buffer: buffer, length: &length, options: options)
-                    return length
-                }
-            }) {
-                return result
+            return String(unsafeUninitializedCapacity: newCapacity) { buffer -> Int in
+                var outputSpan = OutputRawSpan(buffer: UnsafeMutableRawBufferPointer(buffer), initializedCount: 0)
+                Self._encode(input: bytes, buffer: &outputSpan, options: options)
+                return outputSpan.byteCount
             }
-
-            return self.encodeToString(bytes: Array(bytes), options: options)
         } else {
             let bytes: [UInt8] = self.encodeToBytes(bytes: bytes, options: options)
             return String(decoding: bytes, as: Unicode.UTF8.self)
         }
     }
 
-    static func encodeToData<Buffer: Collection>(bytes: Buffer, options: Data.Base64EncodingOptions = [])
-        -> Data where Buffer.Element == UInt8
-    {
+    static func encodeToData(bytes: Span<UInt8>, options: Data.Base64EncodingOptions = []) -> Data {
         let newCapacity = self.encodeComputeCapacity(bytes: bytes.count, options: options)
 
-        if let result = bytes.withContiguousStorageIfAvailable({ input -> Data in
-            var data = Data(count: newCapacity) // initialized with zeroed buffer
-            _ = data.withUnsafeMutableBytes { rawBuffer in
-                rawBuffer.withMemoryRebound(to: UInt8.self) { buffer in
-                    var length = newCapacity
-                    Self._encode(input: input, buffer: buffer, length: &length, options: options)
-                    return length
-                }
-            }
-            return data
-        }) {
-            return result
+        return Data(capacity: newCapacity) { (buffer: inout OutputBuffer<UInt8>) in
+            var length = 0
+            var outputSpan = OutputRawSpan(
+                buffer: UnsafeMutableRawBufferPointer(
+                    start: UnsafeMutableRawPointer(buffer.start),
+                    count: buffer.capacity
+                ),
+                initializedCount: 0
+            )
+            Self._encode(input: bytes, buffer: &outputSpan, options: options)
+            buffer.initialized = outputSpan.byteCount
         }
-
-        return self.encodeToData(bytes: Array(bytes), options: options)
     }
 
-    static func _encode(input: UnsafeBufferPointer<UInt8>, buffer: UnsafeMutableBufferPointer<UInt8>, length: inout Int, options: Data.Base64EncodingOptions) {
+    static func _encode(input: Span<UInt8>, buffer: inout OutputRawSpan, options: Data.Base64EncodingOptions) {
         if options.contains(.lineLength64Characters) || options.contains(.lineLength76Characters) {
-            return self._encodeWithLineBreaks(input: input, buffer: buffer, length: &length, options: options)
+            return self._encodeWithLineBreaks(input: input, buffer: &buffer, options: options)
         }
 
         let omitPaddingCharacter = options.contains(.omitPaddingCharacter)
 
         Self.withEncodingTables(options: options) { (e0, e1) throws(Never) -> Void in
             let to = input.count / 3 * 3
-            var outIndex = 0
 
-            self.loopEncode(e0, e1, input: input, from: 0, to: to, output: buffer, outIndex: &outIndex)
+            self.loopEncode(e0, e1, input: input.extracting(0..<to), output: &buffer)
 
             if to < input.count {
                 let index = to
@@ -390,41 +369,33 @@ extension Base64 {
                 let i2 = index &+ 1 < input.count ? input[index &+ 1] : nil
                 let i3 = index &+ 2 < input.count ? input[index &+ 2] : nil
 
-                buffer[outIndex] = e0[i1]
+                buffer.append(e0[i1])
 
                 if let i2 = i2 {
-                    buffer[outIndex &+ 1] = e1[((i1 & 0x03) &<< 4) | ((i2 &>> 4) & 0x0F)]
+                    buffer.append(e1[((i1 & 0x03) &<< 4) | ((i2 &>> 4) & 0x0F)])
                     if let i3 = i3 {
-                        buffer[outIndex &+ 2] = e1[((i2 & 0x0F) &<< 2) | ((i3 &>> 6) & 0x03)]
-                        buffer[outIndex &+ 3] = e1[i3]
-                        outIndex += 4
+                        buffer.append(e1[((i2 & 0x0F) &<< 2) | ((i3 &>> 6) & 0x03)])
+                        buffer.append(e1[i3])
                     } else {
-                        buffer[outIndex &+ 2] = e1[(i2 & 0x0F) &<< 2]
-                        outIndex += 3
+                        buffer.append(e1[(i2 & 0x0F) &<< 2])
                         if !omitPaddingCharacter {
-                            buffer[outIndex] = Self.encodePaddingCharacter
-                            outIndex &+= 1
+                            buffer.append(Self.encodePaddingCharacter)
                         }
                     }
                 } else {
-                    buffer[outIndex &+ 1] = e1[(i1 & 0x03) << 4]
-                    outIndex &+= 2
+                    buffer.append(e1[(i1 & 0x03) << 4])
                     if !omitPaddingCharacter {
-                        buffer[outIndex] = Self.encodePaddingCharacter
-                        buffer[outIndex &+ 1] = Self.encodePaddingCharacter
-                        outIndex &+= 2
+                        buffer.append(Self.encodePaddingCharacter)
+                        buffer.append(Self.encodePaddingCharacter)
                     }
                 }
             }
-
-            length = outIndex
         }
     }
 
     static func _encodeWithLineBreaks(
-        input: UnsafeBufferPointer<UInt8>,
-        buffer: UnsafeMutableBufferPointer<UInt8>,
-        length: inout Int,
+        input: borrowing Span<UInt8>,
+        buffer: inout OutputRawSpan,
         options: Data.Base64EncodingOptions
     ) {
         let omitPaddingCharacter = options.contains(.omitPaddingCharacter)
@@ -455,42 +426,36 @@ extension Base64 {
         }
 
         Self.withEncodingTables(options: options) { (e0, e1) throws(Never) -> Void in
-            var outIndex = 0
-
             // Note: It's safe to use overflowing math here, as input and output are valid pointers
             //       with a length that is smaller than Int here. For this reason index and outIndex
             //       can never wrap.
 
             // first full line
             if input.count >= lineLength {
-                self.loopEncode(e0, e1, input: input, from: 0, to: lineLength, output: buffer, outIndex: &outIndex)
+                self.loopEncode(e0, e1, input: input.extracting(0..<lineLength), output: &buffer)
             }
 
             // following full lines
             var lineInputIndex = lineLength
             while lineInputIndex < lines * lineLength {
-                buffer[outIndex] = separatorByte1
-                outIndex &+= 1
+                buffer.append(separatorByte1)
                 if let separatorByte2 {
-                    buffer[outIndex] = separatorByte2
-                    outIndex &+= 1
+                    buffer.append(separatorByte2)
                 }
 
-                self.loopEncode(e0, e1, input: input, from: lineInputIndex, to: lineInputIndex + lineLength, output: buffer, outIndex: &outIndex)
+                self.loopEncode(e0, e1, input: input.extracting(lineInputIndex..<lineInputIndex + lineLength), output: &buffer)
                 lineInputIndex &+= lineLength
             }
 
             // last line beginning
             if lines > 0 && lines * lineLength < input.count {
-                buffer[outIndex] = separatorByte1
-                outIndex += 1
+                buffer.append(separatorByte1)
                 if let separatorByte2 {
-                    buffer[outIndex] = separatorByte2
-                    outIndex += 1
+                    buffer.append(separatorByte2)
                 }
             }
             let to = input.count / 3 * 3
-            self.loopEncode(e0, e1, input: input, from: lines * lineLength, to: to, output: buffer, outIndex: &outIndex)
+            self.loopEncode(e0, e1, input: input.extracting((lines * lineLength)..<to), output: &buffer)
 
             // last 2-4 bytes
             if to < input.count {
@@ -500,59 +465,55 @@ extension Base64 {
                 let i2 = index + 1 < input.count ? input[index + 1] : nil
                 let i3 = index + 2 < input.count ? input[index + 2] : nil
 
-                buffer[outIndex] = e0[i1]
+                buffer.append(e0[i1])
 
                 if let i2 = i2, let i3 = i3 {
-                    buffer[outIndex + 1] = e1[((i1 & 0x03) << 4) | ((i2 >> 4) & 0x0F)]
-                    buffer[outIndex + 2] = e1[((i2 & 0x0F) << 2) | ((i3 >> 6) & 0x03)]
-                    buffer[outIndex + 3] = e1[i3]
-                    outIndex += 4
+                    buffer.append(e1[((i1 & 0x03) << 4) | ((i2 >> 4) & 0x0F)])
+                    buffer.append(e1[((i2 & 0x0F) << 2) | ((i3 >> 6) & 0x03)])
+                    buffer.append(e1[i3])
                 } else if let i2 = i2 {
-                    buffer[outIndex + 1] = e1[((i1 & 0x03) << 4) | ((i2 >> 4) & 0x0F)]
-                    buffer[outIndex + 2] = e1[(i2 & 0x0F) << 2]
-                    outIndex += 3
+                    buffer.append(e1[((i1 & 0x03) << 4) | ((i2 >> 4) & 0x0F)])
+                    buffer.append(e1[(i2 & 0x0F) << 2])
                     if !omitPaddingCharacter {
-                        buffer[outIndex] = Self.encodePaddingCharacter
-                        outIndex += 1
+                        buffer.append(Self.encodePaddingCharacter)
                     }
                 } else {
-                    buffer[outIndex + 1] = e1[(i1 & 0x03) << 4]
-                    outIndex += 2
+                    buffer.append(e1[(i1 & 0x03) << 4])
                     if !omitPaddingCharacter {
-                        buffer[outIndex] = Self.encodePaddingCharacter
-                        buffer[outIndex + 1] = Self.encodePaddingCharacter
-                        outIndex += 2
+                        buffer.append(Self.encodePaddingCharacter)
+                        buffer.append(Self.encodePaddingCharacter)
                     }
                 }
             }
-
-            length = outIndex
         }
     }
 
     private static func loopEncode(
         _ e0: Base64EncodingTable,
         _ e1: Base64EncodingTable,
-        input: UnsafeBufferPointer<UInt8>,
-        from: Int,
-        to: Int,
-        output: UnsafeMutableBufferPointer<UInt8>,
-        outIndex: inout Int
+        input: borrowing Span<UInt8>,
+        output: inout OutputRawSpan
     ) {
+        assert(input.count.isMultiple(of: 3))
+        assert(output.freeCapacity >= 4 * (input.count / 3))
         // Note: It's safe to use overflowing math here, as input and output are valid pointers
         //       with a length that is smaller than Int here. For this reason index and outIndex
         //       can never wrap.
-        var index = from
-        while index < to {
-            let i1 = input[index]
-            let i2 = input[index &+ 1]
-            let i3 = input[index &+ 2]
-            output[outIndex] = e0[i1]
-            output[outIndex &+ 1] = e1[((i1 & 0x03) &<< 4) | ((i2 &>> 4) & 0x0F)]
-            output[outIndex &+ 2] = e1[((i2 & 0x0F) &<< 2) | ((i3 &>> 6) & 0x03)]
-            output[outIndex &+ 3] = e1[i3]
-            outIndex &+= 4
-            index &+= 3
+        output.withUnsafeMutableBytes { outPtr, initializedCount in
+            var index = 0
+            var outIndex = initializedCount
+            while index < input.count {
+                let i1 = input[unchecked: index]
+                let i2 = input[unchecked: index &+ 1]
+                let i3 = input[unchecked: index &+ 2]
+                outPtr[outIndex] = e0[i1]
+                outPtr[outIndex &+ 1] = e1[((i1 & 0x03) &<< 4) | ((i2 &>> 4) & 0x0F)]
+                outPtr[outIndex &+ 2] = e1[((i2 & 0x0F) &<< 2) | ((i3 &>> 6) & 0x03)]
+                outPtr[outIndex &+ 3] = e1[i3]
+                index &+= 3
+                outIndex &+= 4
+            }
+            initializedCount = outIndex
         }
     }
 

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2704,7 +2704,7 @@ extension DataTests {
         )
     }
 
-    func test_base64Encode_arrayOfNulls() {
+    @Test func test_base64Encode_arrayOfNulls() {
         let input = Data(repeating: 0, count: 10)
         #expect(input.base64EncodedString() == "AAAAAAAAAAAAAA==")
         #expect(input.base64EncodedData() == Data("AAAAAAAAAAAAAA==".utf8))

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2665,6 +2665,9 @@ extension DataTests {
         let input = Data(repeating: 0, count: 10)
         #expect(input.base64EncodedString() == "AAAAAAAAAAAAAA==")
         #expect(input.base64EncodedData() == Data("AAAAAAAAAAAAAA==".utf8))
+
+        #expect(input.base64EncodedString(options: .omitPaddingCharacter) == "AAAAAAAAAAAAAA")
+        #expect(input.base64EncodedData(options: .omitPaddingCharacter) == Data("AAAAAAAAAAAAAA".utf8))
     }
 
     @Test func base64Encode_allBytesSequentially() {
@@ -2702,15 +2705,6 @@ extension DataTests {
             8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t_g4eLj5OXm5-jp6uvs7e7v8PHy8_T19vf4-fr7_P3-_w
             """
         )
-    }
-
-    @Test func test_base64Encode_arrayOfNulls() {
-        let input = Data(repeating: 0, count: 10)
-        #expect(input.base64EncodedString() == "AAAAAAAAAAAAAA==")
-        #expect(input.base64EncodedData() == Data("AAAAAAAAAAAAAA==".utf8))
-
-        #expect(input.base64EncodedString(options: .omitPaddingCharacter) == "AAAAAAAAAAAAAA")
-        #expect(input.base64EncodedData(options: .omitPaddingCharacter) == Data("AAAAAAAAAAAAAA".utf8))
     }
 
     @Test func base64Encode_differentPaddingNeeds() {


### PR DESCRIPTION
### Motivation:

We love fast and safe code.

### Modifications:

- Use the new Span type as the internal input and output type.

### Result:

- Code that is as fast as before but safer

### Testing:

- The existing test suite validates these changes
