### PR TITLE
Don't allow brackets in a non-IP-literal URL host

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Parsing.swift
+++ b/Sources/FoundationEssentials/URL/URL_Parsing.swift
@@ -595,9 +595,9 @@ extension URL {
                         // host, it would remain in the final string, so fail now.
                         if containsInvalidASCII(host: host) { return false }
                     } else {
-                        // Don't allow an unterminated IP-literal for any scheme
+                        // Don't allow partial IP-literal brackets for any scheme.
                         assert(!host.isEmpty) // Validation failed, so host is non-empty
-                        if host[0] == UInt8(ascii: "[") { return false }
+                        if containsIPLiteralBracket(host: host) { return false }
                     }
                 }
                 flags.insert(.shouldEncodeHost)

--- a/Sources/FoundationEssentials/URL/URL_Validation.swift
+++ b/Sources/FoundationEssentials/URL/URL_Validation.swift
@@ -51,6 +51,19 @@ internal func containsInvalidASCII<T: UnsignedInteger & FixedWidthInteger>(
     return false
 }
 
+// Returns true if the host contains a "[" or "]". A non-IP-literal host should not contain these characters.
+internal func containsIPLiteralBracket<T: UnsignedInteger & FixedWidthInteger>(
+    host: borrowing Span<T>
+) -> Bool {
+    for i in host.indices {
+        let codeUnit = host[i]
+        if codeUnit == UInt8(ascii: "[") || codeUnit == UInt8(ascii: "]") {
+            return true
+        }
+    }
+    return false
+}
+
 // Validates the IP literal host portion inside the "[" and "]"
 // A return value of false can be encoded, nil means reject entirely
 @inline(__always)

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -2953,6 +2953,40 @@ private struct URLTests {
         #expect(invalid == nil)
     }
 
+    @Test(.enabled(if: foundation_swift_url_v2_enabled()))
+    func hostPartialIPLiteralIsRejected() throws {
+        // An "@" inside an IP-literal is still the userinfo delimiter, which
+        // leaves only part of the IP-literal in the host, e.g. host = "host]".
+        // These should be rejected, matching WHATWG and RFC 3986 parsers.
+        #expect(URL(string: "x://[v1.a@host]/") == nil)
+        #expect(URL(string: "x://[@example.com]/") == nil)
+        #expect(URL(string: "x://[v1.a@host]:80/") == nil)
+        #expect(URL(string: "x://[fe80::a%25en1@host]/") == nil)
+
+        // The same is true for a "[" or "]" anywhere else in the host,
+        // whether or not the IP-literal was terminated.
+        #expect(URL(string: "x://a[b]c/") == nil)
+        #expect(URL(string: "x://a]b/") == nil)
+        #expect(URL(string: "x://[unterminated/") == nil)
+
+        // An already percent-encoded bracket is a valid host character.
+        var url = try #require(URL(string: "x://%5Bfoo%5D/"))
+        #expect(url.host(percentEncoded: true) == "%5Bfoo%5D")
+
+        // An "@" after the IP-literal still delimits the userinfo, so the
+        // whole IP-literal belongs to the user and the host is intact.
+        url = try #require(URL(string: "x://[foo]@bar/"))
+        #expect(url.absoluteString == "x://%5Bfoo%5D@bar/")
+        #expect(url.user(percentEncoded: true) == "%5Bfoo%5D")
+        #expect(url.host(percentEncoded: true) == "bar")
+
+        // An unterminated "[" before the "@" only affects the user.
+        url = try #require(URL(string: "x://[v1.a@host/"))
+        #expect(url.absoluteString == "x://%5Bv1.a@host/")
+        #expect(url.user(percentEncoded: true) == "%5Bv1.a")
+        #expect(url.host(percentEncoded: true) == "host")
+    }
+
     #if !os(Windows)
     @Test func tildeFilePath() throws {
         func isAbsolute(_ url: URL) -> Bool {


### PR DESCRIPTION
Don't allow `[` or `]` anywhere in a URL host that's not an IP-literal.

### Motivation:

The non-special-scheme case of host parsing currently disallows a partial IP literal (starting with `[` but not ending with `]`), but otherwise allows `[` and `]` to be percent-encoded within. This means a URL like `scheme://[v1.a@example]` would be parsed as having encoded host `example%5D`.

The previous (v1) URL parsing rejected this because of its wider application of IDNA-encoding, which would fail for `[` or `]`. We should restore that behavior by rejecting `[` and `]` anywhere in a non-IP-literal host. This is also consistent with strict RFC 3986, which doesn't allow `[` and `]` in `reg-name`, and with the WHATWG URL spec.

### Modifications:

Fail URL parsing if a non-IP-literal host contains `[` or `]`.

### Result:

`URL(string:)` returns `nil` for non-IP-literal hosts that contain `[` or `]`.

### Testing:

Added unit test.
