### PR TITLE
[6.4.x] Add >= and <= to Date

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -195,6 +195,18 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
     public static func >(lhs: Date, rhs: Date) -> Bool {
         return lhs.timeIntervalSinceReferenceDate > rhs.timeIntervalSinceReferenceDate
     }
+  
+    /// Returns true if the left hand `Date` is earlier in time than or equal to the right hand `Date`.
+    @export(implementation)
+    public static func <=(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate <= rhs.timeIntervalSinceReferenceDate
+    }
+
+    /// Returns true if the left hand `Date` is later in time than or equal to the right hand `Date`.
+    @export(implementation)
+    public static func >=(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate >= rhs.timeIntervalSinceReferenceDate
+    }
 
     /// Returns a date with a specified amount of time added to it.
     ///

--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -70,6 +70,17 @@ private struct DateTests {
         #expect(distantFuture.timeIntervalSince(currentDate) >
                               3600.0 * 24 * 365 * 100) /* ~1 century in seconds */
     }
+  
+    @Test func nan() {
+        let nan = Date(timeIntervalSince1970: .nan)
+        for other in [Date(timeIntervalSince1970: 0), .distantPast, .distantFuture] {
+            #expect(!(nan < other))
+            #expect(!(nan <= other))
+            #expect(!(nan >= other))
+            #expect(!(nan > other))
+            #expect(!(nan == other))
+        }
+    }
 
     @Test func now() {
         let date1 : Date = .now


### PR DESCRIPTION
Without these, Date falls back on the default implementations from Comparable, which do not handle NaN correctly.

Before this change, both Date(timeIntervalSince1970: .nan) <= Date(timeIntervalSince1970: 0) and Date(timeIntervalSince1970: .nan) >= Date(timeIntervalSince1970: 0) would be true. Now they are false.

This is a cherry-pick of https://github.com/swiftlang/swift-foundation/pull/2223 for release/6.4.x

**Explanation**: Correct the behavior of `<=` and `>=` on `Date`.
**Scope**: New implementations that override the defaults from `Comparable`.
**Issues**: rdar://186560405
**Original PRs**: https://github.com/swiftlang/swift-foundation/pull/2223
**Risk**: Low
**Testing**: CI, including new test case
**Reviewers**: @jmschonfeld 