### PR TITLE
Add compact long number notation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import CompilerPluginSupport
 let availabilityTags: [_Availability] = [
     _Availability("FoundationPreview"), // Default FoundationPreview availability
 ]
-let versionNumbers = ["6.0.2", "6.1", "6.2", "6.3", "6.4", "6.5"]
+let versionNumbers = ["6.0.2", "6.1", "6.2", "6.3", "6.4", "6.5", "6.6"]
 
 // Availability Macro Utilities
 

--- a/Proposals/NNNN-compact-long-number-notation.md
+++ b/Proposals/NNNN-compact-long-number-notation.md
@@ -1,0 +1,99 @@
+# Compact Long Number Notation
+
+* Proposal: [SF-NNNN](NNNN-compact-long-number-notation.md)
+* Authors: [Gary Wade](https://github.com/garywade)
+* Review Manager: TBD
+* Status: **Awaiting review**
+* Implementation: TBD
+
+## Introduction/Motivation
+
+When formatting numbers, percents, or currencies, Foundation already supports a compact notation that abbreviates large values using locale-appropriate symbols or short suffixes:
+
+```swift
+let count = 1_500_000
+let result = count.formatted(.number.notation(.compactName))
+assert(result == "1.5M")
+```
+
+ICU's number-skeleton syntax supports two flavors of compact notation: `compact-short` (which `.compactName` already uses) and `compact-long`, which spells out the same magnitude using full unit names instead of abbreviated symbols, e.g. "1.5 million" instead of "1.5M". Foundation does not currently expose `compact-long`.
+
+The long form is useful whenever an abbreviated symbol is ambiguous, unfamiliar, or simply less appropriate for the context than a spelled-out word — for example, some locales' abbreviated compact symbols are already combined or overloaded at very large magnitudes, where the spelled-out form reads more clearly.
+
+## Proposed solution
+
+Add a `compactLong` notation option alongside the existing `compactName` option, available anywhere `Notation` is used today (integer, floating-point, and currency format styles):
+
+```swift
+let compactLongFormatted = 1234.formatted(.number
+    .locale(Locale(identifier: "en_US"))
+    .notation(.compactLong)) // "1.2 thousand"
+```
+
+## Detailed design
+
+```swift
+extension NumberFormatStyleConfiguration.Notation {
+    /// A locale-appropriate compact long name notation.
+    ///
+    /// A compact long name notation, when available in the format style's locale, that uses the full-length
+    /// unit names corresponding to powers of ten, such as "thousand" or "million", instead of the abbreviated
+    /// symbols that ``compactName`` uses. The following example shows a compact long name notation in the
+    /// `en_US` locale:
+    ///
+    /// ```swift
+    /// let compactLongFormatted = 1234.formatted(.number
+    ///     .locale(Locale(identifier: "en_US"))
+    ///     .notation(.compactLong)) // "1.2 thousand"
+    /// ```
+    ///
+    /// - note: We do not support parsing a number string containing localized prefixes or suffixes.
+    /// - note: When combined with a currency format style, this currently falls back to the same abbreviated
+    ///   output as ``compactName``, since ICU does not yet provide long-form compact patterns for currency;
+    ///   this is expected to improve as upstream ICU/CLDR gains that support.
+    @available(FoundationPreview 6.6, *)
+    public static var compactLong: Self { .init(option: .compactLong) }
+}
+```
+
+Since `CurrencyFormatStyleConfiguration.Notation` is a `typealias` for `NumberFormatStyleConfiguration.Notation` (added in [SF-0008](0008-notation-formatting-for-currencies.md)), this single addition is automatically available to the integer, floating-point, and decimal currency format styles as well, with no further API surface needed:
+
+```swift
+let price = Decimal(1_500_000.59)
+let result = price.formatted(.currency(code: "USD").notation(.compactLong))
+assert(result == "$1.5M") // short-form fallback, not "$1.5 million" — see "Known limitation" below
+```
+
+Internally, this maps to ICU's `compact-long` number-skeleton stem, the direct sibling of the `compact-short` stem that `.compactName` already uses — no new ICU data or plumbing is required for the plain-number case.
+
+### Known limitation: currency formatting falls back to short form
+
+ICU/CLDR currently ships long-form (`patternsLong`) compact pattern data only for plain decimal formatting, not for currency formatting (only `patternsShort` exists for currencies, across all locales). As a result, `notation(.compactLong)` applied to a currency format style silently produces the same output as `notation(.compactName)` today (e.g. `"$1.5M"` rather than `"$1.5 million"`), rather than an error. This is an ICU/CLDR-level gap, not something this proposal's implementation can work around at the Foundation layer — there's no ICU skeleton combination that yields symbol-prefixed currency amounts with spelled-out magnitude words. Plain number and percent formatting are unaffected and get genuine long-form output.
+
+This is called out explicitly in the API's documentation (see `Detailed design` above) so it isn't a silent surprise for adopters. Improving this is tracked as a future direction, contingent on upstream ICU/CLDR support.
+
+## Source compatibility
+
+This change is additive only and is not expected to have an impact on source compatibility.
+
+## Implications on adoption
+
+This new API will have `FoundationPreview 6.6` availability. This feature can be freely adopted and un-adopted in source code with no deployment constraints and without affecting source compatibility.
+
+## Alternatives considered
+
+**Naming it something other than `compactLong`.** `compactName` already establishes the "compact" + descriptor naming pattern for this family of options, so `compactLong` (paired with `compactName` remaining the short form) keeps the two symmetric and discoverable together, rather than introducing an unrelated name for the same family.
+
+**Withholding this from currency format styles until ICU/CLDR gains long-form currency patterns.** Since `Notation` is shared via the `CurrencyFormatStyleConfiguration.Notation` typealias, restricting `compactLong` to only the non-currency format styles would require diverging that typealias relationship, adding real API surface and complexity to work around a temporary upstream data gap. Documenting the known fallback (see Detailed design) is simpler and keeps the option available and consistent across all format styles once ICU/CLDR does add the missing data — no follow-up API change would be needed at that point.
+
+**Folding this into a broader "expose more ICU compact/currency options" proposal.** ICU also exposes other formatting options Foundation doesn't yet surface (e.g. the "cash" currency rounding behavior used by currencies like TWD that don't circulate sub-unit denominations in practice). That is a materially different, currency-rounding-behavior problem — orthogonal to notation — with its own open design question (how a developer would discover and choose between a cash-rounding configuration and the standard one) that has not yet reached consensus. Bundling it here would block this small, uncontroversial notation addition on an unrelated, unresolved design discussion. It's left as a future direction instead.
+
+## Future directions
+
+Exposing ICU's cash-currency rounding behavior (e.g. for currencies like TWD that are formally subdivided but never show fractional amounts in practice) is a natural follow-on, but is a separate proposal: it changes rounding behavior rather than adding a notation option, and needs its own design discussion about discoverability before it's ready to pitch.
+
+Resolving the currency fallback described in "Known limitation" above requires no follow-up API change — once ICU/CLDR ships the missing data, `notation(.compactLong)` on currency format styles will automatically start producing genuine long-form output.
+
+## Acknowledgments
+
+Thanks to everyone who weighed in on the ICU compact-notation gaps that motivated this proposal.

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -358,6 +358,7 @@ public enum NumberFormatStyleConfiguration {
             case automatic
             case scientific
             case compactName
+            case compactLong
         }
         var option: Option
 
@@ -386,6 +387,26 @@ public enum NumberFormatStyleConfiguration {
         /// - note: We do not support parsing a number string containing localized prefixes or suffixes.
         public static var compactName: Self { .init(option: .compactName) }
 
+        /// A locale-appropriate compact long name notation.
+        ///
+        /// A compact long name notation, when available in the format style's locale, that uses the full-length
+        /// unit names corresponding to powers of ten, such as "thousand" or "million", instead of the abbreviated
+        /// symbols that ``compactName`` uses. The following example shows a compact long name notation in the
+        /// `en_US` locale:
+        ///
+        /// ```swift
+        /// let compactLongFormatted = 1234.formatted(.number
+        ///     .locale(Locale(identifier: "en_US"))
+        ///     .notation(.compactLong)) // "1.2 thousand"
+        /// ```
+        ///
+        /// - note: We do not support parsing a number string containing localized prefixes or suffixes.
+        /// - note: When combined with a currency format style, this currently falls back to the same abbreviated
+        ///   output as ``compactName``, since ICU does not yet provide long-form compact patterns for currency;
+        ///   this is expected to improve as upstream ICU/CLDR gains that support.
+        @available(FoundationPreview 6.6, *)
+        public static var compactLong: Self { .init(option: .compactLong) }
+
         public var description: String {
             switch option {
             case .scientific:
@@ -394,6 +415,8 @@ public enum NumberFormatStyleConfiguration {
                 return "automatic"
             case .compactName:
                 return "compact name"
+            case .compactLong:
+                return "compact long name"
             }
         }
     }
