### PR TITLE
Exclude ListFormatData.json from FoundationInternationalization target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -203,6 +203,7 @@ let package = Package(
                 "Calendar/CMakeLists.txt",
                 "CMakeLists.txt",
                 "Predicate/CMakeLists.txt",
+                "Formatting/ListFormatData.json",
             ],
             cSettings: wasiLibcCSettings,
             swiftSettings: [


### PR DESCRIPTION
### Motivation:

`Sources/FoundationInternationalization/Formatting/ListFormatData.json` is an intermediate artifact of the offline data-generation pipeline under `utils/`: `update-list-format-data` extracts it from CLDR, and `build-list-format-data` reads it to emit the checked-in `ListFormatData.swift` tables in `_FoundationInternationalizationData`. Only that generated Swift is compiled and used at runtime, so the JSON plays no part in the SwiftPM build.

Because it sits in the target's source tree but is neither compiled nor declared as a resource, `swift build` emits:

```
warning: 'swift-foundation': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
```

### Modifications:

Added `"Formatting/ListFormatData.json"` to the `exclude:` list of the `FoundationInternationalization` target in `Package.swift`.

### Result:

`swift build` no longer warns about the unhandled file.

### Testing:

Ran `swift build` before and after: the unhandled-file warning is present before the change and gone after.
