### PR TITLE
Keep the directory slash in standardizedFileURL for paths ending in a dot segment

### DIFF
--- a/Sources/FoundationEssentials/URL/URL_Impl.swift
+++ b/Sources/FoundationEssentials/URL/URL_Impl.swift
@@ -1470,10 +1470,8 @@ extension _URL {
         guard !path.isEmpty else {
             return nil
         }
-        // A path ending in a "." or ".." component refers to a directory,
-        // even though hasDirectoryPath reports false for such file paths for
-        // compatibility. Check the URL's own path, since resolving a relative
-        // URL against its base already removes the trailing dot segments.
+        // The file-path initializers don't set .hasDirectoryPath for a trailing
+        // "." or ".." component, so re-check the unresolved path here.
         let isDirectory = hasDirectoryPath || withPathSpan { pathSpan in
             pathSpan.withUnsafeBufferPointer { buffer in
                 URL.hasDirectoryPath(buffer, pathEnd: buffer.count, pathLength: buffer.count)

--- a/Sources/FoundationEssentials/URL/URL_Impl.swift
+++ b/Sources/FoundationEssentials/URL/URL_Impl.swift
@@ -1470,7 +1470,16 @@ extension _URL {
         guard !path.isEmpty else {
             return nil
         }
-        return _URL(filePath: path.standardizingPath, directoryHint: hasDirectoryPath ? .isDirectory : .notDirectory).url
+        // A path ending in a "." or ".." component refers to a directory,
+        // even though hasDirectoryPath reports false for such file paths for
+        // compatibility. Check the URL's own path, since resolving a relative
+        // URL against its base already removes the trailing dot segments.
+        let isDirectory = hasDirectoryPath || withPathSpan { pathSpan in
+            pathSpan.withUnsafeBufferPointer { buffer in
+                URL.hasDirectoryPath(buffer, pathEnd: buffer.count, pathLength: buffer.count)
+            }
+        }
+        return _URL(filePath: path.standardizingPath, directoryHint: isDirectory ? .isDirectory : .notDirectory).url
     }
 
     func resolvingSymlinksInPath() -> URL? {

--- a/Sources/FoundationEssentials/URL/URL_Impl.swift
+++ b/Sources/FoundationEssentials/URL/URL_Impl.swift
@@ -1470,8 +1470,7 @@ extension _URL {
         guard !path.isEmpty else {
             return nil
         }
-        // The file-path initializers don't set .hasDirectoryPath for a trailing
-        // "." or ".." component, so re-check the unresolved path here.
+        // The file-path initializers don't set .hasDirectoryPath for a trailing "." or ".." component, so re-check the unresolved path here.
         let isDirectory = hasDirectoryPath || withPathSpan { pathSpan in
             pathSpan.withUnsafeBufferPointer { buffer in
                 URL.hasDirectoryPath(buffer, pathEnd: buffer.count, pathLength: buffer.count)

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -4493,10 +4493,7 @@ private struct URLTests {
     }
 
     @Test func standardizedFileURLDotSegmentEndings() throws {
-        // A path ending in a "." or ".." component refers to a directory,
-        // but the file path initializers don't set .hasDirectoryPath for
-        // these trailing components. The standardized file URL must still
-        // end in a directory slash, consistent with .standardized.
+        // A path ending in a "." or ".." component refers to a directory, but the file path initializers don't set .hasDirectoryPath for these trailing components. The standardized file URL must still end in a directory slash, consistent with .standardized.
         let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
         let cases = [
             ("a/x/..", "file:///base/dir/a/"),

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -561,6 +561,27 @@ private struct URLTests {
         try FileManager.default.removeItem(at: URL(filePath: "\(tempDirectory.path)/tmp-dir"))
     }
 
+    @Test func standardizedFileURLDotSegmentEndings() throws {
+        // A path ending in a "." or ".." component refers to a directory.
+        // hasDirectoryPath reports false for such file paths for compatibility
+        // (see deletingLastPathComponent), but the standardized file URL must
+        // still end in a directory slash, consistent with .standardized (#2207).
+        let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
+        let cases = [
+            ("a/x/..", "file:///base/dir/a/"),
+            ("a/x/.", "file:///base/dir/a/x/"),
+            ("a/..", "file:///base/dir/"),
+        ]
+        for (path, standardized) in cases {
+            let url = URL(filePath: path, relativeTo: base)
+            #expect(url.standardized.absoluteString == standardized, "standardized \"\(path)\"")
+            #expect(url.standardizedFileURL.absoluteString == standardized, "standardizedFileURL \"\(path)\"")
+        }
+
+        let absolute = URL(filePath: "/base/dir/a/x/..")
+        #expect(absolute.standardizedFileURL.absoluteString == "file:///base/dir/a/")
+    }
+
     @Test func fileURLWithPathDirectoryHintConversion() throws {
         let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
 

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -4492,7 +4492,6 @@ private struct URLTests {
         #expect(url.query() == nil)
     }
 
-    #if !os(Windows)
     @Test func standardizedFileURLDotSegmentEndings() throws {
         // A path ending in a "." or ".." component refers to a directory,
         // but the file path initializers don't set .hasDirectoryPath for
@@ -4514,6 +4513,7 @@ private struct URLTests {
         #expect(absolute.standardizedFileURL.absoluteString == "file:///base/dir/a/")
     }
 
+    #if !os(Windows)
     @Test func standardizedFileURLAndResolvingSymlinks() async throws {
         try await FilePlayground {
             Directory("a") {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -561,27 +561,6 @@ private struct URLTests {
         try FileManager.default.removeItem(at: URL(filePath: "\(tempDirectory.path)/tmp-dir"))
     }
 
-    @Test func standardizedFileURLDotSegmentEndings() throws {
-        // A path ending in a "." or ".." component refers to a directory.
-        // hasDirectoryPath reports false for such file paths for compatibility
-        // (see deletingLastPathComponent), but the standardized file URL must
-        // still end in a directory slash, consistent with .standardized (#2207).
-        let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
-        let cases = [
-            ("a/x/..", "file:///base/dir/a/"),
-            ("a/x/.", "file:///base/dir/a/x/"),
-            ("a/..", "file:///base/dir/"),
-        ]
-        for (path, standardized) in cases {
-            let url = URL(filePath: path, relativeTo: base)
-            #expect(url.standardized.absoluteString == standardized, "standardized \"\(path)\"")
-            #expect(url.standardizedFileURL.absoluteString == standardized, "standardizedFileURL \"\(path)\"")
-        }
-
-        let absolute = URL(filePath: "/base/dir/a/x/..")
-        #expect(absolute.standardizedFileURL.absoluteString == "file:///base/dir/a/")
-    }
-
     @Test func fileURLWithPathDirectoryHintConversion() throws {
         let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
 
@@ -4514,6 +4493,27 @@ private struct URLTests {
     }
 
     #if !os(Windows)
+    @Test func standardizedFileURLDotSegmentEndings() throws {
+        // A path ending in a "." or ".." component refers to a directory,
+        // but the file path initializers don't set .hasDirectoryPath for
+        // these trailing components. The standardized file URL must still
+        // end in a directory slash, consistent with .standardized.
+        let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
+        let cases = [
+            ("a/x/..", "file:///base/dir/a/"),
+            ("a/x/.", "file:///base/dir/a/x/"),
+            ("a/..", "file:///base/dir/"),
+        ]
+        for (path, standardized) in cases {
+            let url = URL(filePath: path, relativeTo: base)
+            #expect(url.standardized.absoluteString == standardized, "standardized \"\(path)\"")
+            #expect(url.standardizedFileURL.absoluteString == standardized, "standardizedFileURL \"\(path)\"")
+        }
+
+        let absolute = URL(filePath: "/base/dir/a/x/..")
+        #expect(absolute.standardizedFileURL.absoluteString == "file:///base/dir/a/")
+    }
+
     @Test func standardizedFileURLAndResolvingSymlinks() async throws {
         try await FilePlayground {
             Directory("a") {


### PR DESCRIPTION
Fixes #2207.

### Motivation:

For a file URL whose path ends in a `.` or `..` component, `standardizedFileURL` returns a URL without the trailing directory slash, while `.standardized` keeps it:

```swift
let base = URL(filePath: "/base/dir/", directoryHint: .isDirectory)
let url = URL(filePath: "a/x/..", relativeTo: base)
url.standardized.absoluteString        // "file:///base/dir/a/"
url.standardizedFileURL.absoluteString // "file:///base/dir/a"
```

A path ending in a dot segment always refers to a directory, so the standardized URL should keep the slash. `_SwiftURL` and Swift 6.3 return `file:///base/dir/a/` for both properties.

The cause: `_URL.standardizedFileURL` derives its directory hint from `hasDirectoryPath`, which reports `false` for file paths ending in a dot segment. That flag value is intentional (`testDeletingLastPathComponent` pins it for compatibility with pre-`_SwiftURL` Foundation), so this change leaves `hasDirectoryPath` alone and computes the directory hint locally.

### Modifications:

- `_URL.standardizedFileURL` now also treats the URL as a directory when its own path ends in a `.` or `..` component, using the existing `URL.hasDirectoryPath` helper that the URL string parser uses. The check runs on the URL's own path rather than `fileSystemPath`, because resolving a relative URL against its base already removes the trailing dot segments.

### Result:

`standardizedFileURL` keeps the trailing directory slash for paths ending in `.` or `..`, matching `.standardized`, `_SwiftURL`, and Swift 6.3. `hasDirectoryPath` is unchanged.

### Testing:

- New test `standardizedFileURLDotSegmentEndings` covering relative `a/x/..`, `a/x/.`, `a/..` against a directory base and an absolute path ending in `..`.
- Full test suite passes with a 2026-08-11 main snapshot toolchain on macOS.
