### PR TITLE
[FoundationInternationalization] Catch and log ICU Resource TimeZone initialization failures 

### DIFF
--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -18,6 +18,10 @@ import FoundationEssentials
 @preconcurrency import Glibc
 #endif
 
+#if canImport(os)
+internal import os
+#endif
+
 #if canImport(ucrt)
 import ucrt
 #endif
@@ -129,8 +133,20 @@ final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
 
         self.name = name
         lock = Mutex(State())
-        if foundation_swift_ICUResourceTimeZone_feature_enabled(), let timeZoneICUResource = try? _TimeZoneICUResource(identifier: name) {
-            // TODO: add logging for when initializaiton fails
+        
+        //adding logging for when initializaiton fails
+        var timeZoneICUResource: _TimeZoneICUResource?
+        if foundation_swift_ICUResourceTimeZone_feature_enabled() {
+            do {
+                timeZoneICUResource = try _TimeZoneICUResource(identifier: name)
+            } catch {
+#if canImport(os)
+                ICUError.logger.error("Failed to initialize ICU resource time zone for identifier '\(name)': \(error)")
+#endif
+            }
+        }
+        
+        if let timeZoneICUResource {
             self._timeZoneICUResource = timeZoneICUResource
             self._timeZone = nil
         } else {


### PR DESCRIPTION

Replaced a silent try? with a proper do/catch block to actively log `ICU TimeZone` initialization errors before falling back to the legacy C parser

### Motivation:

In `TimeZone_ICU.swift` Because the code was using `try?`, any failure would silently return `nil` and fall back to the legacy C parser without leaving any trace of why the modern Swift parser failed in the first place.

This change  resolves the `TODO: add logging for when initializaiton fails` at `TimeZone_ICU.swift:135`

Even tho `_TimeZoneICUResource` : 67 is only being used for `foundation_swift_ICUResourceTimeZone_feature_enabled`
I belive this to be a positive change. 

### Modifications:

I replaced the `try?` assignment with a proper `do/catch` block. If the initialization throws, it now catches the error, logs it via the existing `ICUError.logger.error` (wrapped in `#if canImport(os)` to respect Linux/Windows fallback constraints)

this falls through to the legacy C fallback block just like it originally did in case of failure. 

**If there is another fallback planned for linux/Windows please do let me know about it*** 

### Result:

If the modern `_TimeZoneICUResource` parser fails to initialize, it now leaves a debuggable log trail on Apple platforms instead of silently swallowing the error.

### Testing:

Verified that the existing `FoundationInternationalizationTests` suite passes cleanly locally, ensuring the fallback state machine behaves identically.
