### PR TITLE
Fix the default implementation of CommonDecoder's `decodeString` to match its requirement properly

### DIFF
--- a/Sources/NewCodable/CommonDecodableProtocols.swift
+++ b/Sources/NewCodable/CommonDecodableProtocols.swift
@@ -465,8 +465,8 @@ public extension CommonDecoder where Self: ~Escapable {
     mutating func decode(_: String.Type) throws(CodingError.Decoding) -> String { throw CodingError.unsupportedDecodingType("string") }
     
     @_lifetime(self: copy self)
-    mutating func decodeString<V: DecodingStringVisitor>(_ visitor: V) throws(CodingError.Decoding) -> V.DecodedValue { throw CodingError.unsupportedDecodingType("string") }
-    
+    mutating func decodeString<V: DecodingStringVisitor & ~Copyable>(_ visitor: borrowing V) throws(CodingError.Decoding) -> V.DecodedValue { throw CodingError.unsupportedDecodingType("string") }
+
     @_lifetime(self: copy self)
     mutating func decodeNil() throws(CodingError.Decoding) -> Bool { throw CodingError.unsupportedDecodingType("nil") }
     


### PR DESCRIPTION
Fix the default implementation of CommonDecoder's `decodeString` to match its requirement properly

### Motivation:

All decoding functions requirements of `CommonDecoder` have a default implementation. `decodeString` was supposed to fulfill this for its requirement, but it's signature was mismatching, so it wasn't considered to have a default implementation.

### Modifications:

Match the signature to its requirement.

### Result:

The default implementation is now used where applicable, so clients don't need to implement this requirement themselves.

### Testing:

Tested by creating a type that conforms to the protocol and confirming no implementation of this function is needed.
