### PR TITLE
Fix CMake CI download

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,7 @@ jobs:
         run: apt update && apt install -y ninja-build jq curl
       - name: Install CMake
         id: install-cmake
-        uses: swiftlang/github-workflows/.github/actions/install-cmake@main
+        uses: swiftlang/github-workflows/.github/actions/install-cmake@0.0.15
         with:
           # Version from swiftlang/swift update-checkout-config.json
           cmake-version: 3.30.2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,15 +35,26 @@ jobs:
         uses: actions/checkout@v7
       - name: Install Dependencies
         shell: bash
-        run: apt update && apt install -y cmake ninja-build jq
+        run: apt update && apt install -y ninja-build jq curl
+      - name: Install CMake
+        id: install-cmake
+        uses: swiftlang/github-workflows/.github/actions/install-cmake@main
+        with:
+          # Version from swiftlang/swift update-checkout-config.json
+          cmake-version: 3.30.2
+          hash: cdd7fb352605cee3ae53b0e18b5929b642900e33d6b0173e19f6d4f2067ebf16
       - name: Configure Project
         shell: bash
+        env:
+          CMAKE: ${{ steps.install-cmake.outputs.cmake }}
         run: |
           mkdir -p build/.cmake/api/v1/query
           touch build/.cmake/api/v1/query/codemodel-v2
-          cmake -G 'Ninja' -B build -S . -DCMAKE_C_COMPILER=clang -DCMAKE_Swift_COMPILER=swiftc -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=YES
+          "$CMAKE" -G 'Ninja' -B build -S . -DCMAKE_C_COMPILER=clang -DCMAKE_Swift_COMPILER=swiftc -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=YES
       - name: Validate CMake File Lists Match SwiftPM
         shell: bash
+        env:
+          CMAKE: ${{ steps.install-cmake.outputs.cmake }}
         run: |
           swift package describe --type json | jq '.targets[] | select(.name == "FoundationEssentials") | .sources[]' | sort > /tmp/swiftpm-essentials
           cat build/.cmake/api/v1/reply/target-FoundationEssentials-*.json | jq '.sources[].path[29:]' | sort > /tmp/cmake-essentials
@@ -55,7 +66,10 @@ jobs:
           exit $exit_code
       - name: Build Project
         shell: bash
-        run: cmake --build build
+        env:
+          CMAKE: ${{ steps.install-cmake.outputs.cmake }}
+        run: |
+          "$CMAKE" --build build
 
   soundness:
     name: Soundness

--- a/Foundation_Build_Process.md
+++ b/Foundation_Build_Process.md
@@ -55,7 +55,7 @@ Each individual project can also be built via CMake. This is useful when making 
 
 ### How can I invoke a build via this configuration?
 
-_Note: Building via CMake requires that Ninja and CMake (v3.24 or greater) are both pre-installed_
+_Note: Building via CMake requires that Ninja and CMake are both pre-installed, to find the minimum required versions of these tools, check the Swift repo's [update checkout configuration)(https://github.com/swiftlang/swift/blob/main/utils/update_checkout/update-checkout-config.json). If your system does not ship with the required version of CMake, you can download it from [CMake's website](https://cmake.org/download/)._
 
 1. Ensure external dependencies such as dispatch, curl, libxml, etc. are built _(swift-corelibs-foundation only)_
 2. Configure and generate the cmake build via `cmake -B<build folder> -G Ninja -DCMAKE_INSTALL_PREFIX=<install folder>`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ use and the tradeoffs involved, see [Distributions.md](Distributions.md).
 ## Building and Testing
 
 > [!NOTE]
-> Building swift-foundation requires the in-development Swift 6.2 toolchain. You can download the Swift 6.2 nightly toolchain from [the Swift website](https://swift.org/install).
+> Building swift-foundation requires a matching nightly Swift development snapshot toolchain. For example, building the `main` branch requires a nightly main toolchain and building the `release/6.4.x` branch requires a nightly 6.4 toolchain. You can download Swift nightly toolchains from [the Swift website](https://swift.org/install).
 
 Before building Foundation, first ensure that you have a Swift toolchain installed. Next, check out the _Getting Started_ section of the [Foundation Build Process](Foundation_Build_Process.md#getting-started) guide for detailed steps on building and testing.
 


### PR DESCRIPTION
Fixes the issues with CMake CI

### Motivation:

https://github.com/swiftlang/swift-syntax/pull/3321 broke our current CMake CI workflow by requiring a version of CMake newer than the one that `apt` installs for Ubuntu noble.

### Modifications:

Updates to the new workflow that installs a custom CMake version so that we can install a newer version than the one from `apt`

### Result:

CMake CI should finish successfully

### Testing:

Testing via the GitHub Actions workflow
