### PR TITLE
Handle item replacement directories in FoundationEssentials

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -115,7 +115,7 @@ extension _FileManagerImpl {
         create shouldCreate: Bool
     ) throws -> URL {
         #if FOUNDATION_FRAMEWORK
-        // TODO: Support correct trash/replacement locations in swift-foundation
+        // TODO: Support correct trash locations in FoundationEssentials
         #if os(macOS) || os(iOS)
         if let url, directory == .trashDirectory {
             return try fileManager._URLForTrashingItem(at: url, create: shouldCreate)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -62,6 +62,51 @@ extension _FileManagerImpl {
     var temporaryDirectory: URL {
         URL(filePath: String.temporaryDirectoryPath, directoryHint: .isDirectory)
     }
+
+    #if !FOUNDATION_FRAMEWORK
+    private func itemReplacementDirectory(appropriateFor reference: URL) throws -> URL {
+        guard reference.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileWriteUnsupportedScheme, reference)
+        }
+
+        let temporaryDirectory = fileManager.temporaryDirectory
+        let temporaryItemsDirectory = temporaryDirectory.appending(component: "TemporaryItems", directoryHint: .isDirectory)
+        let referenceDirectory = reference.deletingPathExtension()
+        let useTemporaryDirectory: Bool
+        if let temporaryVolumeIdentifier = systemNumber(for: temporaryDirectory),
+           let referenceVolumeIdentifier = systemNumber(for: reference) {
+            useTemporaryDirectory = temporaryVolumeIdentifier == referenceVolumeIdentifier
+        } else {
+            useTemporaryDirectory = !fileManager.isWritableFile(atPath: referenceDirectory.path)
+        }
+
+        let containerDirectory = useTemporaryDirectory ? temporaryItemsDirectory : referenceDirectory
+        try fileManager.createDirectory(at: containerDirectory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+
+        var attempt = 0
+        while true {
+            let replacementDirectory = containerDirectory.appending(component: itemReplacementDirectoryName(forAttempt: attempt), directoryHint: .isDirectory)
+            do {
+                try fileManager.createDirectory(at: replacementDirectory, withIntermediateDirectories: false)
+                return replacementDirectory
+            } catch let error as CocoaError where error.code == .fileWriteFileExists {
+                attempt += 1
+            }
+        }
+
+        func systemNumber(for url: URL) -> UInt? {
+            try? fileManager.attributesOfItem(atPath: url.path)[.systemNumber] as? UInt
+        }
+    }
+
+    private func itemReplacementDirectoryName(forAttempt attempt: Int) -> String {
+        let processName = ProcessInfo.processInfo.processName.filter { $0.isLetter || $0.isNumber }
+        if attempt == 0 {
+            return "(A Document Being Saved By \(processName))"
+        }
+        return "(A Document Being Saved By \(processName) \(attempt + 1))"
+    }
+    #endif
     
     func url(
         for directory: FileManager.SearchPathDirectory,
@@ -76,10 +121,16 @@ extension _FileManagerImpl {
             return try fileManager._URLForTrashingItem(at: url, create: shouldCreate)
         }
         #endif
+        #endif
         if let url, domain == .userDomainMask, directory == .itemReplacementDirectory {
+            #if FOUNDATION_FRAMEWORK
             // The only place we need to do this is for certain operations, namely the replacing item API.
             return try fileManager._URLForReplacingItem(at: url)
+            #else
+            return try itemReplacementDirectory(appropriateFor: url)
+            #endif
         }
+        #if FOUNDATION_FRAMEWORK
         var domain = domain
         if domain == .systemDomainMask {
             domain = ._partitionedSystemDomainMask

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1110,12 +1110,22 @@ private struct FileManagerTests {
                 try? fileManager.removeItem(at: secondReplacementDirectory)
             }
 
-            var isDirectory = false
-            #expect(fileManager.fileExists(atPath: replacementDirectory.path, isDirectory: &isDirectory))
-            #expect(isDirectory)
-            isDirectory = false
-            #expect(fileManager.fileExists(atPath: secondReplacementDirectory.path, isDirectory: &isDirectory))
-            #expect(isDirectory)
+            #if FOUNDATION_FRAMEWORK
+            var isDir: ObjCBool = false
+            func isDirBool() -> Bool {
+                isDir.boolValue
+            }
+            #else
+            var isDir: Bool = false
+            func isDirBool() -> Bool {
+                isDir
+            }
+            #endif
+            #expect(fileManager.fileExists(atPath: replacementDirectory.path, isDirectory: &isDir))
+            #expect(isDirBool())
+            isDir = false
+            #expect(fileManager.fileExists(atPath: secondReplacementDirectory.path, isDirectory: &isDir))
+            #expect(isDirBool())
             #expect(replacementDirectory != reference)
             #expect(secondReplacementDirectory != replacementDirectory)
         }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1096,6 +1096,31 @@ private struct FileManagerTests {
         assertSearchPaths([.itemReplacementDirectory], exists: false)
     }
 
+    @Test(arguments: [false, true])
+    func itemReplacementDirectory(create: Bool) async throws {
+        try await FilePlayground {
+            Directory("Documents") {}
+        }.test { fileManager in
+            let reference = URL.currentDirectory()
+                .appending(component: "Documents", directoryHint: .isDirectory)
+            let replacementDirectory = try fileManager.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: reference, create: create)
+            let secondReplacementDirectory = try fileManager.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: reference, create: create)
+            defer {
+                try? fileManager.removeItem(at: replacementDirectory)
+                try? fileManager.removeItem(at: secondReplacementDirectory)
+            }
+
+            var isDirectory = false
+            #expect(fileManager.fileExists(atPath: replacementDirectory.path, isDirectory: &isDirectory))
+            #expect(isDirectory)
+            isDirectory = false
+            #expect(fileManager.fileExists(atPath: secondReplacementDirectory.path, isDirectory: &isDirectory))
+            #expect(isDirectory)
+            #expect(replacementDirectory != reference)
+            #expect(secondReplacementDirectory != replacementDirectory)
+        }
+    }
+
     #if !canImport(Darwin) && !os(Windows)
     @Test(.disabled(if: ProcessInfo.processInfo.environment.keys.contains(where: { $0.starts(with: "XDG") }), "Skipping due to presence of XDG environment variables which may affect this test"))
     func searchPaths_XDGEnvironmentVariables() async throws {


### PR DESCRIPTION
### Motivation

Resolves #991.

FoundationEssentials did not handle `.itemReplacementDirectory` in `FileManager.url(for:in:appropriateFor:create:)`. It fell through to normal search-path lookup, which could fail to return a replacement directory.

### Modifications

- Add FoundationEssentials handling for `.itemReplacementDirectory` with a user-domain reference URL.
- Select the replacement container based on the reference volume, using `TemporaryItems` when appropriate and a writable reference location otherwise.
- Always create a unique replacement directory, including when `create` is `false`, matching corelibs Foundation behavior and avoiding races.
- Use the existing FoundationEssentials `.systemNumber` file attribute for volume comparison.
- Add regression coverage for both `create: true` and `create: false`, including existence and uniqueness checks.

### Validation

Using `6.4.x-snapshot-2026-08-28` (`Apple Swift 6.4-dev`):

```text
swift test --filter itemReplacementDirectory

Test itemReplacementDirectory(create:) with 2 test cases passed.
```

Both `create: true` and `create: false` cases pass.