### PR TITLE
Turn on feature flag for Chinese and Hebrew calendar

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Cache.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Cache.swift
@@ -36,12 +36,11 @@ internal func foundation_swift_hebrew_calendar_feature_enabled() -> Bool {
 }
 
 internal func foundation_swift_chinese_calendar_feature_enabled() -> Bool {
-    // _foundation_swift_chinese_calendar_feature_enabled() — once Apple adds the underscored binding
-    return false
+    _foundation_swift_chinese_calendar_feature_enabled()
 }
 #else
-internal func foundation_swift_hebrew_calendar_feature_enabled() -> Bool { return false }
-internal func foundation_swift_chinese_calendar_feature_enabled() -> Bool { return false }
+internal func foundation_swift_hebrew_calendar_feature_enabled() -> Bool { return true }
+internal func foundation_swift_chinese_calendar_feature_enabled() -> Bool { return true }
 #endif
 
 func _calendarClass(identifier: Calendar.Identifier) -> _CalendarProtocol.Type? {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
@@ -1037,12 +1037,6 @@ internal final class _CalendarChinese: _CalendarProtocol, @unchecked Sendable {
         }
         return (diff, current)
     }
-
-#if FOUNDATION_FRAMEWORK
-    func bridgeToNSCalendar() -> NSCalendar {
-        _NSSwiftCalendar(calendar: Calendar(inner: self))
-    }
-#endif
 }
 
 // MARK: - Baked table

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -3194,13 +3194,6 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
         return dc
     }
-
-#if FOUNDATION_FRAMEWORK
-    package func bridgeToNSCalendar() -> NSCalendar {
-        _NSSwiftCalendar(calendar: Calendar(inner: self))
-    }
-#endif
-
 }
 
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -1459,11 +1459,6 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
         return (diff, current)
     }
 
-#if FOUNDATION_FRAMEWORK
-    func bridgeToNSCalendar() -> NSCalendar {
-        fatalError("TODO: bridgeToNSCalendar")
-    }
-#endif
 }
 
 // MARK: - Hebrew calendrical arithmetic (Reingold & Dershowitz)

--- a/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
@@ -81,5 +81,11 @@ extension _CalendarProtocol {
         // We use this to provide a consistent answer for hashing and equality -- null is equal to an empty string
         locale?.identifier ?? ""
     }
+
+#if FOUNDATION_FRAMEWORK
+    package func bridgeToNSCalendar() -> NSCalendar {
+        _NSSwiftCalendar(calendar: Calendar(inner: self))
+    }
+#endif
 }
 

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -262,12 +262,6 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
             hasher.combine(preferredMinimumDaysInFirstweek)
         }
     }
-    
-#if FOUNDATION_FRAMEWORK
-    func bridgeToNSCalendar() -> NSCalendar {
-        _NSSwiftCalendar(calendar: Calendar(inner: self))
-    }
-#endif
 
     // MARK: -
 

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -514,8 +514,8 @@ private struct CalendarTests {
         }
 
         #expect(!loopedForever)
-        // Expected 1126-10-18 07:52:58 +0000
-        #expect(foundDate?.timeIntervalSinceReferenceDate == -27586714022)
+        // Expected 1107-10-18 07:52:58 +0000.
+        #expect(foundDate?.timeIntervalSinceReferenceDate == -28186330022)
     }
 
     @Test func dateFromComponentsNearDSTTransition() {


### PR DESCRIPTION
Also update test expectation

According to @dra8an:

> This new code is using the astro calculations which are better than ICUs
>
> The Swift Chinese calendar implementation is using Reingold and Dershowitz, Calendrical Calculations, which builds on the Meeus theory explained in the doc. ICU is using Duffett-Smith from "Practical Astronomy with your Calculator". It applies no delta-T at all. (deltaT is also explained in the doc)
