### PR TITLE
Remove Data(rawCapacity:initializingWith:)

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -281,38 +281,6 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
         _representation = .empty
     }
 
-    /// Creates a data instance with the specified capacity, and then calls the given
-    /// closure with an output span covering the instance's uninitialized memory.
-    ///
-    /// Inside the closure, initialize elements by appending to the `OutputRawSpan`.
-    /// The `OutputRawSpan` keeps track of the initialized memory, ensuring
-    /// safety. Its `count` at the end of the closure will become the `count` of
-    /// the newly-initialized instance of `Data`.
-    ///
-    /// - Note: While the resulting `Data` may have a capacity larger than the
-    ///   requested amount, the `OutputRawSpan` passed to the closure will cover
-    ///   exactly the number of bytes requested.
-    ///
-    /// - Parameters:
-    ///   - capacity: The number of bytes to allocate space for in the new `Data`.
-    ///   - initializer: A closure to initialize the allocated memory.
-    ///     - Parameters:
-    ///       - span: An `OutputRawSpan` covering uninitialized memory with
-    ///         space for the specified number of bytes.
-    @available(macOS, introduced: 10.14.4, deprecated, renamed: "init(capacity:initializingWith:)")
-    @available(iOS, introduced: 12.2, deprecated, renamed: "init(capacity:initializingWith:)")
-    @available(watchOS, introduced: 5.2, deprecated, renamed: "init(capacity:initializingWith:)")
-    @available(tvOS, introduced: 12.2, deprecated, renamed: "init(capacity:initializingWith:)")
-    @available(visionOS, introduced: 1.0, deprecated, renamed: "init(capacity:initializingWith:)")
-    @export(implementation)
-    @_spi(_) // TODO: Remove after no clients are using this
-    public init<E: Error>(
-        rawCapacity capacity: Int,
-        initializingWith initializer: (_ span: inout OutputRawSpan) throws(E) -> Void
-    ) throws(E) {
-        try self.init(capacity: capacity, initializingWith: initializer)
-    }
-
     /// Creates a new data with the specified capacity, directly initializing its storage using an output raw span.
     ///
     /// - Parameters:

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -85,19 +85,19 @@ extension Data {
         @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
         @export(implementation) @inline(__always)
         init<E: Error>(
-            rawCapacity: Int,
+            capacity: Int,
             initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
             self.init()
             do throws(E) {
                 let count = try Swift.withUnsafeMutableBytes(of: &bytes) {
                     buffer throws(E) in
-                    let prefix = buffer.prefix(rawCapacity)
+                    let prefix = buffer.prefix(capacity)
                     var output = OutputRawSpan(buffer: prefix, initializedCount: 0)
                     try initializer(&output)
                     return output.finalize(for: prefix)
                 }
-                assert(count <= rawCapacity)
+                assert(count <= capacity)
                 length = UInt8(count)
             } catch {
                 self = .init()

--- a/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
@@ -104,7 +104,7 @@ extension Data {
             capacity: Int, _ initializer: (inout OutputRawSpan) throws(E) -> Void
         ) throws(E) {
             if InlineData.canStore(count: capacity) {
-                let inline = try InlineData(rawCapacity: capacity, initializingWith: initializer)
+                let inline = try InlineData(capacity: capacity, initializingWith: initializer)
                 self = (inline.count == 0) ? .empty : .inline(inline)
             } else {
                 let storage = __DataStorage(capacity: capacity)


### PR DESCRIPTION
Remove a stub that is no longer necessary

### Motivation:

This stub is no longer necessary so it can be removed

### Modifications:

Removes the now unused `Data(rawCapacity:initializingWith:)` initializer

### Result:

Stub is no longer present

### Testing:

Validated that the project still builds
