### PR TITLE
Reduce the number of places we import libc and equivalent

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -10,22 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-internal import os
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(CRT)
-import CRT
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#elseif os(Emscripten)
-@preconcurrency import EmscriptenLibc
-#endif
-
 #if FOUNDATION_FRAMEWORK
 // For feature flag
 internal import _ForSwiftFoundation
@@ -915,8 +899,8 @@ public struct Calendar : Hashable, Equatable, Sendable {
             // assumes that time zone or other adjustments are always whole minutes
             var int1 = date1.timeIntervalSinceReferenceDate.rounded(.down)
             var int2 = date2.timeIntervalSinceReferenceDate.rounded(.down)
-            int1 = floor(int1 / 60.0)
-            int2 = floor(int2 / 60.0)
+            int1 = (int1 / 60.0).rounded(.down)
+            int2 = (int2 / 60.0).rounded(.down)
             if int1 == int2 {
                 return .orderedSame
             } else if int2 < int1 {
@@ -1490,7 +1474,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
 
         // Apply an epsilon to comparison of nanosecond values
         if let nanosecond = comp.nanosecond, let tempNanosecond = tempComp.nanosecond {
-            if labs(CLong(nanosecond - tempNanosecond)) > 500 {
+            if (nanosecond - tempNanosecond).magnitude > 500 {
                 return false
             } else {
                 comp.nanosecond = 0

--- a/Sources/FoundationEssentials/Calendar/Calendar_Astronomy.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Astronomy.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(os)
+// Below is for sin/cos
+
+#if canImport(Darwin)
 internal import os
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
@@ -22,6 +24,8 @@ internal import os
 import CRT
 #elseif os(WASI)
 @preconcurrency import WASILibc
+#elseif os(Emscripten)
+@preconcurrency import EmscriptenLibc
 #endif
 
 /// `Docs/Chinese_Calendar_Math.md` explains how all of this works: the two time scales and delta-T, the solar longitude and new-moon series, how a moment becomes a day, and the precision limits. Shared astronomical and Gregorian day-number toolkit for the non-arithmetic calendars (Chinese today; Islamic and Hindu variants can build on it). Solar/lunar theory follows Reingold & Dershowitz, Calendrical Calculations (built on the Meeus and Bretagnon & Simon series); all APIs are calendar-agnostic.
@@ -262,7 +266,7 @@ internal enum _CalendarAstronomy {
         var correction = -0.00017 * sinDegrees(omega)
         for i in 0..<24 {
             let term = newMoonTerms[i]
-            let ePow = pow(e, abs(term.solar))
+            let ePow = pow(e, term.solar.magnitude)
             let arg = term.solar * solarAnomaly + term.lunar * lunarAnomaly + term.argument * moonArgument
             correction += term.sine * ePow * sinDegrees(arg)
         }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Astronomy.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Astronomy.swift
@@ -13,7 +13,7 @@
 // Below is for sin/cos
 
 #if canImport(Darwin)
-internal import os
+import Darwin
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 #elseif canImport(Glibc)

--- a/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Chinese.swift
@@ -10,20 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(os)
-internal import os
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(CRT)
-import CRT
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#endif
-
 // Chinese lunisolar calendar engine. Years 1901-2100 come from a baked table generated from ICU (parity by construction); outside that range, month structure is computed with ICU's chnsecal rules over _CalendarAstronomy at UTC+8.
 
 // MARK: - Month-structure rules over the astronomy engine

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -10,22 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(os)
+#if FOUNDATION_FRAMEWORK
+// For Logger
 internal import os
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(CRT)
-import CRT
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#elseif os(Emscripten)
-@preconcurrency import EmscriptenLibc
 #endif
-
 
 /// Julian date helper
 /// Julian dates are noon-based. Gregorian dates are midnight-based.
@@ -175,7 +163,7 @@ package enum GregorianCalendarError : Error {
 /// This class is a placeholder and work-in-progress to provide an implementation of the Gregorian calendar.
 package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
-#if canImport(os)
+#if FOUNDATION_FRAMEWORK
     internal static let logger: Logger = {
         Logger(subsystem: "com.apple.foundation", category: "gregorian_calendar")
     }()
@@ -737,7 +725,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
             let firstInstant = try _firstInstant(of: unit, at: at)
             return firstInstant
         } catch let error as GregorianCalendarError {
-#if canImport(os)
+#if FOUNDATION_FRAMEWORK
             switch error {
             case .overflow(_, _, _):
                 _CalendarGregorian.logger.error("Overflowing in firstInstant(of:at:). unit: \(unit.debugDescription, privacy: .public), at: \(at.timeIntervalSinceReferenceDate, privacy: .public)")
@@ -886,15 +874,15 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
         case .hour:
             let ti = Double(timeZone.secondsFromGMT(for: at))
             var fixedTime = time + ti // compute local time
-            fixedTime = floor(fixedTime / 3600.0) * 3600.0
+            fixedTime = (fixedTime / 3600.0).rounded(.down) * 3600.0
             fixedTime = fixedTime - ti // compute GMT
             return Date(timeIntervalSinceReferenceDate: fixedTime)
         case .minute:
-            return Date(timeIntervalSinceReferenceDate: floor(time / 60.0) * 60.0)
+            return Date(timeIntervalSinceReferenceDate: (time / 60.0).rounded(.down) * 60.0)
         case .second:
-            return Date(timeIntervalSinceReferenceDate: floor(time))
+            return Date(timeIntervalSinceReferenceDate: time.rounded(.down))
         case .nanosecond:
-            return Date(timeIntervalSinceReferenceDate: floor(time * 1.0e+9) * 1.0e-9)
+            return Date(timeIntervalSinceReferenceDate: (time * 1.0e+9).rounded(.down) * 1.0e-9)
         case .year, .yearForWeekOfYear, .quarter, .month, .day, .dayOfYear, .weekOfMonth, .weekOfYear:
             // Continue to below
             break
@@ -931,7 +919,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
         do {
             result = try _ordinality(of: smaller, in: larger, for: date)
         } catch {
-#if canImport(os)
+#if FOUNDATION_FRAMEWORK
             switch error {
             case .overflow(_, _, _):
                 _CalendarGregorian.logger.error("Overflowing in ordinality(of:in:for:). smaller: \(smaller.debugDescription, privacy: .public), larger: \(larger.debugDescription, privacy: .public), date: \(date.timeIntervalSinceReferenceDate, privacy: .public)")
@@ -967,12 +955,12 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
                 var test: Date
                 var month = 0
                 if let r = maximumRange(of: .day) {
-                    month = Int(floor(
+                    month = Int((
                         (date.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate) /
                         86400.0 /
                         Double(r.count + 1) *
-                        0.96875
-                    ))
+                        0.96875).rounded(.down)
+                    )
                     // low-ball the estimate
                     month = 10 < month ? month - 10 : 0
                     // low-ball the estimate further
@@ -1000,11 +988,11 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
                     startMatchinWeekday -= 7 * 86400.0
                     start -=  7 * 86400.0
                 }
-                var week = Int(floor(
+                var week = Int((
                     (date.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate) /
                     86400.0 /
-                    7.0
-                ))
+                    7.0).rounded(.down)
+                )
                 // low-ball the estimate
                 var test: Date
                 week = 10 < week ? week - 109 : 0
@@ -1025,11 +1013,11 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
                 let targetDOW = dateComponent(.weekday, from: date)
                 let (startMatchingWeekday, _) = try dateAfterDateWithTargetDoW(start, targetDOW)
 
-                var nthWeekday = Int(floor(
+                var nthWeekday = Int((
                     (date.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate) /
                     86400.0 /
-                    7.0
-                ))
+                    7.0).rounded(.down)
+                )
 
                 // Low-ball estimate
                 nthWeekday = (10 < nthWeekday) ? nthWeekday - 10 : 0
@@ -1051,10 +1039,10 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
                 guard let start = start(of: .era, at: date) else {
                     return nil
                 }
-                let day = Int(floor(
+                let day = Int((
                     (date.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate) /
-                    86400.0
-                )) + 1
+                    86400.0).rounded(.down)
+                ) + 1
                 return day
 
             case .hour:
@@ -1145,7 +1133,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .nanosecond:
                 guard let second = try _ordinality(of: .second, in: .year, for: date) else { return nil }
-                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate))
+                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down))
                 return Int(dseconds * 1.0e9) + 1
 
             default:
@@ -1178,7 +1166,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .day, .dayOfYear:
                 guard let start = start(of: .yearForWeekOfYear, at: date) else { return nil }
-                let day = Int(floor((date.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate) / 86400.0)) + 1
+                let day = Int(((date.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate) / 86400.0).rounded(.down)) + 1
                 return day
 
             case .hour:
@@ -1205,7 +1193,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .nanosecond:
                 guard let second = try _ordinality(of: .second, in: .yearForWeekOfYear, for: date) else { return nil }
-                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate))
+                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down))
                 return Int(dseconds * 1.0e9) + 1
 
             default:
@@ -1248,7 +1236,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
             case .day, .dayOfYear:
                 let start = start(of: .quarter, at: date)
                 guard let start else { return nil }
-                let day = Int(floor((date.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate) / 86400.0)) + 1
+                let day = Int(((date.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate) / 86400.0).rounded(.down)) + 1
                 return day
 
             case .hour:
@@ -1273,7 +1261,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .nanosecond:
                 guard let second = try _ordinality(of: .second, in: .quarter, for: date) else { return nil }
-                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate))
+                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down))
                 return Int(dseconds * 1.0e9) + 1
 
             default:
