### PR TITLE
Resolve a warning in the #Predicate macro

### DIFF
--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -402,7 +402,7 @@ extension KeyPathExprSyntax {
                 }
             case .subscript(let sub):
                 result = ExprSyntax(SubscriptCallExprSyntax(calledExpression: result, arguments: sub.arguments))
-            @unknown default:
+            default:
                 return nil
             }
         }


### PR DESCRIPTION
Resolves a warning in FoundationMacros that's bugged be for a little while.

### Motivation:

A number of releases ago, swift-syntax introduced a new case in this enum, however it was marked as SPI and was never made stable and promoted to API, so we can't use it directly.

### Modifications:

Changes the existing `default` case to remove `@unknown` so it includes the known-but-not-usable enum case that is SPI

### Result:

No behavior change, the SPI case is not enabled by default this just silences the warning.

### Testing:

Validated the macro module still builds.
