### PR TITLE
[FoundationEssentials] Fix JSONDecoder silently parsing JSON5 Infinity into Decimal.quietNaN

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -800,8 +800,11 @@ extension JSONDecoderImpl: Decoder {
                         return decimal
                     }
                 } else if isSpecialJSON5DoubleValue {
-                    // Decimal itself doesn't have support for Infinity values yet. Even the part of the old NSJSONSerialization implementation that would try to reinterpret an NaN or Infinity value as an NSDecimalNumber did not have very predictable behavior.
-                    // TODO: Proper handling of Infinity and NaN Decimal values.
+                    
+                    if numberBuffer.contains(UInt8(ascii: "I")) {
+                        throw JSONError.numberIsNotRepresentableInSwift(parsed: String(decoding: numberBuffer, as: UTF8.self))
+                    }
+                    
                     return Decimal.quietNaN
                 } else {
                     switch Decimal._decimal(from: numberBuffer, matchEntireString: true) {

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -2870,7 +2870,7 @@ extension JSONEncoderTests {
     
     @Test func decodeDecimalInfinityAndNaN() throws {
         let decoder = JSONDecoder()
-        decoder.allowsJSON5 = true  // <-- Changed this line
+        decoder.allowsJSON5 = true
         
         let nanData = "NaN".data(using: .utf8)!
         let nanDecimal = try decoder.decode(Decimal.self, from: nanData)

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -2867,6 +2867,27 @@ extension JSONEncoderTests {
         // Optional Decimals should encode the same way.
         _testRoundTrip(of: Optional(decimal), expectedJSON: expectedJSON)
     }
+    
+    @Test func decodeDecimalInfinityAndNaN() throws {
+        let decoder = JSONDecoder()
+        decoder.allowsJSON5 = true  // <-- Changed this line
+        
+        let nanData = "NaN".data(using: .utf8)!
+        let nanDecimal = try decoder.decode(Decimal.self, from: nanData)
+        #expect(nanDecimal.isNaN)
+        
+        let infinityData = "Infinity".data(using: .utf8)!
+        #expect(throws: (any Error).self) {
+            try decoder.decode(Decimal.self, from: infinityData)
+        }
+        
+        let negativeInfinityData = "-Infinity".data(using: .utf8)!
+        #expect(throws: (any Error).self) {
+            try decoder.decode(Decimal.self, from: negativeInfinityData)
+        }
+    }
+    
+    
 
     @Test func hugeNumbers() throws {
         let json = "23456789012000000000000000000000000000000000000000000000000000000000000000000 "


### PR DESCRIPTION
### Resolving the `TODO: Proper handling of Infinity and NaN Decimal values` at `JSONDecoder.swift:804`


### Motivation:

Decimal itself doesn't have support for Infinity values yet. Even the part of the old `NSJSONSerialization` implementation that would try to reinterpret an `NaN` or `Infinity` value as an `NSDecimalNumber` did not have very predictable behavior.

Currently, when `JSONDecoder` is configured to parse JSON5 (`allowsJSON5 = true`), encountering `+Infinity`, 
`-Infinity`, or `Infinity` for a `Decimal` value, silently returns `Decimal.quietNaN`. Because `Decimal` does not have a representation for infinity, the decoder should throw an error instead of silently falling back to `NaN`, which is mathematically incorrect.

### Modifications:

- Updated `unwrapDecimal` logic in `JSONDecoder.swift`
- The string is already pre-validated by `JSON5Scanner.prevalidateJSONNumber` as a valid special double value.
- the code now simply checks if the buffer contains the `I` character.
- If it contains `I`, it correctly throws `JSONError.numberIsNotRepresentableInSwift`.
- If it does not contain `I` (meaning it is `NaN`), it continues to safely return `Decimal.quietNaN`.

### Result:

Decoding `Infinity` into a `Decimal` using JSON5 correctly throws a `DecodingError.dataCorrupted` error (wrapping the `numberIsNotRepresentableInSwift` error) instead of silently succeeding with `quietNaN`.

### Testing:

- Added a new test `decodeDecimalInfinityAndNaN` in `JSONEncoderTests.swift` that verifies `NaN` successfully decodes as `quietNaN`, and that `Infinity` and `-Infinity` successfully throw an error.