@@ -1319,7 +1307,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .nanosecond:
                 guard let second = try _ordinality(of: .second, in: .month, for: date) else { return nil }
-                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate))
+                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down))
                 return Int(dseconds * 1.0e9) + 1
 
             default:
@@ -1360,7 +1348,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .nanosecond:
                 guard let second = try _ordinality(of: .second, in: .weekOfYear, for: date) else { return nil }
-                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate))
+                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down))
                 return Int(dseconds * 1.0e9) + 1
 
             default:
@@ -1387,7 +1375,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .nanosecond:
                 guard let second = try _ordinality(of: .second, in: .day, for: date) else { return nil }
-                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate))
+                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down))
                 return Int(dseconds * 1.0e9) + 1
 
             default:
@@ -1408,7 +1396,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .nanosecond:
                 guard let second = try _ordinality(of: .second, in: .hour, for: date) else { return nil }
-                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate))
+                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down))
                 return Int(dseconds * 1.0e9) + 1
 
             default:
@@ -1423,7 +1411,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
 
             case .nanosecond:
                 guard let second = try _ordinality(of: .second, in: .minute, for: date) else { return nil }
-                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate))
+                let dseconds = (Double(second) - 1.0) + (date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down))
                 return Int(dseconds * 1.0e9) + 1
 
             default:
