### PR TITLE
Handle item replacement directories in FoundationEssentials

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -60,6 +60,45 @@ extension _FileManagerImpl {
     var temporaryDirectory: URL {
         URL(filePath: String.temporaryDirectoryPath, directoryHint: .isDirectory)
     }
+
+    private func itemReplacementDirectory(appropriateFor reference: URL) throws -> URL {
+        guard reference.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileWriteUnsupportedScheme, reference)
+        }
+
+        let temporaryItemsDirectory = temporaryDirectory.appending(component: "TemporaryItems", directoryHint: .isDirectory)
+        let referenceDirectory = reference.deletingPathExtension()
+        let useTemporaryDirectory: Bool
+        if let temporaryVolumeIdentifier = try? temporaryDirectory.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier,
+           let referenceVolumeIdentifier = try? reference.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier {
+            useTemporaryDirectory = temporaryVolumeIdentifier.isEqual(referenceVolumeIdentifier)
+        } else {
+            useTemporaryDirectory = !fileManager.isWritableFile(atPath: referenceDirectory.path)
+        }
+
+        let containerDirectory = useTemporaryDirectory ? temporaryItemsDirectory : referenceDirectory
+        try fileManager.createDirectory(at: containerDirectory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+
+        var attempt = 0
+        while true {
+            let replacementDirectory = containerDirectory.appending(component: itemReplacementDirectoryName(forAttempt: attempt), directoryHint: .isDirectory)
+            do {
+                try fileManager.createDirectory(at: replacementDirectory, withIntermediateDirectories: false)
+                return replacementDirectory
+            } catch let error as CocoaError where error.code == .fileWriteFileExists {
+                attempt += 1
+            }
+        }
+    }
+
+    private func itemReplacementDirectoryName(forAttempt attempt: Int) -> String {
+        let processName = ProcessInfo.processInfo.processName.filter { $0.isLetter || $0.isNumber }
+        let sanitizedProcessName = processName.isEmpty ? "Process" : processName
+        if attempt == 0 {
+            return "(A Document Being Saved By \(sanitizedProcessName))"
+        }
+        return "(A Document Being Saved By \(sanitizedProcessName) \(attempt + 1))"
+    }
     
     func url(
         for directory: FileManager.SearchPathDirectory,
@@ -83,6 +122,10 @@ extension _FileManagerImpl {
             domain = ._partitionedSystemDomainMask
         }
         #endif
+
+        if let url, domain == .userDomainMask, directory == .itemReplacementDirectory {
+            return try itemReplacementDirectory(appropriateFor: url)
+        }
         
         let urls = Array(_SearchPathURLs(for: directory, in: domain, expandTilde: true))
         #if FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1074,6 +1074,31 @@ private struct FileManagerTests {
         assertSearchPaths([.itemReplacementDirectory], exists: false)
     }
 
+    @Test(arguments: [false, true])
+    func itemReplacementDirectory(create: Bool) async throws {
+        try await FilePlayground {
+            Directory("Documents") {}
+        }.test { fileManager in
+            let reference = URL(filePath: fileManager.currentDirectoryPath, directoryHint: .isDirectory)
+                .appending(component: "Documents", directoryHint: .isDirectory)
+            let replacementDirectory = try fileManager.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: reference, create: create)
+            let secondReplacementDirectory = try fileManager.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: reference, create: create)
+            defer {
+                try? fileManager.removeItem(at: replacementDirectory)
+                try? fileManager.removeItem(at: secondReplacementDirectory)
+            }
+
+            var isDirectory = false
+            #expect(fileManager.fileExists(atPath: replacementDirectory.path, isDirectory: &isDirectory))
+            #expect(isDirectory)
+            isDirectory = false
+            #expect(fileManager.fileExists(atPath: secondReplacementDirectory.path, isDirectory: &isDirectory))
+            #expect(isDirectory)
+            #expect(replacementDirectory != reference)
+            #expect(secondReplacementDirectory != replacementDirectory)
+        }
+    }
+
     #if !canImport(Darwin) && !os(Windows)
     @Test(.disabled(if: ProcessInfo.processInfo.environment.keys.contains(where: { $0.starts(with: "XDG") }), "Skipping due to presence of XDG environment variables which may affect this test"))
     func searchPaths_XDGEnvironmentVariables() async throws {


### PR DESCRIPTION
### Motivation

Resolves #991.

FoundationEssentials currently falls through to normal search path lookup for `.itemReplacementDirectory`. That lookup returns no URL, so `FileManager.url(for:in:appropriateFor:create:)` throws on Linux when callers ask for a replacement directory.

### Modifications

Add a FoundationEssentials path for `.itemReplacementDirectory` when the domain is `.userDomainMask` and `appropriateFor` is supplied. It creates a `TemporaryItems` container under the process temporary directory when that directory is on the same volume as the reference URL. Otherwise it falls back to a writable directory based on the reference URL, matching the older corelibs behavior.

The replacement directory itself is always created, including for `create: false`, so callers get a unique directory and avoid races.

Add a regression test that covers `create: false` and `create: true`, verifies the returned directories exist, and checks that repeated calls return distinct directories.

### Validation

- `git diff --check`
- `swiftc -parse Sources/FoundationEssentials/FileManager/FileManager+Directories.swift Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift`

I could not run `swift test --filter FileManager/itemReplacementDirectory` locally with Xcode Swift 6.2.3. The package starts building on the `release/6.4.x` base, but fails in existing source that requires a newer compiler (`@specialized` and `@_lifetime` diagnostics in `String+Internals.swift`) before it reaches this test.