### PR TITLE
[FoundationEssentials] Safely unwrap Calendar month adjustment during enumeration

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -695,7 +695,9 @@ extension Calendar {
                 let dateDay = component(.day, from: date)
                 // We need to make sure we don't surpass the day we want
                 if comps.day ?? Int.max >= dateDay {
-                    let tempDate = self.date(byAdding: .month, value: -1, to: date)! // TODO: Check force unwrap here
+                    guard let tempDate = self.date(byAdding: .month, value: -1, to: date) else {
+                         return adjusted
+                    }
                     adjusted.month = component(.month, from: tempDate)
                 } else {
                     // adjusted is the date components we're trying to match against; dateDay is the current day of the current search date.


### PR DESCRIPTION
Safely unwrap the Calendar month adjustment during enumeration

### Motivation:

In `Calendar_Enumerate.swift`, computing the adjusted components during a backward day enumeration forces an unwrap on the result of `date(byAdding: .month, value: -1, to: date)`.

 If this adjustment fails (for example, if the search reaches the extreme minimum boundary of the calendar's supported range), it will cause a fatal crash.

### Modifications:

Replaced the force-unwrap (`!`) with a safe `guard let`.

If the month subtraction returns `nil`, the function now safely falls back to returning the unadjusted components, allowing the enumeration loop to gracefully handle the boundary rather than crashing the application.

### Result:

Boundary date searches in `Calendar` enumeration are now structurally safe from force-unwrap crashes when traversing months.

### Testing:

Successfully ran `FoundationEssentialsTests` via Swift Package Manager locally. 

Since this mitigates an extreme out-of-bounds crash, no new explicit boundary test cases were required, but all existing`Calendar` regression tests pass successfully.