@@ -1432,7 +1420,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
         case .second:
             switch smaller {
             case .nanosecond:
-                return Int(((date.timeIntervalSinceReferenceDate - floor(date.timeIntervalSinceReferenceDate)) * 1.0e9) + 1)
+                return Int(((date.timeIntervalSinceReferenceDate - (date.timeIntervalSinceReferenceDate).rounded(.down)) * 1.0e9) + 1)
 
             default:
                 return nil
@@ -1465,15 +1453,15 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
         case .hour:
             let ti = Double(timeZone.secondsFromGMT(for: date))
             var fixedTime = time + ti // compute local time
-            fixedTime = floor(fixedTime / 3600.0) * 3600.0
+            fixedTime = (fixedTime / 3600.0).rounded(.down) * 3600.0
             fixedTime = fixedTime - ti // compute GMT
             return DateInterval(start: Date(timeIntervalSinceReferenceDate: fixedTime), duration: 3600.0)
         case .minute:
-            return DateInterval(start: Date(timeIntervalSinceReferenceDate: floor(time / 60.0) * 60.0), duration: 60.0)
+            return DateInterval(start: Date(timeIntervalSinceReferenceDate: (time / 60.0).rounded(.down) * 60.0), duration: 60.0)
         case .second:
-            return DateInterval(start: Date(timeIntervalSinceReferenceDate: floor(time)), duration: 1.0)
+            return DateInterval(start: Date(timeIntervalSinceReferenceDate: time.rounded(.down)), duration: 1.0)
         case .nanosecond:
-            return DateInterval(start: Date(timeIntervalSinceReferenceDate: floor(time * 1.0e+9) * 1.0e-9), duration: 1.0e-9)
+            return DateInterval(start: Date(timeIntervalSinceReferenceDate: (time * 1.0e+9).rounded(.down) * 1.0e-9), duration: 1.0e-9)
         case .year, .yearForWeekOfYear, .quarter, .month, .day, .dayOfYear, .weekOfMonth, .weekOfYear:
             // Continue to below
             break
@@ -3160,7 +3148,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
                         let (diffInNano, overflow) = end >= start ? diff.addingReportingOverflow(diffsInNano) : diff.subtractingReportingOverflow(diffsInNano)
 
                         if overflow {
-#if canImport(os)
+#if FOUNDATION_FRAMEWORK
                             _CalendarGregorian.logger.error("Overflowing in dateComponents(from:start:end:). start: \(start.timeIntervalSinceReferenceDate, privacy: .public). end: \(end.timeIntervalSinceReferenceDate, privacy: .public). component: \(component.debugDescription, privacy: .public)")
 #endif
                             dc.nanosecond = diff
@@ -3172,7 +3160,7 @@ package final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
                         dc.setValue(diff, for: component)
                     }
                 } catch {
-#if canImport(os)
+#if FOUNDATION_FRAMEWORK
                     switch error {
                     case .overflow(_, _, _):
                         _CalendarGregorian.logger.error("Overflowing in dateComponents(from:start:end:). start: \(curr.timeIntervalSinceReferenceDate, privacy: .public). end: \(end.timeIntervalSinceReferenceDate, privacy: .public). component: \(component.debugDescription, privacy: .public)")

--- a/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Hebrew.swift
@@ -10,20 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(os)
-internal import os
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(CRT)
-import CRT
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#endif
-
 internal import Synchronization
 
 /// Pure-Swift implementation of the Hebrew calendar, derived from the
@@ -34,12 +20,6 @@ internal import Synchronization
 /// Foundation's `_CalendarProtocol` contract does not require the ICU
 /// `ucal_set` / `add` / `roll` eager recalculation semantics.
 internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
-
-#if canImport(os)
-    internal static let logger: Logger = {
-        Logger(subsystem: "com.apple.foundation", category: "hebrew_calendar")
-    }()
-#endif
 
     init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
         // .hebrew is the only identifier this class handles. `gregorianStartDate`
@@ -522,16 +502,16 @@ internal final class _CalendarHebrew: _CalendarProtocol, @unchecked Sendable {
             let ti = Double(tz.secondsFromGMT(for: date))
             let time = date.timeIntervalSinceReferenceDate
             var fixedTime = time + ti
-            fixedTime = floor(fixedTime / 3600.0) * 3600.0
+            fixedTime = (fixedTime / 3600.0).rounded(.down) * 3600.0
             fixedTime = fixedTime - ti
             return DateInterval(start: Date(timeIntervalSinceReferenceDate: fixedTime), duration: 3600.0)
         case .minute:
             // Minute and second don't depend on TZ — float floor on UTC seconds is fine.
             let time = date.timeIntervalSinceReferenceDate
-            return DateInterval(start: Date(timeIntervalSinceReferenceDate: floor(time / 60.0) * 60.0), duration: 60.0)
+            return DateInterval(start: Date(timeIntervalSinceReferenceDate: (time / 60.0).rounded(.down) * 60.0), duration: 60.0)
         case .second:
             let time = date.timeIntervalSinceReferenceDate
-            return DateInterval(start: Date(timeIntervalSinceReferenceDate: floor(time)), duration: 1.0)
+            return DateInterval(start: Date(timeIntervalSinceReferenceDate: time.rounded(.down)), duration: 1.0)
         case .nanosecond:
             return DateInterval(start: date, duration: 1e-9)
         case .isLeapMonth, .isRepeatedDay, .calendar, .timeZone:

--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -10,20 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(WASILibc)
-@preconcurrency import WASILibc
-#elseif canImport(EmscriptenLibc)
-@preconcurrency import EmscriptenLibc
-#endif
-
 //===----------------------------------------------------------------------===//
 // Coding Path Node
 //===----------------------------------------------------------------------===//
@@ -707,4 +693,23 @@ package enum DefaultAssociatedValueCodingKeys1: String, CodingKey {
 package enum DefaultAssociatedValueCodingKeys2: String, CodingKey {
     case _0
     case _1
+}
+
+extension RawSpan {
+    func bytesEqual(to other: RawSpan) -> Bool {
+        guard byteCount == other.byteCount else {
+            return false
+        }
+        
+        guard byteCount > 0 else {
+            // Both at 0 bytes are equal
+            return true
+        }
+        
+        return withUnsafeBytes { myBytes in
+            other.withUnsafeBytes { otherBytes in
+                memcmp(myBytes.baseAddress!, otherBytes.baseAddress!, byteCount) == 0
+            }
+        }
+    }
 }

--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -564,7 +564,7 @@ struct BufferReader {
     @inline(__always)
     func string(at dataIdx: BufferViewIndex<UInt8>, matches ptr: UnsafePointer<UInt8>, length: Int) -> Bool {
         fullBuffer[dataIdx...].withUnsafeRawPointer { bufPtr, _ in
-            memcmp(bufPtr, ptr, length) == 0
+            Platform.memcmp(bufPtr, ptr, length) == 0
         }
     }
 
@@ -697,6 +697,10 @@ package enum DefaultAssociatedValueCodingKeys2: String, CodingKey {
 
 extension RawSpan {
     func bytesEqual(to other: RawSpan) -> Bool {
+        if isIdentical(to: other) {
+            return true
+        }
+        
         guard byteCount == other.byteCount else {
             return false
         }
@@ -708,7 +712,7 @@ extension RawSpan {
         
         return withUnsafeBytes { myBytes in
             other.withUnsafeBytes { otherBytes in
-                memcmp(myBytes.baseAddress!, otherBytes.baseAddress!, byteCount) == 0
+                Platform.memcmp(myBytes.baseAddress!, otherBytes.baseAddress!, byteCount) == 0
             }
         }
     }

--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -10,27 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Bionic)
-import Bionic
-#elseif canImport(Glibc)
-import Glibc
-#elseif canImport(Musl)
-import Musl
-#elseif os(Windows)
-import CRT
-import WinSDK
-#elseif os(WASI)
-import WASILibc
-#elseif os(Emscripten)
-import EmscriptenLibc
-#elseif canImport(_FoundationDarwinExtras)
-internal import _FoundationDarwinExtras
-#elseif canImport(stdlib_h)
-import stdlib_h
-#endif
-
 #if !FOUNDATION_FRAMEWORK
 extension Data {
     

--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -653,24 +653,18 @@ extension Base64 {
 
         let outputLength = ((inBuffer.count + 3) / 4) * 3
 
-        let pointer = __DataStorage.allocate(outputLength, false)
-        let other = pointer?.bindMemory(to: UInt8.self, capacity: outputLength)
-        let target = UnsafeMutableBufferPointer(start: other, count: outputLength)
-        var length = outputLength
-        do {
-            if options.contains(.ignoreUnknownCharacters) {
-                try Self._decodeIgnoringErrors(from: inBuffer, into: target, length: &length, options: options)
-            } else {
-                // for whatever reason I can see this being 10% faster for larger payloads. Maybe better
-                // branch prediction?
-                try self._decode(from: inBuffer, into: target, length: &length, options: options)
+        return try Data(capacity: outputLength) { (span) throws(DecodingError) in
+            try span.withUnsafeMutableBytes { (buffer, initializedCount) throws(DecodingError) in
+                let target = buffer.bindMemory(to: UInt8.self)
+                
+                if options.contains(.ignoreUnknownCharacters) {
+                    try Self._decodeIgnoringErrors(from: inBuffer, into: target, length: &initializedCount, options: options)
+                } else {
+                    // for whatever reason I can see this being 10% faster for larger payloads. Maybe better
+                    // branch prediction?
+                    try self._decode(from: inBuffer, into: target, length: &initializedCount, options: options)
+                }
             }
-            
-            return Data(bytesNoCopy: pointer!, count: length, deallocator: .free)
-        } catch {
-            // Do not leak the malloc on error
-            free(pointer)
-            throw error
         }
     }
 

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -67,12 +67,15 @@ private func readExtendedAttributesFromFileDescriptor(_ fd: Int32, attrsToRead: 
                     // ERANGE indicates that the buffer was too small
                     // Get its needed size (passing nil buffer)
                     let neededSize = _fgetxattr(fd, keyStr, nil, 0, 0, 0)
-                    let fullBuffer = Platform.malloc(neededSize)!
-                    if _fgetxattr(fd, keyStr, fullBuffer, neededSize, 0, 0) != neededSize {
-                        // If still an error, then give up
-                        free(fullBuffer)
-                    } else {
-                        output[key] = Data(bytesNoCopy: fullBuffer, count: neededSize, deallocator: .free)
+                    let data = Data(capacity: neededSize, initializingWith: { span in
+                        span.withUnsafeMutableBytes { buffer, initializedBytes in
+                            initializedBytes = _fgetxattr(fd, keyStr, buffer.baseAddress!, neededSize, 0, 0)
+                        }
+                    })
+                    
+                    // Verify we got everything we needed
+                    if data.count == neededSize {
+                        output[key] = data
                     }
                 }
             }

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -69,7 +69,14 @@ private func readExtendedAttributesFromFileDescriptor(_ fd: Int32, attrsToRead: 
                     let neededSize = _fgetxattr(fd, keyStr, nil, 0, 0, 0)
                     let data = Data(capacity: neededSize, initializingWith: { span in
                         span.withUnsafeMutableBytes { buffer, initializedBytes in
-                            initializedBytes = _fgetxattr(fd, keyStr, buffer.baseAddress!, neededSize, 0, 0)
+                            let actualSize = _fgetxattr(fd, keyStr, buffer.baseAddress!, neededSize, 0, 0)
+                            guard actualSize != -1 else {
+                                // We had an error result
+                                initializedBytes = 0
+                                return
+                            }
+                            
+                            initializedBytes = actualSize
                         }
                     })
                     

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -67,7 +67,7 @@ private func readExtendedAttributesFromFileDescriptor(_ fd: Int32, attrsToRead: 
                     // ERANGE indicates that the buffer was too small
                     // Get its needed size (passing nil buffer)
                     let neededSize = _fgetxattr(fd, keyStr, nil, 0, 0, 0)
-                    let fullBuffer = malloc(neededSize)!
+                    let fullBuffer = Platform.malloc(neededSize)!
                     if _fgetxattr(fd, keyStr, fullBuffer, neededSize, 0, 0) != neededSize {
                         // If still an error, then give up
                         free(fullBuffer)
@@ -285,7 +285,7 @@ internal func readBytesFromFile(path inPath: borrowing some FileSystemRepresenta
             }
         }))
     } else {
-        guard let ptr: UnsafeMutableRawPointer = malloc(Int(szFileSize)) else {
+        guard let ptr: UnsafeMutableRawPointer = Platform.malloc(Int(szFileSize)) else {
             throw CocoaError.errorWithFilePath(inPath, errno: ENOMEM, reading: true)
         }
         let buffer = UnsafeMutableRawBufferPointer(start: ptr, count: Int(szFileSize))
@@ -371,7 +371,7 @@ internal func readBytesFromFile(path inPath: borrowing some FileSystemRepresenta
         #if os(Linux) || os(Android) || os(WASI)
         // Linux has some files that may report a size of 0 but actually have contents
         let chunkSize = 1024 * 4
-        var ptr = malloc(chunkSize)!
+        var ptr = Platform.malloc(chunkSize)!
         var totalRead = 0
         while true {
             let buffer = UnsafeMutableRawBufferPointer(start: ptr, count: totalRead + chunkSize)
@@ -419,7 +419,7 @@ internal func readBytesFromFile(path inPath: borrowing some FileSystemRepresenta
 #endif
     } else {
         // We've verified above that fileSize will fit in `Int`
-        guard let bytes = malloc(Int(fileSize)) else {
+        guard let bytes = Platform.malloc(Int(fileSize)) else {
             throw CocoaError.errorWithFilePath(inPath, errno: ENOMEM, reading: true)
         }
         let buffer = UnsafeMutableRawBufferPointer(start: bytes, count: Int(fileSize))

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -17,6 +17,7 @@
 @usableFromInline let memset = ucrt.memset
 @usableFromInline let memcpy = ucrt.memcpy
 #elseif canImport(Bionic)
+@preconcurrency import Bionic
 @usableFromInline let memcmp = Bionic.memcmp
 @usableFromInline let memset = Bionic.memset
 @usableFromInline let memcpy = Bionic.memcpy

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -10,6 +10,38 @@
 //
 //===----------------------------------------------------------------------===//
 
+// These functions are used from inlined methods below
+
+#if os(Windows)
+@usableFromInline let memcmp = ucrt.memcmp
+@usableFromInline let memset = ucrt.memset
+@usableFromInline let memcpy = ucrt.memcpy
+#elseif canImport(Bionic)
+@usableFromInline let memcmp = Bionic.memcmp
+@usableFromInline let memset = Bionic.memset
+@usableFromInline let memcpy = Bionic.memcpy
+#elseif canImport(Glibc)
+@usableFromInline let memcmp = Glibc.memcmp
+@usableFromInline let memset = Glibc.memset
+@usableFromInline let memcpy = Glibc.memcpy
+#elseif canImport(Musl)
+@usableFromInline let memcmp = Musl.memcmp
+@usableFromInline let memset = Musl.memset
+@usableFromInline let memcpy = Musl.memcpy
+#elseif canImport(WASILibc)
+@usableFromInline let memcmp = WASILibc.memcmp
+@usableFromInline let memset = WASILibc.memset
+@usableFromInline let memcpy = WASILibc.memcpy
+#elseif canImport(EmscriptenLibc)
+@usableFromInline let memcmp = EmscriptenLibc.memcmp
+@usableFromInline let memset = EmscriptenLibc.memset
+@usableFromInline let memcpy = EmscriptenLibc.memcpy
+#elseif canImport(_FoundationDarwinExtras)
+@usableFromInline let memcmp = _FoundationDarwinExtras.memcmp
+@usableFromInline let memset = _FoundationDarwinExtras.memset
+@usableFromInline let memcpy = _FoundationDarwinExtras.memcpy
+#endif
+
 #if !NO_CSHIMS
 internal import _FoundationCShims
 #endif
@@ -1126,23 +1158,6 @@ extension Data {
         _representation.hash(into: &hasher)
     }
 }
-
-
-#if os(Windows)
-@usableFromInline let memcmp = ucrt.memcmp
-#elseif canImport(Bionic)
-@usableFromInline let memcmp = Bionic.memcmp
-#elseif canImport(Glibc)
-@usableFromInline let memcmp = Glibc.memcmp
-#elseif canImport(Musl)
-@usableFromInline let memcmp = Musl.memcmp
-#elseif canImport(WASILibc)
-@usableFromInline let memcmp = WASILibc.memcmp
-#elseif canImport(EmscriptenLibc)
-@usableFromInline let memcmp = EmscriptenLibc.memcmp
-#elseif canImport(_FoundationDarwinExtras)
-@usableFromInline let memcmp = _FoundationDarwinExtras.memcmp
-#endif
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -10,55 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Windows)
-@usableFromInline let calloc = ucrt.calloc
-@usableFromInline let malloc = ucrt.malloc
-@usableFromInline let free = ucrt.free
-@usableFromInline let memset = ucrt.memset
-@usableFromInline let memcpy = ucrt.memcpy
-@usableFromInline let memcmp = ucrt.memcmp
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-@usableFromInline let calloc = Bionic.calloc
-@usableFromInline let malloc = Bionic.malloc
-@usableFromInline let free = Bionic.free
-@usableFromInline let memset = Bionic.memset
-@usableFromInline let memcpy = Bionic.memcpy
-@usableFromInline let memcmp = Bionic.memcmp
-#elseif canImport(Glibc)
-@usableFromInline let calloc = Glibc.calloc
-@usableFromInline let malloc = Glibc.malloc
-@usableFromInline let free = Glibc.free
-@usableFromInline let memset = Glibc.memset
-@usableFromInline let memcpy = Glibc.memcpy
-@usableFromInline let memcmp = Glibc.memcmp
-#elseif canImport(Musl)
-@usableFromInline let calloc = Musl.calloc
-@usableFromInline let malloc = Musl.malloc
-@usableFromInline let free = Musl.free
-@usableFromInline let memset = Musl.memset
-@usableFromInline let memcpy = Musl.memcpy
-@usableFromInline let memcmp = Musl.memcmp
-#elseif canImport(WASILibc)
-@usableFromInline let calloc = WASILibc.calloc
-@usableFromInline let malloc = WASILibc.malloc
-@usableFromInline let free = WASILibc.free
-@usableFromInline let memset = WASILibc.memset
-@usableFromInline let memcpy = WASILibc.memcpy
-@usableFromInline let memcmp = WASILibc.memcmp
-#elseif canImport(EmscriptenLibc)
-@usableFromInline let calloc = EmscriptenLibc.calloc
-@usableFromInline let malloc = EmscriptenLibc.malloc
-@usableFromInline let free = EmscriptenLibc.free
-@usableFromInline let memset = EmscriptenLibc.memset
-@usableFromInline let memcpy = EmscriptenLibc.memcpy
-@usableFromInline let memcmp = EmscriptenLibc.memcmp
-#elseif canImport(_FoundationDarwinExtras)
-@usableFromInline let memset = _FoundationDarwinExtras.memset
-@usableFromInline let memcpy = _FoundationDarwinExtras.memcpy
-@usableFromInline let memcmp = _FoundationDarwinExtras.memcmp
-#endif
-
 #if !NO_CSHIMS
 internal import _FoundationCShims
 #endif
@@ -1176,6 +1127,23 @@ extension Data {
     }
 }
 
+
+#if os(Windows)
+@usableFromInline let memcmp = ucrt.memcmp
+#elseif canImport(Bionic)
+@usableFromInline let memcmp = Bionic.memcmp
+#elseif canImport(Glibc)
+@usableFromInline let memcmp = Glibc.memcmp
+#elseif canImport(Musl)
+@usableFromInline let memcmp = Musl.memcmp
+#elseif canImport(WASILibc)
+@usableFromInline let memcmp = WASILibc.memcmp
+#elseif canImport(EmscriptenLibc)
+@usableFromInline let memcmp = EmscriptenLibc.memcmp
+#elseif canImport(_FoundationDarwinExtras)
+@usableFromInline let memcmp = _FoundationDarwinExtras.memcmp
+#endif
+
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {
     /// Returns `true` if the two `Data` arguments are equal.
@@ -1217,6 +1185,7 @@ extension Data {
 
                     // Compare the contents
                     assert(length1 == b2.count)
+                    // Use the inlined memcmp above
                     return memcmp(b1Address, b2Address, length1) == 0
                 }
             }

--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -10,22 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(ucrt)
-import ucrt
-#elseif canImport(WASILibc)
-@preconcurrency import WASILibc
-#elseif canImport(EmscriptenLibc)
-@preconcurrency import EmscriptenLibc
-#elseif canImport(stdlib_h)
-import stdlib_h
-#endif
-
 //===--- DataProtocol -----------------------------------------------------===//
 
 /// A protocol that provides consistent data access to the bytes underlying contiguous and noncontiguous data buffers.

--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -10,6 +10,24 @@
 //
 //===----------------------------------------------------------------------===//
 
+// For memcpy
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(ucrt)
+import ucrt
+#elseif canImport(WASILibc)
+@preconcurrency import WASILibc
+#elseif canImport(EmscriptenLibc)
+@preconcurrency import EmscriptenLibc
+#elseif canImport(stdlib_h)
+import stdlib_h
+#endif
+
 //===--- DataProtocol -----------------------------------------------------===//
 
 /// A protocol that provides consistent data access to the bytes underlying contiguous and noncontiguous data buffers.

--- a/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
+++ b/Sources/FoundationEssentials/Data/Representations/Data+Inline.swift
@@ -12,23 +12,8 @@
 
 #if DATA_LEGACY_ABI
 
-#if canImport(Darwin)
+// Legacy ABI is only enabled on Darwin - other platforms do not use it
 import Darwin
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(ucrt)
-import ucrt
-#elseif canImport(WASILibc)
-@preconcurrency import WASILibc
-#elseif canImport(EmscriptenLibc)
-@preconcurrency import EmscriptenLibc
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(string_h)
-import string_h
-#endif
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Data {

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -69,7 +69,7 @@ internal final class __DataStorage : @unchecked Sendable {
         typeDesc.summary.layout_semantics.contains_generic_data = true
         return malloc_type_realloc(ptr, newSize, typeDesc.type_id);
 #else
-        return realloc(ptr, newSize)
+        return Platform.realloc(ptr, newSize)
 #endif
     }
     

--- a/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
+++ b/Sources/FoundationEssentials/Data/Representations/DataStorage.swift
@@ -56,9 +56,9 @@ internal final class __DataStorage : @unchecked Sendable {
         }
 #else
         if clear {
-            return calloc(1, size)
+            return Platform.calloc(1, size)
         } else {
-            return malloc(size)
+            return Platform.malloc(size)
         }
 #endif
     }

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -10,22 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(CRT)
-import CRT
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#elseif os(Emscripten)
-@preconcurrency import EmscriptenLibc
-#endif
-
 private let _pow10: [39 of UInt128] = [
                                                       1,    //  0
                                                      10,    //  1

--- a/Sources/FoundationEssentials/Decimal/Decimal.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal.swift
@@ -10,14 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(ucrt)
-import ucrt
-#endif
-
 #if !FOUNDATION_FRAMEWORK
 
 /// A structure representing a base-10 number.

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -36,7 +36,7 @@ extension _FILE_ID_128 /* : @retroactive Equatable */ {
     internal static func _equals(_ lhs: _FILE_ID_128, _ rhs: _FILE_ID_128) -> Bool {
         return withUnsafeBytes(of: lhs.Identifier) { pLHS in
             return withUnsafeBytes(of: rhs.Identifier) { pRHS in
-                return memcmp(pLHS.baseAddress, pRHS.baseAddress, MemoryLayout.size(ofValue: lhs.Identifier)) == 0
+                return Platform.memcmp(pLHS.baseAddress, pRHS.baseAddress, MemoryLayout.size(ofValue: lhs.Identifier)) == 0
             }
         }
     }
@@ -197,7 +197,7 @@ internal struct _FileManagerImpl {
                                     return false
                                 }
 
-                                guard memcmp(pLHSBuffer.baseAddress, pRHSBuffer.baseAddress, Int(dwLHSRead)) == 0 else {
+                                guard Platform.memcmp(pLHSBuffer.baseAddress, pRHSBuffer.baseAddress, Int(dwLHSRead)) == 0 else {
                                     return false
                                 }
 

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -513,6 +513,8 @@ extension _FileManagerImpl {
                 guard actualSize != -1 else {
                     throw CocoaError.errorWithFilePath(String(cString: path), errno: errno, reading: true)
                 }
+                
+                initializedCount = actualSize
             }
         }
         

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -502,7 +502,7 @@ extension _FileManagerImpl {
         // Historically we've omitted extended attribute keys with no associated data value
         guard size > 0 else { return nil }
         // Deallocated below in the Data deallocator
-        let buffer = malloc(size)!
+        let buffer = Platform.malloc(size)!
         #if canImport(Darwin)
         size = getxattr(path, key, buffer, size, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
         #elseif os(FreeBSD)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -501,25 +501,26 @@ extension _FileManagerImpl {
         }
         // Historically we've omitted extended attribute keys with no associated data value
         guard size > 0 else { return nil }
-        // Deallocated below in the Data deallocator
-        let buffer = Platform.malloc(size)!
-        #if canImport(Darwin)
-        size = getxattr(path, key, buffer, size, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
-        #elseif os(FreeBSD)
-        size = (followSymlinks ? extattr_get_file : extattr_get_link)(path, EXTATTR_NAMESPACE_USER, key, buffer, size)
-        #else
-        size = followSymlinks ? getxattr(path, key, buffer, size) : lgetxattr(path, key, buffer, size)
-        #endif
-        guard size != -1 else {
-            free(buffer)
-            throw CocoaError.errorWithFilePath(String(cString: path), errno: errno, reading: true)
+        let result = try Data(capacity: size) { span in
+            try span.withUnsafeMutableBytes { buffer, initializedCount in
+#if canImport(Darwin)
+                let actualSize = getxattr(path, key, buffer.baseAddress!, size, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
+#elseif os(FreeBSD)
+                let actualSize = (followSymlinks ? extattr_get_file : extattr_get_link)(path, EXTATTR_NAMESPACE_USER, key, buffer.baseAddress!, size)
+#else
+                let actualSize = followSymlinks ? getxattr(path, key, buffer.baseAddress!, size) : lgetxattr(path, key, buffer.baseAddress!, size)
+#endif
+                guard actualSize != -1 else {
+                    throw CocoaError.errorWithFilePath(String(cString: path), errno: errno, reading: true)
+                }
+            }
         }
-        // Check size again in case something has changed between the two getxattr calls
-        guard size > 0 else {
-            free(buffer)
+        
+        guard result.count > 0 else {
             return nil
         }
-        return Data(bytesNoCopy: buffer, count: size, deallocator: .free)
+        
+        return result
     }
     
     private func _extendedAttributes(at path: UnsafePointer<CChar>, followSymlinks: Bool) throws -> [String : Data]? {

--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -10,22 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif os(Windows)
-import CRT
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#elseif os(Emscripten)
-@preconcurrency import EmscriptenLibc
-#endif
-
 // MARK: - BinaryInteger + Numeric string representation
 
 extension BinaryInteger {
@@ -149,9 +133,9 @@ private func numericStringRepresentationForMutableBinaryInteger(words: UnsafeMut
 private func maxDecimalDigitCountForUnsignedInteger(bitWidth: Int) -> Int {
     // - Int.init(some BinaryFloatingPoint) rounds to zero.
     // - Double.init(exactly:) and UInt.init(_:) for correctness.
-    // - log10(2.0) is: 1.0021010002000002002101⌈01...⌉ * 2^(-2).
+    // - log10(2.0) is: 1.0021010002000002002101⌈01...⌉ * 2^(-2). (0.3010299956639812)
     // - It's an upper bound, so Double/nextUp for peace of mind.
-    return Int(Double(exactly: UInt(bitWidth))! * log10(2.0).nextUp) + 1
+    return Int(Double(exactly: UInt(bitWidth))! * 0.3010299956639812.nextUp) + 1
 }
 
 /// Returns the largest `exponent` and `power` in `pow(10, exponent) <= UInt.max + 1`.

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -610,7 +610,7 @@ extension JSON5Scanner {
         mutating func readExpectedString(_ str: StaticString, typeDescriptor: String) throws {
             let cmp = try bytes[unchecked: readIndex..<endIndex].withUnsafeRawPointer { ptr, count in
                 if count < str.utf8CodeUnitCount { throw JSONError.unexpectedEndOfFile }
-                return memcmp(ptr, str.utf8Start, str.utf8CodeUnitCount)
+                return Platform.memcmp(ptr, str.utf8Start, str.utf8CodeUnitCount)
             }
             guard cmp == 0 else {
                 // Figure out the exact character that is wrong.

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -968,7 +968,7 @@ extension JSON5Scanner {
             throw JSONError.invalidSpecialValue(expected: "\(_json5Infinity)", location: .sourceLocation(at: jsonBytes.startIndex, fullSource: fullSource))
         }
     }
-    
+
     static func validateLeadingDecimal(
       from jsonBytes: BufferView<UInt8>, fullSource: BufferView<UInt8>
     ) throws {

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -10,23 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Android)
-@preconcurrency import Android
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif os(Windows)
-import CRT
-import WinSDK
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#elseif canImport(string_h)
-import string_h
-#endif
-
 internal struct JSON5Scanner {
     let options: Options
     var reader: DocumentReader
@@ -975,27 +958,17 @@ extension JSON5Scanner {
     }
 
     static func validateInfinity(from jsonBytes: BufferView<UInt8>, fullSource: BufferView<UInt8>) throws {
-        try jsonBytes.withUnsafeRawPointer { ptr, count in
-            guard count >= _json5Infinity.utf8CodeUnitCount else {
-                throw JSONError.invalidSpecialValue(expected: "\(_json5Infinity)", location: .sourceLocation(at: jsonBytes.startIndex, fullSource: fullSource))
-            }
-            guard strncmp(ptr, _json5Infinity.utf8Start, _json5Infinity.utf8CodeUnitCount) == 0 else {
-                throw JSONError.invalidSpecialValue(expected: "\(_json5Infinity)", location: .sourceLocation(at: jsonBytes.startIndex, fullSource: fullSource))
-            }
+        if !jsonBytes.bytes.bytesEqual(to: _json5Infinity.span.bytes) {
+            throw JSONError.invalidSpecialValue(expected: "\(_json5Infinity)", location: .sourceLocation(at: jsonBytes.startIndex, fullSource: fullSource))
         }
     }
 
     static func validateNaN(from jsonBytes: BufferView<UInt8>, fullSource: BufferView<UInt8>) throws {
-        try jsonBytes.withUnsafeRawPointer { ptr, count in
-            guard count >= _json5NaN.utf8CodeUnitCount else {
-                throw JSONError.invalidSpecialValue(expected: "\(_json5NaN)", location: .sourceLocation(at: jsonBytes.startIndex, fullSource: fullSource))
-            }
-            guard strncmp(ptr, _json5NaN.utf8Start, _json5NaN.utf8CodeUnitCount) == 0 else {
-                throw JSONError.invalidSpecialValue(expected: "\(_json5NaN)", location: .sourceLocation(at: jsonBytes.startIndex, fullSource: fullSource))
-            }
+        if !jsonBytes.bytes.bytesEqual(to: _json5NaN.span.bytes) {
+            throw JSONError.invalidSpecialValue(expected: "\(_json5Infinity)", location: .sourceLocation(at: jsonBytes.startIndex, fullSource: fullSource))
         }
     }
-
+    
     static func validateLeadingDecimal(
       from jsonBytes: BufferView<UInt8>, fullSource: BufferView<UInt8>
     ) throws {
@@ -1214,8 +1187,22 @@ internal extension UInt8 {
     static var _dot: UInt8 { UInt8(ascii: ".") }
 }
 
-var _json5Infinity: StaticString { "Infinity" }
-var _json5NaN: StaticString { "NaN" }
+let _json5Infinity: InlineArray<_, UInt8> = [
+    UInt8(ascii: "I"),
+    UInt8(ascii: "n"),
+    UInt8(ascii: "f"),
+    UInt8(ascii: "i"),
+    UInt8(ascii: "n"),
+    UInt8(ascii: "i"),
+    UInt8(ascii: "t"),
+    UInt8(ascii: "y")
+]
+
+let _json5NaN: InlineArray<_, UInt8> = [
+    UInt8(ascii: "N"),
+    UInt8(ascii: "a"),
+    UInt8(ascii: "N")
+]
 
 extension UnicodeScalar {
 

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -10,12 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#endif
-
 #if !NO_JSON_FOUNDATION_SPECIALIZATION
 internal import Synchronization
 #endif

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -1003,7 +1003,7 @@ extension JSONDecoderImpl: Decoder {
                 var nanString = nanString
                 return stringBuffer.withUnsafeRawPointer { (ptr, count) -> T? in
                     func bytesAreEqual(_ b: UnsafeBufferPointer<UInt8>) -> Bool {
-                        count == b.count && memcmp(ptr, b.baseAddress!, b.count) == 0
+                        count == b.count && Platform.memcmp(ptr, b.baseAddress!, b.count) == 0
                     }
                     if posInfString.withUTF8(bytesAreEqual(_:)) { return T.infinity }
                     if negInfString.withUTF8(bytesAreEqual(_:)) { return -T.infinity }

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -713,7 +713,7 @@ extension JSONScanner {
         mutating func readExpectedString(_ str: StaticString, typeDescriptor: String) throws {
             let cmp = try bytes[unchecked: readIndex..<endIndex].withUnsafeRawPointer { ptr, count in
                 if count < str.utf8CodeUnitCount { throw JSONError.unexpectedEndOfFile }
-                return memcmp(ptr, str.utf8Start, str.utf8CodeUnitCount)
+                return Platform.memcmp(ptr, str.utf8Start, str.utf8CodeUnitCount)
             }
             guard cmp == 0 else {
                 // Figure out the exact character that is wrong.

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -53,12 +53,6 @@
  6. Pass that byte offset + length into the number parser to produce the corresponding Swift Int value.
 */
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#endif // canImport(Darwin)
-
 #if !NO_JSON_FOUNDATION_SPECIALIZATION
 internal import Synchronization
 #endif

--- a/Sources/FoundationEssentials/Locale/Locale+Components.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Components.swift
@@ -10,10 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Glibc)
-@preconcurrency import Glibc
-#endif
-
 extension Locale {
 
     /// A type that represents the components of a locale, for use when creating a locale with specific overrides.

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -28,6 +28,7 @@ fileprivate let _pageSize: Int = {
     return Int(sysInfo.dwPageSize)
 }()
 #elseif os(WASI)
+@preconcurrency import WASILibc
 // WebAssembly defines a fixed page size
 fileprivate let _pageSize: Int = 65_536
 #elseif os(Emscripten)

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -61,6 +61,10 @@ fileprivate let _pageSize: Int = Int(getpagesize())
 import stdlib_h
 #endif // canImport(Darwin)
 
+#if canImport(Bionic)
+@preconcurrency import Bionic
+#endif
+
 #if FOUNDATION_FRAMEWORK
 internal import CoreFoundation_Private
 #endif
@@ -439,4 +443,60 @@ extension Platform {
         return strtof_l(nptr, endptr, Self.cLocale)
         #endif
     }
+    
+#if canImport(Darwin)
+    static let calloc = Darwin.calloc
+    static let malloc = Darwin.malloc
+    static let free = Darwin.free
+    static let memset = Darwin.memset
+    static let memcpy = Darwin.memcpy
+    static let memcmp = Darwin.memcmp
+#elseif os(Windows)
+    static let calloc = ucrt.calloc
+    static let malloc = ucrt.malloc
+    static let free = ucrt.free
+    static let memset = ucrt.memset
+    static let memcpy = ucrt.memcpy
+    static let memcmp = ucrt.memcmp
+#elseif canImport(Bionic)
+    static let calloc = Bionic.calloc
+    static let malloc = Bionic.malloc
+    static let free = Bionic.free
+    static let memset = Bionic.memset
+    static let memcpy = Bionic.memcpy
+    static let memcmp = Bionic.memcmp
+#elseif canImport(Glibc)
+    static let calloc = Glibc.calloc
+    static let malloc = Glibc.malloc
+    static let free = Glibc.free
+    static let memset = Glibc.memset
+    static let memcpy = Glibc.memcpy
+    static let memcmp = Glibc.memcmp
+#elseif canImport(Musl)
+    static let calloc = Musl.calloc
+    static let malloc = Musl.malloc
+    static let free = Musl.free
+    static let memset = Musl.memset
+    static let memcpy = Musl.memcpy
+    static let memcmp = Musl.memcmp
+#elseif canImport(WASILibc)
+    static let calloc = WASILibc.calloc
+    static let malloc = WASILibc.malloc
+    static let free = WASILibc.free
+    static let memset = WASILibc.memset
+    static let memcpy = WASILibc.memcpy
+    static let memcmp = WASILibc.memcmp
+#elseif canImport(EmscriptenLibc)
+    static let calloc = EmscriptenLibc.calloc
+    static let malloc = EmscriptenLibc.malloc
+    static let free = EmscriptenLibc.free
+    static let memset = EmscriptenLibc.memset
+    static let memcpy = EmscriptenLibc.memcpy
+    static let memcmp = EmscriptenLibc.memcmp
+#elseif canImport(_FoundationDarwinExtras)
+    static let memset = _FoundationDarwinExtras.memset
+    static let memcpy = _FoundationDarwinExtras.memcpy
+    static let memcmp = _FoundationDarwinExtras.memcmp
+#endif
+
 }

--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -10,24 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Bionic)
-@preconcurrency import Bionic
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif os(WASI)
-@preconcurrency import WASILibc
-#elseif os(Emscripten)
-@preconcurrency import EmscriptenLibc
-#endif
-
-#if canImport(CRT)
-import CRT
-#endif
-
 private struct _ParseInfo {
     let utf16 : String.UTF16View
     var curr : String.UTF16View.Index
@@ -324,12 +306,20 @@ private func parseOctal(startingWith ch: UInt16, _ pInfo: inout _ParseInfo) -> U
     return .init(nextStep: num)
 }
 
+extension UInt16 {
+    fileprivate var isHexDigit: Bool {
+        (self >= UInt16(ascii: "0") && self <= UInt16(ascii: "9")) ||
+        (self >= UInt16(ascii: "A") && self <= UInt16(ascii: "F")) ||
+        (self >= UInt16(ascii: "a") && self <= UInt16(ascii: "f"))
+    }
+}
+
 private func parseU16Scalar(_ pInfo: inout _ParseInfo) -> UInt16? {
     var num : UInt16 = 0
     var numDigits = 4
     while !pInfo.isAtEnd && numDigits > 0 {
         let ch2 = pInfo.currChar
-        if ch2 < 128 && isxdigit(Int32(ch2)) != 0 {
+        if ch2 < 128 && ch2.isHexDigit {
             pInfo.advance()
             num = num << 4
             if ch2 <= UInt16(ascii: "9") {
@@ -440,7 +430,7 @@ private func getDataBytes(_ pInfo: inout _ParseInfo, bytes: UnsafeMutableBufferP
             guard let ch = UInt8(exactly: ch) else {
                 return nil
             }
-            if isdigit(Int32(ch)) != 0 {
+            if (ch >= UInt8(ascii: "0") && (ch <= UInt8(ascii: "9"))) {
                 return ch &- UInt8(ascii: "0")
             }
             if (ch >= UInt8(ascii: "a")) && (ch <= UInt8(ascii: "f")) {

--- a/Sources/FoundationEssentials/PropertyList/XMLPlistScanner.swift
+++ b/Sources/FoundationEssentials/PropertyList/XMLPlistScanner.swift
@@ -285,7 +285,7 @@ class XMLPlistMap : PlistDecodingMap {
                 return self.withBuffer(for: region) { bufferView, _ in
                     bufferView.withUnsafeRawPointer { ptr, _ in
                         cfuid.withUTF8Buffer { cfuidBuf in
-                            memcmp(ptr, cfuidBuf.baseAddress!, cfuid.utf8CodeUnitCount) == 0
+                            Platform.memcmp(ptr, cfuidBuf.baseAddress!, cfuid.utf8CodeUnitCount) == 0
                         }
                     }
                 }

--- a/Sources/FoundationEssentials/String/Span+Path.swift
+++ b/Sources/FoundationEssentials/String/Span+Path.swift
@@ -225,7 +225,7 @@ extension Span<UInt8> {
         guard self.count >= prefixLength else { return false }
         // Precondition: self.count > 0
         return withUnsafeBufferPointer { buffer in
-            memcmp(buffer.baseAddress.unsafelyUnwrapped, prefix.utf8Start, prefixLength) == 0
+            Platform.memcmp(buffer.baseAddress.unsafelyUnwrapped, prefix.utf8Start, prefixLength) == 0
         }
     }
 

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -13,12 +13,6 @@
 internal import _ForSwiftFoundation
 #endif
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#endif
-
 internal import _FoundationCShims
 
 // These provides concrete implementations for String and Substring, enhancing performance over generic StringProtocol.

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -101,7 +101,7 @@ extension String {
             let outputCount = bom == nil ? inputCount : inputCount + 1
             
             // Allocate enough memory to hold the UTF16 bytes after conversion. We will pass this off to Data.
-            let utf16Pointer = calloc(outputCount, MemoryLayout<UInt16>.size)!.assumingMemoryBound(to: UInt16.self)
+            let utf16Pointer = Platform.calloc(outputCount, MemoryLayout<UInt16>.size)!.assumingMemoryBound(to: UInt16.self)
             let utf16Buffer = UnsafeMutableBufferPointer<UInt16>(start: utf16Pointer, count: outputCount)
             
             if let bom {

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -10,12 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#endif
-
 internal import _FoundationCShims
 
 /// Information about standard time conventions associated with a specific geopolitical region.

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -10,18 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Android)
-import unistd
-#elseif canImport(Glibc)
-@preconcurrency import Glibc
-#elseif canImport(Musl)
-@preconcurrency import Musl
-#elseif canImport(ucrt)
-import ucrt
-#endif
-
 #if os(Windows)
 import WinSDK
 #endif

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -10,6 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+// For tzset, localtime
+
+#if canImport(Android)
+import unistd
+#elseif canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(ucrt)
+import ucrt
+#endif
+
 #if os(Windows)
 import WinSDK
 #endif

--- a/Sources/FoundationEssentials/URL/URL_Parsing.swift
+++ b/Sources/FoundationEssentials/URL/URL_Parsing.swift
@@ -764,7 +764,7 @@ extension URL {
             return false
         }
         if T.self == UInt8.self {
-            return memcmp(buffer.baseAddress!.advanced(by: pathStart), "/.file/id=", 10) == 0
+            return Platform.memcmp(buffer.baseAddress!.advanced(by: pathStart), "/.file/id=", 10) == 0
         }
         return (
             buffer[pathStart] == UInt8(ascii: "/") &&
@@ -822,7 +822,7 @@ extension URL {
             return false
         }
         if T.self == UInt8.self {
-            return memcmp(buffer.baseAddress!, "addressbook", 11) == 0
+            return Platform.memcmp(buffer.baseAddress!, "addressbook", 11) == 0
         }
         return (
             buffer[0] == UInt8(ascii: "a") &&

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -24,6 +24,8 @@ import Darwin
 @preconcurrency import Glibc
 #elseif canImport(Musl)
 @preconcurrency import Musl
+#elseif canImport(ucrt)
+@preconcurrency import ucrt
 #endif
 
 #if FOUNDATION_FRAMEWORK


### PR DESCRIPTION
Reduce the number of places we import libc and equivalent

### Motivation:

Every import of `Darwin` (or `Glibc` or other equivalents) complicates our ability to port Foundation to different platforms or embedded environments. I want to reduce the number of places we rely on libc API - sometimes we do not need it all, and sometimes it can be replaced with a trivial amount of Swift.

### Modifications:

Removed imports, added a few convenience helpers.

### Result:

No behavior change.

### Testing:

Cross-platform building and testing.