### PR TITLE
Add missing Data.resetBytes lower bounds check

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -817,9 +817,6 @@ public struct Data : RandomAccessCollection, MutableCollection, RangeReplaceable
     /// - parameter range: The range in the data to set to `0`.
     @inlinable // This is @inlinable as trivially forwarding.
     public mutating func resetBytes(in range: Range<Index>) {
-        // it is worth noting that the range here may be out of bounds of the Data itself (which triggers a growth)
-        precondition(range.lowerBound >= 0, "Ranges must not be negative bounds")
-        precondition(range.upperBound >= 0, "Ranges must not be negative bounds")
         _representation.resetBytes(in: range)
     }
 

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -255,7 +255,7 @@ extension Data {
         mutating func resetBytes(in range: Range<Index>) {
             assert(range.lowerBound <= MemoryLayout<Buffer>.size)
             assert(range.upperBound <= MemoryLayout<Buffer>.size)
-            precondition(range.lowerBound <= length, "index \(range.lowerBound) is out of bounds of 0..<\(length)")
+            precondition(range.lowerBound >= 0 && range.lowerBound <= length, "index \(range.lowerBound) is out of bounds of 0..<\(length)")
             if length < range.upperBound {
                 length = UInt8(range.upperBound)
             }

--- a/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+InlineSlice.swift
@@ -261,7 +261,7 @@ extension Data {
         mutating func resetBytes(in range: Range<Index>) {
             assert(range.lowerBound < HalfInt.max)
             assert(range.upperBound < HalfInt.max)
-            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound >= startIndex && range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
             ensureUniqueReference()
             storage.resetBytes(in: range)
             if slice.upperBound < range.upperBound {

--- a/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LargeSlice.swift
@@ -244,7 +244,7 @@ extension Data {
         
         @inlinable // This is @inlinable as reasonably small.
         mutating func resetBytes(in range: Range<Int>) {
-            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound >= startIndex && range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
             ensureUniqueReference()
             storage.resetBytes(in: range)
             if slice.range.upperBound < range.upperBound {

--- a/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+LegacyRepresentation.swift
@@ -479,16 +479,14 @@ extension Data {
         mutating func resetBytes(in range: Range<Index>) {
             switch self {
             case .empty:
+                precondition(range.lowerBound == 0, "index \(range.lowerBound) is out of bounds of 0..<0)")
                 if range.upperBound == 0 {
                     self = .empty
                 } else if InlineData.canStore(count: range.upperBound) {
-                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
                     self = .inline(InlineData(count: range.upperBound))
                 } else if InlineSlice.canStore(count: range.upperBound) {
-                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
                     self = .slice(InlineSlice(count: range.upperBound))
                 } else {
-                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
                     self = .large(LargeSlice(count: range.upperBound))
                 }
             case .inline(var inline):

--- a/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Representation.swift
@@ -180,7 +180,7 @@ extension Data {
         
         @_alwaysEmitIntoClient
         mutating func resetBytes(in range: Range<Index>) {
-            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound >= startIndex && range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
             ensureUniqueReference()
             _storage.resetBytes(in: range)
             if _slice.upperBound < range.upperBound {

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -2199,8 +2199,33 @@ private final class DataTests {
     
     @Test func bounding_failure_reset_range() async {
         await #expect(processExitsWith: .failure) {
+            var data = Data()
+            data.resetBytes(in: -1..<0)
+        }
+
+        await #expect(processExitsWith: .failure) {
+            var data = Data()
+            data.resetBytes(in: 2..<3)
+        }
+
+        await #expect(processExitsWith: .failure) {
+            var data = try #require("Hello World".data(using: .utf8))
+            data.resetBytes(in: -1..<2)
+        }
+
+        await #expect(processExitsWith: .failure) {
             var data = try #require("Hello World".data(using: .utf8))
             data.resetBytes(in: 100..<200)
+        }
+
+        await #expect(processExitsWith: .failure) {
+            var data = Data(count: 128)
+            data.resetBytes(in: -1..<2)
+        }
+
+        await #expect(processExitsWith: .failure) {
+            var data = Data(count: 128)
+            data.resetBytes(in: 200..<201)
         }
     }
     
@@ -3399,6 +3424,20 @@ struct LargeDataTests {
         #expect(large[1] == 0xBB)
         #expect(large[2] == 0xCC)
     }
+
+    #if FOUNDATION_EXIT_TESTS
+    @Test func resetBytesBounds() async {
+        await #expect(processExitsWith: .failure) {
+            var data = Data(count: largeCount)
+            data.resetBytes(in: -1..<2)
+        }
+
+        await #expect(processExitsWith: .failure) {
+            var data = Data(count: largeCount)
+            data.resetBytes(in: (data.endIndex + 1) ..< (data.endIndex + 2))
+        }
+    }
+    #endif
 }
 
 private func expectLargeIfLegacyABI(_ data: Data, sourceLocation: SourceLocation = #_sourceLocation) {


### PR DESCRIPTION
Adds a missing bounds check

### Motivation:

`Data.resetBytes` validated that `range.lowerBound >= 0`, but not `range.lowerBound >= startIndex`

### Modifications:

Defer bounds checking to the representation types and ensure that `startIndex` is used instead of 0 where applicable

### Result:

`Data.resetBytes` correctly checks bounds

### Testing:

Added additional exit tests to validate preconditions
