### PR TITLE
Adopt @c @implementation in favor of @_cdecl

### DIFF
--- a/Sources/FoundationEssentials/Decimal/Decimal+Compatibility.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Compatibility.swift
@@ -93,8 +93,9 @@ private func __NSDecimalAdd(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalAdd")
-internal func _NSDecimalAdd(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalAdd(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
     __NSDecimalAdd(result, lhs, rhs, roundingMode)
 }
 #else
@@ -127,8 +128,9 @@ private func __NSDecimalSubtract(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalSubtract")
-internal func _NSDecimalSubtract(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalSubtract(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
     __NSDecimalSubtract(result, lhs, rhs, roundingMode)
 }
 #else
@@ -163,8 +165,9 @@ private func __NSDecimalMultiply(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalMultiply")
-internal func _NSDecimalMultiply(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalMultiply(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
     __NSDecimalMultiply(result, lhs, rhs, roundingMode)
 }
 #else
@@ -199,8 +202,9 @@ private func __NSDecimalDivide(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalDivide")
-internal func _NSDecimalDivide(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalDivide(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
     __NSDecimalDivide(result, lhs, rhs, roundingMode)
 }
 #else
@@ -230,8 +234,9 @@ private func __NSDecimalPower(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalPower")
-internal func _NSDecimalPower(_ result: UnsafeMutablePointer<Decimal>, _ decimal: UnsafePointer<Decimal>, _ exponent: Int, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalPower(_ result: UnsafeMutablePointer<Decimal>, _ decimal: UnsafePointer<Decimal>, _ exponent: Int, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
     __NSDecimalPower(result, decimal, exponent, roundingMode)
 }
 #else
@@ -259,8 +264,9 @@ private func __NSDecimalMultiplyByPowerOf10(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalMultiplyByPowerOf10")
-internal func _NSDecimalMultiplyByPowerOf10(_ result: UnsafeMutablePointer<Decimal>, _ decimal: UnsafePointer<Decimal>, _ power: CShort, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalMultiplyByPowerOf10(_ result: UnsafeMutablePointer<Decimal>, _ decimal: UnsafePointer<Decimal>, _ power: CShort, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
     __NSDecimalMultiplyByPowerOf10(result, decimal, power, roundingMode)
 }
 #else
@@ -278,8 +284,9 @@ private func __NSDecimalCompare(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalCompare")
-internal func _NSDecimalCompare(_ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>) -> ComparisonResult {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalCompare(_ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>) -> ComparisonResult {
     __NSDecimalCompare(lhs, rhs)
 }
 #else
@@ -308,8 +315,9 @@ private func __NSDecimalRound(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalRound")
-internal func _NSDecimalRound(_ result: UnsafeMutablePointer<Decimal>, _ decimal: UnsafePointer<Decimal>, _ scale: Int, _ roundingMode: Decimal.RoundingMode) {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalRound(_ result: UnsafeMutablePointer<Decimal>, _ decimal: UnsafePointer<Decimal>, _ scale: Int, _ roundingMode: Decimal.RoundingMode) {
     __NSDecimalRound(result, decimal, scale, roundingMode)
 }
 #else
@@ -343,8 +351,9 @@ private func __NSDecimalNormalize(
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalNormalize")
-internal func _NSDecimalNormalize(_ lhs: UnsafeMutablePointer<Decimal>, _ rhs: UnsafeMutablePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalNormalize(_ lhs: UnsafeMutablePointer<Decimal>, _ rhs: UnsafeMutablePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
     __NSDecimalNormalize(lhs, rhs, roundingMode)
 }
 #else
@@ -355,8 +364,9 @@ public func _NSDecimalNormalize(_ lhs: UnsafeMutablePointer<Decimal>, _ rhs: Uns
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_NSDecimalCompact")
-internal func _NSDecimalCompact(_ number: UnsafeMutablePointer<Decimal>) {
+@c @implementation
+@available(macOS 10.0, iOS 2.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+public func NSDecimalCompact(_ number: UnsafeMutablePointer<Decimal>) {
     var value = number.pointee
     value.compact()
     number.pointee = value

--- a/Sources/FoundationEssentials/Locale/Locale_Notifications.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Notifications.swift
@@ -12,6 +12,10 @@
 
 internal import Synchronization
 
+#if FOUNDATION_FRAMEWORK
+internal import _ForSwiftFoundation
+#endif
+
 /// Keeps a global generation count for updated Locale information, including locale, time zone, and calendar preferences.
 /// If any of those preferences change, then `count` will update to a new value. Compare that to a cached value to see if your cached `Locale.current`, `TimeZone.current`, or `Calendar.current` to see if it is out of date.
 /// If any cached values need to be recalculated process-wide, call `reset`.
@@ -34,7 +38,7 @@ struct LocaleNotifications : Sendable, ~Copyable {
 }
 
 #if FOUNDATION_FRAMEWORK
-@_cdecl("_localeNotificationCount")
+@c @implementation
 func _localeNotificationCount() -> Int {
     LocaleNotifications.cache.count()
 }


### PR DESCRIPTION
Adopts `@c @implementation` in favor of `@_cdecl` where appropriate

### Motivation:

`@c @implementation` is the new, non-underscored way to declare a function implements a global C function in a C header

### Modifications:

Change `@_cdecl` to `@c @implementation`

### Result:

Compiler now validates that Swift functions match the C function declaration

### Testing:

Validated the project still builds
