### PR TITLE
Foundation improperly parses .strings files with Full-width Spaces (U+3000)

### DIFF
--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -67,8 +67,9 @@ internal func __ParseOldStylePropertyList(utf16: String.UTF16View) throws -> Any
         if advanceToNonSpace(&parseInfo) {
             if result is String {
                 // Reset info and keep parsing
+                // Check for a strings file (looks like a dictionary without the opening/closing curly braces). With no closing brace to look for, the content has to run to the end of the input.
                 parseInfo = _ParseInfo(utf16: utf16, curr: utf16.startIndex)
-                result = parsePlistDictContent(&parseInfo, depth: 0)
+                result = parsePlistDictContent(&parseInfo, depth: 0, expectsEOFTermination: true)
             } else {
                 parseInfo.err = OpenStepPlistError("Junk after plist at line \(lineNumberStrings(parseInfo))")
                 result = nil
@@ -116,21 +117,19 @@ private func parsePlistObject(_ pInfo: inout _ParseInfo, requireObject: Bool, de
 }
 
 private func parsePlistDict(_ pInfo: inout _ParseInfo, depth: UInt32) -> [String:Any]? {
-    guard let dict = parsePlistDictContent(&pInfo, depth: depth) else {
+    guard let dict = parsePlistDictContent(&pInfo, depth: depth, expectsEOFTermination: false) else {
         return nil
     }
-    guard advanceToNonSpace(&pInfo) && pInfo.currChar == UInt16(ascii: "}") else {
-        pInfo.err = OpenStepPlistError("Expected terminating '}' for dictionary at line \(lineNumberStrings(pInfo))")
-        return nil
-    }
-    pInfo.advance()
+    // parsePlistDictContent only succeeds having seeing the closing brace.
+    pInfo.advance() // consume the '}'
     return dict
 }
 
-private func parsePlistDictContent(_ pInfo: inout _ParseInfo, depth: UInt32) -> [String:Any]? {
+// `expectsEOFTermination` is true when the dictionary is ended by the end of the input rather than by a closing brace, as in a strings file.
+private func parsePlistDictContent(_ pInfo: inout _ParseInfo, depth: UInt32, expectsEOFTermination: Bool) -> [String:Any]? {
     var dict = [String:Any]()
 
-    while let key = parsePlistString(&pInfo, requireObject: false) {
+    while let key = parsePlistKeyOrEndOfDictionary(&pInfo, expectsEOFTermination: expectsEOFTermination) {
         guard advanceToNonSpace(&pInfo) else {
             pInfo.err = OpenStepPlistError("Missing ';' on line \(lineNumberStrings(pInfo))")
             return nil
@@ -160,6 +159,11 @@ private func parsePlistDictContent(_ pInfo: inout _ParseInfo, depth: UInt32) -> 
         }
 
         pInfo.advance()
+    }
+
+    // Check for errors from parsePlistKeyOrEndOfDictionary.
+    if pInfo.err != nil {
+        return nil
     }
 
     // this is a success path, so clear errors (NOTE: this seems weird, but is historical)
@@ -198,10 +202,11 @@ private func parsePlistArray(_ pInfo: inout _ParseInfo, depth: UInt32) -> [Any]?
     return array
 }
 
-private func parsePlistString(_ pInfo: inout _ParseInfo, requireObject: Bool) -> String? {
+// Parses the next key of a dictionary's contents, or recognizes the end of that dictionary. `expectsEOFTermination` is true when the dictionary is ended by the end of the input rather than by a closing brace, as in a strings file. Returns nil if no key is found. Sets pInfo.err if that nil is caused by a parsing error instead of the legitimate end of the dictionary.
+private func parsePlistKeyOrEndOfDictionary(_ pInfo: inout _ParseInfo, expectsEOFTermination: Bool) -> String? {
     guard advanceToNonSpace(&pInfo) else {
-        if requireObject {
-            pInfo.err = OpenStepPlistError("Unexpected EOF while parsing string")
+        if !expectsEOFTermination {
+            pInfo.err = OpenStepPlistError("Expected terminating '}' for dictionary at line \(lineNumberStrings(pInfo))")
         }
         return nil
     }
@@ -212,12 +217,15 @@ private func parsePlistString(_ pInfo: inout _ParseInfo, requireObject: Bool) ->
         return parseQuotedPlistString(&pInfo, quote: ch)
     } else if isValidUnquotedStringCharacter(ch) {
         return parseUnquotedPlistString(&pInfo)
-    } else {
-        if requireObject {
-            pInfo.err = OpenStepPlistError("Invalid string character at line \(lineNumberStrings(pInfo))")
-        }
-        return nil
     }
+
+    // Not the start of a key. For a braced dictionary that is acceptable only if it is the closing brace, which is left for the caller to consume.
+    if expectsEOFTermination {
+        pInfo.err = OpenStepPlistError("Invalid string character at line \(lineNumberStrings(pInfo))")
+    } else if ch != UInt16(ascii: "}") {
+        pInfo.err = OpenStepPlistError("Expected terminating '}' for dictionary at line \(lineNumberStrings(pInfo))")
+    }
+    return nil
 }
 
 private func parseQuotedPlistString(_ pInfo: inout _ParseInfo, quote: UInt16) -> String? {

--- a/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/PropertyListEncoderTests.swift
@@ -886,6 +886,18 @@ private struct PropertyListEncoderTests {
         }
     }
 
+    @Test func oldStylePlist_stringsFileWithInterstitialJunkIsRejected() {
+        // A full-width space (U+3000) is considered neither whitespace nor a valid unquoted string character so parsing must stop there.
+        let stringsFile = "\"key1\" = \"text1\";\n\"key2\" = \"text2\";\n\u{3000}\n\"key3\" = \"text3\";\n\"key4\" = \"text4\";"
+        let data = stringsFile.data(using: .utf8)!
+
+        #expect {
+            try PropertyListDecoder().decode([String:String].self, from: data)
+        } throws: {
+            String(describing: $0).contains("Invalid string character at line 3")
+        }
+    }
+
     // <rdar://problem/34321354> Microsoft: Microsoft vso 1857102 : High Sierra regression that caused data loss : CFBundleCopyLocalizedString returns incorrect string
     // Escaped octal chars can be shorter than 3 chars long; i.e. \5 ≡ \05 ≡ \005.
     @Test func oldStylePlist_getSlashedChars_octal() throws {


### PR DESCRIPTION
Reject stray characters between keys during OpenStep plist parsing.

### Motivation:

Any non-quote, non-key, non-EOF character between keys in an implied top-level dictionary of the OpenStep plist format presently immediately terminates the parse and returns all the key-value pairs parsed so far. Thus, a stray character could cause silent, unexpected data loss instead of properly emitting an error.

### Modifications:

Refactoring to ensure error conditions are set and checked while attempting to parse implied dictionary keys.

### Result:

Error generated as expected.

### Testing:

New unit test added that exercises this case.