### PR TITLE
Define FoundationPreview 6.4.2 availability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ list(APPEND _SwiftFoundation_versions
     "6.2"
     "6.3"
     "6.4"
+    "6.4.2"
     )
 
 # Each availability name to define

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import CompilerPluginSupport
 let availabilityTags: [_Availability] = [
     _Availability("FoundationPreview"), // Default FoundationPreview availability
 ]
-let versionNumbers = ["6.0.2", "6.1", "6.2", "6.3", "6.4"]
+let versionNumbers = ["6.0.2", "6.1", "6.2", "6.3", "6.4", "6.4.2"]
 
 // Availability Macro Utilities
 


### PR DESCRIPTION
Defines FoundationPreview 6.4.2 availability in `release/6.4.x`

### Motivation:

Allows APIs to specify availability for the 6.4.2 Swift release

### Modifications:

Adds new availability definitions to the CMake and SwiftPM builds

### Result:

Code can use `FoundationPreview 6.4.2` availability on the appropriate branches

### Testing:

Validated the project still builds