@@ -963,6 +986,8 @@ extension NumberFormatStyleConfiguration.Notation {
             stem = ""
         case .compactName:
             stem = "compact-short"
+        case .compactLong:
+            stem = "compact-long"
         }
         return stem
     }

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -608,6 +608,113 @@ private struct NumberFormatStyleTests {
         #expect((-922337203685477 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$1000T")
     }
 
+    @available(FoundationPreview 6.6, *)
+    @Test func currency_compactLong() throws {
+        let baseStyle = Decimal.FormatStyle.Currency(code: "USD", locale: Locale(identifier: "en_US")).notation(.compactLong)
+
+        // significant digits
+        // ICU currently has no long-form compact patterns for currency, so `compactLong` falls back to the same
+        // abbreviated output as `compactName` when combined with a currency style. See `currency_compactName` above
+        // for the equivalent non-currency-specific expectations.
+        #expect( (922337203685477 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$920T")
+        #expect(  (92233720368547 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$92T")
+        #expect(   (9223372036854 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$9.2T")
+        #expect(    (922337203685 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$920B")
+        #expect(     (92233720368 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$92B")
+        #expect(      (9223372036 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$9.2B")
+        #expect(       (922337203 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$920M")
+        #expect(        (92233720 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$92M")
+        #expect(         (9223372 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$9.2M")
+        #expect(          (922337 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$920K")
+        #expect(           (92233 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$92K")
+        #expect(            (9223 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$9.2K")
+        #expect(             (922 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$920")
+        #expect(              (92 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$92")
+        #expect(               (9 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$9.0")
+        #expect(               (0 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "$0.0")
+        #expect(              (-9 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$9.0")
+        #expect(             (-92 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$92")
+        #expect(            (-922 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$920")
+        #expect(           (-9223 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$9.2K")
+        #expect(          (-92233 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$92K")
+        #expect(         (-922337 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$920K")
+        #expect(        (-9223372 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$9.2M")
+        #expect(       (-92233720 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$92M")
+        #expect(      (-922337203 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$920M")
+        #expect(     (-9223372036 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$9.2B")
+        #expect(    (-92233720368 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$92B")
+        #expect(   (-922337203685 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$920B")
+        #expect(  (-9223372036854 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$9.2T")
+        #expect( (-92233720368547 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$92T")
+        #expect((-922337203685477 as Decimal).formatted(baseStyle.precision(.significantDigits(2...2))) == "-$920T")
+
+        // fraction length
+        #expect( (922337203685477 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$922.34T")
+        #expect(  (92233720368547 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$92.23T")
+        #expect(   (9223372036854 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$9.22T")
+        #expect(    (922337203685 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$922.34B")
+        #expect(     (92233720368 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$92.23B")
+        #expect(      (9223372036 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$9.22B")
+        #expect(       (922337203 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$922.34M")
+        #expect(        (92233720 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$92.23M")
+        #expect(         (9223372 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$9.22M")
+        #expect(          (922337 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$922.34K")
+        #expect(           (92233 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$92.23K")
+        #expect(            (9223 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$9.22K")
+        #expect(             (922 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$922.00")
+        #expect(              (92 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$92.00")
+        #expect(               (9 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$9.00")
+        #expect(               (0 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "$0.00")
+        #expect(              (-9 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$9.00")
+        #expect(             (-92 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$92.00")
+        #expect(            (-922 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$922.00")
+        #expect(           (-9223 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$9.22K")
+        #expect(          (-92233 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$92.23K")
+        #expect(         (-922337 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$922.34K")
+        #expect(        (-9223372 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$9.22M")
+        #expect(       (-92233720 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$92.23M")
+        #expect(      (-922337203 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$922.34M")
+        #expect(     (-9223372036 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$9.22B")
+        #expect(    (-92233720368 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$92.23B")
+        #expect(   (-922337203685 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$922.34B")
+        #expect(  (-9223372036854 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$9.22T")
+        #expect( (-92233720368547 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$92.23T")
+        #expect((-922337203685477 as Decimal).formatted(baseStyle.precision(.fractionLength(2...2))) == "-$922.34T")
+
+        // rounded
+        #expect( (922337203685477 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$1000T")
+        #expect(  (92233720368547 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100T")
+        #expect(   (9223372036854 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100T")
+        #expect(    (922337203685 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100T")
+        #expect(     (92233720368 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100B")
+        #expect(      (9223372036 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100B")
+        #expect(       (922337203 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100B")
+        #expect(        (92233720 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100M")
+        #expect(         (9223372 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100M")
+        #expect(          (922337 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100M")
+        #expect(           (92233 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100K")
+        #expect(            (9223 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100K")
+        #expect(             (922 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100K")
+        #expect(              (92 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100")
+        #expect(               (9 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$100")
+        #expect(               (0 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "$0")
+        #expect(              (-9 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100")
+        #expect(             (-92 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100")
+        #expect(            (-922 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100K")
+        #expect(           (-9223 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100K")
+        #expect(          (-92233 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100K")
+        #expect(         (-922337 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100M")
+        #expect(        (-9223372 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100M")
+        #expect(       (-92233720 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100M")
+        #expect(      (-922337203 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100B")
+        #expect(     (-9223372036 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100B")
+        #expect(    (-92233720368 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100B")
+        #expect(   (-922337203685 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100T")
+        #expect(  (-9223372036854 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100T")
+        #expect( (-92233720368547 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$100T")
+        #expect((-922337203685477 as Decimal).formatted(baseStyle.rounded(rule: .awayFromZero, increment: 100)) == "-$1000T")
+    }
+
     @Test func currency_Codable() throws {
         let gbpInUS = Decimal.FormatStyle.Currency(code: "GBP", locale: enUSLocale)
         let _ = try JSONEncoder().encode(gbpInUS)
@@ -1629,6 +1736,141 @@ private struct IntegerFormatStyleExhaustiveTests {
                 "-92,300T",
                 "-922,400T",
                 "-9,223,400T",
+            ],
+        ]
+        for (style, expectedStrings) in expectations {
+            for i in 0..<exhaustiveIntNumbers.count {
+                #expect(style.format(Int(exhaustiveIntNumbers[i])) == expectedStrings[i], "Style: \(style.collection.debugDescription) is failing")
+            }
+        }
+    }
+
+    @available(FoundationPreview 6.6, *)
+    @Test func plainStyle_compactLong() throws {
+        let expectations: [IntegerFormatStyle<Int> : [String]] = [
+            // `compactLong` naturally rounds the number to the closest "name", just like `compactName`, but spells the name out in full.
+            baseStyle.precision(.significantDigits(2...2)).notation(.compactLong): [
+                "9,200,000 trillion",
+                "920,000 trillion",
+                "92,000 trillion",
+                "9200 trillion",
+                "920 trillion",
+                "92 trillion",
+                "9.2 trillion",
+                "920 billion",
+                "92 billion",
+                "9.2 billion",
+                "920 million",
+                "92 million",
+                "9.2 million",
+                "920 thousand",
+                "92 thousand",
+                "9.2 thousand",
+                "920",
+                "92",
+                "9.0",
+                "0.0",
+                "-9.0",
+                "-92",
+                "-920",
+                "-9.2 thousand",
+                "-92 thousand",
+                "-920 thousand",
+                "-9.2 million",
+                "-92 million",
+                "-920 million",
+                "-9.2 billion",
+                "-92 billion",
+                "-920 billion",
+                "-9.2 trillion",
+                "-92 trillion",
+                "-920 trillion",
+                "-9200 trillion",
+                "-92,000 trillion",
+                "-920,000 trillion",
+                "-9,200,000 trillion",
+            ],
+            baseStyle.notation(.compactLong).precision(.fractionLength(2...2)): [
+                "9,223,372.04 trillion",
+                "922,337.20 trillion",
+                "92,233.72 trillion",
+                "9223.37 trillion",
+                "922.34 trillion",
+                "92.23 trillion",
+                "9.22 trillion",
+                "922.34 billion",
+                "92.23 billion",
+                "9.22 billion",
+                "922.34 million",
+                "92.23 million",
+                "9.22 million",
+                "922.34 thousand",
+                "92.23 thousand",
+                "9.22 thousand",
+                "922.00",
+                "92.00",
+                "9.00",
+                "0.00",
+                "-9.00",
+                "-92.00",
+                "-922.00",
+                "-9.22 thousand",
+                "-92.23 thousand",
+                "-922.34 thousand",
+                "-9.22 million",
+                "-92.23 million",
+                "-922.34 million",
+                "-9.22 billion",
+                "-92.23 billion",
+                "-922.34 billion",
+                "-9.22 trillion",
+                "-92.23 trillion",
+                "-922.34 trillion",
+                "-9223.37 trillion",
+                "-92,233.72 trillion",
+                "-922,337.20 trillion",
+                "-9,223,372.04 trillion",
+            ],
+            baseStyle.notation(.compactLong).rounded(rule: .awayFromZero, increment: 100): [
+                "9,223,400 trillion",
+                "922,400 trillion",
+                "92,300 trillion",
+                "9300 trillion",
+                "1000 trillion",
+                "100 trillion",
+                "100 trillion",
+                "100 trillion",
+                "100 billion",
+                "100 billion",
+                "100 billion",
+                "100 million",
+                "100 million",
+                "100 million",
+                "100 thousand",
+                "100 thousand",
+                "100 thousand",
+                "100",
+                "100",
+                "0",
+                "-100",
+                "-100",
+                "-100 thousand",
+                "-100 thousand",
+                "-100 thousand",
+                "-100 million",
+                "-100 million",
+                "-100 million",
+                "-100 billion",
+                "-100 billion",
+                "-100 billion",
+                "-100 trillion",
+                "-100 trillion",
+                "-100 trillion",
+                "-1000 trillion",
+                "-9300 trillion",
+                "-92,300 trillion",
+                "-922,400 trillion",
+                "-9,223,400 trillion",
             ],
         ]
         for (style, expectedStrings) in expectations {


### PR DESCRIPTION
### Summary
- Adds `.compactLong` to `NumberFormatStyleConfiguration.Notation`, the full-name sibling of the existing `.compactName` short-form notation, backed by ICU's
`compact-long` skeleton stem.
- Evolution proposal: Proposals/0043-compact-long-number-notation.md (abbreviated review)
- Known limitation: currency formatting currently falls back to `.compactName`'s short-form output, since ICU/CLDR has no long-form compact currency pattern data
yet — documented in the proposal and in the API doc comment. 

### Motivation:
- The compact long option is missing.  Users wish to use it.

### Modifications:
- Added the option so that FormatStyle calls can make use of it

### Result:
- Users will be able to format values with the long-form name of values such as "1 billion"

### Test plan
- [x] `swift test --filter NumberFormatStyleTests` passes (42/42), including `currency_compactLong` and `plainStyle_compactLong`
- [x] `swift test --filter FoundationInternationalizationTests` passes (401/401, no regressions)